### PR TITLE
fix(init): wrong signal for sigkill

### DIFF
--- a/src/common/static_init.hpp
+++ b/src/common/static_init.hpp
@@ -9,7 +9,7 @@ namespace taraxa {
 inline void static_init() {
   signal(SIGABRT, abortHandler);
   signal(SIGSEGV, abortHandler);
-  signal(SIGILL, abortHandler);
+  signal(SIGKILL, abortHandler);
   signal(SIGFPE, abortHandler);
   if (sodium_init() == -1) {
     throw std::runtime_error("libsodium init failure");


### PR DESCRIPTION
## Purpose

The docker container doesn't stop when sending sigkill via CRTL+C
