### PR TITLE
fix(syncing): refactor error checking for pbft block syncing

### DIFF
--- a/src/network/taraxa_capability.cpp
+++ b/src/network/taraxa_capability.cpp
@@ -570,14 +570,29 @@ void TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
         peer->markPbftBlockAsKnown(pbft_blk_hash);
         LOG(log_nf_pbft_sync_) << "Received pbft block: " << pbft_blk_and_votes.pbft_blk->getBlockHash();
 
-        if (pbft_sync_period + 1 != pbft_blk_and_votes.pbft_blk->getPeriod()) {
-          LOG(log_er_pbft_sync_) << "PBFT SYNC ERROR, UNEXPECTED PBFT BLOCK HEIGHT: "
-                                 << pbft_blk_and_votes.pbft_blk->getPeriod()
-                                 << ", has synced period: " << pbft_sync_period
-                                 << ", PBFT chain size: " << pbft_chain_->getPbftChainSize()
-                                 << ", synced queue size : " << pbft_chain_->pbftSyncedQueueSize();
-          syncing_ = false;
-          return;
+        if (pbft_chain_->isKnownPbftBlockForSyncing(pbft_blk_hash)) {
+          // This is ok I gues...?
+        } else {
+          blk_hash_t last_local_pbft_blockhash;
+          if (pbft_chain_->pbftSyncedQueueEmpty()) {
+            // Look at the chain...
+            last_local_pbft_blockhash = pbft_chain_->getLastPbftBlockHash();
+          } else {
+            last_local_pbft_blockhash = pbft_chain_->pbftSyncedQueueBack().pbft_blk->getBlockHash();
+          }
+
+          if (last_local_pbft_blockhash != pbft_blk_and_votes.pbft_blk->getPrevBlockHash()) {
+            // This block is out of order...
+            if (_nodeID == peer_syncing_pbft_) {
+              LOG(log_si_pbft_sync_) << "PBFT SYNC ERROR, UNEXPECTED PBFT BLOCK HEIGHT: "
+                                     << pbft_blk_and_votes.pbft_blk->getPeriod()
+                                     << ", has synced period: " << pbft_sync_period
+                                     << ", PBFT chain size: " << pbft_chain_->getPbftChainSize()
+                                     << ", synced queue size : " << pbft_chain_->pbftSyncedQueueSize();
+              syncing_ = false;
+            }
+            return;
+          }
         }
 
         if (peer->pbft_chain_size_ < pbft_blk_and_votes.pbft_blk->getPeriod()) {
@@ -604,12 +619,14 @@ void TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
           for (auto const &block : block_level.second) {
             auto status = checkDagBlockValidation(block.second.first);
             if (!status.first) {
-              LOG(log_er_pbft_sync_) << "PBFT SYNC ERROR, DAG missing a tip/pivot in period "
-                                     << pbft_blk_and_votes.pbft_blk->getPeriod()
-                                     << ", has synced period: " << pbft_sync_period
-                                     << ", PBFT chain size: " << pbft_chain_->getPbftChainSize()
-                                     << ", synced queue size: " << pbft_chain_->pbftSyncedQueueSize();
-              syncing_ = false;
+              if (peer_syncing_pbft_ == _nodeID) {
+                LOG(log_si_pbft_sync_) << "PBFT SYNC ERROR, DAG missing a tip/pivot in period "
+                                       << pbft_blk_and_votes.pbft_blk->getPeriod()
+                                       << ", has synced period: " << pbft_sync_period
+                                       << ", PBFT chain size: " << pbft_chain_->getPbftChainSize()
+                                       << ", synced queue size: " << pbft_chain_->pbftSyncedQueueSize();
+                syncing_ = false;
+              }
               return;
             }
             LOG(log_nf_dag_sync_) << "Storing DAG block " << block.second.first.getHash().toString() << " with "

--- a/src/network/taraxa_capability.cpp
+++ b/src/network/taraxa_capability.cpp
@@ -571,7 +571,8 @@ void TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
         LOG(log_nf_pbft_sync_) << "Received pbft block: " << pbft_blk_and_votes.pbft_blk->getBlockHash();
 
         if (pbft_chain_->isKnownPbftBlockForSyncing(pbft_blk_hash)) {
-          // This is ok I gues...?
+          // Already have this block...
+          return;
         } else {
           blk_hash_t last_local_pbft_blockhash;
           if (pbft_chain_->pbftSyncedQueueEmpty()) {


### PR DESCRIPTION
## Purpose

The current logic for checking if a pbft block + certs that is sent over the network is valid doesn't seem to hold up.

## Related Github issues

Fixes #759 

## Testing

_I tested it against the devnet as follows and syncing is continuous without stopping..._

```
docker login -u _token -p "$(gcloud auth print-access-token)" https://gcr.io
docker pull gcr.io/jovial-meridian-249123/taraxa-node:pr-769-build-1
docker run --rm --name taraxa-devnet gcr.io/jovial-meridian-249123/taraxa-node:pr-761-build-1 join devnet
```