### PR TITLE
Fix for crash on long run

### DIFF
--- a/transaction.hpp
+++ b/transaction.hpp
@@ -41,9 +41,8 @@ class TransactionStatusTable
 
   void eraseOldest() override {
     for (auto i = 0; i < delete_step_; i++) {
-      auto status_hash = expiration_.front();
+      trx_hash_t status_hash = expiration_.front();
       auto status = cache_[status_hash];
-      expiration_.pop_front();
       // Skip delete if transaction in queue or in nonce_gap and put in at back
       // of the queue
       if (status == TransactionStatus::nonce_gap ||
@@ -51,8 +50,9 @@ class TransactionStatusTable
           status == TransactionStatus::in_queue_verified) {
         expiration_.push_back(status_hash);
       } else {
-        cache_.erase(expiration_.front());
+        cache_.erase(status_hash);
       }
+      expiration_.pop_front();
     }
   }
 };


### PR DESCRIPTION
auto status_hash = expiration_.front();
was actually storing reference to the value in expiration_ queue and not a copy. C++ "auto" has a strange way of sometimes assigning a reference even if not using auto&. More can be found here:
https://blog.petrzemek.net/2017/12/08/when-auto-seemingly-deduces-a-reference-in-cpp/

This was in some cases after long run causing the same variable to be deallocated twice which caused crash in the long run.