### PR TITLE
transaction verification improvements

### DIFF
--- a/core_tests/full_node_test.cpp
+++ b/core_tests/full_node_test.cpp
@@ -1583,7 +1583,7 @@ TEST_F(FullNodeTest,
                             samples::TEST_TX_GAS_LIMIT, addr(), bytes(),
                             node->getSecretKey());
   for (auto const &trx : transactions) {
-    node->insertTransaction(trx);
+    node->insertTransaction(trx, false);
   }
   auto trx_executed = node->getNumTransactionExecuted();
   for (auto i(0); i < SYNC_TIMEOUT; ++i) {

--- a/core_tests/pbft_chain_test.cpp
+++ b/core_tests/pbft_chain_test.cpp
@@ -257,7 +257,7 @@ TEST_F(PbftChainTest, get_dag_block_hash) {
   Transaction trx_master_boot_node_to_receiver(nonce, coins_value, gas_price,
                                                TEST_TX_GAS_LIMIT, receiver,
                                                data, g_secret);
-  node->insertTransaction(trx_master_boot_node_to_receiver);
+  node->insertTransaction(trx_master_boot_node_to_receiver, false);
 
   for (int i = 0; i < 1000; i++) {
     // test timeout is 100 seconds

--- a/core_tests/pbft_manager_test.cpp
+++ b/core_tests/pbft_manager_test.cpp
@@ -46,7 +46,7 @@ TEST_F(PbftManagerTest, pbft_manager_run_single_node) {
   Transaction trx_master_boot_node_to_receiver(nonce, coins_value, gas_price,
                                                TEST_TX_GAS_LIMIT, receiver,
                                                data, g_secret);
-  node->insertTransaction(trx_master_boot_node_to_receiver);
+  node->insertTransaction(trx_master_boot_node_to_receiver, false);
 
   for (int i = 0; i < 100; i++) {
     // test timeout is 10 seconds
@@ -148,7 +148,7 @@ TEST_F(PbftManagerTest, pbft_manager_run_multi_nodes) {
                                             TEST_TX_GAS_LIMIT, node2_addr, data,
                                             g_secret);
   // broadcast trx and insert
-  node1->insertTransaction(trx_master_boot_node_to_node2);
+  node1->insertTransaction(trx_master_boot_node_to_node2, false);
 
   std::cout << "Checking all nodes see transaction from node 1 to node 2..."
             << std::endl;
@@ -193,7 +193,7 @@ TEST_F(PbftManagerTest, pbft_manager_run_multi_nodes) {
                                             TEST_TX_GAS_LIMIT, node3_addr, data,
                                             g_secret);
   // broadcast trx and insert
-  node1->insertTransaction(trx_master_boot_node_to_node3);
+  node1->insertTransaction(trx_master_boot_node_to_node3, false);
 
   std::cout << "Checking all nodes see transaction from node 1 to node 3..."
             << std::endl;

--- a/core_tests/performance_test.cpp
+++ b/core_tests/performance_test.cpp
@@ -47,7 +47,7 @@ TEST_F(PerformanceTest, execute_transactions) {
   EXPECT_EQ(res.first, initbal);
 
   for (auto const &t : transactions) {
-    node->insertTransaction(t);
+    node->insertTransaction(t, false);
     // taraxa::thisThreadSleepForMilliSeconds(50);
   }
 

--- a/core_tests/util/transaction_client.hpp
+++ b/core_tests/util/transaction_client.hpp
@@ -61,7 +61,7 @@ struct TransactionClient {
         Transaction(sender_nonce, val, 0, constants::TEST_TX_GAS_LIMIT, to,
                     bytes(), key_pair_.secret()),
     };
-    if (!node_->insertTransaction(ctx.trx)) {
+    if (!node_->insertTransaction(ctx.trx, false)) {
       return ctx;
     }
     ctx.stage = TransactionStage::inserted;

--- a/eth/eth_service.cpp
+++ b/eth/eth_service.cpp
@@ -94,7 +94,7 @@ h256 EthService::submitTransaction(TransactionSkeleton const& _t,
 
 h256 EthService::importTransaction(Transaction const& _t) {
   auto taraxa_trx = util::trx_eth_2_taraxa(_t);
-  auto ok = node_.lock()->insertTransaction(taraxa_trx);
+  auto ok = node_.lock()->insertTransaction(taraxa_trx, true);
   if (!ok) throw err("could not insert transaction");
   return taraxa_trx.getHash();
 }

--- a/full_node.hpp
+++ b/full_node.hpp
@@ -118,8 +118,9 @@ class FullNode : public std::enable_shared_from_this<FullNode> {
   // transactions
   void insertBroadcastedBlockWithTransactions(
       DagBlock const &blk, std::vector<Transaction> const &transactions);
-  // Insert new transaction, critical
-  bool insertTransaction(Transaction const &trx);
+  // Insert new transaction to unverified queue or if verify flag true
+  // synchronously verify and insert into verified queue
+  bool insertTransaction(Transaction const &trx, bool verify);
   // Transactions coming from broadcasting is less critical
   void insertBroadcastedTransactions(
       std::vector<taraxa::bytes> const &transactions);

--- a/net/Test.cpp
+++ b/net/Test.cpp
@@ -96,7 +96,7 @@ Json::Value Test::send_coin_transaction(const Json::Value &param1) {
       taraxa::Transaction trx(nonce, value, gas_price, gas, receiver, data, sk);
       LOG(log_time) << "Transaction " << trx.getHash()
                     << " received at: " << now;
-      node->insertTransaction(trx);
+      node->insertTransaction(trx, true);
       res = toHex(trx.rlp(true));
     }
   } catch (std::exception &e) {
@@ -135,7 +135,7 @@ Json::Value Test::create_test_coin_transactions(const Json::Value &param1) {
                     taraxa::samples::TEST_TX_GAS_LIMIT, receiver, data, sk);
                 LOG(log_time) << "Transaction " << trx.getHash()
                               << " received at: " << now;
-                node->insertTransaction(trx);
+                node->insertTransaction(trx, false);
                 thisThreadSleepForMicroSeconds(delay);
               }
             });


### PR DESCRIPTION
FullNode insertTransaction now has a parameter to decide if we want to insert transaction to the unverified queue for the verification to be done asynchronously on a separate thread  or if we want to do synchronous verification and inserting transaction directly to the verified queue of transactions. Verification of transaction is now done always with eth_service and from a single point in the code