### PR TITLE
Separate tests from build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,9 +107,7 @@ RUN mkdir $BUILD_OUTPUT_DIR \
              ../ \
     && make -j$(nproc) all \
     && make install \
-    && strip bin_install/taraxad \
-    && cd tests/ \
-    && ctest --output-on-failure
+    && strip bin_install/taraxad
 
 ###############################################################################
 # Taraxa Cli #

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,7 +92,7 @@ pipeline {
             steps {
                 sh '''
                     mkdir -p  $PWD/tmp_docker
-                    docker run --rm -v $PWD/tmp_docker:/tmp --name taraxa-node-ctest-$$DOCKER_BRANCH_TAG ${IMAGE}-${DOCKER_BRANCH_TAG}-${BUILD_NUMBER}-ctest sh -c \
+                    docker run --rm -v $PWD/tmp_docker:/tmp --name taraxa-node-ctest-$DOCKER_BRANCH_TAG ${IMAGE}-${DOCKER_BRANCH_TAG}-${BUILD_NUMBER}-ctest sh -c \
                        'cd cmake-docker-build-release/tests \
                            && ctest --output-on-failure'
                 '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,6 +80,30 @@ pipeline {
                 '''
             }
         }
+        stage('Build Docker Image for tests') {
+            steps {
+                sh '''
+                    DOCKER_BUILDKIT=1 docker build --target build \
+                    -t ${IMAGE}-${DOCKER_BRANCH_TAG}-${BUILD_NUMBER}-ctest .
+                '''
+            }
+        }
+        stage('Run ctest') {
+            steps {
+                sh '''
+                    mkdir -p  $PWD/tmp_docker
+                    docker run --rm -v $PWD/tmp_docker:/tmp --name taraxa-node-ctest-$$DOCKER_BRANCH_TAG ${IMAGE}-${DOCKER_BRANCH_TAG}-${BUILD_NUMBER}-ctest sh -c \
+                       'cd cmake-docker-build-release/tests \
+                           && ctest --output-on-failure'
+                '''
+            }
+            post {
+                failure {
+                    zip zipFile: 'coredumpAndTmp.zip', archive: false, dir: 'tmp_docker'
+                    archiveArtifacts artifacts: 'coredumpAndTmp.zip', fingerprint: true
+                }
+            }
+        }
         stage('Smoke Test') {
             steps {
                 sh '''


### PR DESCRIPTION
Remove ctest from docker build
Add new image build for ctest
Add steps to run the ctest on Jenkins instead of docker build
Add artifacts to jenkins on failure

## Purpose

Run ctest separated from docker build so we can capture coredums.

## For reviewers

I am trying to get the temp folder, this also seems to contain the databases and some other files, for now, I don't know how big they will be, if they are too big, we may not able to get everything.

Does this folder help in figuring out the problem? If not I can get the coredump only.

ps: The new image build should be cached so not much time added

