### PR TITLE
changed ws to writeImpl for newOrderedBlock

### DIFF
--- a/libweb3jsonrpc/WSServer.cpp
+++ b/libweb3jsonrpc/WSServer.cpp
@@ -141,9 +141,8 @@ void WSSession::newOrderedBlock(std::shared_ptr<taraxa::DagBlock> const &blk,
     std::string response = fastWriter.write(res);
     ws_.text(ws_.got_text());
     LOG(log_tr_) << "WS WRITE " << response.c_str();
-    ws_.async_write(boost::asio::buffer(response),
-                    beast::bind_front_handler(&WSSession::on_write_no_read,
-                                              shared_from_this()));
+    ws_.get_executor().post(boost::bind(&WSSession::writeImpl, this, response),
+                            std::allocator<void>());
   }
 }
 


### PR DESCRIPTION
## Purpose

Looks like just one case where write was originally used failed to be changed to writeImpl for queued writing.

## For reviewers
_Describe anything you want to call out to the reviewers e.g. areas to focus on, decisions you made, specific feedback you are looking for, etc._

## Jira Tickets

## Changes

## Tests
_Describe what you did to test the changes you made. Include evidence such as screenshots or terminal commands and output._

## Deployment Considerations

## Version Notes ##
{ major | minor | patch }

_Decide whether this is a major, minor, or patch version change. Major is for backwards incompatible changes (This is only relevant once the service is live and in production and the major version is at least 1. While the major version is 0, it is ok to have backwards incompatible changes in a minor version.). Minor is for additional features. Patch is for bug fixes._

_Describe the changes in this version. This is essentially the details you would include in the squash commit message._

_NOTE: Include the version notes in the squash commit message_
