### PR TITLE
Build improvements #2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,59 +87,9 @@ ifeq ($(OS), Darwin)
 	OSX_FRAMEWORKS := CoreFoundation Security
 endif
 
-NODE_SRCS := \
-	util.cpp \
-	dag_block.cpp \
-	network.cpp \
-	full_node.cpp \
-	types.cpp \
-	dag.cpp \
-	block_proposer.cpp \
-	transaction.cpp \
-	transaction_queue.cpp \
-	transaction_manager.cpp \
-	executor.cpp \
-	transaction_order_manager.cpp \
-	pbft_chain.cpp \
-	taraxa_capability.cpp \
-	sortition.cpp \
-	pbft_manager.cpp \
-	vote.cpp \
-	top.cpp \
-	config.cpp \
-	trx_engine/types.cpp \
-	trx_engine/trx_engine.cpp \
-	pbft_sortition_account.cpp \
-	replay_protection/sender_state.cpp \
-	replay_protection/replay_protection_service.cpp \
-	vrf_wrapper.cpp \
-	net/RpcServer.cpp \
-	net/WSServer.cpp \
-	net/Test.cpp \
-	net/Taraxa.cpp \
-	net/Net.cpp \
-	eth/eth_service.cpp \
-	eth/eth.cpp \
-	eth/taraxa_seal_engine.cpp \
-	eth/pending_block_header.cpp \
-	db_storage.cpp \
-	vdf_sortition.cpp \
-	conf/chain_config.cpp \
-	eth/database_adapter.cpp \
-
+NODE_SRCS := $(shell scripts/find_files_cxx_node_main.sh)
 NODE_OBJS := $(addprefix $(OBJ_DIR)/, $(NODE_SRCS:.cpp=.o))
-
-TEST_SRCS := \
-	core_tests/full_node_test.cpp \
-	core_tests/dag_block_test.cpp \
-	core_tests/network_test.cpp \
-	core_tests/dag_test.cpp \
-	core_tests/transaction_test.cpp \
-	core_tests/p2p_test.cpp \
-	core_tests/crypto_test.cpp \
-    core_tests/pbft_chain_test.cpp \
-	core_tests/pbft_rpc_test.cpp \
-	core_tests/pbft_manager_test.cpp
+TEST_SRCS := $(shell scripts/find_files_cxx_node_tests.sh)
 TEST_OBJS := $(addprefix $(OBJ_DIR)/, $(TEST_SRCS:.cpp=.o))
 TESTS := $(addprefix $(BIN_DIR)/, $(basename $(TEST_SRCS)))
 
@@ -165,7 +115,8 @@ $(BIN_DIR)/%: $(NODE_OBJS) $(OBJ_DIR)/%.o
 		$(addprefix -framework , $(OSX_FRAMEWORKS)) \
 	)
 
-.PHONY: all main test run_test perf_test run_perf_test pdemo ct c clean
+.PHONY: all main test run_test perf_test run_perf_test pdemo ct c clean \
+	print_var
 
 all: main
 
@@ -194,3 +145,8 @@ c: clean
 
 clean:
 	rm -rf $(BUILD_DIR)
+
+# Can be used to borrow configuration from this build
+# to another build e.g. Cmake
+print_var:
+	@echo $($(ARG))

--- a/Makefile.submodules
+++ b/Makefile.submodules
@@ -71,6 +71,7 @@ submodules/taraxa-vdf/ok: submodules/openssl/ok
 
 submodules/taraxa-vrf/ok:
 	$(SUBMODULE_BUILD_INIT); \
+	autoreconf; \
 	automake; \
 	./configure --prefix=$(DEPS_INSTALL_PREFIX); \
 	$(MAKE); \

--- a/scripts/find_files_cxx.sh
+++ b/scripts/find_files_cxx.sh
@@ -3,7 +3,7 @@
 cd "$(dirname "$0")"
 cd ..
 
-find $(git ls-files) \
+find . \
   -type f \
   -and \( \
   -path "*.cpp" \
@@ -13,6 +13,9 @@ find $(git ls-files) \
   -or -path "*.h" \
   \) \
   -and ! \( \
-  -path "submodules/*" \
-  -or -path "unused_yet_useful/*" \
-  \)
+  -path "./submodules/*" \
+  -or -path "./unused_yet_useful/*" \
+  -or -path "./build/*" \
+  -or -path "./cmake-*" \
+  \) |
+  cut -c3-

