### PR TITLE
Circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
    build-docker-image:
     environment:
       IMAGE=taraxa-node
+      GCP_IMAGE=gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}
     machine:
       image: ubuntu-1604:202007-01
       docker_layer_caching: true
@@ -36,16 +37,18 @@ jobs:
 
            mkdir -p  $PWD/tmp_docker 
       - gcp-gcr/build-image:
-         image: $IMAGE-$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM
+         image: $IMAGE
          tag: $DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM
       - gcp-gcr/build-image:
-         image: $IMAGE-$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM-ctest
+         image: $IMAGE-ctest
          tag: $DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM
          extra_build_args: --target build
       - run:
          name: Run Ctest
          command: |
-           docker run -d --rm -v $PWD/tmp_docker:/tmp --name taraxa-node-ctest-$DOCKER_BRANCH_TAG gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}-ctest sh -c \
+           docker run -d --rm -v $PWD/tmp_docker:/tmp --name taraxa-node-ctest-$DOCKER_BRANCH_TAG \
+                       ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}-ctest\
+                        sh -c \
                        'cd cmake-docker-build-debug/tests \
                         && ctest --output-on-failure' 
       - run:
@@ -67,7 +70,7 @@ jobs:
           docker run --rm -d \
               --name taraxa-node-smoke-test-${DOCKER_BRANCH_TAG} \
               --net smoke-test-net-${DOCKER_BRANCH_TAG} \
-              gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} \
+              ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} \
               single
           mkdir -p  $PWD/test_build-d/
           sleep 30
@@ -98,18 +101,13 @@ jobs:
           docker kill taraxa-node-smoke-test-${DOCKER_BRANCH_TAG} || true
           docker network rm smoke-test-net-${DOCKER_BRANCH_TAG} || true
           docker images -a
-      - gcp-gcr/gcr-auth
-      - gcp-gcr/push-image:
-         image: $IMAGE-$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM
-         tag: $DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM
-         when:
-          condition:
-            equal: [ "develop", << pipeline.git.branch >> ]
+      - run:
+         name: Add Tags and push images
+         command: |
+           docker tag $IMAGE:$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM $GCP_IMAGE:$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM
+           docker tag $IMAGE:$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM $GCP_IMAGE:$START_TIME
+           docker tag $IMAGE:$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM $GCP_IMAGE:$START_TIME-$CIRCLE_SHA1
 
-      - gcp-gcr/tag-image:
-         image: $IMAGE-$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM
-         source-tag: $DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM
-         target-tag: $IMAGE-$CIRCLE_SHA1
       - store_artifacts:
           path: tmp_docker
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,13 +36,15 @@ jobs:
            sudo bash -c 'echo /tmp/core.%t.%e.%p >/proc/sys/kernel/core_pattern'
 
            mkdir -p  $PWD/tmp_docker 
-      - gcp-gcr/build-image:
-         image: $IMAGE
-         tag: $DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM
-      - gcp-gcr/build-image:
-         image: $IMAGE-ctest
-         tag: $DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM
-         extra_build_args: --target build
+      - run:
+         name: Docker Build taraxa-node
+         command: |
+           docker build -t $IMAGE:$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM .
+      - run:
+         name: Docker Build taraxa-node-ctest
+         command:|
+          docker build -t $IMAGE-ctest:$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM \
+            --target build
       - run:
          name: Run Ctest
          command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,7 @@ jobs:
           fi
           docker kill taraxa-node-smoke-test-${DOCKER_BRANCH_TAG} || true
           docker network rm smoke-test-net-${DOCKER_BRANCH_TAG} || true
+          docker images -a
       - gcp-gcr/tag-image:
          image: $IMAGE-$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM
          source-tag: latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
            docker push ${GCP_IMAGE}:${START_TIME}
            docker push ${GCP_IMAGE}:${CIRCLE_SHA1}
            docker push ${GCP_IMAGE}:${START_TIME}-${CIRCLE_SHA1}
-           if [[ ! ${CIRCLE_BRANCH =~ ^PR-* }]];then
+           if [[ ! ${CIRCLE_BRANCH} =~ ^PR-* ]];then
               docker push ${GCP_IMAGE}:latest
            fi
            if [[ ${CIRCLE_BRANCH} == "master" ]];then
@@ -125,7 +125,7 @@ jobs:
              docker push ${IMAGE}:${START_TIME}
              docker push ${IMAGE}:${CIRCLE_SHA1}
              docker push ${IMAGE}:${START_TIME}-${CIRCLE_SHA1}
-             if [[ ! ${CIRCLE_BRANCH =~ ^PR-* }]];then
+             if [[ ! ${CIRCLE_BRANCH} =~ ^PR-* ]];then
                docker push ${IMAGE}:latest
              fi
            fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,8 @@ jobs:
            docker push ${GCP_IMAGE}:${CIRCLE_SHA1}
            docker push ${GCP_IMAGE}:${START_TIME}-${CIRCLE_SHA1}
            if [[ ! ${CIRCLE_BRANCH} =~ ^PR-* ]];then
-              docker push ${GCP_IMAGE}:latest
+              docker tag ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} ${GCP_IMAGE}:latest
+              #docker push ${GCP_IMAGE}:latest
            fi
            if [[ ${CIRCLE_BRANCH} == "master" ]];then
              echo ${DOCKERHUB_PASS} | docker login -u taraxa --password-stdin
@@ -126,7 +127,8 @@ jobs:
              docker push ${IMAGE}:${CIRCLE_SHA1}
              docker push ${IMAGE}:${START_TIME}-${CIRCLE_SHA1}
              if [[ ! ${CIRCLE_BRANCH} =~ ^PR-* ]];then
-               docker push ${IMAGE}:latest
+               docker tag ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} ${IMAGE}:latest
+               #docker push ${IMAGE}:latest
              fi
            fi
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ jobs:
    build-docker-image:
     environment:
       - IMAGE: taraxa-node
-      - GCP_IMAGE: gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}
     machine:
       image: ubuntu-1604:202007-01
       docker_layer_caching: true
