### PR TITLE
removing thisThreadSleepForSeconds(1) from dag sync methods...

### DIFF
--- a/taraxa_capability.cpp
+++ b/taraxa_capability.cpp
@@ -104,8 +104,8 @@ void TaraxaCapability::continueSyncDag(NodeID const &_nodeID) {
         uint64_t max_level = full_node->getMaxDagLevel();
         if (max_block_level_received >
             max_level + (10 * conf_.network_sync_level_size)) {
-          LOG(log_dg_) << "Syncing blocks faster than processing "
-                       << max_block_level_received << " " << max_level;
+          LOG(log_dg_) << "Syncing blocks faster than processing. Synced level: "
+                       << max_block_level_received << "  Dag Level: " << max_level << " delayedDagSync counter 1";
           host_.scheduleExecution(
               1000, [this, _nodeID, max_block_level_received]() {
                 delayedDagSync(_nodeID, max_block_level_received, 1);
@@ -139,8 +139,8 @@ void TaraxaCapability::delayedDagSync(NodeID _nodeID,
         uint64_t max_level = full_node->getMaxDagLevel();
         if (max_block_level_received >
             max_level + (10 * conf_.network_sync_level_size)) {
-          LOG(log_dg_) << "Syncing blocks faster than processing "
-                       << max_block_level_received << " " << max_level;
+          LOG(log_dg_) << "Syncing blocks faster than processing. Synced level: "
+                       << max_block_level_received << "  Dag Level: " << max_level << " delayedDagSync counter " << (counter + 1);
           host_.scheduleExecution(
               1000, [this, _nodeID, max_block_level_received, counter]() {
                 delayedDagSync(_nodeID, max_block_level_received, counter + 1);


### PR DESCRIPTION
I believe it was intended to have been removed already during @mfrankovi 's PR 393

## Purpose

_Provide any information reviewers might need to have context on your changes_

## For reviewers
_Describe anything you want to call out to the reviewers e.g. areas to focus on, decisions you made, specific feedback you are looking for, etc._

## Jira Tickets

## Changes

## Tests
_Describe what you did to test the changes you made. Include evidence such as screenshots or terminal commands and output._

## Deployment Considerations

## Version Notes ##
{ major | minor | patch }

_Decide whether this is a major, minor, or patch version change. Major is for backwards incompatible changes (This is only relevant once the service is live and in production and the major version is at least 1. While the major version is 0, it is ok to have backwards incompatible changes in a minor version.). Minor is for additional features. Patch is for bug fixes._

_Describe the changes in this version. This is essentially the details you would include in the squash commit message._

_NOTE: Include the version notes in the squash commit message_
