### PR TITLE
vote pbft block hash remains the same throughout round

### DIFF
--- a/core_tests/pbft_rpc_test.cpp
+++ b/core_tests/pbft_rpc_test.cpp
@@ -64,10 +64,11 @@ TEST_F(VoteManagerTest, add_cleanup_get_votes) {
   for (int i = 1; i <= 3; i++) {
     for (int j = 1; j <= 2; j++) {
       blk_hash_t blockhash(1);
+      blk_hash_t pbft_blockhash = pbft_mgr->getLastPbftBlockHashAtStartOfRound();
       PbftVoteTypes type = propose_vote_type;
       uint64_t round = i;
       size_t step = j;
-      Vote vote = node->generateVote(blockhash, type, round, step);
+      Vote vote = node->generateVote(blockhash, type, round, step, pbft_blockhash);
       node->addVote(vote);
     }
   }
@@ -152,10 +153,11 @@ TEST_F(NetworkTest, transfer_vote) {
 
   // generate vote
   blk_hash_t blockhash(1);
+  blk_hash_t pbft_blockhash(1);
   PbftVoteTypes type = propose_vote_type;
   uint64_t period = 1;
   size_t step = 1;
-  Vote vote = node2->generateVote(blockhash, type, period, step);
+  Vote vote = node2->generateVote(blockhash, type, period, step, pbft_blockhash);
 
   node1->clearUnverifiedVotesTable();
   node2->clearUnverifiedVotesTable();
@@ -238,10 +240,11 @@ TEST_F(NetworkTest, vote_broadcast) {
 
   // generate vote
   blk_hash_t blockhash(1);
+  blk_hash_t pbft_blockhash(1);
   PbftVoteTypes type = propose_vote_type;
   uint64_t period = 1;
   size_t step = 1;
-  Vote vote = node1->generateVote(blockhash, type, period, step);
+  Vote vote = node1->generateVote(blockhash, type, period, step, pbft_blockhash);
 
   node1->clearUnverifiedVotesTable();
   node2->clearUnverifiedVotesTable();

--- a/full_node.cpp
+++ b/full_node.cpp
@@ -828,8 +828,8 @@ void FullNode::setVerifiedPbftBlock(PbftBlock const &pbft_block) {
 }
 
 Vote FullNode::generateVote(blk_hash_t const &blockhash, PbftVoteTypes type,
-                            uint64_t period, size_t step) {
-  blk_hash_t last_pbft_block_hash = pbft_chain_->getLastPbftBlockHash();
+                            uint64_t period, size_t step, blk_hash_t const &last_pbft_block_hash) {
+  
   // sortition signature
   sig_t sortition_signature =
       vote_mgr_->signVote(node_sk_, last_pbft_block_hash, type, period, step);

--- a/full_node.hpp
+++ b/full_node.hpp
@@ -210,7 +210,7 @@ class FullNode : public std::enable_shared_from_this<FullNode> {
   // PBFT RPC
   void broadcastVote(Vote const &vote);
   Vote generateVote(blk_hash_t const &blockhash, PbftVoteTypes type,
-                    uint64_t period, size_t step);
+                    uint64_t period, size_t step, blk_hash_t const &last_pbft_block_hash);
 
   // get dag block for rpc
   std::pair<blk_hash_t, bool> getDagBlockHash(uint64_t dag_block_height) const;

--- a/pbft_manager.hpp
+++ b/pbft_manager.hpp
@@ -44,6 +44,8 @@ class PbftManager {
   void run();
   bool isActive() { return daemon_ != nullptr; }
 
+  blk_hash_t getLastPbftBlockHashAtStartOfRound() const { return pbft_chain_last_block_hash_; }
+
   size_t getSortitionThreshold() const { return sortition_threshold_; }
   void setSortitionThreshold(size_t const sortition_threshold) {
     sortition_threshold_ = sortition_threshold;
@@ -141,6 +143,8 @@ class PbftManager {
   // Database
   std::shared_ptr<SimpleDBFace> db_votes_;
   std::shared_ptr<SimpleDBFace> db_pbftchain_;
+
+  blk_hash_t pbft_chain_last_block_hash_;
 
   uint64_t pbft_round_ = 1;
   uint64_t pbft_round_last_ = 1;

--- a/vote.cpp
+++ b/vote.cpp
@@ -238,7 +238,7 @@ std::vector<Vote> VoteManager::getVotes(uint64_t pbft_round,
     return verified_votes;
   }
 
-  blk_hash_t last_pbft_block_hash = pbft_chain_->getLastPbftBlockHash();
+  blk_hash_t last_pbft_block_hash = pbft_mgr_->getLastPbftBlockHashAtStartOfRound();
   size_t sortition_threshold = pbft_mgr_->getSortitionThreshold();
 
   std::map<uint64_t, std::vector<Vote>>::const_iterator it;
@@ -279,7 +279,7 @@ std::vector<Vote> VoteManager::getVotes(uint64_t pbft_round,
     return verified_votes;
   }
 
-  blk_hash_t last_pbft_block_hash = pbft_chain_->getLastPbftBlockHash();
+  blk_hash_t last_pbft_block_hash = pbft_mgr_->getLastPbftBlockHashAtStartOfRound();
   size_t sortition_threshold = pbft_mgr_->getSortitionThreshold();
 
   std::map<uint64_t, std::vector<Vote>>::const_iterator it;
@@ -303,7 +303,8 @@ std::vector<Vote> VoteManager::getVotes(uint64_t pbft_round,
       verified_votes.emplace_back(v);
     } else if ( v.getRound() == pbft_round + 1 ) {
       //We know that votes in our current round should reference our latest PBFT chain block
-      LOG(log_deb_) << "Vote in current round points to different block hash. vote hash: "
+      //This is not immune to malacious attack!!!
+      LOG(log_deb_) << "Vote in current round " << pbft_round + 1 << " points to different block hash " << last_pbft_block_hash << " | vote hash: "
                     << v.getHash() << " vote address: " << vote_address;
       sync_peers_pbft_chain = true;
     }


### PR DESCRIPTION
## Purpose

_Want the pbft block hash used for vote validation to remain the same so nodes can more assuredly validate each others votes_

## For reviewers
_Describe anything you want to call out to the reviewers e.g. areas to focus on, decisions you made, specific feedback you are looking for, etc._

## Jira Tickets

## Changes

## Tests
_Describe what you did to test the changes you made. Include evidence such as screenshots or terminal commands and output._

## Deployment Considerations

## Version Notes ##
{ major | minor | patch }

_Decide whether this is a major, minor, or patch version change. Major is for backwards incompatible changes (This is only relevant once the service is live and in production and the major version is at least 1. While the major version is 0, it is ok to have backwards incompatible changes in a minor version.). Minor is for additional features. Patch is for bug fixes._

_Describe the changes in this version. This is essentially the details you would include in the squash commit message._

_NOTE: Include the version notes in the squash commit message_