@@ -32,6 +31,7 @@ jobs:
            echo "export HELM_TEST_NAME=$(echo $CIRCLE_BRANCH | sed 's/[^A-Za-z0-9\\-]*//g' | tr '[:upper:]' '[:lower:]')" >>$BASH_ENV
            echo "export DOCKER_BRANCH_TAG=$(./scripts/docker_tag_from_branch.sh $CIRCLE_BRANCH)" >>$BASH_ENV
            echo "export START_TIME=$(date +%Y%m%d-%Hh%Mm%Ss)" >>$BASH_ENV
+           echo "export GCP_IMAGE=gcr.io/${GOOGLE_PROJECT_ID}/${IMAGE}" >> $BASH_ENV
            sudo service apport stop
            sudo bash -c 'echo /tmp/core.%t.%e.%p >/proc/sys/kernel/core_pattern'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
            docker build -t $IMAGE:$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM .
       - run:
          name: Docker Build taraxa-node-ctest
-         command:|
+         command: |
           docker build -t $IMAGE-ctest:$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM \
             --target build
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,7 @@ jobs:
           docker kill taraxa-node-smoke-test-${DOCKER_BRANCH_TAG} || true
           docker network rm smoke-test-net-${DOCKER_BRANCH_TAG} || true
           docker images -a
+      - gcp-gcr/gcr-auth
       - gcp-gcr/tag-image:
          image: $IMAGE-$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM
          source-tag: latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
               helm delete --purge ${HELM_TEST_NAME} || true
               curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
               chmod +x ./kubectl
-              ./kubectl delete ns ${HELM_TEST_NAME || true"
+              ./kubectl delete ns ${HELM_TEST_NAME || true
            fi
 
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,9 +107,32 @@ jobs:
       - run:
          name: Add Tags and push images
          command: |
+           echo ${GCLOUD_SERVICE_KEY} | docker login -u _json_key --password-stdin https://gcr.io
+           docker tag ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} ${GCP_IMAGE}:${CIRCLE_SHA1}
            docker tag ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} ${GCP_IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}
            docker tag ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} ${GCP_IMAGE}:${START_TIME}
            docker tag ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} ${GCP_IMAGE}:${START_TIME}-${CIRCLE_SHA1}
+           docker push ${GCP_IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}
+           docker push ${GCP_IMAGE}:${START_TIME}
+           docker push ${GCP_IMAGE}:${CIRCLE_SHA1}
+           docker push ${GCP_IMAGE}:${START_TIME}-${CIRCLE_SHA1}
+           if [[ ! ${CIRCLE_BRANCH =~ ^PR-* }]];then
+              docker push ${GCP_IMAGE}:latest
+           fi
+           if [[ ${CIRCLE_BRANCH} == "master" ]];then
+             echo ${DOCKERHUB_PASS} | docker login -u taraxa --password-stdin
+             docker push ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}
+             docker push ${IMAGE}:${START_TIME}
+             docker push ${IMAGE}:${CIRCLE_SHA1}
+             docker push ${IMAGE}:${START_TIME}-${CIRCLE_SHA1}
+             if [[ ! ${CIRCLE_BRANCH =~ ^PR-* }]];then
+               docker push ${IMAGE}:latest
+             fi
+           fi
+      - run:
+         name: Get helm chart
+         command: |
+            git clone --branch development  https://github.com/Taraxa-project/taraxa-testnet.git
 
       - store_artifacts:
           path: tmp_docker 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,8 +37,10 @@ jobs:
            mkdir -p  $PWD/tmp_docker 
       - gcp-gcr/build-image:
          image: $IMAGE-$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM
+         tag: $DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM
       - gcp-gcr/build-image:
          image: $IMAGE-$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM-ctest
+         tag: $DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM
          extra_build_args: --target build
       - run:
          name: Run Ctest
@@ -97,9 +99,16 @@ jobs:
           docker network rm smoke-test-net-${DOCKER_BRANCH_TAG} || true
           docker images -a
       - gcp-gcr/gcr-auth
+      - gcp-gcr/push-image:
+         image: $IMAGE-$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM
+         tag: $DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM
+         when:
+          condition:
+            equal: [ "develop", << pipeline.parameters.job_env >> ]
+
       - gcp-gcr/tag-image:
          image: $IMAGE-$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM
-         source-tag: latest
+         source-tag: $DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM
          target-tag: $IMAGE-$CIRCLE_SHA1
       - store_artifacts:
           path: tmp_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
       - run:
          name: Run Ctest
          command: |
-           docker run -d --rm -v $PWD/tmp_docker:/tmp \
+           docker run --rm -v $PWD/tmp_docker:/tmp \
                        --name taraxa-node-ctest-${DOCKER_BRANCH_TAG} \
                        ${IMAGE}-ctest:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}\
                         sh -c \
@@ -132,38 +132,42 @@ jobs:
              fi
            fi
       - run:
-         name: Get helm chart
+         name: Install/configure helm and chart
          command: |
-            git clone --branch development  https://github.com/Taraxa-project/taraxa-testnet.git
-      - run:
-         name: Install kubeconfig
-         command: |
-          mkdir -p $HOME/.kube
-          echo -n "${KUBECONFIG}" | base64 --decode > $HOME/.kube/config
-      - run:
-         name: install helm
-         command: |
-           curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
-      - run:
-         name: Install helm chart
-         command: |
-              helm list --namespace taraxa-community-prod
-              #helm install --name ${DOCKER_BRANCH_TAG} taraxa-node \
-              #  --wait \
-              #  --atomic \
-              #  --timeout 1200 \
-              #  --namespace ${DOCKER_BRANCH_TAG} \
-              #  --set replicaCount=5 \
-              #  --set test.pythontester.script=jenkins.py \
-              #  --set image.repository=${GCP_IMAGE} \
-              #  --set image.tag=${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} \
-              #  -f taraxa-node/values.yaml
+            if [[ ${CIRCLE_BRANCH} =~ ^PR-* ]];then
+              git clone --branch development  https://github.com/Taraxa-project/taraxa-testnet.git
+              mkdir -p $HOME/.kube
+              echo -n "${KUBE_CONFIG}" | base64 --decode > $HOME/.kube/config
+              curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+              helm install --name ${HELM_TEST_NAME} taraxa-node \
+                --wait \
+                --atomic \
+                --timeout 1200 \
+                --namespace ${HELM_TEST_NAME} \
+                --set replicaCount=5 \
+                --set test.pythontester.script=jenkins.py \
+                --set image.repository=${GCP_IMAGE} \
+                --set image.tag=${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} \
+                -f taraxa-node/values.yaml
+            fi
       - run:
          name: Run helm test
          command: |
