### PR TITLE
enable endomorphism in secp256k1

### DIFF
--- a/Makefile_submodules.mk
+++ b/Makefile_submodules.mk
@@ -149,6 +149,7 @@ submodules/secp256k1/ok:
 		--disable-jni --with-bignum=no --with-field=64bit \
 		--with-scalar=64bit --with-asm=no \
 		--enable-module-ecdh --enable-module-recovery \
+		--enable-endomorphism \
 		--enable-experimental; \
 	$(MAKE); \
 	$(MAKE) install; \


### PR DESCRIPTION
update secp256k1 configure to enable the GLV endomorphism optimisation, which is no longer covered by patents (expired)