### PR TITLE
Fix PBFT next voting 2 values in the same step issue

### DIFF
--- a/src/chain/chain_config.cpp
+++ b/src/chain/chain_config.cpp
@@ -57,8 +57,8 @@ decltype(ChainConfig::predefined_) const ChainConfig::predefined_([] {
     cfg.vdf.threshold_selection = 0x8000;
     cfg.vdf.threshold_vdf_omit = 0x7200;
     cfg.vdf.difficulty_min = 16;
-    cfg.vdf.difficulty_max = 19;
-    cfg.vdf.difficulty_stale = 21;
+    cfg.vdf.difficulty_max = 21;
+    cfg.vdf.difficulty_stale = 22;
     cfg.vdf.lambda_bound = 100;
     // PBFT config
     cfg.pbft.lambda_ms_min = 2000;

--- a/src/chain/chain_config.cpp
+++ b/src/chain/chain_config.cpp
@@ -57,8 +57,8 @@ decltype(ChainConfig::predefined_) const ChainConfig::predefined_([] {
     cfg.vdf.threshold_selection = 0x8000;
     cfg.vdf.threshold_vdf_omit = 0x7200;
     cfg.vdf.difficulty_min = 16;
-    cfg.vdf.difficulty_max = 21;
-    cfg.vdf.difficulty_stale = 22;
+    cfg.vdf.difficulty_max = 19;
+    cfg.vdf.difficulty_stale = 21;
     cfg.vdf.lambda_bound = 100;
     // PBFT config
     cfg.pbft.lambda_ms_min = 2000;

--- a/src/consensus/pbft_chain.cpp
+++ b/src/consensus/pbft_chain.cpp
@@ -236,11 +236,7 @@ std::vector<PbftBlockCert> PbftChain::getPbftBlocks(size_t period, size_t count)
       assert(false);
     }
     // Get PBFT cert votes in DB
-    auto cert_votes_raw = db_->getVotes(*pbft_block_hash);
-    vector<Vote> cert_votes;
-    for (auto const& cert_vote : RLP(cert_votes_raw)) {
-      cert_votes.emplace_back(cert_vote);
-    }
+    auto cert_votes = db_->getCertVotes(*pbft_block_hash);
     if (cert_votes.empty()) {
       LOG(log_er_) << "Cannot find any cert votes for PBFT block " << pbft_block;
       assert(false);

--- a/src/consensus/pbft_chain.cpp
+++ b/src/consensus/pbft_chain.cpp
@@ -211,7 +211,7 @@ std::shared_ptr<PbftBlock> PbftChain::getUnverifiedPbftBlock(const taraxa::blk_h
     sharedLock_ lock(unverified_access_);
     return unverified_blocks_[pbft_block_hash];
   }
-  return {};
+  return nullptr;
 }
 
 std::vector<PbftBlockCert> PbftChain::getPbftBlocks(size_t period, size_t count) {

--- a/src/consensus/pbft_chain.cpp
+++ b/src/consensus/pbft_chain.cpp
@@ -180,11 +180,6 @@ blk_hash_t PbftChain::getLastPbftBlockHash() const {
 }
 
 bool PbftChain::findPbftBlockInChain(taraxa::blk_hash_t const& pbft_block_hash) {
-  if (!db_) {
-    LOG(log_er_) << "Pbft chain DB unavailable in findPbftBlockInChain!";
-    return false;
-  }
-  assert(db_);
   return db_->pbftBlockInDb(pbft_block_hash);
 }
 

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -626,8 +626,7 @@ void PbftManager::identifyBlock_() {
         placeVote_(leader_block.first, soft_vote_type, round, step_);
       }
     }
-  } else if (auto voted_value = previous_round_next_votes_->getVotedValue();
-             round >= 2 && voted_value != NULL_BLOCK_HASH) {
+  } else if (round >= 2 && voted_value != NULL_BLOCK_HASH) {
     if (shouldSpeak(soft_vote_type, round, step_)) {
       LOG(log_dg_) << "Soft voting " << voted_value << " from previous round";
       placeVote_(voted_value, soft_vote_type, round, step_);

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -323,16 +323,19 @@ void PbftManager::initialState_() {
     // Start from DB
     state_ = finish_state;
     setPbftStep(4);
+  }
+  setPbftRound(round);
 
+  if (round > 1) {
     // Get next votes for previous round from DB
     auto next_votes_in_previous_round = db_->getNextVotes(round - 1);
     if (next_votes_in_previous_round.empty()) {
-      LOG(log_er_) << "Cannot get any next votes in previous round " << round - 1;
+      LOG(log_er_) << "Cannot get any next votes in previous round " << round - 1 << ". Currrent round " << round
+                   << " step " << step;
       assert(false);
     }
     previous_round_next_votes_->update(next_votes_in_previous_round);
   }
-  setPbftRound(round);
 
   // Initial last sync request
   pbft_round_last_requested_sync_ = 0;
@@ -643,8 +646,7 @@ void PbftManager::certifyBlock_() {
         comparePbftBlockScheduleWithDAGblocks_(soft_voted_block_for_this_round_.first)) {
       LOG(log_tr_) << "Finished comparePbftBlockScheduleWithDAGblocks_";
 
-      // NOTE: If we have already executed this round
-      //       then block won't be found in unverified queue...
+      // NOTE: If we have already executed this round then block won't be found in unverified queue...
       bool executed_soft_voted_block_for_this_round = false;
       if (have_executed_this_round_) {
         LOG(log_tr_) << "Have already executed before certifying in step 3 in round " << round;

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -541,7 +541,7 @@ bool PbftManager::stateOperations_() {
       if (pushCertVotedPbftBlockIntoChain_(cert_voted_block_hash.first, cert_votes_for_round)) {
         db_->savePbftMgrStatus(PbftMgrStatus::executed_in_round, true);
         have_executed_this_round_ = true;
-        LOG(log_nf_) << "Write " << cert_votes_for_round.size() << " votes ... in round " << round;
+        LOG(log_nf_) << "Write " << cert_votes_for_round.size() << " cert votes ... in round " << round;
 
         duration_ = std::chrono::system_clock::now() - now_;
         auto execute_trxs_in_ms = std::chrono::duration_cast<std::chrono::milliseconds>(duration_).count();

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -609,14 +609,13 @@ void PbftManager::proposeBlock_() {
         }
       }
       if (pbft_block) {
-        LOG(log_nf_) << "Rebroadcasting next voted block " << own_starting_value_for_round_
+        LOG(log_nf_) << "Rebroadcasting and proposing next voted block " << own_starting_value_for_round_
                      << " from previous round. In round " << round;
         // broadcast pbft block
         network_->onNewPbftBlock(*pbft_block);
+        // place vote
+        placeVote_(own_starting_value_for_round_, propose_vote_type, round, step_);
       }
-      LOG(log_nf_) << "Proposing next voted block " << own_starting_value_for_round_
-                   << " from previous round. In round " << round;
-      placeVote_(own_starting_value_for_round_, propose_vote_type, round, step_);
     }
   }
 }

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -1115,10 +1115,9 @@ bool PbftManager::comparePbftBlockScheduleWithDAGblocks_(blk_hash_t const &pbft_
 
     pbft_block = db_->getPbftCertVotedBlock(pbft_block_hash);
     if (!pbft_block) {
-      LOG(log_nf_) << "Can't get proposal block " << pbft_block_hash << " in DB. Have not got the PBFT block "
-                   << pbft_block_hash << " yet.";
-
       if (!round_began_wait_proposal_block_) {
+        LOG(log_nf_) << "Can't get proposal block " << pbft_block_hash << " in DB. Have not got the PBFT block "
+                     << pbft_block_hash << " yet.";
         round_began_wait_proposal_block_ = round_;
       } else if (round_ > round_began_wait_proposal_block_) {
         size_t wait_proposal_block_rounds = round_ - round_began_wait_proposal_block_;

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -807,6 +807,11 @@ void PbftManager::secondFinish_() {
     syncPbftChainFromPeers_(true);
   }
 
+  if (step_ > MAX_STEPS) {
+    LOG(log_nf_) << "Node " << node_addr_ << " broadcast next votes for previous round. In round " << round;
+    network_->broadcastPreviousRoundNextVotesBundle();
+  }
+
   loop_back_finish_state_ = elapsed_time_in_round_ms_ > (step_ + 1) * LAMBDA_ms + STEP_4_DELAY - POLLING_INTERVAL_ms;
 }
 

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -1120,7 +1120,7 @@ bool PbftManager::comparePbftBlockScheduleWithDAGblocks_(blk_hash_t const &pbft_
 
       if (!round_began_wait_proposal_block_) {
         round_began_wait_proposal_block_ = round_;
-      } else {
+      } else if (round_ > round_began_wait_proposal_block_) {
         size_t wait_proposal_block_rounds = round_ - round_began_wait_proposal_block_;
         if (wait_proposal_block_rounds < max_wait_rounds_for_proposal_block_) {
           LOG(log_nf_) << "Have been waiting " << wait_proposal_block_rounds << " rounds for proposal block "
@@ -1134,12 +1134,11 @@ bool PbftManager::comparePbftBlockScheduleWithDAGblocks_(blk_hash_t const &pbft_
       }
       return false;
     }
-    // Back to zero to signify no longer waiting...
-    round_began_wait_proposal_block_ = 0;
-
     // Read from DB pushing into unverified queue
     pbft_chain_->pushUnverifiedPbftBlock(pbft_block);
   }
+  // Back to zero to signify no longer waiting...
+  round_began_wait_proposal_block_ = 0;
 
   return comparePbftBlockScheduleWithDAGblocks_(*pbft_block);
 }

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -21,7 +21,8 @@ using vrf_output_t = vrf_wrapper::vrf_output_t;
 
 PbftManager::PbftManager(PbftConfig const &conf, std::string const &genesis, addr_t node_addr,
                          std::shared_ptr<DbStorage> db, std::shared_ptr<PbftChain> pbft_chain,
-                         std::shared_ptr<VoteManager> vote_mgr, std::shared_ptr<DagManager> dag_mgr,
+                         std::shared_ptr<VoteManager> vote_mgr,
+                         std::shared_ptr<NextVotesForPreviousRound> next_votes_mgr, std::shared_ptr<DagManager> dag_mgr,
                          std::shared_ptr<DagBlockManager> dag_blk_mgr, std::shared_ptr<FinalChain> final_chain,
                          std::shared_ptr<Executor> executor, secret_t node_sk, vrf_sk_t vrf_sk)
     : LAMBDA_ms_MIN(conf.lambda_ms_min),
@@ -34,6 +35,7 @@ PbftManager::PbftManager(PbftConfig const &conf, std::string const &genesis, add
       db_(db),
       pbft_chain_(pbft_chain),
       vote_mgr_(vote_mgr),
+      previous_round_next_votes_(next_votes_mgr),
       dag_mgr_(dag_mgr),
       dag_blk_mgr_(dag_blk_mgr),
       final_chain_(final_chain),
@@ -41,7 +43,6 @@ PbftManager::PbftManager(PbftConfig const &conf, std::string const &genesis, add
       node_sk_(node_sk),
       vrf_sk_(vrf_sk) {
   LOG_OBJECTS_CREATE("PBFT_MGR");
-  previous_round_next_votes_ = std::make_shared<NextVotesForPreviousRound>(node_addr);
   update_dpos_state_();
 }
 

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -492,7 +492,6 @@ bool PbftManager::stateOperations_() {
   // Reset continue finish polling state
   continue_finish_polling_state_ = false;
 
-  // NOTE: PUSHING OF SYNCED BLOCKS CAN TAKE A LONG TIME SHOULD DO BEFORE WE SET THE ELAPSED TIME IN ROUND
   pushSyncedPbftBlocksIntoChain_();
 
   now_ = std::chrono::system_clock::now();

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -1347,11 +1347,6 @@ bool PbftManager::pushPbftBlock_(PbftBlockCert const &pbft_block_cert_votes) {
 
   executor_->execute(pbft_block);
 
-  // Update the latest certified block hash in the chain for current round
-  push_block_values_for_round_[round] = pbft_block_hash;
-  LOG(log_nf_) << node_addr_ << " push certified PBFT block hash " << pbft_block_hash << " in period " << pbft_period
-               << ", in round " << round;
-
   // Update pbft chain last block hash
   pbft_chain_last_block_hash_ = pbft_block_hash;
   assert(pbft_chain_last_block_hash_ == pbft_chain_->getLastPbftBlockHash());

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -1115,12 +1115,13 @@ bool PbftManager::comparePbftBlockScheduleWithDAGblocks_(blk_hash_t const &pbft_
 
     pbft_block = db_->getPbftCertVotedBlock(pbft_block_hash);
     if (!pbft_block) {
+      auto round = getPbftRound();
       if (!round_began_wait_proposal_block_) {
         LOG(log_nf_) << "Can't get proposal block " << pbft_block_hash << " in DB. Have not got the PBFT block "
                      << pbft_block_hash << " yet.";
-        round_began_wait_proposal_block_ = round_;
-      } else if (round_ > round_began_wait_proposal_block_) {
-        size_t wait_proposal_block_rounds = round_ - round_began_wait_proposal_block_;
+        round_began_wait_proposal_block_ = round;
+      } else if (round > round_began_wait_proposal_block_) {
+        auto wait_proposal_block_rounds = round - round_began_wait_proposal_block_;
         if (wait_proposal_block_rounds < max_wait_rounds_for_proposal_block_) {
           LOG(log_nf_) << "Have been waiting " << wait_proposal_block_rounds << " rounds for proposal block "
                        << pbft_block_hash;

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -608,7 +608,7 @@ void PbftManager::proposeBlock_() {
           LOG(log_nf_) << "Can't get proposal block " << own_starting_value_for_round_ << " in database";
         }
       }
-      if (!pbft_block) {
+      if (pbft_block) {
         LOG(log_nf_) << "Rebroadcasting next voted block " << own_starting_value_for_round_
                      << " from previous round. In round " << round;
         // broadcast pbft block

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -1347,6 +1347,14 @@ bool PbftManager::pushPbftBlock_(PbftBlockCert const &pbft_block_cert_votes) {
 
   executor_->execute(pbft_block);
 
+  // Update the latest certified block hash in the chain for current round
+  if (cert_voted_values_for_round_.find(round) != cert_voted_values_for_round_.end() &&
+      cert_voted_values_for_round_.find(round)->second == pbft_block_hash) {
+    push_block_values_for_round_[round] = pbft_block_hash;
+    LOG(log_nf_) << node_addr_ << " push certified PBFT block hash " << pbft_block_hash << " in period " << pbft_period
+                 << ", in round " << round;
+  }
+
   // Update pbft chain last block hash
   pbft_chain_last_block_hash_ = pbft_block_hash;
   assert(pbft_chain_last_block_hash_ == pbft_chain_->getLastPbftBlockHash());

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -1132,6 +1132,9 @@ bool PbftManager::comparePbftBlockScheduleWithDAGblocks_(blk_hash_t const &pbft_
 
       return false;
     }
+    // Back to zero rounds since couldn't get proposal block...
+    wait_proposal_block_rounds_ = 0;
+
     // Read from DB pushing into unverified queue
     pbft_chain_->pushUnverifiedPbftBlock(pbft_block);
   }

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -1348,12 +1348,9 @@ bool PbftManager::pushPbftBlock_(PbftBlockCert const &pbft_block_cert_votes) {
   executor_->execute(pbft_block);
 
   // Update the latest certified block hash in the chain for current round
-  if (cert_voted_values_for_round_.find(round) != cert_voted_values_for_round_.end() &&
-      cert_voted_values_for_round_.find(round)->second == pbft_block_hash) {
-    push_block_values_for_round_[round] = pbft_block_hash;
-    LOG(log_nf_) << node_addr_ << " push certified PBFT block hash " << pbft_block_hash << " in period " << pbft_period
-                 << ", in round " << round;
-  }
+  push_block_values_for_round_[round] = pbft_block_hash;
+  LOG(log_nf_) << node_addr_ << " push certified PBFT block hash " << pbft_block_hash << " in period " << pbft_period
+               << ", in round " << round;
 
   // Update pbft chain last block hash
   pbft_chain_last_block_hash_ = pbft_block_hash;

--- a/src/consensus/pbft_manager.hpp
+++ b/src/consensus/pbft_manager.hpp
@@ -182,7 +182,6 @@ class PbftManager {
   bool loop_back_finish_state_ = false;
 
   uint64_t round_began_wait_proposal_block_ = 0;
-  // size_t wait_proposal_block_rounds_ = 0;
   size_t max_wait_rounds_for_proposal_block_ = 5;
 
   uint64_t pbft_round_last_requested_sync_ = 0;

--- a/src/consensus/pbft_manager.hpp
+++ b/src/consensus/pbft_manager.hpp
@@ -30,9 +30,9 @@ class PbftManager {
 
   PbftManager(PbftConfig const &conf, std::string const &genesis, addr_t node_addr, std::shared_ptr<DbStorage> db,
               std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<VoteManager> vote_mgr,
-              std::shared_ptr<DagManager> dag_mgr, std::shared_ptr<DagBlockManager> dag_blk_mgr,
-              std::shared_ptr<FinalChain> final_chain, std::shared_ptr<Executor> executor, secret_t node_sk,
-              vrf_sk_t vrf_sk);
+              std::shared_ptr<NextVotesForPreviousRound> next_votes_mgr, std::shared_ptr<DagManager> dag_mgr,
+              std::shared_ptr<DagBlockManager> dag_blk_mgr, std::shared_ptr<FinalChain> final_chain,
+              std::shared_ptr<Executor> executor, secret_t node_sk, vrf_sk_t vrf_sk);
   ~PbftManager();
 
   void setNetwork(std::shared_ptr<Network> network);
@@ -134,9 +134,10 @@ class PbftManager {
   // Using to check if PBFT block has been proposed already in one period
   std::pair<blk_hash_t, bool> proposed_block_hash_ = std::make_pair(NULL_BLOCK_HASH, false);
 
-  std::shared_ptr<DbStorage> db_ = nullptr;
   std::unique_ptr<std::thread> daemon_ = nullptr;
+  std::shared_ptr<DbStorage> db_ = nullptr;
   std::shared_ptr<VoteManager> vote_mgr_ = nullptr;
+  std::shared_ptr<NextVotesForPreviousRound> previous_round_next_votes_ = nullptr;
   std::shared_ptr<PbftChain> pbft_chain_ = nullptr;
   std::shared_ptr<DagManager> dag_mgr_ = nullptr;
   std::shared_ptr<Network> network_ = nullptr;
@@ -144,7 +145,6 @@ class PbftManager {
   std::shared_ptr<DagBlockManager> dag_blk_mgr_;
   std::shared_ptr<FinalChain> final_chain_;
   std::shared_ptr<Executor> executor_;
-  std::shared_ptr<NextVotesForPreviousRound> previous_round_next_votes_;
 
   addr_t node_addr_;
   secret_t node_sk_;

--- a/src/consensus/pbft_manager.hpp
+++ b/src/consensus/pbft_manager.hpp
@@ -162,8 +162,6 @@ class PbftManager {
   blk_hash_t own_starting_value_for_round_ = NULL_BLOCK_HASH;
   // <round, cert_voted_block_hash>
   std::unordered_map<size_t, blk_hash_t> cert_voted_values_for_round_;
-  // <round, block_hash_added_into_chain>
-  std::unordered_map<size_t, blk_hash_t> push_block_values_for_round_;
   std::pair<blk_hash_t, bool> soft_voted_block_for_this_round_ = std::make_pair(NULL_BLOCK_HASH, false);
 
   std::vector<Vote> votes_;

--- a/src/consensus/pbft_manager.hpp
+++ b/src/consensus/pbft_manager.hpp
@@ -181,7 +181,8 @@ class PbftManager {
   bool go_finish_state_ = false;
   bool loop_back_finish_state_ = false;
 
-  size_t wait_proposal_block_rounds_ = 0;
+  uint64_t round_began_wait_proposal_block_ = 0;
+  // size_t wait_proposal_block_rounds_ = 0;
   size_t max_wait_rounds_for_proposal_block_ = 5;
 
   uint64_t pbft_round_last_requested_sync_ = 0;

--- a/src/consensus/pbft_manager.hpp
+++ b/src/consensus/pbft_manager.hpp
@@ -111,6 +111,8 @@ class PbftManager {
 
   void syncPbftChainFromPeers_(bool force);
 
+  bool broadcastAlreadyThisStep_() const;
+
   bool comparePbftBlockScheduleWithDAGblocks_(blk_hash_t const &pbft_block_hash);
   bool comparePbftBlockScheduleWithDAGblocks_(PbftBlock const &pbft_block);
 
@@ -184,6 +186,8 @@ class PbftManager {
 
   uint64_t pbft_round_last_requested_sync_ = 0;
   size_t pbft_step_last_requested_sync_ = 0;
+  uint64_t pbft_round_last_broadcast_ = 0;
+  size_t pbft_step_last_broadcast_ = 0;
 
   size_t pbft_last_observed_synced_queue_size_ = 0;
 

--- a/src/consensus/pbft_manager.hpp
+++ b/src/consensus/pbft_manager.hpp
@@ -42,7 +42,6 @@ class PbftManager {
 
   bool shouldSpeak(PbftVoteTypes type, uint64_t round, size_t step);
 
-  std::shared_ptr<NextVotesForPreviousRound> getNextVotesForPreviousRoundPtr() const;
   std::pair<bool, uint64_t> getDagBlockPeriod(blk_hash_t const &hash);
   uint64_t getPbftRound() const;
   void setPbftRound(uint64_t const round);
@@ -113,10 +112,6 @@ class PbftManager {
   bool syncRequestedAlreadyThisStep_() const;
 
   void syncPbftChainFromPeers_(bool force);
-
-  bool nextVotesSyncAlreadyThisRoundStep_();
-
-  void syncNextVotes_();
 
   bool comparePbftBlockScheduleWithDAGblocks_(blk_hash_t const &pbft_block_hash);
   bool comparePbftBlockScheduleWithDAGblocks_(PbftBlock const &pbft_block);
@@ -190,8 +185,6 @@ class PbftManager {
 
   uint64_t pbft_round_last_requested_sync_ = 0;
   size_t pbft_step_last_requested_sync_ = 0;
-  uint64_t pbft_round_last_next_votes_sync_ = 0;
-  size_t pbft_step_last_next_votes_sync_ = 0;
 
   size_t pbft_last_observed_synced_queue_size_ = 0;
 

--- a/src/consensus/pbft_manager.hpp
+++ b/src/consensus/pbft_manager.hpp
@@ -101,8 +101,6 @@ class PbftManager {
 
   void placeVote_(blk_hash_t const &blockhash, PbftVoteTypes vote_type, uint64_t round, size_t step);
 
-  std::pair<blk_hash_t, bool> softVotedBlockForRound_(std::vector<Vote> &votes, uint64_t round);
-
   std::pair<blk_hash_t, bool> proposeMyPbftBlock_();
 
   std::pair<blk_hash_t, bool> identifyLeaderBlock_(std::vector<Vote> const &votes);

--- a/src/consensus/pbft_manager.hpp
+++ b/src/consensus/pbft_manager.hpp
@@ -134,14 +134,14 @@ class PbftManager {
   // Using to check if PBFT block has been proposed already in one period
   std::pair<blk_hash_t, bool> proposed_block_hash_ = std::make_pair(NULL_BLOCK_HASH, false);
 
-  std::unique_ptr<std::thread> daemon_ = nullptr;
-  std::shared_ptr<DbStorage> db_ = nullptr;
-  std::shared_ptr<VoteManager> vote_mgr_ = nullptr;
-  std::shared_ptr<NextVotesForPreviousRound> previous_round_next_votes_ = nullptr;
-  std::shared_ptr<PbftChain> pbft_chain_ = nullptr;
-  std::shared_ptr<DagManager> dag_mgr_ = nullptr;
-  std::shared_ptr<Network> network_ = nullptr;
-  std::shared_ptr<TaraxaCapability> capability_ = nullptr;
+  std::unique_ptr<std::thread> daemon_;
+  std::shared_ptr<DbStorage> db_;
+  std::shared_ptr<VoteManager> vote_mgr_;
+  std::shared_ptr<NextVotesForPreviousRound> previous_round_next_votes_;
+  std::shared_ptr<PbftChain> pbft_chain_;
+  std::shared_ptr<DagManager> dag_mgr_;
+  std::shared_ptr<Network> network_;
+  std::shared_ptr<TaraxaCapability> capability_;
   std::shared_ptr<DagBlockManager> dag_blk_mgr_;
   std::shared_ptr<FinalChain> final_chain_;
   std::shared_ptr<Executor> executor_;

--- a/src/consensus/pbft_manager.hpp
+++ b/src/consensus/pbft_manager.hpp
@@ -183,6 +183,9 @@ class PbftManager {
   bool go_finish_state_ = false;
   bool loop_back_finish_state_ = false;
 
+  size_t wait_proposal_block_rounds_ = 0;
+  size_t max_wait_rounds_for_proposal_block_ = 5;
+
   uint64_t pbft_round_last_requested_sync_ = 0;
   size_t pbft_step_last_requested_sync_ = 0;
 

--- a/src/consensus/vote.cpp
+++ b/src/consensus/vote.cpp
@@ -122,8 +122,8 @@ bool VoteManager::addVote(taraxa::Vote const& vote) {
       unverified_votes_[pbft_round] = votes;
     }
   }
-  LOG(log_dg_) << "Add vote " << hash << ", block hash " << vote.getBlockHash() << ", vote type " << vote.getType()
-               << ", in round " << pbft_round << ", for step " << vote.getStep();
+  LOG(log_dg_) << "Add unverified vote " << vote;
+
   return true;
 }
 
@@ -310,7 +310,7 @@ bool VoteManager::pbftBlockHasEnoughValidCertVotes(PbftBlockCert const& pbft_blo
 }
 
 NextVotesForPreviousRound::NextVotesForPreviousRound(addr_t node_addr)
-    : enough_votes_for_null_block_hash_(false), voted_value_(blk_hash_t(0)) {
+    : enough_votes_for_null_block_hash_(false), voted_value_(blk_hash_t(0)), next_votes_size_(0) {
   LOG_OBJECTS_CREATE("NEXT_VOTES");
 }
 
@@ -318,6 +318,7 @@ void NextVotesForPreviousRound::clear() {
   uniqueLock_ lock(access_);
   enough_votes_for_null_block_hash_ = false;
   voted_value_ = blk_hash_t(0);
+  next_votes_size_ = 0;
   next_votes_.clear();
 }
 
@@ -340,8 +341,19 @@ std::vector<Vote> NextVotesForPreviousRound::getNextVotes() {
       next_votes_bundle.emplace_back(v);
     }
   }
+  assert(next_votes_bundle.size() == next_votes_size_);
 
   return next_votes_bundle;
+}
+
+size_t NextVotesForPreviousRound::getNextVotesSize() const {
+  sharedLock_ lock(access_);
+  return next_votes_size_;
+}
+
+void NextVotesForPreviousRound::setNextVotesSize(size_t const size) {
+  uniqueLock_ lock(access_);
+  next_votes_size_ = size;
 }
 
 // Assumption is that all votes are validated, in next phase, in the same round and step
@@ -353,53 +365,64 @@ void NextVotesForPreviousRound::update(std::vector<Vote> const& next_votes, size
 
   clear();
 
-  upgradableLock_ lock(access_);
-  // Copy all next votes
-  for (auto const& v : next_votes) {
-    LOG(log_dg_) << "Next vote: " << v;
+  {
+    upgradableLock_ lock(access_);
+    // Copy all next votes
+    for (auto const& v : next_votes) {
+      LOG(log_dg_) << "Next vote: " << v;
 
-    auto voted_block_hash = v.getBlockHash();
-    if (next_votes_.count(voted_block_hash)) {
-      upgradeLock_ locked(lock);
-      next_votes_[voted_block_hash].emplace_back(v);
-    } else {
-      std::vector<Vote> votes{v};
-      upgradeLock_ locked(lock);
-      next_votes_[voted_block_hash] = votes;
+      auto voted_block_hash = v.getBlockHash();
+      if (next_votes_.count(voted_block_hash)) {
+        upgradeLock_ locked(lock);
+        next_votes_[voted_block_hash].emplace_back(v);
+      } else {
+        std::vector<Vote> votes{v};
+        upgradeLock_ locked(lock);
+        next_votes_[voted_block_hash] = votes;
+      }
     }
   }
 
+  auto next_votes_size = next_votes.size();
+
   if (TWO_T_PLUS_ONE == 0) {
-    // Next votes from own DB. Don't need check
+    // Next votes from own DB. Don't need compare with 2t+1
     assert(next_votes_.size() == 1 || next_votes_.size() == 2);
+    setNextVotesSize(next_votes_size);
     return;
   }
 
   // Protect for malicious players. If no malicious players, will include either/both NULL BLOCK HASH and a non NULL
   // BLOCK HASH
-  auto it = next_votes_.begin();
-  while (it != next_votes_.end()) {
-    if (it->second.size() >= TWO_T_PLUS_ONE) {
-      LOG(log_nf_) << "Voted PBFT block hash " << it->first << " has " << it->second.size() << " next votes";
+  {
+    upgradableLock_ lock(access_);
+    auto it = next_votes_.begin();
+    while (it != next_votes_.end()) {
+      if (it->second.size() >= TWO_T_PLUS_ONE) {
+        LOG(log_nf_) << "Voted PBFT block hash " << it->first << " has " << it->second.size() << " next votes";
 
-      if (it->first == NULL_BLOCK_HASH) {
-        upgradeLock_ locked(lock);
-        enough_votes_for_null_block_hash_ = true;
+        if (it->first == NULL_BLOCK_HASH) {
+          upgradeLock_ locked(lock);
+          enough_votes_for_null_block_hash_ = true;
+        } else {
+          upgradeLock_ locked(lock);
+          voted_value_ = it->first;
+        }
+
+        it++;
       } else {
+        LOG(log_dg_) << "Voted PBFT block hash " << it->first << " has " << it->second.size()
+                     << " next votes. Not enough, removed!";
+        next_votes_size -= it->second.size();
         upgradeLock_ locked(lock);
-        voted_value_ = it->first;
+        it = next_votes_.erase(it);
       }
-
-      it++;
-    } else {
-      LOG(log_dg_) << "Voted PBFT block hash " << it->first << " has " << it->second.size()
-                   << " next votes. Not enough, removed!";
-      upgradeLock_ locked(lock);
-      it = next_votes_.erase(it);
     }
   }
 
   assert(next_votes_.size() == 1 || next_votes_.size() == 2);
+
+  setNextVotesSize(next_votes_size);
 }
 
 }  // namespace taraxa

--- a/src/consensus/vote.hpp
+++ b/src/consensus/vote.hpp
@@ -185,6 +185,8 @@ class NextVotesForPreviousRound {
 
   void clear();
 
+  bool find(blk_hash_t next_vote_hash);
+
   bool haveEnoughVotesForNullBlockHash() const;
 
   blk_hash_t getVotedValue() const;
@@ -212,6 +214,7 @@ class NextVotesForPreviousRound {
   blk_hash_t voted_value_;  // For value is not null block hash
   size_t next_votes_size_;
   std::unordered_map<blk_hash_t, std::vector<Vote>> next_votes_;  // <voted PBFT block hash, next votes list>
+  std::unordered_set<blk_hash_t> next_votes_set_;
 
   LOG_OBJECTS_DEFINE;
 };

--- a/src/consensus/vote.hpp
+++ b/src/consensus/vote.hpp
@@ -144,7 +144,10 @@ class VoteManager {
 
   bool voteValidation(blk_hash_t const& last_pbft_block_hash, Vote const& vote, size_t const valid_sortition_players,
                       size_t const sortition_threshold) const;
+
   bool addVote(taraxa::Vote const& vote);
+  void addVotes(std::vector<Vote> const& votes);
+
   void cleanupVotes(uint64_t pbft_round);
   void clearUnverifiedVotesTable();
   uint64_t getUnverifiedVotesSize() const;
@@ -178,7 +181,7 @@ class VoteManager {
 
 class NextVotesForPreviousRound {
  public:
-  NextVotesForPreviousRound(addr_t node_addr);
+  NextVotesForPreviousRound(addr_t node_addr, std::shared_ptr<DbStorage> db);
 
   void clear();
 
@@ -193,6 +196,8 @@ class NextVotesForPreviousRound {
 
   void update(std::vector<Vote> const& next_votes, size_t const TWO_T_PLUS_ONE = 0);
 
+  void updateWithSyncedVotes(std::vector<Vote> const& votes);
+
  private:
   using uniqueLock_ = boost::unique_lock<boost::shared_mutex>;
   using sharedLock_ = boost::shared_lock<boost::shared_mutex>;
@@ -200,6 +205,8 @@ class NextVotesForPreviousRound {
   using upgradeLock_ = boost::upgrade_to_unique_lock<boost::shared_mutex>;
 
   mutable boost::shared_mutex access_;
+
+  std::shared_ptr<DbStorage> db_;
 
   bool enough_votes_for_null_block_hash_;
   blk_hash_t voted_value_;  // For value is not null block hash

--- a/src/consensus/vote.hpp
+++ b/src/consensus/vote.hpp
@@ -176,4 +176,29 @@ class VoteManager {
   LOG_OBJECTS_DEFINE;
 };
 
+class NextVotesForPreviousRound {
+ public:
+  NextVotesForPreviousRound(addr_t node_addr);
+
+  void clear();
+  bool haveEnoughVotesForNullBlockHash() const;
+  blk_hash_t getVotedValue() const;
+  std::vector<Vote> getNextVotes();
+  void update(std::vector<Vote> const& next_votes, size_t const TWO_T_PLUS_ONE = 0);
+
+ private:
+  using uniqueLock_ = boost::unique_lock<boost::shared_mutex>;
+  using sharedLock_ = boost::shared_lock<boost::shared_mutex>;
+  using upgradableLock_ = boost::upgrade_lock<boost::shared_mutex>;
+  using upgradeLock_ = boost::upgrade_to_unique_lock<boost::shared_mutex>;
+
+  mutable boost::shared_mutex access_;
+
+  bool enough_votes_for_null_block_hash_;
+  blk_hash_t voted_value_;                                        // For value is not null block hash
+  std::unordered_map<blk_hash_t, std::vector<Vote>> next_votes_;  // <voted PBFT block hash, next votes list>
+
+  LOG_OBJECTS_DEFINE;
+};
+
 }  // namespace taraxa

--- a/src/consensus/vote.hpp
+++ b/src/consensus/vote.hpp
@@ -194,9 +194,9 @@ class NextVotesForPreviousRound {
   size_t getNextVotesSize() const;
   void setNextVotesSize(size_t const size);
 
-  void update(std::vector<Vote> const& next_votes, size_t const TWO_T_PLUS_ONE = 0);
+  void update(std::vector<Vote> const& next_votes, size_t const pbft_2t_plus_1);
 
-  void updateWithSyncedVotes(std::vector<Vote> const& votes);
+  void updateWithSyncedVotes(std::vector<Vote> const& votes, size_t const pbft_2t_plus_1);
 
  private:
   using uniqueLock_ = boost::unique_lock<boost::shared_mutex>;

--- a/src/consensus/vote.hpp
+++ b/src/consensus/vote.hpp
@@ -181,9 +181,16 @@ class NextVotesForPreviousRound {
   NextVotesForPreviousRound(addr_t node_addr);
 
   void clear();
+
   bool haveEnoughVotesForNullBlockHash() const;
+
   blk_hash_t getVotedValue() const;
+
   std::vector<Vote> getNextVotes();
+
+  size_t getNextVotesSize() const;
+  void setNextVotesSize(size_t const size);
+
   void update(std::vector<Vote> const& next_votes, size_t const TWO_T_PLUS_ONE = 0);
 
  private:
@@ -195,7 +202,8 @@ class NextVotesForPreviousRound {
   mutable boost::shared_mutex access_;
 
   bool enough_votes_for_null_block_hash_;
-  blk_hash_t voted_value_;                                        // For value is not null block hash
+  blk_hash_t voted_value_;  // For value is not null block hash
+  size_t next_votes_size_;
   std::unordered_map<blk_hash_t, std::vector<Vote>> next_votes_;  // <voted PBFT block hash, next votes list>
 
   LOG_OBJECTS_DEFINE;

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -199,4 +199,9 @@ void Network::sendPbftBlock(const NodeID &id, const taraxa::PbftBlock &pbft_bloc
   taraxa_capability_->sendPbftBlock(id, pbft_block, pbft_chain_size);
 }
 
+void Network::broadcastPreviousRoundNextVotesBundle() {
+  LOG(log_dg_) << "Network broadcast previous round next votes bundle";
+  taraxa_capability_->broadcastPreviousRoundNextVotesBundle();
+}
+
 }  // namespace taraxa

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -12,28 +12,31 @@ namespace taraxa {
 
 Network::Network(NetworkConfig const &config, std::string const &genesis, addr_t node_addr)
     : Network(config, "", secret_t(), genesis, node_addr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-              public_t(), 2000) {}
+              nullptr, public_t(), 2000) {}
 Network::Network(NetworkConfig const &config, std::string const &network_file, std::string const &genesis,
                  addr_t node_addr, std::shared_ptr<DbStorage> db, std::shared_ptr<PbftManager> pbft_mgr,
                  std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<VoteManager> vote_mgr,
-                 std::shared_ptr<DagManager> dag_mgr, std::shared_ptr<DagBlockManager> dag_blk_mgr,
-                 std::shared_ptr<TransactionManager> trx_mgr, public_t node_pk, uint32_t lambda_ms_min)
-    : Network(config, network_file, secret_t(), genesis, node_addr, db, pbft_mgr, pbft_chain, vote_mgr, dag_mgr,
-              dag_blk_mgr, trx_mgr, node_pk, lambda_ms_min) {}
+                 std::shared_ptr<NextVotesForPreviousRound> next_votes_mgr, std::shared_ptr<DagManager> dag_mgr,
+                 std::shared_ptr<DagBlockManager> dag_blk_mgr, std::shared_ptr<TransactionManager> trx_mgr,
+                 public_t node_pk, uint32_t lambda_ms_min)
+    : Network(config, network_file, secret_t(), genesis, node_addr, db, pbft_mgr, pbft_chain, vote_mgr, next_votes_mgr,
+              dag_mgr, dag_blk_mgr, trx_mgr, node_pk, lambda_ms_min) {}
 Network::Network(NetworkConfig const &config, std::string const &network_file, secret_t const &sk,
                  std::string const &genesis, addr_t node_addr, std::shared_ptr<DbStorage> db,
                  std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<PbftChain> pbft_chain,
-                 std::shared_ptr<VoteManager> vote_mgr, std::shared_ptr<DagManager> dag_mgr,
-                 std::shared_ptr<DagBlockManager> dag_blk_mgr, std::shared_ptr<TransactionManager> trx_mgr,
-                 public_t node_pk, uint32_t lambda_ms_min) try : conf_(config),
-                                                                 db_(db),
-                                                                 pbft_mgr_(pbft_mgr),
-                                                                 pbft_chain_(pbft_chain),
-                                                                 vote_mgr_(vote_mgr),
-                                                                 dag_mgr_(dag_mgr),
-                                                                 dag_blk_mgr_(dag_blk_mgr),
-                                                                 trx_mgr_(trx_mgr),
-                                                                 node_pk_(node_pk) {
+                 std::shared_ptr<VoteManager> vote_mgr, std::shared_ptr<NextVotesForPreviousRound> next_votes_mgr,
+                 std::shared_ptr<DagManager> dag_mgr, std::shared_ptr<DagBlockManager> dag_blk_mgr,
+                 std::shared_ptr<TransactionManager> trx_mgr, public_t node_pk, uint32_t lambda_ms_min) try
+    : conf_(config),
+      db_(db),
+      pbft_mgr_(pbft_mgr),
+      pbft_chain_(pbft_chain),
+      vote_mgr_(vote_mgr),
+      next_votes_mgr_(next_votes_mgr),
+      dag_mgr_(dag_mgr),
+      dag_blk_mgr_(dag_blk_mgr),
+      trx_mgr_(trx_mgr),
+      node_pk_(node_pk) {
   LOG_OBJECTS_CREATE("NETWORK");
   LOG(log_nf_) << "Read Network Config: " << std::endl << conf_ << std::endl;
   auto key = dev::KeyPair::create();
@@ -60,9 +63,9 @@ Network::Network(NetworkConfig const &config, std::string const &network_file, s
         dev::p2p::NetworkConfig(conf_.network_address, conf_.network_tcp_port, false, true), conf_.network_encrypted,
         conf_.network_ideal_peer_count, conf_.network_max_peer_count, conf_.net_log);
   }
-  taraxa_capability_ =
-      std::make_shared<TaraxaCapability>(*host_.get(), conf_, genesis, conf_.network_performance_log, node_addr, db,
-                                         pbft_mgr, pbft_chain, vote_mgr, dag_mgr, dag_blk_mgr, trx_mgr, lambda_ms_min);
+  taraxa_capability_ = std::make_shared<TaraxaCapability>(*host_.get(), conf_, genesis, conf_.network_performance_log,
+                                                          node_addr, db, pbft_mgr, pbft_chain, vote_mgr, next_votes_mgr,
+                                                          dag_mgr, dag_blk_mgr, trx_mgr, lambda_ms_min);
   host_->registerCapability(taraxa_capability_);
 } catch (std::exception &e) {
   std::cerr << "Construct Network Error ... " << e.what() << "\n";

--- a/src/network/network.hpp
+++ b/src/network/network.hpp
@@ -69,6 +69,7 @@ class Network {
   void sendPbftVote(NodeID const &id, Vote const &vote);
   void onNewPbftBlock(PbftBlock const &pbft_block);
   void sendPbftBlock(NodeID const &id, PbftBlock const &pbft_block, uint64_t const &pbft_chain_size);
+  void broadcastPreviousRoundNextVotesBundle();
 
   std::pair<bool, bi::tcp::endpoint> resolveHost(string const &addr, uint16_t port);
 

--- a/src/network/network.hpp
+++ b/src/network/network.hpp
@@ -32,14 +32,15 @@ class Network {
   Network(NetworkConfig const &config, std::string const &genesis, addr_t node_addr);
   Network(NetworkConfig const &config, std::string const &networkFile, std::string const &genesis, addr_t node_addr,
           std::shared_ptr<DbStorage> db, std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<PbftChain> pbft_chain,
-          std::shared_ptr<VoteManager> vote_mgr, std::shared_ptr<DagManager> dag_mgr,
-          std::shared_ptr<DagBlockManager> dag_blk_mgr, std::shared_ptr<TransactionManager> trx_mgr, public_t node_pk,
-          uint32_t lambda_ms_min);
+          std::shared_ptr<VoteManager> vote_mgr, std::shared_ptr<NextVotesForPreviousRound> next_votes_mgr,
+          std::shared_ptr<DagManager> dag_mgr, std::shared_ptr<DagBlockManager> dag_blk_mgr,
+          std::shared_ptr<TransactionManager> trx_mgr, public_t node_pk, uint32_t lambda_ms_min);
   Network(NetworkConfig const &config, std::string const &networkFile, secret_t const &sk, std::string const &genesis,
           addr_t node_addr, std::shared_ptr<DbStorage> db, std::shared_ptr<PbftManager> pbft_mgr,
           std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<VoteManager> vote_mgr,
-          std::shared_ptr<DagManager> dag_mgr, std::shared_ptr<DagBlockManager> dag_blk_mgr,
-          std::shared_ptr<TransactionManager> trx_mgr, public_t node_pk, uint32_t lambda_ms_min);
+          std::shared_ptr<NextVotesForPreviousRound> next_votes_mgr, std::shared_ptr<DagManager> dag_mgr,
+          std::shared_ptr<DagBlockManager> dag_blk_mgr, std::shared_ptr<TransactionManager> trx_mgr, public_t node_pk,
+          uint32_t lambda_ms_min);
   ~Network();
   void start(bool boot_node = false);
   void stop();
@@ -83,6 +84,7 @@ class Network {
   std::shared_ptr<PbftManager> pbft_mgr_;
   std::shared_ptr<PbftChain> pbft_chain_;
   std::shared_ptr<VoteManager> vote_mgr_;
+  std::shared_ptr<NextVotesForPreviousRound> next_votes_mgr_;
   std::shared_ptr<DagManager> dag_mgr_;
   std::shared_ptr<DagBlockManager> dag_blk_mgr_;
   std::shared_ptr<TransactionManager> trx_mgr_;

--- a/src/network/taraxa_capability.cpp
+++ b/src/network/taraxa_capability.cpp
@@ -1146,7 +1146,7 @@ void TaraxaCapability::requestPbftNextVotes(NodeID const &peerID, uint64_t const
 }
 
 void TaraxaCapability::sendPbftNextVotes(NodeID const &peerID) {
-  std::vector<Vote> next_votes_bundle = pbft_mgr_->getNextVotesForPreviousRoundPtr()->getNextVotes();
+  std::vector<Vote> next_votes_bundle = next_votes_mgr_->getNextVotes();
   LOG(log_dg_next_votes_sync_) << "Send size of " << next_votes_bundle.size() << " PBFT next votes to " << peerID;
 
   RLPStream s;

--- a/src/network/taraxa_capability.cpp
+++ b/src/network/taraxa_capability.cpp
@@ -224,18 +224,16 @@ bool TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
           LOG(log_dg_dag_sync_) << "Received status message from " << _nodeID
                                 << " peer DAG max level:" << peer->dag_level_;
           LOG(log_dg_pbft_sync_) << "Received status message from " << _nodeID << ", peer sycning: " << peer->syncing_
-                                 << ", PBFT chain size:" << peer->pbft_chain_size_
-                                 << ". Own peer syncing pbft chain size: " << peer_syncing_pbft_chain_size_;
+                                 << ", PBFT chain size:" << peer->pbft_chain_size_;
           LOG(log_dg_next_votes_sync_) << "Received status message from " << _nodeID << ", PBFT round "
                                        << peer->pbft_round_ << ", peer PBFT previous round next votes size "
                                        << peer->pbft_previous_round_next_votes_size_;
 
           if (peer->syncing_) {
-            LOG(log_dg_pbft_sync_) << "Peer node has a short PBFT chain, prevent gossiping to " << _nodeID
-                                   << ". Own pbft chain size " << pbft_chain_size << " Peer pbft chain size "
-                                   << peer->pbft_chain_size_;
             if (syncing_ && peer_syncing_pbft_ == _nodeID) {
               // We are currently syncing to a node that just reported it is not synced, force a switch to a new node
+              LOG(log_nf_) << "Restart syncing, currently syncing from the node " << _nodeID
+                           << " that is itself syncing";
               restartSyncingPbft(true);
             }
           }
@@ -653,7 +651,6 @@ void TaraxaCapability::restartSyncingPbft(bool force) {
       requesting_pending_dag_blocks_ = false;
       syncing_ = true;
       peer_syncing_pbft_ = max_pbft_chain_nodeID;
-      peer_syncing_pbft_chain_size_ = max_pbft_chain_size;
       syncPeerPbft(peer_syncing_pbft_, pbft_sync_period_ + 1);
     }
   } else {

--- a/src/network/taraxa_capability.cpp
+++ b/src/network/taraxa_capability.cpp
@@ -153,28 +153,32 @@ bool TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
         } break;
         case StatusPacket: {
           peer->statusReceived();
-          bool initial_status = _r.itemCount() == 9;
-          uint64_t peer_level;
+          bool initial_status = _r.itemCount() == 10;
+          uint64_t peer_dag_max_level;
           uint64_t peer_pbft_chain_size;
-          auto pbft_chain_size = pbft_chain_->getPbftChainSize();
           uint64_t peer_pbft_round;
+          size_t peer_pbft_previous_round_next_votes_size;
+          auto pbft_chain_size = pbft_chain_->getPbftChainSize();
+
           if (initial_status) {
             auto it = _r.begin();
             auto const peer_protocol_version = (*it++).toInt<unsigned>();
             auto const network_id = (*it++).toPositiveInt64();
-            peer_level = (*it++).toPositiveInt64();
+            peer_dag_max_level = (*it++).toPositiveInt64();
             auto const genesis_hash = (*it++).toString();
             peer_pbft_chain_size = (*it++).toPositiveInt64();
             peer->syncing_ = (*it++).toInt();
             peer_pbft_round = (*it++).toPositiveInt64();
+            peer_pbft_previous_round_next_votes_size = (*it++).toInt<unsigned>();
             auto node_major_version = (*it++).toInt();
             auto node_minor_version = (*it++).toInt();
             LOG(log_dg_) << "Received initial status message from " << _nodeID << ", peer protocol version "
-                         << peer_protocol_version << ", network id " << network_id << ", peer level " << peer_level
-                         << ", genesis " << genesis_ << ", peer pbft chain size " << peer_pbft_chain_size
-                         << ", peer syncing " << peer->syncing_ << ", peer pbft round " << peer_pbft_round
-                         << ", node major version" << node_major_version << ", node minor version"
-                         << node_minor_version;
+                         << peer_protocol_version << ", network id " << network_id << ", peer DAG max level "
+                         << peer_dag_max_level << ", genesis " << genesis_ << ", peer pbft chain size "
+                         << peer_pbft_chain_size << ", peer syncing " << peer->syncing_ << ", peer pbft round "
+                         << peer_pbft_round << ", peer pbft previous round next votes size "
+                         << peer_pbft_previous_round_next_votes_size << ", node major version" << node_major_version
+                         << ", node minor version" << node_minor_version;
 
             if (peer_protocol_version != FullNode::c_network_protocol_version) {
               LOG(log_er_) << "Incorrect protocol version " << peer_protocol_version << ", host " << _nodeID
@@ -204,33 +208,45 @@ bool TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
             peer->syncing_ |= peer_pbft_chain_size < pbft_chain_size;
           } else {
             auto it = _r.begin();
-            peer_level = (*it++).toPositiveInt64();
+            peer_dag_max_level = (*it++).toPositiveInt64();
             peer_pbft_chain_size = (*it++).toPositiveInt64();
             peer->syncing_ = (*it++).toInt();
             peer_pbft_round = (*it++).toPositiveInt64();
-            LOG(log_dg_) << "Received status message from " << _nodeID << ", peer level " << peer_level
+            peer_pbft_previous_round_next_votes_size = (*it++).toInt<unsigned>();
+            LOG(log_dg_) << "Received status message from " << _nodeID << ", peer DAG max level " << peer_dag_max_level
                          << ", peer pbft chain size " << peer_pbft_chain_size << ", peer syncing " << peer->syncing_
-                         << ", peer pbft round " << peer_pbft_round;
+                         << ", peer pbft round " << peer_pbft_round << ", peer pbft previous round next votes size "
+                         << peer_pbft_previous_round_next_votes_size;
           }
-          LOG(log_dg_dag_sync_) << "Received status message from " << _nodeID << " DAG level:" << peer_level;
+          LOG(log_dg_dag_sync_) << "Received status message from " << _nodeID
+                                << " peer DAG max level:" << peer_dag_max_level;
           LOG(log_dg_pbft_sync_) << "Received status message from " << _nodeID
                                  << " PBFT chain size:" << peer_pbft_chain_size << " " << peer->syncing_;
-          LOG(log_dg_next_votes_sync_) << "Received status message from " << _nodeID
-                                       << " PBFT round: " << peer_pbft_round;
+          LOG(log_dg_next_votes_sync_) << "Received status message from " << _nodeID << ", PBFT round "
+                                       << peer_pbft_round << ", peer PBFT previous round next votes size "
+                                       << peer_pbft_previous_round_next_votes_size;
           peer->pbft_chain_size_ = peer_pbft_chain_size;
-          peer->dag_level_ = peer_level;
+          peer->dag_level_ = peer_dag_max_level;
           peer->pbft_round_ = peer_pbft_round;
-          LOG(log_dg_pbft_sync_) << "peer_pbft_chain_size: " << peer_pbft_chain_size
-                                 << ", peer_syncing_pbft_chain_size_: " << peer_syncing_pbft_chain_size_;
+          peer->pbft_previous_round_next_votes_size_ = peer_pbft_previous_round_next_votes_size;
+          LOG(log_dg_pbft_sync_) << "peer pbft chain size: " << peer_pbft_chain_size
+                                 << ", peer syncing pbft chain size: " << peer_syncing_pbft_chain_size_;
           if (peer->syncing_) {
-            LOG(log_dg_pbft_sync_) << "Other node is behind, prevent gossiping " << _nodeID
-                                   << "Our pbft chain size: " << pbft_chain_size
-                                   << " Peer pbft chain size: " << peer_pbft_chain_size;
-            if (syncing_ && peer_syncing_pbft == _nodeID) {
-              // We are currently syncing to a node that just reported it is
-              // not synced, force a switch to a new node
+            LOG(log_dg_pbft_sync_) << "Peer node has a short PBFT chain, prevent gossiping to " << _nodeID
+                                   << ". Own pbft chain size " << pbft_chain_size << " Peer pbft chain size "
+                                   << peer_pbft_chain_size;
+            if (syncing_ && peer_syncing_pbft_ == _nodeID) {
+              // We are currently syncing to a node that just reported it is not synced, force a switch to a new node
               restartSyncingPbft(true);
             }
+          }
+
+          auto pbft_current_round = pbft_mgr_->getPbftRound();
+          auto pbft_previous_round_next_votes_size = next_votes_mgr_->getNextVotesSize();
+          if (pbft_current_round < peer_pbft_round ||
+              (pbft_current_round == peer_pbft_round &&
+               pbft_previous_round_next_votes_size < peer_pbft_previous_round_next_votes_size)) {
+            syncPbftNextVotes(pbft_current_round, pbft_previous_round_next_votes_size);
           }
 
           break;
@@ -378,23 +394,36 @@ bool TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
         }
         case GetPbftNextVotes: {
           LOG(log_dg_next_votes_sync_) << "Received GetPbftNextVotes request";
+
           uint64_t peer_pbft_round = _r[0].toPositiveInt64();
+          size_t peer_pbft_previous_round_next_votes_size = _r[1].toInt<unsigned>();
           uint64_t pbft_round = pbft_mgr_->getPbftRound();
-          if (pbft_round > peer_pbft_round) {
-            LOG(log_dg_next_votes_sync_) << "Current PBFT round is " << pbft_round << ", and peer PBFT round is "
-                                         << peer_pbft_round << ". Will send bundle of next votes";
+          size_t pbft_previous_round_next_votes_size = next_votes_mgr_->getNextVotesSize();
+
+          if (pbft_round > peer_pbft_round ||
+              (pbft_round == peer_pbft_round &&
+               pbft_previous_round_next_votes_size > peer_pbft_previous_round_next_votes_size)) {
+            LOG(log_dg_next_votes_sync_) << "Current PBFT round is " << pbft_round << " previous round next votes size "
+                                         << pbft_previous_round_next_votes_size << ", and peer PBFT round is "
+                                         << peer_pbft_round << " previous round next votes size "
+                                         << peer_pbft_previous_round_next_votes_size
+                                         << ". Will send out bundle of next votes";
             sendPbftNextVotes(_nodeID);
           }
+
           break;
         }
         case PbftNextVotesPacket: {
           auto next_votes_count = _r.itemCount();
-          LOG(log_dg_next_votes_sync_) << "In PbftNextVotesPacket received " << next_votes_count << " next votes";
+          LOG(log_nf_next_votes_sync_) << "Received " << next_votes_count << " next votes from peer " << _nodeID;
+
           for (auto i = 0; i < next_votes_count; i++) {
             Vote next_vote(_r[i].data().toBytes());
-            LOG(log_dg_next_votes_sync_) << "Received PBFT next vote " << next_vote.getHash();
+            LOG(log_nf_next_votes_sync_) << "Received PBFT next vote " << next_vote.getHash();
+            // TODO: Cannot add next votes to unverified queue, need update NextVotesForPreviousRound
             vote_mgr_->addVote(next_vote);
           }
+
           break;
         }
         case GetPbftBlockPacket: {
@@ -506,7 +535,7 @@ bool TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
             }
           }
           if (pbft_blk_count > 0) {
-            if (syncing_ && peer_syncing_pbft == _nodeID) {
+            if (syncing_ && peer_syncing_pbft_ == _nodeID) {
               if (pbft_sync_period_ > pbft_chain_->getPbftChainSize() + (10 * conf_.network_sync_level_size)) {
                 LOG(log_dg_pbft_sync_) << "Syncing pbft blocks faster than processing " << pbft_sync_period_ << " "
                                        << pbft_chain_->getPbftChainSize();
@@ -516,7 +545,7 @@ bool TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
               }
             } else {
               LOG(log_dg_pbft_sync_) << "Received PbftBlockPacket from node " << _nodeID
-                                     << " but currently syncing with peer " << peer_syncing_pbft;
+                                     << " but currently syncing with peer " << peer_syncing_pbft_;
             }
           } else {
             LOG(log_dg_pbft_sync_) << "Syncing PBFT is completed";
@@ -558,7 +587,7 @@ void TaraxaCapability::delayedPbftSync(NodeID _nodeID, int counter) {
       LOG(log_dg_pbft_sync_) << "Syncing PBFT is stopping";
       return;
     }
-    if (syncing_ && peer_syncing_pbft == _nodeID) {
+    if (syncing_ && peer_syncing_pbft_ == _nodeID) {
       if (pbft_sync_period_ > pbft_chain_->getPbftChainSize() + (10 * conf_.network_sync_level_size)) {
         LOG(log_dg_pbft_sync_) << "Syncing pbft blocks faster than processing " << pbft_sync_period_ << " "
                                << pbft_chain_->getPbftChainSize();
@@ -600,9 +629,9 @@ void TaraxaCapability::restartSyncingPbft(bool force) {
       LOG(log_si_pbft_sync_) << "Restarting syncing PBFT" << max_pbft_chain_size << " " << pbft_sync_period_;
       requesting_pending_dag_blocks_ = false;
       syncing_ = true;
-      peer_syncing_pbft = max_pbft_chain_nodeID;
+      peer_syncing_pbft_ = max_pbft_chain_nodeID;
       peer_syncing_pbft_chain_size_ = max_pbft_chain_size;
-      syncPeerPbft(peer_syncing_pbft, pbft_sync_period_ + 1);
+      syncPeerPbft(peer_syncing_pbft_, pbft_sync_period_ + 1);
     }
   } else {
     LOG(log_nf_pbft_sync_) << "Restarting syncing PBFT not needed since our pbft chain "
@@ -627,7 +656,7 @@ void TaraxaCapability::onDisconnect(NodeID const &_nodeID) {
   cnt_received_messages_.erase(_nodeID);
   test_sums_.erase(_nodeID);
   erasePeer(_nodeID);
-  if (syncing_ && peer_syncing_pbft == _nodeID && getPeersCount() > 0) {
+  if (syncing_ && peer_syncing_pbft_ == _nodeID && getPeersCount() > 0) {
     LOG(log_dg_pbft_sync_) << "Syncing PBFT is stopping";
     restartSyncingPbft(true);
   }
@@ -651,21 +680,26 @@ void TaraxaCapability::sendStatus(NodeID const &_id, bool _initial) {
                    << dag_mgr_->getMaxLevel() << ", genesis " << genesis_ << ", pbft chain size "
                    << pbft_chain_->getPbftChainSize();
     }
+
     auto dag_max_level = dag_mgr_->getMaxLevel();
     auto pbft_chain_size = pbft_chain_->getPbftChainSize();
     auto pbft_round = pbft_mgr_->getPbftRound();
+    auto pbft_previous_round_next_votes_size = next_votes_mgr_->getNextVotesSize();
     LOG(log_dg_dag_sync_) << "Sending status message to " << _id << " with dag level: " << dag_max_level;
     LOG(log_dg_pbft_sync_) << "Sending status message to " << _id << " with pbft chain size: " << pbft_chain_size;
-    LOG(log_dg_next_votes_sync_) << "Sending status message to " << _id << " with PBFT round: " << pbft_round;
+    LOG(log_dg_next_votes_sync_) << "Sending status message to " << _id << " with PBFT round: " << pbft_round
+                                 << ", previous round next votes size " << pbft_previous_round_next_votes_size;
+
     if (_initial) {
-      host_.capabilityHost()->sealAndSend(_id, host_.capabilityHost()->prep(_id, name(), s, StatusPacket, 9)
+      host_.capabilityHost()->sealAndSend(_id, host_.capabilityHost()->prep(_id, name(), s, StatusPacket, 10)
                                                    << FullNode::c_network_protocol_version << conf_.network_id
                                                    << dag_max_level << genesis_ << pbft_chain_size << syncing_
-                                                   << pbft_round << FullNode::c_node_major_version
-                                                   << FullNode::c_node_minor_version);
+                                                   << pbft_round << pbft_previous_round_next_votes_size
+                                                   << FullNode::c_node_major_version << FullNode::c_node_minor_version);
     } else {
-      host_.capabilityHost()->sealAndSend(_id, host_.capabilityHost()->prep(_id, name(), s, StatusPacket, 4)
-                                                   << dag_max_level << pbft_chain_size << syncing_ << pbft_round);
+      host_.capabilityHost()->sealAndSend(_id, host_.capabilityHost()->prep(_id, name(), s, StatusPacket, 5)
+                                                   << dag_max_level << pbft_chain_size << syncing_ << pbft_round
+                                                   << pbft_previous_round_next_votes_size);
     }
   }
 }
@@ -959,8 +993,7 @@ void TaraxaCapability::sendTransactions() {
 
 void TaraxaCapability::doBackgroundWork() {
   for (auto const &peer : peers_) {
-    // Disconnect any node that did not send any message for 3 status
-    // intervals
+    // Disconnect any node that did not send any message for 3 status intervals
     if (!peer.second->checkStatus(5)) {
       LOG(log_nf_) << "Host disconnected, no status message in " << 5 * check_status_interval_ << " ms" << peer.first;
       host_.capabilityHost()->disconnect(peer.first, p2p::PingTimeout);
@@ -1113,47 +1146,66 @@ void TaraxaCapability::sendPbftBlock(NodeID const &_id, taraxa::PbftBlock const 
   host_.capabilityHost()->sealAndSend(_id, s);
 }
 
-void TaraxaCapability::syncPbftNextVotes(uint64_t const pbft_round) {
+void TaraxaCapability::syncPbftNextVotes(uint64_t const pbft_round, size_t const pbft_previous_round_next_votes_size) {
   if (stopped_) {
     return;
   }
 
-  NodeID max_pbft_round_peerID;
+  NodeID peer_node_ID;
   uint64_t peer_max_pbft_round = 1;
+  size_t peer_max_previous_round_next_votes_size = 0;
   {
     boost::shared_lock<boost::shared_mutex> lock(peers_mutex_);
-    for (auto const peer : peers_) {
+    // Find max peer PBFT round
+    for (auto const &peer : peers_) {
       if (peer.second->pbft_round_ > peer_max_pbft_round) {
         peer_max_pbft_round = peer.second->pbft_round_;
-        max_pbft_round_peerID = peer.first;
+        peer_node_ID = peer.first;
+      }
+    }
+
+    if (pbft_round == peer_max_pbft_round) {
+      // No peers ahead, find peer PBFT previous round max next votes size
+      for (auto const &peer : peers_) {
+        if (peer.second->pbft_previous_round_next_votes_size_ > peer_max_previous_round_next_votes_size) {
+          peer_max_previous_round_next_votes_size = peer.second->pbft_previous_round_next_votes_size_;
+          peer_node_ID = peer.first;
+        }
       }
     }
   }
 
-  if (!stopped_ && pbft_round < peer_max_pbft_round) {
-    LOG(log_dg_next_votes_sync_) << "Syncing PBFT next votes. Current PBFT round " << pbft_round << ", peer "
-                                 << max_pbft_round_peerID << " is in PBFT round " << peer_max_pbft_round;
-    requestPbftNextVotes(max_pbft_round_peerID, pbft_round);
+  if (!stopped_ && (pbft_round < peer_max_pbft_round ||
+                    (pbft_round == peer_max_pbft_round &&
+                     pbft_previous_round_next_votes_size < peer_max_previous_round_next_votes_size))) {
+    LOG(log_dg_next_votes_sync_) << "Syncing PBFT next votes. Current PBFT round " << pbft_round
+                                 << " previous round next votes size " << pbft_previous_round_next_votes_size
+                                 << ", peer " << peer_node_ID << " is in PBFT round " << peer_max_pbft_round
+                                 << " previous round next votes size " << peer_max_previous_round_next_votes_size;
+    requestPbftNextVotes(peer_node_ID, pbft_round, pbft_previous_round_next_votes_size);
   }
 }
 
-void TaraxaCapability::requestPbftNextVotes(NodeID const &peerID, uint64_t const pbft_round) {
+void TaraxaCapability::requestPbftNextVotes(NodeID const &peerID, uint64_t const pbft_round,
+                                            size_t const pbft_previous_round_next_votes_size) {
   RLPStream s;
-  host_.capabilityHost()->prep(peerID, name(), s, GetPbftNextVotes, 1);
+  host_.capabilityHost()->prep(peerID, name(), s, GetPbftNextVotes, 2);
   s << pbft_round;
-  LOG(log_dg_next_votes_sync_) << "Sending GetPbftNextVotes with round: " << pbft_round;
+  s << pbft_previous_round_next_votes_size;
+  LOG(log_dg_next_votes_sync_) << "Sending GetPbftNextVotes with round " << pbft_round
+                               << " previous round next votes size " << pbft_previous_round_next_votes_size;
   host_.capabilityHost()->sealAndSend(peerID, s);
 }
 
 void TaraxaCapability::sendPbftNextVotes(NodeID const &peerID) {
   std::vector<Vote> next_votes_bundle = next_votes_mgr_->getNextVotes();
-  LOG(log_dg_next_votes_sync_) << "Send size of " << next_votes_bundle.size() << " PBFT next votes to " << peerID;
+  LOG(log_nf_next_votes_sync_) << "Send out size of " << next_votes_bundle.size() << " PBFT next votes to " << peerID;
 
   RLPStream s;
   host_.capabilityHost()->prep(peerID, name(), s, PbftNextVotesPacket, next_votes_bundle.size());
   for (auto const &next_vote : next_votes_bundle) {
     s.appendRaw(next_vote.rlp());
-    LOG(log_dg_next_votes_sync_) << "Send next vote " << next_vote.getHash();
+    LOG(log_nf_next_votes_sync_) << "Send out next vote " << next_vote.getHash() << " to peer " << peerID;
   }
   host_.capabilityHost()->sealAndSend(peerID, s);
 }

--- a/src/network/taraxa_capability.cpp
+++ b/src/network/taraxa_capability.cpp
@@ -413,7 +413,7 @@ bool TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
         case PbftNextVotesPacket: {
           auto next_votes_count = _r.itemCount();
           if (next_votes_count == 0) {
-            LOG(log_er_next_votes_sync_) << "Synced 0 next votes from peer " << _nodeID
+            LOG(log_er_next_votes_sync_) << "Receive 0 next votes from peer " << _nodeID
                                          << ". The peer may be a malicous player, will be disconnected";
             host_.capabilityHost()->disconnect(_nodeID, p2p::UserReason);
 
@@ -436,7 +436,8 @@ bool TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
           if (pbft_current_round < peer_pbft_round) {
             // Add into votes unverified queue
             vote_mgr_->addVotes(next_votes);
-          } else if (pbft_current_round == peer_pbft_round && pbft_previous_round_next_votes_size < next_votes_count) {
+          } else if (pbft_current_round == peer_pbft_round) {
+            // Update previous round next votes
             auto pbft_2t_plus_1 = db_->getPbft2TPlus1(pbft_current_round - 1);
             if (pbft_2t_plus_1) {
               next_votes_mgr_->updateWithSyncedVotes(next_votes, pbft_2t_plus_1);
@@ -1232,6 +1233,19 @@ void TaraxaCapability::sendPbftNextVotes(NodeID const &peerID) {
     LOG(log_nf_next_votes_sync_) << "Send out next vote " << next_vote.getHash() << " to peer " << peerID;
   }
   host_.capabilityHost()->sealAndSend(peerID, s);
+}
+
+void TaraxaCapability::broadcastPreviousRoundNextVotesBundle() {
+  std::vector<NodeID> peers_to_send;
+  {
+    boost::shared_lock<boost::shared_mutex> lock(peers_mutex_);
+    for (auto const &peer : peers_) {
+      peers_to_send.push_back(peer.first);
+    }
+  }
+  for (auto const &peer : peers_to_send) {
+    sendPbftNextVotes(peer);
+  }
 }
 
 Json::Value TaraxaCapability::getStatus() const {

--- a/src/network/taraxa_capability.cpp
+++ b/src/network/taraxa_capability.cpp
@@ -439,7 +439,12 @@ bool TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
             // Add into votes unverified queue
             vote_mgr_->addVotes(next_votes);
           } else if (pbft_current_round == peer_pbft_round && pbft_previous_round_next_votes_size < next_votes_count) {
-            next_votes_mgr_->updateWithSyncedVotes(next_votes);
+            auto pbft_2t_plus_1 = db_->getPbft2TPlus1(pbft_current_round - 1);
+            if (pbft_2t_plus_1) {
+              next_votes_mgr_->updateWithSyncedVotes(next_votes, pbft_2t_plus_1);
+            } else {
+              LOG(log_er_) << "Cannot get PBFT 2t+1 in PBFT round " << pbft_current_round - 1;
+            }
           }
 
           break;

--- a/src/network/taraxa_capability.cpp
+++ b/src/network/taraxa_capability.cpp
@@ -844,11 +844,6 @@ void TaraxaCapability::sendSyncedMessage() {
 
 void TaraxaCapability::onNewBlockVerified(DagBlock const &block) {
   LOG(log_dg_dag_prp_) << "Verified NewBlock " << block.getHash().toString();
-  verified_blocks_.insert(block.getHash());
-  {
-    std::unique_lock<std::mutex> lck(mtx_for_verified_blocks);
-    condition_for_verified_blocks_.notify_all();
-  }
   auto const peersWithoutBlock =
       selectPeers([&](TaraxaPeer const &_peer) { return !_peer.isBlockKnown(block.getHash()); });
 

--- a/src/network/taraxa_capability.cpp
+++ b/src/network/taraxa_capability.cpp
@@ -1146,8 +1146,7 @@ void TaraxaCapability::requestPbftNextVotes(NodeID const &peerID, uint64_t const
 }
 
 void TaraxaCapability::sendPbftNextVotes(NodeID const &peerID) {
-  std::vector<Vote> next_votes_bundle;
-  pbft_mgr_->getNextVotesForLastRound(next_votes_bundle);
+  std::vector<Vote> next_votes_bundle = pbft_mgr_->getNextVotesForPreviousRoundPtr()->getNextVotes();
   LOG(log_dg_next_votes_sync_) << "Send size of " << next_votes_bundle.size() << " PBFT next votes to " << peerID;
 
   RLPStream s;

--- a/src/network/taraxa_capability.hpp
+++ b/src/network/taraxa_capability.hpp
@@ -248,7 +248,6 @@ class TaraxaCapability : public CapabilityFace, public Worker {
   boost::thread_group delay_threads_;
   boost::asio::io_service io_service_;
   std::shared_ptr<boost::asio::io_service::work> io_work_;
-  unsigned long peer_syncing_pbft_chain_size_ = 1;
   uint64_t dag_level_ = 0;
   uint64_t pbft_sync_period_ = 1;
   NodeID peer_syncing_pbft_;

--- a/src/network/taraxa_capability.hpp
+++ b/src/network/taraxa_capability.hpp
@@ -89,6 +89,7 @@ class TaraxaPeer : public boost::noncopyable {
   uint64_t dag_level_ = 0;
   uint64_t pbft_chain_size_ = 0;
   uint64_t pbft_round_ = 1;
+  size_t pbft_previous_round_next_votes_size_ = 0;
 
  private:
   ExpirationCache<blk_hash_t> known_blocks_;
@@ -201,8 +202,9 @@ class TaraxaCapability : public CapabilityFace, public Worker {
   void sendPbftBlock(NodeID const &_id, taraxa::PbftBlock const &pbft_block, uint64_t const &pbft_chain_size);
   void requestPbftBlocks(NodeID const &_id, size_t height_to_sync);
   void sendPbftBlocks(NodeID const &_id, size_t height_to_sync, size_t blocks_to_transfer);
-  void syncPbftNextVotes(uint64_t const pbft_round);
-  void requestPbftNextVotes(NodeID const &peerID, uint64_t const pbft_round);
+  void syncPbftNextVotes(uint64_t const pbft_round, size_t const pbft_previous_round_next_votes_size);
+  void requestPbftNextVotes(NodeID const &peerID, uint64_t const pbft_round,
+                            size_t const pbft_previous_round_next_votes_size);
   void sendPbftNextVotes(NodeID const &peerID);
 
   // Peers
@@ -249,7 +251,7 @@ class TaraxaCapability : public CapabilityFace, public Worker {
   unsigned long peer_syncing_pbft_chain_size_ = 1;
   uint64_t dag_level_ = 0;
   uint64_t pbft_sync_period_ = 1;
-  NodeID peer_syncing_pbft;
+  NodeID peer_syncing_pbft_;
   std::string genesis_;
   bool performance_log_;
   mutable std::mt19937_64 urng_;  // Mersenne Twister psuedo-random number generator

--- a/src/network/taraxa_capability.hpp
+++ b/src/network/taraxa_capability.hpp
@@ -206,6 +206,7 @@ class TaraxaCapability : public CapabilityFace, public Worker {
   void requestPbftNextVotes(NodeID const &peerID, uint64_t const pbft_round,
                             size_t const pbft_previous_round_next_votes_size);
   void sendPbftNextVotes(NodeID const &peerID);
+  void broadcastPreviousRoundNextVotesBundle();
 
   // Peers
   std::shared_ptr<TaraxaPeer> getPeer(NodeID const &node_id);

--- a/src/network/taraxa_capability.hpp
+++ b/src/network/taraxa_capability.hpp
@@ -223,10 +223,6 @@ class TaraxaCapability : public CapabilityFace, public Worker {
   std::unordered_map<NodeID, int> cnt_received_messages_;
   std::unordered_map<NodeID, int> test_sums_;
 
-  std::set<blk_hash_t> verified_blocks_;
-  std::condition_variable condition_for_verified_blocks_;
-  std::mutex mtx_for_verified_blocks;
-
   // Only used for testing without the full node set
   std::map<blk_hash_t, taraxa::DagBlock> test_blocks_;
   std::map<trx_hash_t, Transaction> test_transactions_;

--- a/src/network/taraxa_capability.hpp
+++ b/src/network/taraxa_capability.hpp
@@ -107,8 +107,9 @@ class TaraxaCapability : public CapabilityFace, public Worker {
   TaraxaCapability(Host &_host, NetworkConfig &_conf, std::string const &genesis, bool const &performance_log,
                    addr_t node_addr, std::shared_ptr<DbStorage> db, std::shared_ptr<PbftManager> pbft_mgr,
                    std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<VoteManager> vote_mgr,
-                   std::shared_ptr<DagManager> dag_mgr, std::shared_ptr<DagBlockManager> dag_blk_mgr,
-                   std::shared_ptr<TransactionManager> trx_mgr, uint32_t lambda_ms_min)
+                   std::shared_ptr<NextVotesForPreviousRound> next_votes_mgr, std::shared_ptr<DagManager> dag_mgr,
+                   std::shared_ptr<DagBlockManager> dag_blk_mgr, std::shared_ptr<TransactionManager> trx_mgr,
+                   uint32_t lambda_ms_min)
       : Worker("taraxa"),
         host_(_host),
         conf_(_conf),
@@ -121,6 +122,7 @@ class TaraxaCapability : public CapabilityFace, public Worker {
         pbft_mgr_(pbft_mgr),
         pbft_chain_(pbft_chain),
         vote_mgr_(vote_mgr),
+        next_votes_mgr_(next_votes_mgr),
         dag_mgr_(dag_mgr),
         dag_blk_mgr_(dag_blk_mgr),
         trx_mgr_(trx_mgr),
@@ -232,6 +234,7 @@ class TaraxaCapability : public CapabilityFace, public Worker {
   std::shared_ptr<PbftManager> pbft_mgr_;
   std::shared_ptr<PbftChain> pbft_chain_;
   std::shared_ptr<VoteManager> vote_mgr_;
+  std::shared_ptr<NextVotesForPreviousRound> next_votes_mgr_;
   std::shared_ptr<DagManager> dag_mgr_;
   std::shared_ptr<DagBlockManager> dag_blk_mgr_;
   std::shared_ptr<TransactionManager> trx_mgr_;

--- a/src/node/full_node.cpp
+++ b/src/node/full_node.cpp
@@ -96,7 +96,7 @@ void FullNode::init() {
   }
   auto genesis_hash = conf_.chain.dag_genesis_block.getHash().toString();
   emplace(pbft_chain_, genesis_hash, node_addr, db_);
-  emplace(next_votes_mgr_, node_addr);
+  emplace(next_votes_mgr_, node_addr, db_);
   emplace(dag_mgr_, genesis_hash, node_addr, trx_mgr_, pbft_chain_, db_);
   emplace(dag_blk_mgr_, node_addr, conf_.chain.vdf, conf_.chain.final_chain.state.dpos, 1024 /*capacity*/,
           4 /* verifer thread*/, db_, trx_mgr_, final_chain_, pbft_chain_, log_time_,

--- a/src/node/full_node.cpp
+++ b/src/node/full_node.cpp
@@ -96,6 +96,7 @@ void FullNode::init() {
   }
   auto genesis_hash = conf_.chain.dag_genesis_block.getHash().toString();
   emplace(pbft_chain_, genesis_hash, node_addr, db_);
+  emplace(next_votes_mgr_, node_addr);
   emplace(dag_mgr_, genesis_hash, node_addr, trx_mgr_, pbft_chain_, db_);
   emplace(dag_blk_mgr_, node_addr, conf_.chain.vdf, conf_.chain.final_chain.state.dpos, 1024 /*capacity*/,
           4 /* verifer thread*/, db_, trx_mgr_, final_chain_, pbft_chain_, log_time_,
@@ -104,12 +105,12 @@ void FullNode::init() {
   emplace(trx_order_mgr_, node_addr, db_);
   emplace(executor_, node_addr, db_, dag_mgr_, trx_mgr_, final_chain_, pbft_chain_,
           conf_.test_params.block_proposer.transaction_limit);
-  emplace(pbft_mgr_, conf_.chain.pbft, genesis_hash, node_addr, db_, pbft_chain_, vote_mgr_, dag_mgr_, dag_blk_mgr_,
-          final_chain_, executor_, kp_.secret(), conf_.vrf_secret);
+  emplace(pbft_mgr_, conf_.chain.pbft, genesis_hash, node_addr, db_, pbft_chain_, vote_mgr_, next_votes_mgr_, dag_mgr_,
+          dag_blk_mgr_, final_chain_, executor_, kp_.secret(), conf_.vrf_secret);
   emplace(blk_proposer_, conf_.test_params.block_proposer, conf_.chain.vdf, dag_mgr_, trx_mgr_, dag_blk_mgr_,
           final_chain_, node_addr, getSecretKey(), getVrfSecretKey(), log_time_);
   emplace(network_, conf_.network, conf_.net_file_path().string(), kp_.secret(), genesis_hash, node_addr, db_,
-          pbft_mgr_, pbft_chain_, vote_mgr_, dag_mgr_, dag_blk_mgr_, trx_mgr_, kp_.pub(),
+          pbft_mgr_, pbft_chain_, vote_mgr_, next_votes_mgr_, dag_mgr_, dag_blk_mgr_, trx_mgr_, kp_.pub(),
           conf_.chain.pbft.lambda_ms_min);
 
   // Inits rpc related members

--- a/src/node/full_node.hpp
+++ b/src/node/full_node.hpp
@@ -154,11 +154,11 @@ class FullNode : public std::enable_shared_from_this<FullNode> {
   static constexpr uint16_t c_node_minor_version = 1;
 
   // Any time a change in the network protocol is introduced this version should be increased
-  static constexpr uint16_t c_network_protocol_version = 2;
+  static constexpr uint16_t c_network_protocol_version = 3;
 
   // Major version is modified when DAG blocks, pbft blocks and any basic building blocks of our blockchan is modified
   // in the db
-  static constexpr uint16_t c_database_major_version = 0;
+  static constexpr uint16_t c_database_major_version = 1;
   // Minor version should be modified when changes to the database are made in the tables that can be rebuilt from the
   // basic tables
   static constexpr uint16_t c_database_minor_version = 1;

--- a/src/node/full_node.hpp
+++ b/src/node/full_node.hpp
@@ -69,6 +69,7 @@ class FullNode : public std::enable_shared_from_this<FullNode> {
   std::shared_ptr<BlockProposer> blk_proposer_;
   std::vector<std::thread> block_workers_;
   std::shared_ptr<VoteManager> vote_mgr_;
+  std::shared_ptr<NextVotesForPreviousRound> next_votes_mgr_;
   std::shared_ptr<PbftManager> pbft_mgr_;
   std::shared_ptr<PbftChain> pbft_chain_;
   std::shared_ptr<Executor> executor_;
@@ -118,6 +119,7 @@ class FullNode : public std::enable_shared_from_this<FullNode> {
   auto const &getDB() const { return db_; }
   auto const &getPbftManager() const { return pbft_mgr_; }
   auto const &getVoteManager() const { return vote_mgr_; }
+  auto const &getNextVotesManager() const { return next_votes_mgr_; }
   auto const &getPbftChain() const { return pbft_chain_; }
   auto const &getExecutor() const { return executor_; }
   auto const &getFinalChain() const { return final_chain_; }

--- a/src/storage/db_storage.cpp
+++ b/src/storage/db_storage.cpp
@@ -430,6 +430,41 @@ void DbStorage::addPbftMgrVotedValueToBatch(PbftMgrVotedValue const& field, blk_
   batch_put(write_batch, Columns::pbft_mgr_voted_value, toSlice((uint8_t)field), toSlice(value.asBytes()));
 }
 
+shared_ptr<blk_hash_t> DbStorage::getPbftCertVotedBlockHash(uint64_t const& pbft_round) {
+  auto hash = asBytes(lookup(toSlice(pbft_round), Columns::pbft_cert_voted_block_hash));
+  if (hash.size() > 0) {
+    return make_shared<blk_hash_t>(hash);
+  }
+  return nullptr;
+}
+
+void DbStorage::savePbftCertVotedBlockHash(uint64_t const& pbft_round, blk_hash_t const& cert_voted_block_hash) {
+  insert(Columns::pbft_cert_voted_block_hash, toSlice(pbft_round), toSlice(cert_voted_block_hash.asBytes()));
+}
+
+void DbStorage::addPbftCertVotedBlockHashToBatch(uint64_t const& pbft_round, blk_hash_t const& cert_voted_block_hash,
+                                                 BatchPtr const& write_batch) {
+  batch_put(*write_batch, Columns::pbft_cert_voted_block_hash, toSlice(pbft_round),
+            toSlice(cert_voted_block_hash.asBytes()));
+}
+
+shared_ptr<PbftBlock> DbStorage::getPbftCertVotedBlock(blk_hash_t const& block_hash) {
+  auto block = lookup(toSlice(block_hash.asBytes()), Columns::pbft_cert_voted_block);
+  if (!block.empty()) {
+    return s_ptr(new PbftBlock(dev::RLP(block)));
+  }
+  return nullptr;
+}
+
+void DbStorage::savePbftCertVotedBlock(PbftBlock const& pbft_block) {
+  insert(Columns::pbft_cert_voted_block, toSlice(pbft_block.getBlockHash().asBytes()), toSlice(pbft_block.rlp(true)));
+}
+
+void DbStorage::addPbftCertVotedBlockToBatch(PbftBlock const& pbft_block, BatchPtr const& write_batch) {
+  batch_put(*write_batch, Columns::pbft_cert_voted_block, toSlice(pbft_block.getBlockHash().asBytes()),
+            toSlice(pbft_block.rlp(true)));
+}
+
 shared_ptr<blk_hash_t> DbStorage::getPbftChainPushedValue(uint64_t const& pbft_round) {
   auto hash = asBytes(lookup(toSlice(pbft_round), Columns::pbft_chain_pushed_values));
   if (hash.size() > 0) {

--- a/src/storage/db_storage.cpp
+++ b/src/storage/db_storage.cpp
@@ -380,6 +380,23 @@ void DbStorage::addPbftMgrFieldToBatch(PbftMgrRoundStep const& field, uint64_t c
   batch_put(write_batch, DbStorage::Columns::pbft_mgr_round_step, toSlice((uint8_t)field), toSlice(value));
 }
 
+size_t DbStorage::getPbft2TPlus1(uint64_t const& round) {
+  auto status = lookup(toSlice(round), Columns::pbft_round_2t_plus_1);
+  if (!status.empty()) {
+    return *(size_t*)&status[0];
+  }
+  return 0;
+}
+
+void DbStorage::savePbft2TPlus1(uint64_t const& pbft_round, size_t const& pbft_2t_plus_1) {
+  insert(Columns::pbft_round_2t_plus_1, toSlice(pbft_round), toSlice(pbft_2t_plus_1));
+}
+
+void DbStorage::addPbft2TPlus1ToBatch(uint64_t const& pbft_round, size_t const& pbft_2t_plus_1,
+                                      BatchPtr const& write_batch) {
+  batch_put(write_batch, DbStorage::Columns::pbft_round_2t_plus_1, toSlice(pbft_round), toSlice(pbft_2t_plus_1));
+}
+
 bool DbStorage::getPbftMgrStatus(PbftMgrStatus const& field) {
   auto status = lookup(toSlice((uint8_t)field), Columns::pbft_mgr_status);
   if (!status.empty()) {

--- a/src/storage/db_storage.cpp
+++ b/src/storage/db_storage.cpp
@@ -465,23 +465,6 @@ void DbStorage::addPbftCertVotedBlockToBatch(PbftBlock const& pbft_block, BatchP
             toSlice(pbft_block.rlp(true)));
 }
 
-shared_ptr<blk_hash_t> DbStorage::getPbftChainPushedValue(uint64_t const& pbft_round) {
-  auto hash = asBytes(lookup(toSlice(pbft_round), Columns::pbft_chain_pushed_values));
-  if (hash.size() > 0) {
-    return make_shared<blk_hash_t>(hash);
-  }
-  return nullptr;
-}
-
-void DbStorage::savePbftChainPushedValue(uint64_t const& pbft_round, blk_hash_t const& pushed_block_hash) {
-  insert(Columns::pbft_chain_pushed_values, toSlice(pbft_round), toSlice(pushed_block_hash.asBytes()));
-}
-
-void DbStorage::addPbftChainPushedValueToBatch(uint64_t const& pbft_round, blk_hash_t const& pushed_block_hash,
-                                               BatchPtr const& write_batch) {
-  batch_put(write_batch, Columns::pbft_chain_pushed_values, toSlice(pbft_round), toSlice(pushed_block_hash.asBytes()));
-}
-
 std::shared_ptr<PbftBlock> DbStorage::getPbftBlock(blk_hash_t const& hash) {
   auto block = lookup(hash, Columns::pbft_blocks);
   if (!block.empty()) {

--- a/src/storage/db_storage.cpp
+++ b/src/storage/db_storage.cpp
@@ -430,6 +430,23 @@ void DbStorage::addPbftMgrVotedValueToBatch(PbftMgrVotedValue const& field, blk_
   batch_put(write_batch, Columns::pbft_mgr_voted_value, toSlice((uint8_t)field), toSlice(value.asBytes()));
 }
 
+shared_ptr<blk_hash_t> DbStorage::getPbftChainPushedValue(uint64_t const& pbft_round) {
+  auto hash = asBytes(lookup(toSlice(pbft_round), Columns::pbft_chain_pushed_values));
+  if (hash.size() > 0) {
+    return make_shared<blk_hash_t>(hash);
+  }
+  return nullptr;
+}
+
+void DbStorage::savePbftChainPushedValue(uint64_t const& pbft_round, blk_hash_t const& pushed_block_hash) {
+  insert(Columns::pbft_chain_pushed_values, toSlice(pbft_round), toSlice(pushed_block_hash.asBytes()));
+}
+
+void DbStorage::addPbftChainPushedValueToBatch(uint64_t const& pbft_round, blk_hash_t const& pushed_block_hash,
+                                               BatchPtr const& write_batch) {
+  batch_put(write_batch, Columns::pbft_chain_pushed_values, toSlice(pbft_round), toSlice(pushed_block_hash.asBytes()));
+}
+
 std::shared_ptr<PbftBlock> DbStorage::getPbftBlock(blk_hash_t const& hash) {
   auto block = lookup(hash, Columns::pbft_blocks);
   if (!block.empty()) {

--- a/src/storage/db_storage.hpp
+++ b/src/storage/db_storage.hpp
@@ -190,8 +190,12 @@ struct DbStorage {
   void addPbftMgrStatusToBatch(PbftMgrStatus const& field, bool const& value, BatchPtr const& write_batch);
   shared_ptr<blk_hash_t> getPbftMgrVotedValue(PbftMgrVotedValue const& field);
   void savePbftMgrVotedValue(PbftMgrVotedValue const& field, blk_hash_t const& value);
+<<<<<<< HEAD
   void addPbftMgrVotedValueToBatch(PbftMgrVotedValue const& field, blk_hash_t const& value,
                                    BatchPtr const& write_batch);
+=======
+  void addPbftMgrVotedValueToBatch(PbftMgrVotedValue const& field, blk_hash_t const& value, BatchPtr const& write_batch);
+>>>>>>> 7b4f5b8c (Add fields of PBFT manager in DB, and add unit tests)
 
   // pbft_blocks
   shared_ptr<PbftBlock> getPbftBlock(blk_hash_t const& hash);

--- a/src/storage/db_storage.hpp
+++ b/src/storage/db_storage.hpp
@@ -93,11 +93,9 @@ struct DbStorage {
     COLUMN(trx_status);
     COLUMN(status);
     COLUMN(pbft_mgr_round_step);
+    COLUMN(pbft_round_2t_plus_1);
     COLUMN(pbft_mgr_status);
     COLUMN(pbft_mgr_voted_value);
-    COLUMN(pbft_mgr_own_starting_value);
-    COLUMN(pbft_mgr_soft_voted_block);
-    COLUMN(pbft_mgr_next_voted_block_in_previous_round);
     COLUMN(pbft_head);
     COLUMN(pbft_blocks);
     COLUMN(cert_votes);
@@ -184,9 +182,15 @@ struct DbStorage {
   uint64_t getPbftMgrField(PbftMgrRoundStep const& field);
   void savePbftMgrField(PbftMgrRoundStep const& field, uint64_t const& value);
   void addPbftMgrFieldToBatch(PbftMgrRoundStep const& field, uint64_t const& value, BatchPtr const& write_batch);
+
+  size_t getPbft2TPlus1(uint64_t const& pbft_round);
+  void savePbft2TPlus1(uint64_t const& pbft_round, size_t const& pbft_2t_plus_1);
+  void addPbft2TPlus1ToBatch(uint64_t const& pbft_round, size_t const& pbft_2t_plus_1, BatchPtr const& write_batch);
+
   bool getPbftMgrStatus(PbftMgrStatus const& field);
   void savePbftMgrStatus(PbftMgrStatus const& field, bool const& value);
   void addPbftMgrStatusToBatch(PbftMgrStatus const& field, bool const& value, BatchPtr const& write_batch);
+
   shared_ptr<blk_hash_t> getPbftMgrVotedValue(PbftMgrVotedValue const& field);
   void savePbftMgrVotedValue(PbftMgrVotedValue const& field, blk_hash_t const& value);
   void addPbftMgrVotedValueToBatch(PbftMgrVotedValue const& field, blk_hash_t const& value,

--- a/src/storage/db_storage.hpp
+++ b/src/storage/db_storage.hpp
@@ -99,6 +99,7 @@ struct DbStorage {
     COLUMN(pbft_cert_voted_block);
     COLUMN(pbft_head);
     COLUMN(pbft_blocks);
+    COLUMN(soft_votes);
     COLUMN(cert_votes);
     COLUMN(next_votes);
     COLUMN(period_pbft_block);
@@ -222,6 +223,14 @@ struct DbStorage {
   void saveStatusField(StatusDbField const& field,
                        uint64_t const& value);  // unit test
   void addStatusFieldToBatch(StatusDbField const& field, uint64_t const& value, BatchPtr const& write_batch);
+
+  // Soft votes
+  std::vector<Vote> getSoftVotes(uint64_t const& pbft_round);
+  void saveSoftVotes(uint64_t const& pbft_round, std::vector<Vote> const& soft_votes);
+  void addSoftVotesToBatch(uint64_t const& pbft_round, std::vector<Vote> const& soft_votes,
+                           BatchPtr const& write_batch);
+  void removeSoftVotesToBatch(uint64_t const& pbft_round, BatchPtr const& write_batch);
+
   // Certified votes
   std::vector<Vote> getCertVotes(blk_hash_t const& hash);
   void addCertVotesToBatch(taraxa::blk_hash_t const& pbft_block_hash, std::vector<Vote> const& cert_votes,

--- a/src/storage/db_storage.hpp
+++ b/src/storage/db_storage.hpp
@@ -190,12 +190,8 @@ struct DbStorage {
   void addPbftMgrStatusToBatch(PbftMgrStatus const& field, bool const& value, BatchPtr const& write_batch);
   shared_ptr<blk_hash_t> getPbftMgrVotedValue(PbftMgrVotedValue const& field);
   void savePbftMgrVotedValue(PbftMgrVotedValue const& field, blk_hash_t const& value);
-<<<<<<< HEAD
   void addPbftMgrVotedValueToBatch(PbftMgrVotedValue const& field, blk_hash_t const& value,
                                    BatchPtr const& write_batch);
-=======
-  void addPbftMgrVotedValueToBatch(PbftMgrVotedValue const& field, blk_hash_t const& value, BatchPtr const& write_batch);
->>>>>>> 7b4f5b8c (Add fields of PBFT manager in DB, and add unit tests)
 
   // pbft_blocks
   shared_ptr<PbftBlock> getPbftBlock(blk_hash_t const& hash);

--- a/src/storage/db_storage.hpp
+++ b/src/storage/db_storage.hpp
@@ -96,6 +96,7 @@ struct DbStorage {
     COLUMN(pbft_round_2t_plus_1);
     COLUMN(pbft_mgr_status);
     COLUMN(pbft_mgr_voted_value);
+    COLUMN(pbft_chain_pushed_values);
     COLUMN(pbft_head);
     COLUMN(pbft_blocks);
     COLUMN(cert_votes);
@@ -195,6 +196,11 @@ struct DbStorage {
   void savePbftMgrVotedValue(PbftMgrVotedValue const& field, blk_hash_t const& value);
   void addPbftMgrVotedValueToBatch(PbftMgrVotedValue const& field, blk_hash_t const& value,
                                    BatchPtr const& write_batch);
+
+  shared_ptr<blk_hash_t> getPbftChainPushedValue(uint64_t const& pbft_round);
+  void savePbftChainPushedValue(uint64_t const& pbft_round, blk_hash_t const& pushed_block_hash);
+  void addPbftChainPushedValueToBatch(uint64_t const& pbft_round, blk_hash_t const& pushed_block_hash,
+                                      BatchPtr const& write_batch);
 
   // pbft_blocks
   shared_ptr<PbftBlock> getPbftBlock(blk_hash_t const& hash);

--- a/src/storage/db_storage.hpp
+++ b/src/storage/db_storage.hpp
@@ -97,7 +97,6 @@ struct DbStorage {
     COLUMN(pbft_mgr_voted_value);
     COLUMN(pbft_cert_voted_block_hash);
     COLUMN(pbft_cert_voted_block);
-    COLUMN(pbft_chain_pushed_values);
     COLUMN(pbft_head);
     COLUMN(pbft_blocks);
     COLUMN(cert_votes);
@@ -206,11 +205,6 @@ struct DbStorage {
   shared_ptr<PbftBlock> getPbftCertVotedBlock(blk_hash_t const& block_hash);
   void savePbftCertVotedBlock(PbftBlock const& pbft_block);
   void addPbftCertVotedBlockToBatch(PbftBlock const& pbft_block, BatchPtr const& write_batch);
-
-  shared_ptr<blk_hash_t> getPbftChainPushedValue(uint64_t const& pbft_round);
-  void savePbftChainPushedValue(uint64_t const& pbft_round, blk_hash_t const& pushed_block_hash);
-  void addPbftChainPushedValueToBatch(uint64_t const& pbft_round, blk_hash_t const& pushed_block_hash,
-                                      BatchPtr const& write_batch);
 
   // pbft_blocks
   shared_ptr<PbftBlock> getPbftBlock(blk_hash_t const& hash);

--- a/src/storage/db_storage.hpp
+++ b/src/storage/db_storage.hpp
@@ -40,12 +40,10 @@ enum PbftMgrStatus {
   cert_voted_in_round,
   next_voted_soft_value,
   next_voted_null_block_hash,
-  next_voted_block_in_previous_round
 };
 enum PbftMgrVotedValue {
   own_starting_value_in_round = 0,
   soft_voted_block_hash_in_round,
-  next_voted_block_hash_in_previous_round,
 };
 
 class DbException : public exception {
@@ -102,7 +100,8 @@ struct DbStorage {
     COLUMN(pbft_mgr_next_voted_block_in_previous_round);
     COLUMN(pbft_head);
     COLUMN(pbft_blocks);
-    COLUMN(votes);
+    COLUMN(cert_votes);
+    COLUMN(next_votes);
     COLUMN(period_pbft_block);
     COLUMN(dag_block_period);
     COLUMN(replay_protection);
@@ -209,10 +208,15 @@ struct DbStorage {
   void saveStatusField(StatusDbField const& field,
                        uint64_t const& value);  // unit test
   void addStatusFieldToBatch(StatusDbField const& field, uint64_t const& value, BatchPtr const& write_batch);
-  // votes
-  bytes getVotes(blk_hash_t const& hash);
-  void addPbftCertVotesToBatch(taraxa::blk_hash_t const& pbft_block_hash, std::vector<Vote> const& cert_votes,
-                               BatchPtr const& write_batch);
+  // Certified votes
+  std::vector<Vote> getCertVotes(blk_hash_t const& hash);
+  void addCertVotesToBatch(taraxa::blk_hash_t const& pbft_block_hash, std::vector<Vote> const& cert_votes,
+                           BatchPtr const& write_batch);
+  // Next votes
+  std::vector<Vote> getNextVotes(uint64_t const& pbft_round);
+  void saveNextVotes(uint64_t const& pbft_round, std::vector<Vote> const& next_votes);
+  void addNextVotesToBatch(uint64_t const& pbft_round, std::vector<Vote> const& next_votes,
+                           BatchPtr const& write_batch);
   // period_pbft_block
   shared_ptr<blk_hash_t> getPeriodPbftBlock(uint64_t const& period);
   void addPbftBlockPeriodToBatch(uint64_t const& period, taraxa::blk_hash_t const& pbft_block_hash,

--- a/src/storage/db_storage.hpp
+++ b/src/storage/db_storage.hpp
@@ -37,7 +37,6 @@ enum PbftMgrStatus {
   soft_voted_block_in_round = 0,
   executed_block,
   executed_in_round,
-  cert_voted_in_round,
   next_voted_soft_value,
   next_voted_null_block_hash,
 };
@@ -96,6 +95,8 @@ struct DbStorage {
     COLUMN(pbft_round_2t_plus_1);
     COLUMN(pbft_mgr_status);
     COLUMN(pbft_mgr_voted_value);
+    COLUMN(pbft_cert_voted_block_hash);
+    COLUMN(pbft_cert_voted_block);
     COLUMN(pbft_chain_pushed_values);
     COLUMN(pbft_head);
     COLUMN(pbft_blocks);
@@ -196,6 +197,15 @@ struct DbStorage {
   void savePbftMgrVotedValue(PbftMgrVotedValue const& field, blk_hash_t const& value);
   void addPbftMgrVotedValueToBatch(PbftMgrVotedValue const& field, blk_hash_t const& value,
                                    BatchPtr const& write_batch);
+
+  shared_ptr<blk_hash_t> getPbftCertVotedBlockHash(uint64_t const& pbft_round);
+  void savePbftCertVotedBlockHash(uint64_t const& pbft_round, blk_hash_t const& cert_voted_block_hash);
+  void addPbftCertVotedBlockHashToBatch(uint64_t const& pbft_round, blk_hash_t const& cert_voted_block_hash,
+                                        BatchPtr const& write_batch);
+
+  shared_ptr<PbftBlock> getPbftCertVotedBlock(blk_hash_t const& block_hash);
+  void savePbftCertVotedBlock(PbftBlock const& pbft_block);
+  void addPbftCertVotedBlockToBatch(PbftBlock const& pbft_block, BatchPtr const& write_batch);
 
   shared_ptr<blk_hash_t> getPbftChainPushedValue(uint64_t const& pbft_round);
   void savePbftChainPushedValue(uint64_t const& pbft_round, blk_hash_t const& pushed_block_hash);

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -165,6 +165,7 @@ TEST_F(FullNodeTest, db_test) {
   EXPECT_FALSE(db.getPbftMgrStatus(PbftMgrStatus::cert_voted_in_round));
   EXPECT_FALSE(db.getPbftMgrStatus(PbftMgrStatus::next_voted_soft_value));
   EXPECT_FALSE(db.getPbftMgrStatus(PbftMgrStatus::next_voted_null_block_hash));
+
   // PBFT manager voted value
   EXPECT_EQ(db.getPbftMgrVotedValue(PbftMgrVotedValue::own_starting_value_in_round), nullptr);
   EXPECT_EQ(db.getPbftMgrVotedValue(PbftMgrVotedValue::soft_voted_block_hash_in_round), nullptr);
@@ -178,6 +179,18 @@ TEST_F(FullNodeTest, db_test) {
   db.commitWriteBatch(batch);
   EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::own_starting_value_in_round), blk_hash_t(4));
   EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::soft_voted_block_hash_in_round), blk_hash_t(5));
+
+  // PBFT pushed block hash
+  EXPECT_EQ(db.getPbftChainPushedValue(1), nullptr);
+  db.savePbftChainPushedValue(1, blk_hash_t(1));
+  EXPECT_EQ(*db.getPbftChainPushedValue(1), blk_hash_t(1));
+  batch = db.createWriteBatch();
+  db.addPbftChainPushedValueToBatch(1, blk_hash_t(2), batch);
+  db.addPbftChainPushedValueToBatch(2, blk_hash_t(3), batch);
+  db.commitWriteBatch(batch);
+  EXPECT_EQ(*db.getPbftChainPushedValue(1), blk_hash_t(2));
+  EXPECT_EQ(*db.getPbftChainPushedValue(2), blk_hash_t(3));
+
   // pbft_blocks
   auto pbft_block1 = make_simple_pbft_block(blk_hash_t(1), 2);
   auto pbft_block2 = make_simple_pbft_block(blk_hash_t(2), 3);

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -205,18 +205,9 @@ TEST_F(FullNodeTest, db_test) {
   EXPECT_EQ(db.getPbftCertVotedBlock(pbft_block3.getBlockHash())->rlp(false), pbft_block3.rlp(false));
   EXPECT_EQ(db.getPbftCertVotedBlock(pbft_block4.getBlockHash())->rlp(false), pbft_block4.rlp(false));
 
-  // PBFT pushed block hash
-  EXPECT_EQ(db.getPbftChainPushedValue(1), nullptr);
-  db.savePbftChainPushedValue(1, blk_hash_t(1));
-  EXPECT_EQ(*db.getPbftChainPushedValue(1), blk_hash_t(1));
-  batch = db.createWriteBatch();
-  db.addPbftChainPushedValueToBatch(1, blk_hash_t(2), batch);
-  db.addPbftChainPushedValueToBatch(2, blk_hash_t(3), batch);
-  db.commitWriteBatch(batch);
-  EXPECT_EQ(*db.getPbftChainPushedValue(1), blk_hash_t(2));
-  EXPECT_EQ(*db.getPbftChainPushedValue(2), blk_hash_t(3));
-
   // pbft_blocks
+  EXPECT_FALSE(db.pbftBlockInDb(blk_hash_t(0)));
+  EXPECT_FALSE(db.pbftBlockInDb(blk_hash_t(1)));
   pbft_block1 = make_simple_pbft_block(blk_hash_t(1), 2);
   pbft_block2 = make_simple_pbft_block(blk_hash_t(2), 3);
   pbft_block3 = make_simple_pbft_block(blk_hash_t(3), 4);

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -121,6 +121,17 @@ TEST_F(FullNodeTest, db_test) {
   db.commitWriteBatch(batch);
   EXPECT_EQ(db.getPbftMgrField(PbftMgrRoundStep::PbftRound), pbft_round);
   EXPECT_EQ(db.getPbftMgrField(PbftMgrRoundStep::PbftStep), pbft_step);
+
+  // PBFT 2t+1
+  db.savePbft2TPlus1(10, 3);
+  EXPECT_EQ(db.getPbft2TPlus1(10), 3);
+  batch = db.createWriteBatch();
+  db.addPbft2TPlus1ToBatch(10, 6, batch);
+  db.addPbft2TPlus1ToBatch(11, 3, batch);
+  db.commitWriteBatch(batch);
+  EXPECT_EQ(db.getPbft2TPlus1(10), 6);
+  EXPECT_EQ(db.getPbft2TPlus1(11), 3);
+
   // PBFT manager status
   EXPECT_FALSE(db.getPbftMgrStatus(PbftMgrStatus::soft_voted_block_in_round));
   EXPECT_FALSE(db.getPbftMgrStatus(PbftMgrStatus::executed_block));

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -166,17 +166,29 @@ TEST_F(FullNodeTest, db_test) {
   db.savePbftMgrVotedValue(PbftMgrVotedValue::own_starting_value_in_round, blk_hash_t(1));
   db.savePbftMgrVotedValue(PbftMgrVotedValue::soft_voted_block_hash_in_round, blk_hash_t(2));
   db.savePbftMgrVotedValue(PbftMgrVotedValue::next_voted_block_hash_in_previous_round, blk_hash_t(3));
+<<<<<<< HEAD
   EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::own_starting_value_in_round), blk_hash_t(1));
   EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::soft_voted_block_hash_in_round), blk_hash_t(2));
   EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::next_voted_block_hash_in_previous_round), blk_hash_t(3));
+=======
+  EXPECT_EQ(db.getPbftMgrVotedValue(PbftMgrVotedValue::own_starting_value_in_round), blk_hash_t(1));
+  EXPECT_EQ(db.getPbftMgrVotedValue(PbftMgrVotedValue::soft_voted_block_hash_in_round), blk_hash_t(2));
+  EXPECT_EQ(db.getPbftMgrVotedValue(PbftMgrVotedValue::next_voted_block_hash_in_previous_round), blk_hash_t(3));
+>>>>>>> 7b4f5b8c (Add fields of PBFT manager in DB, and add unit tests)
   batch = db.createWriteBatch();
   db.addPbftMgrVotedValueToBatch(PbftMgrVotedValue::own_starting_value_in_round, blk_hash_t(4), batch);
   db.addPbftMgrVotedValueToBatch(PbftMgrVotedValue::soft_voted_block_hash_in_round, blk_hash_t(5), batch);
   db.addPbftMgrVotedValueToBatch(PbftMgrVotedValue::next_voted_block_hash_in_previous_round, blk_hash_t(6), batch);
   db.commitWriteBatch(batch);
+<<<<<<< HEAD
   EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::own_starting_value_in_round), blk_hash_t(4));
   EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::soft_voted_block_hash_in_round), blk_hash_t(5));
   EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::next_voted_block_hash_in_previous_round), blk_hash_t(6));
+=======
+  EXPECT_EQ(db.getPbftMgrVotedValue(PbftMgrVotedValue::own_starting_value_in_round), blk_hash_t(4));
+  EXPECT_EQ(db.getPbftMgrVotedValue(PbftMgrVotedValue::soft_voted_block_hash_in_round), blk_hash_t(5));
+  EXPECT_EQ(db.getPbftMgrVotedValue(PbftMgrVotedValue::next_voted_block_hash_in_previous_round), blk_hash_t(6));
+>>>>>>> 7b4f5b8c (Add fields of PBFT manager in DB, and add unit tests)
   // pbft_blocks
   auto pbft_block1 = make_simple_pbft_block(blk_hash_t(1), 2);
   auto pbft_block2 = make_simple_pbft_block(blk_hash_t(2), 3);

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -166,29 +166,17 @@ TEST_F(FullNodeTest, db_test) {
   db.savePbftMgrVotedValue(PbftMgrVotedValue::own_starting_value_in_round, blk_hash_t(1));
   db.savePbftMgrVotedValue(PbftMgrVotedValue::soft_voted_block_hash_in_round, blk_hash_t(2));
   db.savePbftMgrVotedValue(PbftMgrVotedValue::next_voted_block_hash_in_previous_round, blk_hash_t(3));
-<<<<<<< HEAD
   EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::own_starting_value_in_round), blk_hash_t(1));
   EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::soft_voted_block_hash_in_round), blk_hash_t(2));
   EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::next_voted_block_hash_in_previous_round), blk_hash_t(3));
-=======
-  EXPECT_EQ(db.getPbftMgrVotedValue(PbftMgrVotedValue::own_starting_value_in_round), blk_hash_t(1));
-  EXPECT_EQ(db.getPbftMgrVotedValue(PbftMgrVotedValue::soft_voted_block_hash_in_round), blk_hash_t(2));
-  EXPECT_EQ(db.getPbftMgrVotedValue(PbftMgrVotedValue::next_voted_block_hash_in_previous_round), blk_hash_t(3));
->>>>>>> 7b4f5b8c (Add fields of PBFT manager in DB, and add unit tests)
   batch = db.createWriteBatch();
   db.addPbftMgrVotedValueToBatch(PbftMgrVotedValue::own_starting_value_in_round, blk_hash_t(4), batch);
   db.addPbftMgrVotedValueToBatch(PbftMgrVotedValue::soft_voted_block_hash_in_round, blk_hash_t(5), batch);
   db.addPbftMgrVotedValueToBatch(PbftMgrVotedValue::next_voted_block_hash_in_previous_round, blk_hash_t(6), batch);
   db.commitWriteBatch(batch);
-<<<<<<< HEAD
   EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::own_starting_value_in_round), blk_hash_t(4));
   EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::soft_voted_block_hash_in_round), blk_hash_t(5));
   EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::next_voted_block_hash_in_previous_round), blk_hash_t(6));
-=======
-  EXPECT_EQ(db.getPbftMgrVotedValue(PbftMgrVotedValue::own_starting_value_in_round), blk_hash_t(4));
-  EXPECT_EQ(db.getPbftMgrVotedValue(PbftMgrVotedValue::soft_voted_block_hash_in_round), blk_hash_t(5));
-  EXPECT_EQ(db.getPbftMgrVotedValue(PbftMgrVotedValue::next_voted_block_hash_in_previous_round), blk_hash_t(6));
->>>>>>> 7b4f5b8c (Add fields of PBFT manager in DB, and add unit tests)
   // pbft_blocks
   auto pbft_block1 = make_simple_pbft_block(blk_hash_t(1), 2);
   auto pbft_block2 = make_simple_pbft_block(blk_hash_t(2), 3);

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -214,7 +214,7 @@ TEST_F(FullNodeTest, db_test) {
   // Certified votes
   std::vector<Vote> cert_votes;
   blk_hash_t last_pbft_block_hash(0);
-  VrfPbftMsg msg(last_pbft_block_hash, propose_vote_type, 1, 3);
+  VrfPbftMsg msg(last_pbft_block_hash, soft_vote_type, 1, 2);
   vrf_wrapper::vrf_sk_t vrf_sk(
       "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
       "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
@@ -226,7 +226,7 @@ TEST_F(FullNodeTest, db_test) {
   batch = db.createWriteBatch();
   db.addCertVotesToBatch(voted_pbft_block_hash, cert_votes, batch);
   db.commitWriteBatch(batch);
-  auto pbft_block = make_simple_pbft_block(voted_pbft_block_hash, 2);
+  auto pbft_block = make_simple_pbft_block(voted_pbft_block_hash, 1);
   PbftBlockCert pbft_block_cert_votes(pbft_block, cert_votes);
   auto cert_votes_from_db = db.getCertVotes(voted_pbft_block_hash);
   PbftBlockCert pbft_block_cert_votes_from_db(pbft_block, cert_votes_from_db);

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -328,7 +328,7 @@ TEST_F(NetworkTest, node_pbft_sync) {
       node1->getPbftManager()->generateVote(pbft_block1.getBlockHash(), cert_vote_type, 1, 3, prev_block_hash));
   std::cout << "Generate 1 vote for first PBFT block" << std::endl;
   // Add cert votes in DB
-  db1->addPbftCertVotesToBatch(pbft_block1.getBlockHash(), votes_for_pbft_blk1, batch);
+  db1->addCertVotesToBatch(pbft_block1.getBlockHash(), votes_for_pbft_blk1, batch);
   // Add PBFT block in DB
   db1->addPbftBlockToBatch(pbft_block1, batch);
   // Update period_pbft_block in DB
@@ -366,7 +366,7 @@ TEST_F(NetworkTest, node_pbft_sync) {
   std::cout << "Generate 1 vote for second PBFT block" << std::endl;
   // node1 put block2 into pbft chain and store into DB
   // Add cert votes in DB
-  db1->addPbftCertVotesToBatch(pbft_block2.getBlockHash(), votes_for_pbft_blk2, batch);
+  db1->addCertVotesToBatch(pbft_block2.getBlockHash(), votes_for_pbft_blk2, batch);
   // Add PBFT block in DB
   db1->addPbftBlockToBatch(pbft_block2, batch);
   // Update period_pbft_block in DB
@@ -452,7 +452,7 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
       node1->getPbftManager()->generateVote(pbft_block1.getBlockHash(), cert_vote_type, 1, 3, prev_block_hash));
   std::cout << "Generate 1 vote for first PBFT block" << std::endl;
   // Add cert votes in DB
-  db1->addPbftCertVotesToBatch(pbft_block1.getBlockHash(), votes_for_pbft_blk1, batch);
+  db1->addCertVotesToBatch(pbft_block1.getBlockHash(), votes_for_pbft_blk1, batch);
   // Add PBFT block in DB
   db1->addPbftBlockToBatch(pbft_block1, batch);
   // Update period_pbft_block in DB
@@ -488,7 +488,7 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   std::cout << "Use fake votes for the second PBFT block" << std::endl;
   // node1 put block2 into pbft chain and use fake votes storing into DB (malicious player)
   // Add fake votes in DB
-  db1->addPbftCertVotesToBatch(pbft_block2.getBlockHash(), votes_for_pbft_blk1, batch);
+  db1->addCertVotesToBatch(pbft_block2.getBlockHash(), votes_for_pbft_blk1, batch);
   // Add PBFT block in DB
   db1->addPbftBlockToBatch(pbft_block2, batch);
   // Update period_pbft_block in DB
@@ -556,7 +556,7 @@ TEST_F(NetworkTest, pbft_next_votes_bundle_sync) {
     next_votes.emplace_back(vote);
   }
   // Update next votes bundle and set PBFT round
-  pbft_mgr1->updateNextVotesForRound(next_votes);
+  pbft_mgr1->getNextVotesForPreviousRoundPtr()->update(next_votes);
   pbft_mgr1->setPbftRound(11);  // Make sure node2 round less than node1
 
   // Start node2

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -182,8 +182,7 @@ TEST_F(NetworkTest, save_network) {
   ASSERT_EQ(1, nw3->getPeerCount());
 }
 
-// Test creates one node with testnet network ID and one node with main ID and
-// verifies that connection fails
+// Test creates one node with testnet network ID and one node with main ID and verifies that connection fails
 TEST_F(NetworkTest, node_network_id) {
   auto node_cfgs = make_node_cfgs(2);
   {

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -166,10 +166,10 @@ TEST_F(NetworkTest, save_network) {
 
   std::shared_ptr<Network> nw2(
       new taraxa::Network(g_conf2->network, "/tmp/nw2", g_conf2->chain.dag_genesis_block.getHash().toString(), addr_t(),
-                          nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, public_t(), 2000));
+                          nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, public_t(), 2000));
   std::shared_ptr<Network> nw3(
       new taraxa::Network(g_conf3->network, "/tmp/nw3", g_conf2->chain.dag_genesis_block.getHash().toString(), addr_t(),
-                          nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, public_t(), 2000));
+                          nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, public_t(), 2000));
   nw2->start();
   nw3->start();
 
@@ -546,7 +546,7 @@ TEST_F(NetworkTest, pbft_next_votes_bundle_sync) {
   // Generate 3 next votes
   std::vector<Vote> next_votes;
   for (auto i = 0; i < 3; i++) {
-    blk_hash_t propose_pbft_block_hash(i + 1);
+    blk_hash_t propose_pbft_block_hash(i % 2);  // Next votes could vote on 2 values
     blk_hash_t last_pbft_block_hash(i);
     PbftVoteTypes type = next_vote_type;
     uint64_t round = 10;
@@ -864,7 +864,7 @@ TEST_F(NetworkTest, node_transaction_sync) {
 // intervals on randomly selected nodes It verifies that the blocks created from
 // these transactions which get created on random nodes are synced and the
 // resulting DAG is the same on all nodes
-TEST_F(NetworkTest, node_full_sync) {
+TEST_F(NetworkTest, DISABLED_node_full_sync) {
   constexpr auto numberOfNodes = 5;
   auto node_cfgs = make_node_cfgs<20>(numberOfNodes);
   auto nodes = launch_nodes(slice(node_cfgs, 0, numberOfNodes - 1));

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -538,11 +538,13 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
 
 // Test PBFT next votes bundle network propagation
 TEST_F(NetworkTest, pbft_next_votes_bundle_sync) {
-  auto node_cfgs = make_node_cfgs<5>(2);
+  auto node_cfgs = make_node_cfgs<20>(2);
   FullNode::Handle node1(node_cfgs[0], true);
+
   // Stop PBFT manager, that will place vote
   std::shared_ptr<PbftManager> pbft_mgr1 = node1->getPbftManager();
   pbft_mgr1->stop();
+
   // Generate 3 next votes
   std::vector<Vote> next_votes;
   for (auto i = 0; i < 3; i++) {
@@ -551,15 +553,19 @@ TEST_F(NetworkTest, pbft_next_votes_bundle_sync) {
     PbftVoteTypes type = next_vote_type;
     uint64_t round = 10;
     size_t step = 21;
-    Vote vote = node1->getPbftManager()->generateVote(propose_pbft_block_hash, type, round, step, last_pbft_block_hash);
+    Vote vote = pbft_mgr1->generateVote(propose_pbft_block_hash, type, round, step, last_pbft_block_hash);
     next_votes.emplace_back(vote);
   }
+
   // Update next votes bundle and set PBFT round
-  pbft_mgr1->getNextVotesForPreviousRoundPtr()->update(next_votes);
+  node1->getNextVotesManager()->update(next_votes);
   pbft_mgr1->setPbftRound(11);  // Make sure node2 round less than node1
 
-  // Start node2
   FullNode::Handle node2(node_cfgs[1], true);
+  // Stop PBFT manager, that will place vote
+  std::shared_ptr<PbftManager> pbft_mgr2 = node2->getPbftManager();
+  pbft_mgr2->stop();
+
   std::shared_ptr<Network> nw1 = node1->getNetwork();
   std::shared_ptr<Network> nw2 = node2->getNetwork();
   // Wait node1 and node2 connect to each other
@@ -573,19 +579,22 @@ TEST_F(NetworkTest, pbft_next_votes_bundle_sync) {
   }
   EXPECT_EQ(nw1->getPeerCount(), 1);
   EXPECT_EQ(nw2->getPeerCount(), 1);
-  // Stop PBFT manager, that will place vote
-  std::shared_ptr<PbftManager> pbft_mgr2 = node2->getPbftManager();
-  pbft_mgr2->stop();
+
   node2->getVoteManager()->clearUnverifiedVotesTable();
-  // Wait 6 PBFT lambda time for sending network status, 2000 / 5 * 6 = 2400
-  taraxa::thisThreadSleepForMilliSeconds(2400);
-  // node2 sync next votes bundle from node1
-  uint64_t node2_pbft_round = 10;
-  nw2->getTaraxaCapability()->syncPbftNextVotes(node2_pbft_round);
-  // Waiting node2 get next votes bundle from node1
-  taraxa::thisThreadSleepForMilliSeconds(100);
-  size_t node2_vote_queue_size = node2->getVoteManager()->getUnverifiedVotesSize();
-  EXPECT_EQ(node2_vote_queue_size, next_votes.size());
+
+  auto expect_size = next_votes.size();
+  auto node2_vote_mgr = node2->getVoteManager();
+  auto node2_next_votes_size = node2_vote_mgr->getUnverifiedVotesSize();
+  for (auto i = 0; i < 10; i++) {
+    if (node2_next_votes_size == expect_size) {
+      break;
+    }
+
+    // Wait 6 PBFT lambda time for sending network status, 2000 / 20 * 6 = 600
+    taraxa::thisThreadSleepForMilliSeconds(600);
+    node2_next_votes_size = node2_vote_mgr->getUnverifiedVotesSize();
+  }
+  EXPECT_EQ(node2_vote_mgr->getUnverifiedVotesSize(), expect_size);
 }
 
 // Test creates a DAG on one node and verifies

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -864,7 +864,7 @@ TEST_F(NetworkTest, node_transaction_sync) {
 // intervals on randomly selected nodes It verifies that the blocks created from
 // these transactions which get created on random nodes are synced and the
 // resulting DAG is the same on all nodes
-TEST_F(NetworkTest, DISABLED_node_full_sync) {
+TEST_F(NetworkTest, node_full_sync) {
   constexpr auto numberOfNodes = 5;
   auto node_cfgs = make_node_cfgs<20>(numberOfNodes);
   auto nodes = launch_nodes(slice(node_cfgs, 0, numberOfNodes - 1));

--- a/tests/p2p_test.cpp
+++ b/tests/p2p_test.cpp
@@ -92,10 +92,10 @@ TEST_F(P2PTest, capability_send_test) {
   network_conf.network_bandwidth = 40;
   network_conf.network_transaction_interval = 1000;
   auto thc1 = make_shared<TaraxaCapability>(host1, network_conf, GENESIS, false, addr_t(), nullptr, nullptr, nullptr,
-                                            nullptr, nullptr, nullptr, nullptr, 2000);
+                                            nullptr, nullptr, nullptr, nullptr, nullptr, 2000);
   host1.registerCapability(thc1);
   auto thc2 = make_shared<TaraxaCapability>(host2, network_conf, GENESIS, false, addr_t(), nullptr, nullptr, nullptr,
-                                            nullptr, nullptr, nullptr, nullptr, 2000);
+                                            nullptr, nullptr, nullptr, nullptr, nullptr, 2000);
   host2.registerCapability(thc2);
   host1.start();
   host2.start();
@@ -154,10 +154,10 @@ TEST_F(P2PTest, capability_send_block) {
   network_conf.network_bandwidth = 40;
   network_conf.network_transaction_interval = 1000;
   auto thc1 = make_shared<TaraxaCapability>(host1, network_conf, GENESIS, false, addr_t(), nullptr, nullptr, nullptr,
-                                            nullptr, nullptr, nullptr, nullptr, 2000);
+                                            nullptr, nullptr, nullptr, nullptr, nullptr, 2000);
   host1.registerCapability(thc1);
   auto thc2 = make_shared<TaraxaCapability>(host2, network_conf, GENESIS, false, addr_t(), nullptr, nullptr, nullptr,
-                                            nullptr, nullptr, nullptr, nullptr, 2000);
+                                            nullptr, nullptr, nullptr, nullptr, nullptr, 2000);
   host2.registerCapability(thc2);
   host1.start();
   host2.start();
@@ -232,12 +232,13 @@ TEST_F(P2PTest, block_propagate) {
   network_conf.network_transaction_interval = 1000;
 
   auto thc1 = make_shared<TaraxaCapability>(host1, network_conf, GENESIS, false, addr_t(), nullptr, nullptr, nullptr,
-                                            nullptr, nullptr, nullptr, nullptr, 2000);
+                                            nullptr, nullptr, nullptr, nullptr, nullptr, 2000);
   host1.registerCapability(thc1);
   std::vector<std::shared_ptr<TaraxaCapability>> vCapabilities;
   for (int i = 0; i < nodeCount; i++) {
     vCapabilities.push_back(make_shared<TaraxaCapability>(*vHosts[i], network_conf, GENESIS, false, addr_t(), nullptr,
-                                                          nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, 2000));
+                                                          nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+                                                          2000));
     vHosts[i]->registerCapability(vCapabilities[i]);
   }
   host1.start(true);


### PR DESCRIPTION
Fix PBFT next voting 2 values in the same step issue
* Implement next votes for previous PBFT round class and integrate with PBFT manager
* Implement next votes read/write in DB APIs and add unit tests
* Implement next votes syncing. Not only sync when node is behind to peer PBFT round,  but also will sync when node has a short next votes size in previous PBFT round
* Process synced next votes. If node is behind to peer, push synced next votes into unverified queue. If node has same PBFT round with peer but has a short previous next votes size, verify the votes and update own previous next votes structure
* Add next votes bundle syncing unit tests