-            #helm test ${DOCKER_BRANCH_TAG} \
-            #    --timeout 3600 \
-            #    --cleanup
+            if [[ ${CIRCLE_BRANCH =~ ^PR-* }]];then
+              helm test ${HELM_TEST_NAME} \
+                --timeout 3600 \
+                --cleanup
+              ./scripts/kibana-url.sh || true
+            fi
+      - run:
+         name: Cleanup helm tests
+         command: |
+           if [[ ${CIRCLE_BRANCH ~= ^PR-* }]];then
+              helm delete --purge ${HELM_TEST_NAME} || true
+              curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+              chmod +x ./kubectl
+              ./kubectl delete ns ${HELM_TEST_NAME || true"
+           fi
 
       - store_artifacts:
           path: tmp_docker 
@@ -344,8 +348,10 @@ workflows:
           branches: 
             only: 
               - circleci
-              
-
+              - develop
+              - master
+              - /^PR-*/
+                           
   build-and-release:
     jobs:
       - create-and-push-builder:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,10 @@ jobs:
            fi
            echo "HELM_TEST_NAME=$(echo $CIRCLE_BRANCH | sed 's/[^A-Za-z0-9\\-]*//g' | tr '[:upper:]' '[:lower:]')" >>$BASH_ENV
            echo "export DOCKER_BRANCH_TAG=$(./scripts/docker_tag_from_branch.sh $CIRCLE_BRANCH)" >>$BASH_ENV
-           cat $BASH_ENV
+           echo "START_TIME=$(date +%Y%m%d-%Hh%Mm%Ss)" >>$BASH_ENV
            sudo service apport stop
            sudo bash -c 'echo /tmp/core.%t.%e.%p >/proc/sys/kernel/core_pattern'
+
            mkdir -p  $PWD/tmp_docker 
       - gcp-gcr/build-image:
          image: $IMAGE-$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM
@@ -94,6 +95,10 @@ jobs:
           fi
           docker kill taraxa-node-smoke-test-${DOCKER_BRANCH_TAG} || true
           docker network rm smoke-test-net-${DOCKER_BRANCH_TAG} || true
+      - gcp-gcr/tag-image:
+         image: $IMAGE-$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM
+         source-tag: latest
+         target-tag: 
       - store_artifacts:
           path: tmp_docker
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
       - run:
          name: Cleanup helm tests
          command: |
-           if [[ ${CIRCLE_BRANCH} ~= ^PR-* ]];then
+           if [[ ${CIRCLE_BRANCH} =~ ^PR-* ]];then
               helm delete --purge ${HELM_TEST_NAME} || true
               curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
               chmod +x ./kubectl

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
       - gcp-gcr/tag-image:
          image: $IMAGE-$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM
          source-tag: latest
-         target-tag: 
+         target-tag: $IMAGE-$CIRCLE_SHA1
       - store_artifacts:
           path: tmp_docker
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
               helm delete --purge ${HELM_TEST_NAME} || true
               curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
               chmod +x ./kubectl
-              ./kubectl delete ns ${HELM_TEST_NAME || true
+              ./kubectl delete ns ${HELM_TEST_NAME} || true
            fi
 
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,35 @@ jobs:
          name: Get helm chart
          command: |
             git clone --branch development  https://github.com/Taraxa-project/taraxa-testnet.git
+      - run:
+         name: Install kubeconfig
+         command: |
+          mkdir -p $HOME/.kube
+          echo -n "${KUBECONFIG}" | base64 --decode > $HOME/.kube/config
+      - run:
+         name: install helm
+         command: |
+           curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+      - run:
+         name: Install helm chart
+         command: |
+              hel list
+              #helm install --name ${DOCKER_BRANCH_TAG} taraxa-node \
+              #  --wait \
+              #  --atomic \
+              #  --timeout 1200 \
+              #  --namespace ${DOCKER_BRANCH_TAG} \
+              #  --set replicaCount=5 \
+              #  --set test.pythontester.script=jenkins.py \
+              #  --set image.repository=${GCP_IMAGE} \
+              #  --set image.tag=${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} \
+              #  -f taraxa-node/values.yaml
+      - run:
+         name: Run helm test
+         command: |
+            #helm test ${DOCKER_BRANCH_TAG} \
+            #    --timeout 3600 \
+            #    --cleanup
 
       - store_artifacts:
           path: tmp_docker 
@@ -309,12 +338,13 @@ jobs:
 workflows:
   deploy-testnet:
     jobs:
-      - build-docker-image:
+      - build-and-push-docker-image:
          context: taraxa-node
          filters:
           branches: 
             only: 
               - circleci
+              
 
   build-and-release:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
          name: Docker Build taraxa-node-ctest
          command: |
           docker build -t $IMAGE-ctest:$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM \
-            --target build
+            --target build .
       - run:
          name: Run Ctest
          command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
          name: Run Ctest
          command: |
            docker run -d --rm -v $PWD/tmp_docker:/tmp --name taraxa-node-ctest-$DOCKER_BRANCH_TAG \
-                       ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}-ctest\
+                       ${IMAGE}-ctest:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}\
                         sh -c \
                        'cd cmake-docker-build-debug/tests \
                         && ctest --output-on-failure' 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,9 +29,9 @@ jobs:
               export CIRCLE_BRANCH=circleci
               export CIRCLE_BUILD_NUM=300
            fi
-           echo "HELM_TEST_NAME=$(echo $CIRCLE_BRANCH | sed 's/[^A-Za-z0-9\\-]*//g' | tr '[:upper:]' '[:lower:]')" >>$BASH_ENV
+           echo "export HELM_TEST_NAME=$(echo $CIRCLE_BRANCH | sed 's/[^A-Za-z0-9\\-]*//g' | tr '[:upper:]' '[:lower:]')" >>$BASH_ENV
            echo "export DOCKER_BRANCH_TAG=$(./scripts/docker_tag_from_branch.sh $CIRCLE_BRANCH)" >>$BASH_ENV
-           echo "START_TIME=$(date +%Y%m%d-%Hh%Mm%Ss)" >>$BASH_ENV
+           echo "export START_TIME=$(date +%Y%m%d-%Hh%Mm%Ss)" >>$BASH_ENV
            sudo service apport stop
            sudo bash -c 'echo /tmp/core.%t.%e.%p >/proc/sys/kernel/core_pattern'
 
