### PR TITLE
Made the rocksdb build portable across architectures

### DIFF
--- a/dockerfiles/base.ubuntu.dockerfile
+++ b/dockerfiles/base.ubuntu.dockerfile
@@ -38,7 +38,7 @@ FROM gtest-layer as rocksdb-layer
 RUN wget https://github.com/facebook/rocksdb/archive/v5.14.3.zip \
     && unzip v5.14.3.zip -d /tmp \
     && cd /tmp/rocksdb-5.14.3 \
-    && make shared_lib \
+    && make shared_lib PORTABLE=1 \
     && cp librocksdb.so* /usr/local/lib \
     && cp -r ./include/* /usr/local/include
 


### PR DESCRIPTION
Fix for: 
https://phragmites.slack.com/archives/GGAMXMA05/p1563080656014600

In short, by default, the compilation host computer architecture matters when building rocksdb. Since we build the image on one machine, and may potentially run on another, we might get a SIGILL error inside rocksdb.
The fix makes sure the rocksdb build is portable across the architectures.

Rationale: https://github.com/facebook/rocksdb/blob/v5.14.3/build_tools/build_detect_platform#L507