--- a/scripts/find_files_cxx_node.sh
+++ b/scripts/find_files_cxx_node.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+"$(dirname "$0")"/find_files_cxx.sh |
+  grep ".*.cpp" |
+  grep -v "prometheus_demo.cpp" |
+  grep -v "main.cpp"

--- a/scripts/find_files_cxx_node_main.sh
+++ b/scripts/find_files_cxx_node_main.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+"$(dirname "$0")"/find_files_cxx_node.sh | grep -v ".*_test.cpp"

--- a/scripts/find_files_cxx_node_tests.sh
+++ b/scripts/find_files_cxx_node_tests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+"$(dirname "$0")"/find_files_cxx_node.sh |
+  grep ".*_test.cpp" |
+  grep -v "core_tests/performance_test.cpp"


### PR DESCRIPTION
- Fixed and used scripts that return C++ file sets in the build
- Fixed taraxa_vrf sensitivity to autoconf version
- Added an ability to print makefile variable. This can be used to borrow makefile build config in alternative build system e.g. Cmake. Me and @gaoqi8649 are using Cmake, and this feature simplifies cmake configuration a lot and makes it tolerant to makefile changes. Now my local cmake config looks like this:
```
cmake_minimum_required(VERSION 3.13)

set(CMAKE_C_COMPILER gcc)
set(CMAKE_CXX_COMPILER g++)
set(CMAKE_OSX_SYSROOT /)
set(CMAKE_MACOSX_RPATH 0)

project(taraxa-node)

set(CMAKE_CXX_STANDARD 17)

set(IS_DEBUG 0)
if (CMAKE_BUILD_TYPE MATCHES Debug)
    set(IS_DEBUG 1)
endif ()

macro(read_makefile_var var_name)
    execute_process(
        COMMAND
        make DEBUG=${IS_DEBUG} NO_INSTALL_SUBMODULES=1
        print_var ARG=${var_name}
        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
        OUTPUT_VARIABLE ${var_name}
    )
    string(REPLACE " " ";" ${var_name} ${${var_name}})
    list(TRANSFORM ${var_name} STRIP)
endmacro()

read_makefile_var(COMPILE_DEFINITIONS)
add_compile_definitions(${COMPILE_DEFINITIONS})

read_makefile_var(INCLUDE_DIRS)
include_directories(${INCLUDE_DIRS})

read_makefile_var(LINK_FLAGS)
add_link_options(${LINK_FLAGS})

read_makefile_var(LIB_DIRS)
link_directories(${LIB_DIRS})

add_custom_target(
    submodules_build
    COMMAND $(MAKE) DEBUG=${IS_DEBUG} -f Makefile.submodules submodules
    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
)
add_library(submodules INTERFACE)
add_dependencies(submodules submodules_build)
read_makefile_var(LIBS)
read_makefile_var(OSX_FRAMEWORKS)
list(TRANSFORM OSX_FRAMEWORKS PREPEND "-framework ")
link_libraries(submodules ${LIBS} ${OSX_FRAMEWORKS})

read_makefile_var(NODE_SRCS)
add_library(node_objects OBJECT ${NODE_SRCS})
add_executable(main $<TARGET_OBJECTS:node_objects> main.cpp)

enable_testing()
read_makefile_var(TEST_SRCS)
foreach (test_src ${TEST_SRCS})
    string(REPLACE "/" "_" __test_target__ ${test_src})
    get_filename_component(__test_target__ ${__test_target__} NAME_WE)
    add_executable(${__test_target__} $<TARGET_OBJECTS:node_objects> ${test_src})
    list(APPEND ALL_TESTS_TARGETS ${__test_target__})
    list(APPEND ALL_TESTS_EXE_PATHS $<TARGET_FILE:${__test_target__}>)
endforeach ()
add_custom_target(all_test DEPENDS ${ALL_TESTS_TARGETS})
add_custom_target(
    run_test
    COMMAND scripts/run_commands_long_circuit.sh ${ALL_TESTS_EXE_PATHS}
    DEPENDS all_test
    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
)

add_custom_target(all_bin DEPENDS main all_test)
```