@@ -39,16 +39,17 @@ jobs:
       - run:
          name: Docker Build taraxa-node
          command: |
-           docker build -t $IMAGE:$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM .
+           docker build -t ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} .
       - run:
          name: Docker Build taraxa-node-ctest
          command: |
-          docker build -t $IMAGE-ctest:$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM \
+          docker build -t ${IMAGE}-ctest:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} \
             --target build .
       - run:
          name: Run Ctest
          command: |
-           docker run -d --rm -v $PWD/tmp_docker:/tmp --name taraxa-node-ctest-$DOCKER_BRANCH_TAG \
+           docker run -d --rm -v $PWD/tmp_docker:/tmp \
+                       --name taraxa-node-ctest-${DOCKER_BRANCH_TAG} \
                        ${IMAGE}-ctest:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}\
                         sh -c \
                        'cd cmake-docker-build-debug/tests \
@@ -106,12 +107,12 @@ jobs:
       - run:
          name: Add Tags and push images
          command: |
-           docker tag $IMAGE:$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM $GCP_IMAGE:$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM
-           docker tag $IMAGE:$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM $GCP_IMAGE:$START_TIME
-           docker tag $IMAGE:$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM $GCP_IMAGE:$START_TIME-$CIRCLE_SHA1
+           docker tag ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} ${GCP_IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}
+           docker tag ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} ${GCP_IMAGE}:${START_TIME}
+           docker tag ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} ${GCP_IMAGE}:${START_TIME}-${CIRCLE_SHA1}
 
       - store_artifacts:
-          path: tmp_docker
+          path: tmp_docker 
 
    create-and-push-builder:
      docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 
 
 jobs: 
-   build-docker-image:
+   build-and-push-docker-image:
     environment:
       - IMAGE: taraxa-node
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
          tag: $DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM
          when:
           condition:
-            equal: [ "develop", << pipeline.parameters.job_env >> ]
+            equal: [ "develop", << pipeline.git.branch >> ]
 
       - gcp-gcr/tag-image:
          image: $IMAGE-$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,8 @@ orbs:
 jobs: 
    build-docker-image:
     environment:
-      IMAGE=taraxa-node
-      GCP_IMAGE=gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}
+      - IMAGE: taraxa-node
+      - GCP_IMAGE: gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}
     machine:
       image: ubuntu-1604:202007-01
       docker_layer_caching: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ jobs:
       - run:
          name: Run helm test
          command: |
-            if [[ ${CIRCLE_BRANCH =~ ^PR-* }]];then
+            if [[ ${CIRCLE_BRANCH} =~ ^PR-* ]];then
               helm test ${HELM_TEST_NAME} \
                 --timeout 3600 \
                 --cleanup
@@ -162,7 +162,7 @@ jobs:
       - run:
          name: Cleanup helm tests
          command: |
-           if [[ ${CIRCLE_BRANCH ~= ^PR-* }]];then
+           if [[ ${CIRCLE_BRANCH} ~= ^PR-* ]];then
               helm delete --purge ${HELM_TEST_NAME} || true
               curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
               chmod +x ./kubectl

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
       - run:
          name: Install helm chart
          command: |
-              hel list
+              helm list --namespace taraxa-community-prod
               #helm install --name ${DOCKER_BRANCH_TAG} taraxa-node \
               #  --wait \
               #  --atomic \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
       - run: 
          name: Run SmokeTest
          command: |
-          docker run --rm -d --name taraxa-node-smoke-test-${DOCKER_BRANCH_TAG} ${IMAGE}-${DOCKER_BRANCH_TAG}-${BUILD_NUMBER} single
+          docker run --rm -d --name taraxa-node-smoke-test-${DOCKER_BRANCH_TAG}gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} single
           mkdir -p  $PWD/test_build-d/
           sleep 30
           http_code=$(docker run --rm  -v $PWD/test_build-d:/data byrnedo/alpine-curl \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ jobs:
       - run:
          name: Run Ctest
          command: |
+           docker images -a 
            mkdir -p  $PWD/tmp_docker 
            docker run --rm -v $PWD/tmp_docker:/tmp --name taraxa-node-ctest-$DOCKER_BRANCH_TAG ${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}-ctest sh -c \
                        'cd cmake-docker-build-debug/tests \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ jobs:
 #        user: root
     machine:
       image: ubuntu-1604:202007-01
+      docker_layer_caching: true
     resource_class: xlarge
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
     machine:
       image: ubuntu-1604:202007-01
       docker_layer_caching: true
+      user: root
     resource_class: xlarge
     steps:
       - checkout
@@ -43,7 +44,8 @@ jobs:
       - run:
          name: Run Ctest
          command: |
-           docker images -a 
+           service apport stop
+           echo '/tmp/core.%t.%e.%p' >/proc/sys/kernel/core_pattern
            mkdir -p  $PWD/tmp_docker 
            docker run --rm -v $PWD/tmp_docker:/tmp --name taraxa-node-ctest-$DOCKER_BRANCH_TAG gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}-ctest sh -c \
                        'cd cmake-docker-build-debug/tests \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
       - run: 
          name: Run SmokeTest
          command: |
