### PR TITLE
Adding aleth db Unit-Test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,20 +211,20 @@ ${OBJECTDIR}/grpc_test.o: core_tests/grpc_test.cpp
 	${RM} "$@.d"
 	${COMPILE} ${CXXFLAGS} "$@.d" -o ${OBJECTDIR}/grpc_test.o core_tests/grpc_test.cpp $(CPPFLAGS)
 
-${OBJECTDIR}/memorydb_test.o: core_tests/memorydb.cpp
+${OBJECTDIR}/memorydb_test.o: core_tests/memorydb_test.cpp
 	${MKDIR} -p ${OBJECTDIR}
 	${RM} "$@.d"
-	${COMPILE} ${CXXFLAGS} "$@.d" -o ${OBJECTDIR}/memorydb_test.o core_tests/memorydb.cpp $(CPPFLAGS)
+	${COMPILE} ${CXXFLAGS} "$@.d" -o ${OBJECTDIR}/memorydb_test.o core_tests/memorydb_test.cpp $(CPPFLAGS)
 
-${OBJECTDIR}/overlaydb_test.o: core_tests/overlaydb.cpp
+${OBJECTDIR}/overlaydb_test.o: core_tests/overlaydb_test.cpp
 	${MKDIR} -p ${OBJECTDIR}
 	${RM} "$@.d"
-	${COMPILE} ${CXXFLAGS} "$@.d" -o ${OBJECTDIR}/overlaydb_test.o core_tests/overlaydb.cpp $(CPPFLAGS)
+	${COMPILE} ${CXXFLAGS} "$@.d" -o ${OBJECTDIR}/overlaydb_test.o core_tests/overlaydb_test.cpp $(CPPFLAGS)
 
-${OBJECTDIR}/statecachedb_test.o: core_tests/statecachedb.cpp
+${OBJECTDIR}/statecachedb_test.o: core_tests/statecachedb_test.cpp
 	${MKDIR} -p ${OBJECTDIR}
 	${RM} "$@.d"
-	${COMPILE} ${CXXFLAGS} "$@.d" -o ${OBJECTDIR}/statecachedb_test.o core_tests/statecachedb.cpp $(CPPFLAGS)
+	${COMPILE} ${CXXFLAGS} "$@.d" -o ${OBJECTDIR}/statecachedb_test.o core_tests/statecachedb_test.cpp $(CPPFLAGS)
 
 DEPENDENCIES = submodules/cryptopp/libcryptopp.a \
 	submodules/ethash/build/lib/ethash/libethash.a \

--- a/core_tests/memorydb_test.cpp
+++ b/core_tests/memorydb_test.cpp
@@ -1,23 +1,8 @@
 /*
-    This file is part of cpp-ethereum.
-
-    cpp-ethereum is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    cpp-ethereum is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    This file is a modified version of cpp-ethereum unit-test for MemoryDB.
 */
 
 #include <gtest/gtest.h>
-#include "dag.hpp"
-#include "types.hpp"
 #include "libdevcore/Log.h"
 
 #include <libdevcore/MemoryDB.h>

--- a/core_tests/overlaydb_test.cpp
+++ b/core_tests/overlaydb_test.cpp
@@ -1,29 +1,18 @@
 /*
-    This file is part of cpp-ethereum.
-
-    cpp-ethereum is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    cpp-ethereum is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    This file is a modified version of cpp-ethereum unit-test for OverlayDB.
 */
 
 #include <libdevcore/DBFactory.h>
 #include <libdevcore/OverlayDB.h>
 
 #include <gtest/gtest.h>
+#include "libdevcore/Log.h"
 
 using namespace std;
 using namespace dev;
 using namespace db;
 
+namespace taraxa{
 TEST(OverlayDB, basicUsage)
 {
     std::unique_ptr<db::DatabaseFace> db = DBFactory::create(DatabaseKind::MemoryDB);
@@ -103,4 +92,14 @@ TEST(OverlayDB, rollback)
     EXPECT_TRUE(odb.get().size());
     odb.rollback();
     EXPECT_TRUE(!odb.get().size());
+}
+
+}  //namespace taraxa
+
+int main(int argc, char** argv){
+    dev::LoggingOptions logOptions;
+    logOptions.verbosity = dev::VerbositySilent;
+    dev::setupLogging(logOptions);
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/core_tests/statecachedb_test.cpp
+++ b/core_tests/statecachedb_test.cpp
@@ -1,27 +1,16 @@
 /*
-    This file is part of cpp-ethereum.
-
-    cpp-ethereum is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    cpp-ethereum is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    This file is a modified version of cpp-ethereum unit-test for StateCacheDB.
 */
 
 #include <libdevcore/StateCacheDB.h>
 
 #include <gtest/gtest.h>
+#include "libdevcore/Log.h"
 
 using namespace std;
 using namespace dev;
 
+namespace taraxa{
 TEST(StateCacheDB, kill)
 {
     StateCacheDB myDB;
@@ -197,4 +186,14 @@ TEST(StateCacheDB, stream)
     EXPECT_EQ(stream.str(),
         "000000000000000000000000000000000000000000000000000000000000002a: 0x43 "
         "43\n000000000000000000000000000000000000000000000000000000000000002b: 0x43 43\n");
+}
+
+}  //namespace taraxa
+
+int main(int argc, char** argv){
+    dev::LoggingOptions logOptions;
+    logOptions.verbosity = dev::VerbositySilent;
+    dev::setupLogging(logOptions);
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Porting the [Unit test from aleth](https://github.com/ethereum/aleth/tree/030ad9ca2e5b41043554096af7a10216a9fb2fe9/test/unittests/libweb3core) to Taraxa
MemoryDB
OverlayDB
StateCacheDB