### PR TITLE
Additionally tag docker image with only commit hash for PR

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -151,7 +151,8 @@ pipeline {
             when { branch 'PR-*' }
             steps {
                 sh 'docker tag ${IMAGE}-${DOCKER_BRANCH_TAG}-${BUILD_NUMBER} ${GCP_REGISTRY}/${IMAGE}:${HELM_TEST_NAME}-build-${BUILD_NUMBER}'
-                sh 'docker push ${GCP_REGISTRY}/${IMAGE}:${HELM_TEST_NAME}-build-${BUILD_NUMBER}'
+                sh 'docker tag ${IMAGE}-${DOCKER_BRANCH_TAG}-${BUILD_NUMBER} ${GCP_REGISTRY}/${IMAGE}:${GIT_COMMIT}'
+                sh 'docker push ${GCP_REGISTRY}/${IMAGE}:${GIT_COMMIT}'
             }
         }
         stage('Run kubernetes tests') {


### PR DESCRIPTION
Additionally tag the docker image for PR with just the git hash

This make it easier to do automated deploys from Jenkins parameterized build