-          docker run --rm -d --name taraxa-node-smoke-test-${DOCKER_BRANCH_TAG}gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} single
+          docker run --rm -d --name taraxa-node-smoke-test-${DOCKER_BRANCH_TAG} gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} single
           mkdir -p  $PWD/test_build-d/
           sleep 30
           http_code=$(docker run --rm  -v $PWD/test_build-d:/data byrnedo/alpine-curl \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,9 @@ jobs:
               export CIRCLE_BRANCH=circleci
               export CIRCLE_BUILD_NUM=300
            fi
+           echo "HELM_TEST_NAME=$(echo ${BRANCH_NAME} | sed 's/[^A-Za-z0-9\\-]*//g' | tr '[:upper:]' '[:lower:]')" >>$BASH_ENV
            echo "export DOCKER_BRANCH_TAG=$(./scripts/docker_tag_from_branch.sh $CIRCLE_BRANCH)" >>$BASH_ENV
+           cat $BASH_ENV
            sudo service apport stop
            sudo bash -c 'echo /tmp/core.%t.%e.%p >/proc/sys/kernel/core_pattern'
            mkdir -p  $PWD/tmp_docker 
@@ -90,7 +92,8 @@ jobs:
           else
               exit $http_code
           fi
-
+          docker kill taraxa-node-smoke-test-${DOCKER_BRANCH_TAG} || true
+          docker network rm smoke-test-net-${DOCKER_BRANCH_TAG} || true
       - store_artifacts:
           path: tmp_docker
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,8 +42,8 @@ jobs:
          command: |
            docker run -d --rm -v $PWD/tmp_docker:/tmp --name taraxa-node-ctest-$DOCKER_BRANCH_TAG gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}-ctest sh -c \
                        'cd cmake-docker-build-debug/tests \
-                        && ctest --output-on-failure && sleep 100'
-            sleep 30 && killall -3 ctest
+                        && ctest --output-on-failure && sleep 100' &
+            sleep 5 && sudo killall -3 ctest
       - store_artifacts:
           path: tmp_docker
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,8 +51,8 @@ jobs:
             fi
           when: on_fail
       - run: 
-        name: Run SmokeTest
-        command: |
+         name: Run SmokeTest
+         command: |
           docker run --rm -d --name taraxa-node-smoke-test-${DOCKER_BRANCH_TAG} ${IMAGE}-${DOCKER_BRANCH_TAG}-${BUILD_NUMBER} single
           mkdir -p  $PWD/test_build-d/
           sleep 30

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,9 @@ jobs:
            docker run --rm -v $PWD/tmp_docker:/tmp --name taraxa-node-ctest-$DOCKER_BRANCH_TAG gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}-ctest sh -c \
                        'cd cmake-docker-build-debug/tests \
                         && ctest --output-on-failure'
-          
+      - store_artifacts:
+          path: /tmp
+          when: on_fail
 
    create-and-push-builder:
      docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,10 +35,8 @@ jobs:
            echo 'export CIRCLE_BUILD_NUM=300'  >>$BASH_ENV
            echo "export DOCKER_BRANCH_TAG=$(./scripts/docker_tag_from_branch.sh $CIRCLE_BRANCH)" >>$BASH_ENV
       - gcp-gcr/build-image:
-         name: Build Image
          image: $IMAGE-$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM
       - gcp-gcr/build-image:
-         name: Build Ctest Image
          image: $IMAGE-$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM-ctest
          extra_build_args: --target build
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
                         && ctest --output-on-failure && sleep 100' &
             sleep 5 && sudo killall -3 ctest 
             if [ -f tmp_docker/core* ];then
-              chmod 777 tmp_docker/core*
+              sudo chmod 777 tmp_docker/core*
             fi
       - store_artifacts:
           path: tmp_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,6 @@ jobs:
               export CIRCLE_BRANCH=circleci
               export CIRCLE_BUILD_NUM=300
            fi
-#           echo 'export CIRCLE_BRANCH=cirleci' >>$BASH_ENV
-#           echo 'export CIRCLE_BUILD_NUM=300'  >>$BASH_ENV
            echo "export DOCKER_BRANCH_TAG=$(./scripts/docker_tag_from_branch.sh $CIRCLE_BRANCH)" >>$BASH_ENV
            sudo service apport stop
            sudo bash -c 'echo /tmp/core.%t.%e.%p >/proc/sys/kernel/core_pattern'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,9 +44,10 @@ jobs:
          command: |
            docker images -a 
            mkdir -p  $PWD/tmp_docker 
-           docker run --rm -v $PWD/tmp_docker:/tmp --name taraxa-node-ctest-$DOCKER_BRANCH_TAG ${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}-ctest sh -c \
+           docker run --rm -v $PWD/tmp_docker:/tmp --name taraxa-node-ctest-$DOCKER_BRANCH_TAG gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}-ctest sh -c \
                        'cd cmake-docker-build-debug/tests \
-           && ctest --output-on-failure'docker run $IMAGE-DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM-ctest bash
+                        && ctest --output-on-failure'
+          
 
    create-and-push-builder:
      docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
               export CIRCLE_BRANCH=circleci
               export CIRCLE_BUILD_NUM=300
            fi
-           echo "HELM_TEST_NAME=$(echo ${BRANCH_NAME} | sed 's/[^A-Za-z0-9\\-]*//g' | tr '[:upper:]' '[:lower:]')" >>$BASH_ENV
+           echo "HELM_TEST_NAME=$(echo ${CIRCLE_BRANCH | sed 's/[^A-Za-z0-9\\-]*//g' | tr '[:upper:]' '[:lower:]')" >>$BASH_ENV
            echo "export DOCKER_BRANCH_TAG=$(./scripts/docker_tag_from_branch.sh $CIRCLE_BRANCH)" >>$BASH_ENV
            cat $BASH_ENV
            sudo service apport stop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ jobs:
     machine:
       image: ubuntu-1604:202007-01
       docker_layer_caching: true
-      user: root
     resource_class: xlarge
     steps:
       - checkout
@@ -44,8 +43,8 @@ jobs:
       - run:
          name: Run Ctest
          command: |
-           service apport stop
-           echo '/tmp/core.%t.%e.%p' >/proc/sys/kernel/core_pattern
+           sudo service apport stop
+           sudo echo '/tmp/core.%t.%e.%p' >/proc/sys/kernel/core_pattern
            mkdir -p  $PWD/tmp_docker 
            docker run --rm -v $PWD/tmp_docker:/tmp --name taraxa-node-ctest-$DOCKER_BRANCH_TAG gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}-ctest sh -c \
                        'cd cmake-docker-build-debug/tests \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,9 @@ jobs:
                        'cd cmake-docker-build-debug/tests \
                         && ctest --output-on-failure && sleep 100' &
             sleep 5 && sudo killall -3 ctest 
-            sleep 30
+            if [ -f tmp_docker/core* ]
+              chmod 777 tmp_docker/core*
+            fi
       - store_artifacts:
           path: tmp_docker
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,10 +10,6 @@ jobs:
    build-docker-image:
     environment:
       IMAGE=taraxa-node
-#    docker: 
-#      - image: circleci/buildpack-deps:stretch
-#      - image: ubuntu-1604:201903-01
-#        user: root
     machine:
       image: ubuntu-1604:202007-01
       docker_layer_caching: true
