### PR TITLE
TN-45

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,8 +65,6 @@ pipeline {
     } 
 post {
     always {
-        sh 'docker rmi $(docker images -f "dangling=true" -q) || true'
-        sh 'docker rmi ${IMAGE}-${BRANCH_NAME}-${BUILD_NUMBER} || true'
         cleanWs()
     }
     success {


### PR DESCRIPTION
Do not remove any image in order to avoid problems in parallel builds.