### PR TITLE
Decrease image size test

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -15,6 +15,11 @@ RUN make DEPS_INSTALL_PREFIX=${APP_LIBRARY_HOME} -j $(nproc) main
 # Remove .a files to avoid it ben copied at final image
 RUN find /usr/ -iname '*.a' -delete
 
+# HACK: Remove all .so symlinks
+RUN find -L /usr/local/lib/ -xtype l -iname '*.so*' -delete
+# HACK: Remove duplicated librocksdb
+RUN rm -rf /usr/local/lib/librocksdb.so.*
+
 # Copy over only minimal information
 FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND noninteractive
@@ -34,6 +39,9 @@ COPY ./core_tests/conf/*.json ./default_config/
 # this will be removed once we have a dedicated key gen
 COPY --from=builder ${APP_PATH}/build/debug/bin/core_tests/crypto_test .
 COPY core_tests ./core_tests
+
+# HACK: Because we removed symlinks before
+RUN ldconfig
 
 ENV DEBUG 0
 ENTRYPOINT [ "./docker-entrypoint.sh" ]


### PR DESCRIPTION
## Purpose
Decrease image size

## For reviewers
Removing `*.a` files makes a big difference.

The next hack is regarding symlinks, as docker multi-stage copy the files instead of the symlink.
To work around it, I remove all symlinks before copying, but this causes missing libs/symlinks at the final image, I checked the `main` binary using `ldd` so I had to use `ldconfig` to recreate a few symlinks and it seemed to work. 
I am also removing the `librocksdb.so.*` because they were not symlinks, probably already copied from docker multistage build or something, but each of them was 165MB.

I am not sure about the problems this can cause, but I am opening the PR to see all the tests running.

If we are not confident, I can remove the part about the libraries and just remove the `*.a` files.

## Jira Tickets
related
https://taraxa.atlassian.net/browse/TL-452