@@ -26,15 +22,18 @@ jobs:
               git submodule sync
               git submodule update --init --recursive --jobs 8
       - run:
-         name: Docker Build
+         name: Prepare Environment
          command: |
            if [[ ${CIRCLE_SHELL_ENV} =~ "localbuild" ]]; then
               export CIRCLE_BRANCH=circleci
               export CIRCLE_BUILD_NUM=300
            fi
-           echo 'export CIRCLE_BRANCH=cirleci' >>$BASH_ENV
-           echo 'export CIRCLE_BUILD_NUM=300'  >>$BASH_ENV
+#           echo 'export CIRCLE_BRANCH=cirleci' >>$BASH_ENV
+#           echo 'export CIRCLE_BUILD_NUM=300'  >>$BASH_ENV
            echo "export DOCKER_BRANCH_TAG=$(./scripts/docker_tag_from_branch.sh $CIRCLE_BRANCH)" >>$BASH_ENV
+           sudo service apport stop
+           sudo bash -c 'echo /tmp/core.%t.%e.%p >/proc/sys/kernel/core_pattern'
+           mkdir -p  $PWD/tmp_docker 
       - gcp-gcr/build-image:
          image: $IMAGE-$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM
       - gcp-gcr/build-image:
@@ -43,12 +42,10 @@ jobs:
       - run:
          name: Run Ctest
          command: |
-           sudo service apport stop
-           sudo bash -c 'echo /tmp/core.%t.%e.%p >/proc/sys/kernel/core_pattern'
-           mkdir -p  $PWD/tmp_docker 
-           docker run --rm -v $PWD/tmp_docker:/tmp --name taraxa-node-ctest-$DOCKER_BRANCH_TAG gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}-ctest sh -c \
+           docker run -d --rm -v $PWD/tmp_docker:/tmp --name taraxa-node-ctest-$DOCKER_BRANCH_TAG gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}-ctest sh -c \
                        'cd cmake-docker-build-debug/tests \
-                        && ctest --output-on-failure'
+                        && ctest --output-on-failure && sleep 100'
+            sleep 30 && killal -3 ctest
       - store_artifacts:
           path: tmp_docker
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
                        'cd cmake-docker-build-debug/tests \
                         && ctest --output-on-failure'
       - store_artifacts:
-          path: /tmp
+          path: tmp_docker
           when: on_fail
 
    create-and-push-builder:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,13 @@ jobs:
       - run: 
          name: Run SmokeTest
          command: |
-          docker run --rm -d --name taraxa-node-smoke-test-${DOCKER_BRANCH_TAG} gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} single
+          docker network create --driver=bridge \
+                      smoke-test-net-${DOCKER_BRANCH_TAG}
+          docker run --rm -d \
+              --name taraxa-node-smoke-test-${DOCKER_BRANCH_TAG} \
+              --net smoke-test-net-${DOCKER_BRANCH_TAG} \
+              gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} \
+              single
           mkdir -p  $PWD/test_build-d/
           sleep 30
           http_code=$(docker run --rm  -v $PWD/test_build-d:/data byrnedo/alpine-curl \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
               export CIRCLE_BRANCH=circleci
               export CIRCLE_BUILD_NUM=300
            fi
-           echo "HELM_TEST_NAME=$(echo ${CIRCLE_BRANCH | sed 's/[^A-Za-z0-9\\-]*//g' | tr '[:upper:]' '[:lower:]')" >>$BASH_ENV
+           echo "HELM_TEST_NAME=$(echo $CIRCLE_BRANCH | sed 's/[^A-Za-z0-9\\-]*//g' | tr '[:upper:]' '[:lower:]')" >>$BASH_ENV
            echo "export DOCKER_BRANCH_TAG=$(./scripts/docker_tag_from_branch.sh $CIRCLE_BRANCH)" >>$BASH_ENV
            cat $BASH_ENV
            sudo service apport stop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
       - run:
          name: Run Ctest
          command: |
-           docker run --rm -v $PWD/tmp_docker:/tmp --name taraxa-node-ctest-$DOCKER_BRANCH_TAG gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}-ctest sh -c \
+           docker run -d --rm -v $PWD/tmp_docker:/tmp --name taraxa-node-ctest-$DOCKER_BRANCH_TAG gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}-ctest sh -c \
                        'cd cmake-docker-build-debug/tests \
                         && ctest --output-on-failure' 
       - run:
@@ -53,6 +53,10 @@ jobs:
       - run: 
          name: Run SmokeTest
          command: |
+          if [ ! -z "$(docker network list --format '{{.Name}}' | grep -o smoke-test-net-${DOCKER_BRANCH_TAG})" ]; then
+            docker network rm \
+              smoke-test-net-${DOCKER_BRANCH_TAG} >/dev/null;
+          fi         
           docker network create --driver=bridge \
                       smoke-test-net-${DOCKER_BRANCH_TAG}
           docker run --rm -d \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
          name: Run Ctest
          command: |
            sudo service apport stop
-           sudo echo '/tmp/core.%t.%e.%p' >/proc/sys/kernel/core_pattern
+           sudo bash -c 'echo /tmp/core.%t.%e.%p >/proc/sys/kernel/core_pattern'
            mkdir -p  $PWD/tmp_docker 
            docker run --rm -v $PWD/tmp_docker:/tmp --name taraxa-node-ctest-$DOCKER_BRANCH_TAG gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}-ctest sh -c \
                        'cd cmake-docker-build-debug/tests \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
          name: Run Ctest
          command: |
            mkdir -p  $PWD/tmp_docker 
-           docker run --rm -v $PWD/tmp_docker:/tmp --name taraxa-node-ctest-$DOCKER_BRANCH_TAG ${IMAGE}-${DOCKER_BRANCH_TAG}-${BUILD_NUMBER}-ctest sh -c \
+           docker run --rm -v $PWD/tmp_docker:/tmp --name taraxa-node-ctest-$DOCKER_BRANCH_TAG ${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}-ctest sh -c \
                        'cd cmake-docker-build-debug/tests \
            && ctest --output-on-failure'docker run $IMAGE-DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM-ctest bash
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,12 @@ jobs:
          image: $IMAGE-$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM-ctest
          extra_build_args: --target build
       - run:
