### PR TITLE
better printing of seconds in summary log

### DIFF
--- a/src/network/taraxa_capability.cpp
+++ b/src/network/taraxa_capability.cpp
@@ -1189,8 +1189,8 @@ void TaraxaCapability::logNodeStats() {
   if (is_syncing) {
     // Syncing...
     auto percent_synced = (local_pbft_sync_period * 100) / peer_max_pbft_chain_size;
-    auto syncing_time_sec = static_cast<float>(summary_interval_ms_ * syncing_interval_count_) / 1000.0f;
-    LOG(log_nf_summary_) << "Syncing for " << std::setprecision(2) << syncing_time_sec << " seconds, " << percent_synced
+    auto syncing_time_sec = summary_interval_ms_ * syncing_interval_count_ / 1000;
+    LOG(log_nf_summary_) << "Syncing for " << syncing_time_sec << " seconds, " << percent_synced
                          << "% synced";
     LOG(log_nf_summary_) << "Currently syncing from node " << peer_syncing_pbft_;
     LOG(log_nf_summary_) << "Max peer PBFT chain size:      " << peer_max_pbft_chain_size << " (peer "
@@ -1225,6 +1225,8 @@ void TaraxaCapability::logNodeStats() {
     LOG(log_nf_summary_) << "DAG level growth:              " << dag_level_growh;
   }
 
+  LOG(log_nf_summary_) << "##################################";
+
   if (making_pbft_chain_progress) {
     if (is_syncing) {
       LOG(log_si_summary_) << "STATUS: GOOD. ACTIVELY SYNCING";
@@ -1245,9 +1247,8 @@ void TaraxaCapability::logNodeStats() {
     LOG(log_si_summary_) << "STATUS: PBFT STALLED, POSSIBLY PARTITIONED. NODE HAS NOT RESTARTED SYNCING";
   } else if (peers_size) {
     if (is_syncing) {
-      auto syncing_stalled_time_sec =
-          static_cast<float>(summary_interval_ms_ * syncing_stalled_interval_count_) / 1000.0f;
-      LOG(log_si_summary_) << "STATUS: SYNCING STALLED. NO PROGRESS MADE IN LAST " << std::setprecision(2)
+      auto syncing_stalled_time_sec = summary_interval_ms_ * syncing_stalled_interval_count_ / 1000;
+      LOG(log_si_summary_) << "STATUS: SYNCING STALLED. NO PROGRESS MADE IN LAST "
                            << syncing_stalled_time_sec << " SECONDS";
     } else {
       LOG(log_si_summary_) << "STATUS: STUCK. NODE HAS NOT RESTARTED SYNCING";


### PR DESCRIPTION
Currently summary log prints something like this:
```
2021-05-14 16:47:11.150796 SUMMARY INFO Syncing for 1.2e+02 seconds, 12% synced
```
this should improve readability