### PR TITLE
Db close fix

### DIFF
--- a/src/storage/db_storage.cpp
+++ b/src/storage/db_storage.cpp
@@ -186,7 +186,10 @@ void DbStorage::deleteSnapshot(uint64_t const& period) {
 }
 
 DbStorage::~DbStorage() {
-  db_->Close();
+  for (auto cf : handles_) {
+    checkStatus(db_->DestroyColumnFamilyHandle(cf));
+  }
+  checkStatus(db_->Close());
   delete db_;
 }
 


### PR DESCRIPTION
The issue is that in newer rocksdb versions it is required that all column family handles are closed strictly before the db is closed. In taraxa-evm as well as taraxa-node we didn't follow that requirement. 

This issue was only visible in cmake DEBUG build, that's why nobody saw it (on jenkins we use RELEASE).

Also see Taraxa-project/taraxa-evm#23