-         command: docker run $IMAGE-DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM-ctest bash
+         name: Run Ctest
+         command: |
+           mkdir -p  $PWD/tmp_docker 
+           docker run --rm -v $PWD/tmp_docker:/tmp --name taraxa-node-ctest-$DOCKER_BRANCH_TAG ${IMAGE}-${DOCKER_BRANCH_TAG}-${BUILD_NUMBER}-ctest sh -c \
+                       'cd cmake-docker-build-debug/tests \
+           && ctest --output-on-failure'docker run $IMAGE-DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM-ctest bash
 
    create-and-push-builder:
      docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,9 +40,9 @@ jobs:
       - run:
          name: Run Ctest
          command: |
-           docker run -d --rm -v $PWD/tmp_docker:/tmp --name taraxa-node-ctest-$DOCKER_BRANCH_TAG gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}-ctest sh -c \
+           docker run --rm -v $PWD/tmp_docker:/tmp --name taraxa-node-ctest-$DOCKER_BRANCH_TAG gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}-ctest sh -c \
                        'cd cmake-docker-build-debug/tests \
-                        && ctest --output-on-failure && sleep 100' 
+                        && ctest --output-on-failure' 
       - run:
           name: Chmod core dump if fail
           command: |
@@ -53,18 +53,15 @@ jobs:
       - run: 
          name: Run SmokeTest
          command: |
-          docker network create --driver=bridge \
-                      smoke-test-net-${DOCKER_BRANCH_TAG}
           docker run --rm -d \
               --name taraxa-node-smoke-test-${DOCKER_BRANCH_TAG} \
-              --net smoke-test-net-${DOCKER_BRANCH_TAG} \
               gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} \
               single
           mkdir -p  $PWD/test_build-d/
           sleep 30
           http_code=$(docker run --rm  -v $PWD/test_build-d:/data byrnedo/alpine-curl \
                 -sS --fail -w '%{http_code}' -o /data/http.out \
-                --url taraxa-node-smoke-test-${DOCKER_BRANCH_TAG}:7777 \
+                --url gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}:7777 \
                 -d '{
                         "jsonrpc": "2.0",
                         "id":"0",

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,13 +53,17 @@ jobs:
       - run: 
          name: Run SmokeTest
          command: |
+          docker network create --driver=bridge \
+                      smoke-test-net-${DOCKER_BRANCH_TAG}
           docker run --rm -d \
               --name taraxa-node-smoke-test-${DOCKER_BRANCH_TAG} \
+              --net smoke-test-net-${DOCKER_BRANCH_TAG} \
               gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} \
               single
           mkdir -p  $PWD/test_build-d/
           sleep 30
           http_code=$(docker run --rm  -v $PWD/test_build-d:/data byrnedo/alpine-curl \
+                --net smoke-test-net-${DOCKER_BRANCH_TAG}
                 -sS --fail -w '%{http_code}' -o /data/http.out \
                 --url taraxa-node-smoke-test-${DOCKER_BRANCH_TAG}:7777 \
                 -d '{

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
           sleep 30
           http_code=$(docker run --rm  -v $PWD/test_build-d:/data byrnedo/alpine-curl \
                 -sS --fail -w '%{http_code}' -o /data/http.out \
-                --url gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}:7777 \
+                --url taraxa-node-smoke-test-${DOCKER_BRANCH_TAG}:7777 \
                 -d '{
                         "jsonrpc": "2.0",
                         "id":"0",

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,14 +42,45 @@ jobs:
          command: |
            docker run -d --rm -v $PWD/tmp_docker:/tmp --name taraxa-node-ctest-$DOCKER_BRANCH_TAG gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}-ctest sh -c \
                        'cd cmake-docker-build-debug/tests \
-                        && ctest --output-on-failure && sleep 100' &
-            sleep 5 && sudo killall -3 ctest 
+                        && ctest --output-on-failure && sleep 100' 
+      - run:
+          name: Chmod core dump if fail
+          command: |
             if [ -f tmp_docker/core* ];then
               sudo chmod 777 tmp_docker/core*
             fi
+          when: on_fail
+      - run: 
+        name: Run SmokeTest
+        command: |
+          docker run --rm -d --name taraxa-node-smoke-test-${DOCKER_BRANCH_TAG} ${IMAGE}-${DOCKER_BRANCH_TAG}-${BUILD_NUMBER} single
+          mkdir -p  $PWD/test_build-d/
+          sleep 30
+          http_code=$(docker run --rm  -v $PWD/test_build-d:/data byrnedo/alpine-curl \
+                -sS --fail -w '%{http_code}' -o /data/http.out \
+                --url taraxa-node-smoke-test-${DOCKER_BRANCH_TAG}:7777 \
+                -d '{
+                        "jsonrpc": "2.0",
+                        "id":"0",
+                        "method": "send_coin_transaction",
+                        "params":[{
+                            "nonce": 0,
+                            "value": 0,
+                            "gas": 0,
+                            "gas_price": 0,
+                            "receiver": "973ecb1c08c8eb5a7eaa0d3fd3aab7924f2838b0",
+                            "secret": "3800b2875669d9b2053c1aff9224ecfdc411423aac5b5a73d7a45ced1c3b9dcd"
+                        }]
+                    }')
+          cat $PWD/test_build-d/http.out || true
+          if [[ $http_code -eq 200 ]] ; then
+              exit 0
+          else
+              exit $http_code
+          fi
+
       - store_artifacts:
           path: tmp_docker
-          when: on_fail
 
    create-and-push-builder:
      docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,8 @@ jobs:
            docker run -d --rm -v $PWD/tmp_docker:/tmp --name taraxa-node-ctest-$DOCKER_BRANCH_TAG gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}-ctest sh -c \
                        'cd cmake-docker-build-debug/tests \
                         && ctest --output-on-failure && sleep 100' &
-            sleep 5 && sudo killall -3 ctest
+            sleep 5 && sudo killall -3 ctest 
+            sleep 30
       - store_artifacts:
           path: tmp_docker
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,15 +33,13 @@ jobs:
            fi
            echo 'export CIRCLE_BRANCH=cirleci' >>$BASH_ENV
            echo 'export CIRCLE_BUILD_NUM=300'  >>$BASH_ENV
