### PR TITLE
Fix log

### DIFF
--- a/libdevcore/Log.cpp
+++ b/libdevcore/Log.cpp
@@ -127,7 +127,7 @@ void setThreadName(std::string const& _n) {
 #endif
 }
 
-void setupLogging(LoggingOptions const& _options) {
+boost::shared_ptr<log_sink<boost::log::sinks::text_ostream_backend>> setupLoggingSink(LoggingOptions const& _options) {
   auto sink =
       boost::make_shared<log_sink<boost::log::sinks::text_ostream_backend>>();
 
@@ -171,6 +171,11 @@ void setupLogging(LoggingOptions const& _options) {
             std::cerr << "Exception from the logging library: " << _ex.what()
                       << '\n';
           }));
+  return sink;
+}
+
+void setupLogging(LoggingOptions const& _options) {
+  static boost::shared_ptr<log_sink<boost::log::sinks::text_ostream_backend>> sink = setupLoggingSink(_options);
 }
 
 }  // namespace dev

--- a/top.cpp
+++ b/top.cpp
@@ -41,8 +41,6 @@ void Top::start(int argc, const char* argv[]) {
         boost::program_options::parse_command_line(argc, argv, allowed_options),
         option_vars);
     boost::program_options::notify(option_vars);
-    // so we will have only one sink at a time
-    boost::log::core::get()->remove_all_sinks();
     dev::setupLogging(loggingOptions);
 
     if (option_vars.count("help")) {


### PR DESCRIPTION
Lazy initialization for singleton static instance sink. This sink will only be removed when the executable finishes running. The setting could not be changed during the running of execution either. 

Duplicated logs are observed during testing:
      04-30 16:54:19      FULLND Node public key: 92bcda2b6e1cc7f2514f442db141264c765078ed6033808cf7ff7058fdcdfb2898f8ea825a0e4bfdaea076621faca3aa360737f8a553c6e6a739754b1ef18cee

      04-30 16:54:19      FULLND Node public key: 92bcda2b6e1cc7f2514f442db141264c765078ed6033808cf7ff7058fdcdfb2898f8ea825a0e4bfdaea076621faca3aa360737f8a553c6e6a739754b1ef18cee

      04-30 16:54:19      FULLND Node public key: 92bcda2b6e1cc7f2514f442db141264c765078ed6033808cf7ff7058fdcdfb2898f8ea825a0e4bfdaea076621faca3aa360737f8a553c6e6a739754b1ef18cee

Whenever we called Top, we are adding a boost.Log sinks (the objects that write log files) to the system.
I am assuming one single binary will only need one 'sink' to 