### PR TITLE
Mf crash fix

### DIFF
--- a/taraxa_capability.cpp
+++ b/taraxa_capability.cpp
@@ -616,8 +616,8 @@ void TaraxaCapability::onNewBlockVerified(DagBlock block) {
     return !_peer.isBlockKnown(block.getHash());
   });
 
-  auto const peersToSendNumber =
-      std::max<std::size_t>(c_minBlockBroadcastPeers, std::sqrt(getPeersCount()));
+  auto const peersToSendNumber = std::max<std::size_t>(
+      c_minBlockBroadcastPeers, std::sqrt(getPeersCount()));
 
   std::vector<NodeID> peersToSend;
   std::vector<NodeID> peersToAnnounce;

--- a/taraxa_capability.h
+++ b/taraxa_capability.h
@@ -210,9 +210,10 @@ class TaraxaCapability : public CapabilityFace, public Worker {
 
   // Peers
   std::shared_ptr<TaraxaPeer> getPeer(NodeID const &node_id);
-  unsigned int  getPeersCount();
+  unsigned int getPeersCount();
   void erasePeer(NodeID const &node_id);
-  void insertPeer(NodeID const &node_id, std::shared_ptr<TaraxaPeer> const &peer);
+  void insertPeer(NodeID const &node_id,
+                  std::shared_ptr<TaraxaPeer> const &peer);
 
  private:
   Host &host_;


### PR DESCRIPTION
The crash was caused by peers_ map in taraxa_capability not being thread-safe and protected with the mutex. I have changed this to protect the map with read/write mutex.