-           #echo 'export DOCKER_BUILDKIT=1' >>$BASH_ENV
-           export DOCKER_BRANCH_TAG=$(./scripts/docker_tag_from_branch.sh $CIRCLE_BRANCH)
-           #DOCKER_BUILDKIT=1 docker build -t "${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}" .
-      #- setup_remote_docker:
-      #   docker_layer_caching: true
+           echo "export DOCKER_BRANCH_TAG=$(./scripts/docker_tag_from_branch.sh $CIRCLE_BRANCH)" >>$BASH_ENV
       - gcp-gcr/build-image:
+         name: Build Image
          image: $IMAGE-$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM
       - gcp-gcr/build-image:
-         image: $IMAGE-DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM-ctest
+         name: Build Ctest Image
+         image: $IMAGE-$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM-ctest
          extra_build_args: --target build
       - run:
          command: docker run $IMAGE-DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM-ctest bash

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,46 @@ orbs:
 
 
 jobs: 
+   build-docker-image:
+    environment:
+      IMAGE=taraxa-node
+#    docker: 
+#      - image: circleci/buildpack-deps:stretch
+#      - image: ubuntu-1604:201903-01
+#        user: root
+    machine:
+      image: ubuntu-1604:202007-01
+    resource_class: xlarge
+    steps:
+      - checkout
+      - run: 
+         name: Checkout Submodules
+         command: |
+              git submodule sync
+              git submodule update --init --recursive --jobs 8
+      - run:
+         name: Docker Build
+         command: |
+           if [[ ${CIRCLE_SHELL_ENV} =~ "localbuild" ]]; then
+              export CIRCLE_BRANCH=circleci
+              export CIRCLE_BUILD_NUM=300
+           fi
+           echo 'export CIRCLE_BRANCH=cirleci' >>$BASH_ENV
+           echo 'export CIRCLE_BUILD_NUM=300'  >>$BASH_ENV
+           #echo 'export DOCKER_BUILDKIT=1' >>$BASH_ENV
+           export DOCKER_BRANCH_TAG=$(./scripts/docker_tag_from_branch.sh $CIRCLE_BRANCH)
+           #DOCKER_BUILDKIT=1 docker build -t "${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}" .
+      #- setup_remote_docker:
+      #   docker_layer_caching: true
+      - gcp-gcr/build-image:
+         image: $IMAGE-$DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM
+      - gcp-gcr/build-image:
+         image: $IMAGE-DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM-ctest
+         extra_build_args: --target build
+      - run:
+         command: docker run $IMAGE-DOCKER_BRANCH_TAG-$CIRCLE_BUILD_NUM-ctest bash
+
    create-and-push-builder:
-     #executor: gcp-gcr/default
      docker:
        - image: circleci/buildpack-deps:stretch
      steps:
@@ -176,6 +214,15 @@ jobs:
            paths: [ bin_install ]
 
 workflows:
+  deploy-testnet:
+    jobs:
+      - build-docker-image:
+         context: taraxa-node
+         filters:
+          branches: 
+            only: 
+              - circleci
+
   build-and-release:
     jobs:
       - create-and-push-builder:
@@ -183,14 +230,9 @@ workflows:
           filters:
             branches: 
               only: 
-                #- develop
+#               - develop
                - cirleci
-      #- gcp-gcr/build-and-push-image:
-      #    executor: docker
-      #    image: taraxa-node/taraxa-builder
-      #    context: taraxa-node
-      #    setup-remote-docker: true
-      #    use-docker-layer-caching: true
+
       - build-linux:
           filters:
             branches: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
                        'cd cmake-docker-build-debug/tests \
                         && ctest --output-on-failure && sleep 100' &
             sleep 5 && sudo killall -3 ctest 
-            if [ -f tmp_docker/core* ]
+            if [ -f tmp_docker/core* ];then
               chmod 777 tmp_docker/core*
             fi
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,8 +66,9 @@ jobs:
               single
           mkdir -p  $PWD/test_build-d/
           sleep 30
-          http_code=$(docker run --rm  -v $PWD/test_build-d:/data byrnedo/alpine-curl \
-                --net smoke-test-net-${DOCKER_BRANCH_TAG}
+          http_code=$(docker run --rm  -v $PWD/test_build-d:/data \
+                --net smoke-test-net-${DOCKER_BRANCH_TAG} \
+                byrnedo/alpine-curl \
                 -sS --fail -w '%{http_code}' -o /data/http.out \
                 --url taraxa-node-smoke-test-${DOCKER_BRANCH_TAG}:7777 \
                 -d '{

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
            docker run -d --rm -v $PWD/tmp_docker:/tmp --name taraxa-node-ctest-$DOCKER_BRANCH_TAG gcr.io/$GOOGLE_PROJECT_ID/${IMAGE}-${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}-ctest sh -c \
                        'cd cmake-docker-build-debug/tests \
                         && ctest --output-on-failure && sleep 100'
-            sleep 30 && killal -3 ctest
+            sleep 30 && killall -3 ctest
       - store_artifacts:
           path: tmp_docker
           when: on_fail


### PR DESCRIPTION
## Purpose

Adding support for build and push test and official Docker images

## For reviewers

The main changes are in just one job **build-and-push-docker-image** tested many ways, using docker executor found that the fastest method was to use machine executor and take advantage of docker_layer_caching, also using just one job speeds up the process since no other VMs needs to be spinned up, so everything on one job, multiple steps, which execution is filtered by comparing to ${CIRCLE_BRANCH}, probably code can be cleaned up and improved by creating an orb and commands.
Some testing still needs to be done, regarding the branch filtering for branches PR-* i did no tested that part., rest should be working i tested the code as thoroughly as i could without impacting existing process

## Related Github issues

<!-- Include related github issues. -->

## Changes

<!-- Summary or changes that have been made. -->

## Tests

<!-- Describe what you did to test these changes, including unit tests that have been added or changed. -->

## Deployment Considerations

## Version Notes ##
{ major | minor | patch }

<!--

Decide whether this is a major, minor, or patch version change. Major is for backwards incompatible changes (This is only relevant once the service is live and in production and the major version is at least 1. While the major version is 0, it is ok to have backwards incompatible changes in a minor version.). Minor is for additional features. Patch is for bug fixes.

Describe the changes in this version. This is essentially the details you would include in the squash commit message.
-->

**NOTE: Include the version notes in the squash commit message**
