### PR TITLE
bugfix(vote): Remove last PBFT block hash for vote VRF sortition

### DIFF
--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -272,6 +272,7 @@ bool PbftManager::resetRound_() {
     soft_voted_block_for_this_round_ = std::make_pair(NULL_BLOCK_HASH, false);
 
     if (executed_pbft_block_) {
+      vote_mgr_->removeVerifiedVotes();
       update_dpos_state_();
       // reset sortition_threshold and TWO_T_PLUS_ONE
       updateTwoTPlusOneAndThreshold_();
@@ -1330,6 +1331,7 @@ void PbftManager::pushSyncedPbftBlocksIntoChain_() {
     // Remove from PBFT synced queue
     pbft_chain_->pbftSyncedQueuePopFront();
     if (executed_pbft_block_) {
+      vote_mgr_->removeVerifiedVotes();
       update_dpos_state_();
       // update sortition_threshold and TWO_T_PLUS_ONE
       updateTwoTPlusOneAndThreshold_();

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -200,7 +200,7 @@ size_t PbftManager::dpos_eligible_vote_count_(addr_t const &addr) {
 
 bool PbftManager::shouldSpeak(PbftVoteTypes type, uint64_t round, size_t step, size_t weighted_index) {
   // compute sortition
-  VrfPbftMsg msg(vrf_pbft_chain_last_block_hash_, type, round, step, weighted_index);
+  VrfPbftMsg msg(type, round, step, weighted_index);
   VrfPbftSortition vrf_sortition(vrf_sk_, msg);
   if (!vrf_sortition.canSpeak(sortition_threshold_, getDposTotalVotesCount())) {
     LOG(log_tr_) << "Don't get sortition";
@@ -244,15 +244,6 @@ bool PbftManager::resetRound_() {
     resetStep_();
     state_ = value_proposal_state;
 
-    // Update VRF pbft chain last block hash in each new round
-    auto last_pbft_block_hash = pbft_chain_->getLastPbftBlockHash();
-    if (vrf_pbft_chain_last_block_hash_ != last_pbft_block_hash) {
-      vrf_pbft_chain_last_block_hash_ = last_pbft_block_hash;
-      vote_mgr_->removeVerifiedVotes();
-      LOG(log_nf_) << "In new round " << consensus_pbft_round << ", update VRF last PBFT block hash "
-                   << vrf_pbft_chain_last_block_hash_ << ". Remove all verified votes";
-    }
-
     LOG(log_dg_) << "Advancing clock to pbft round " << consensus_pbft_round << ", step 1, and resetting clock.";
 
     // Update in DB first
@@ -263,8 +254,6 @@ bool PbftManager::resetRound_() {
     db_->addPbftMgrStatusToBatch(PbftMgrStatus::next_voted_soft_value, false, batch);
     db_->addPbftMgrStatusToBatch(PbftMgrStatus::soft_voted_block_in_round, false, batch);
     db_->addPbftMgrVotedValueToBatch(PbftMgrVotedValue::soft_voted_block_hash_in_round, NULL_BLOCK_HASH, batch);
-    db_->addPbftMgrVotedValueToBatch(PbftMgrVotedValue::vrf_pbft_chain_last_block_hash, vrf_pbft_chain_last_block_hash_,
-                                     batch);
     if (soft_voted_block_for_this_round_.second && soft_voted_block_for_this_round_.first != NULL_BLOCK_HASH) {
       db_->removeSoftVotesToBatch(round, batch);
     }
@@ -388,16 +377,6 @@ void PbftManager::initialState_() {
   } else {
     // Default value
     soft_voted_block_for_this_round_ = std::make_pair(NULL_BLOCK_HASH, soft_voted_block);
-  }
-
-  // Initialize VRF PBFT last block hash (PBFT genesis block in beginning)
-  auto vrf_pbft_last_block_hash = db_->getPbftMgrVotedValue(PbftMgrVotedValue::vrf_pbft_chain_last_block_hash);
-  if (vrf_pbft_last_block_hash) {
-    // From DB
-    vrf_pbft_chain_last_block_hash_ = *vrf_pbft_last_block_hash;
-  } else {
-    // Default value
-    vrf_pbft_chain_last_block_hash_ = NULL_BLOCK_HASH;
   }
 
   executed_pbft_block_ = db_->getPbftMgrStatus(PbftMgrStatus::executed_block);
@@ -543,7 +522,7 @@ bool PbftManager::stateOperations_() {
   // ONLY CHECK IF HAVE *NOT* YET EXECUTED THIS ROUND...
   if (state_ == certify_state && !have_executed_this_round_) {
     std::vector<Vote> cert_votes_for_round = getVotesOfTypeFromVotesForRoundAndStep_(
-        cert_vote_type, votes_, round, 3, vrf_pbft_chain_last_block_hash_, std::make_pair(NULL_BLOCK_HASH, false));
+        cert_vote_type, votes_, round, 3, std::make_pair(NULL_BLOCK_HASH, false));
     std::pair<blk_hash_t, bool> cert_voted_block_hash = blockWithEnoughVotes_(cert_votes_for_round);
     if (cert_voted_block_hash.second) {
       LOG(log_dg_) << "PBFT block " << cert_voted_block_hash.first << " has enough certed votes";
@@ -679,8 +658,8 @@ void PbftManager::certifyBlock_() {
     LOG(log_tr_) << "In step 3";
 
     if (!soft_voted_block_for_this_round_.second) {
-      auto soft_votes = getVotesOfTypeFromVotesForRoundAndStep_(
-          soft_vote_type, votes_, round, 2, vrf_pbft_chain_last_block_hash_, std::make_pair(NULL_BLOCK_HASH, false));
+      auto soft_votes = getVotesOfTypeFromVotesForRoundAndStep_(soft_vote_type, votes_, round, 2,
+                                                                std::make_pair(NULL_BLOCK_HASH, false));
       auto soft_voted_block_hash = blockWithEnoughVotes_(soft_votes);
 
       auto batch = db_->createWriteBatch();
@@ -793,8 +772,8 @@ void PbftManager::secondFinish_() {
   auto end_time_for_step = (step_ + 1) * LAMBDA_ms + STEP_4_DELAY - POLLING_INTERVAL_ms;
 
   if (!soft_voted_block_for_this_round_.second) {
-    auto soft_votes = getVotesOfTypeFromVotesForRoundAndStep_(
-        soft_vote_type, votes_, round, 2, vrf_pbft_chain_last_block_hash_, std::make_pair(NULL_BLOCK_HASH, false));
+    auto soft_votes = getVotesOfTypeFromVotesForRoundAndStep_(soft_vote_type, votes_, round, 2,
+                                                              std::make_pair(NULL_BLOCK_HASH, false));
     auto soft_voted_block_hash = blockWithEnoughVotes_(soft_votes);
 
     auto batch = db_->createWriteBatch();
@@ -882,8 +861,7 @@ uint64_t PbftManager::roundDeterminedFromVotes_() {
   for (auto const &rs_votes : next_votes_tally_by_round_step) {
     if (rs_votes.second >= TWO_T_PLUS_ONE) {
       std::vector<Vote> next_votes_for_round_step = getVotesOfTypeFromVotesForRoundAndStep_(
-          next_vote_type, votes_, rs_votes.first.first, rs_votes.first.second, vrf_pbft_chain_last_block_hash_,
-          std::make_pair(NULL_BLOCK_HASH, false));
+          next_vote_type, votes_, rs_votes.first.first, rs_votes.first.second, std::make_pair(NULL_BLOCK_HASH, false));
       if (blockWithEnoughVotes_(next_votes_for_round_step).second) {
         LOG(log_dg_) << "Found sufficient next votes in round " << rs_votes.first.first << ", step "
                      << rs_votes.first.second << ", PBFT 2t+1 " << TWO_T_PLUS_ONE;
@@ -918,7 +896,6 @@ std::pair<blk_hash_t, bool> PbftManager::blockWithEnoughVotes_(std::vector<Vote>
   auto vote_type = votes[0].getType();
   auto vote_round = votes[0].getRound();
   auto vote_step = votes[0].getStep();
-  auto last_pbft_block_hash = votes[0].getVrfLastPbftBlockHash();
 
   for (Vote const &v : votes) {
     if (v.getType() != vote_type) {
@@ -930,9 +907,6 @@ std::pair<blk_hash_t, bool> PbftManager::blockWithEnoughVotes_(std::vector<Vote>
     } else if (v.getStep() != vote_step) {
       LOG(log_er_) << "Next phase vote has a different step with " << vote_step << ". VOTE: " << v;
       assert(false);
-    } else if (v.getVrfLastPbftBlockHash() != last_pbft_block_hash) {
-      LOG(log_er_) << "Vote has a different VRF last PBFT block hash with " << last_pbft_block_hash << ". VOTE: " << v;
-      continue;
     }
 
     auto blockhash = v.getBlockHash();
@@ -962,13 +936,11 @@ std::pair<blk_hash_t, bool> PbftManager::blockWithEnoughVotes_(std::vector<Vote>
 std::vector<Vote> PbftManager::getVotesOfTypeFromVotesForRoundAndStep_(PbftVoteTypes vote_type,
                                                                        std::vector<Vote> &votes, uint64_t round,
                                                                        size_t step,
-                                                                       blk_hash_t const &last_pbft_block_hash,
                                                                        std::pair<blk_hash_t, bool> blockhash) {
   std::vector<Vote> votes_of_requested_type;
   std::copy_if(votes.begin(), votes.end(), std::back_inserter(votes_of_requested_type),
-               [vote_type, round, step, last_pbft_block_hash, blockhash](Vote const &v) {
+               [vote_type, round, step, blockhash](Vote const &v) {
                  return (v.getType() == vote_type && v.getRound() == round && v.getStep() == step &&
-                         v.getVrfLastPbftBlockHash() == last_pbft_block_hash &&
                          (blockhash.second == false || blockhash.first == v.getBlockHash()));
                });
 
@@ -976,9 +948,9 @@ std::vector<Vote> PbftManager::getVotesOfTypeFromVotesForRoundAndStep_(PbftVoteT
 }
 
 Vote PbftManager::generateVote(blk_hash_t const &blockhash, PbftVoteTypes type, uint64_t round, size_t step,
-                               size_t weighted_index, blk_hash_t const &last_pbft_block_hash) {
+                               size_t weighted_index) {
   // sortition proof
-  VrfPbftMsg msg(last_pbft_block_hash, type, round, step, weighted_index);
+  VrfPbftMsg msg(type, round, step, weighted_index);
   VrfPbftSortition vrf_sortition(vrf_sk_, msg);
   Vote vote(node_sk_, vrf_sortition, blockhash);
 
@@ -994,7 +966,7 @@ size_t PbftManager::placeVote_(taraxa::blk_hash_t const &blockhash, PbftVoteType
       break;
     }
     if (shouldSpeak(propose_vote_type, round, step_, weighted_index)) {
-      auto vote = generateVote(blockhash, vote_type, round, step, weighted_index, vrf_pbft_chain_last_block_hash_);
+      auto vote = generateVote(blockhash, vote_type, round, step, weighted_index);
       votes.emplace_back(vote);
       db_->saveVerifiedVote(vote);
       vote_mgr_->addVerifiedVote(vote);
@@ -1292,8 +1264,7 @@ bool PbftManager::pushCertVotedPbftBlockIntoChain_(taraxa::blk_hash_t const &cer
     return false;
   }
   PbftBlockCert pbft_block_cert_votes(*pbft_block, cert_votes_for_round);
-  bool updated_vrf_last_pbft_block_hash = false;
-  if (!pushPbftBlock_(pbft_block_cert_votes, false, updated_vrf_last_pbft_block_hash)) {
+  if (!pushPbftBlock_(pbft_block_cert_votes)) {
     LOG(log_er_) << "Failed push PBFT block " << pbft_block->getBlockHash() << " into chain";
     return false;
   }
@@ -1304,7 +1275,6 @@ bool PbftManager::pushCertVotedPbftBlockIntoChain_(taraxa::blk_hash_t const &cer
 
 void PbftManager::pushSyncedPbftBlocksIntoChain_() {
   size_t pbft_synced_queue_size;
-  bool updated_vrf_last_pbft_block_hash = false;
   while (!pbft_chain_->pbftSyncedQueueEmpty()) {
     PbftBlockCert pbft_block_and_votes = pbft_chain_->pbftSyncedQueueFront();
     auto round = getPbftRound();
@@ -1349,7 +1319,7 @@ void PbftManager::pushSyncedPbftBlocksIntoChain_() {
     if (!comparePbftBlockScheduleWithDAGblocks_(*pbft_block_and_votes.pbft_blk)) {
       break;
     }
-    if (pushPbftBlock_(pbft_block_and_votes, true, updated_vrf_last_pbft_block_hash)) {
+    if (pushPbftBlock_(pbft_block_and_votes)) {
       LOG(log_nf_) << node_addr_ << " push synced PBFT block " << pbft_block_and_votes.pbft_blk->getBlockHash()
                    << " in round " << round;
     } else {
@@ -1373,16 +1343,9 @@ void PbftManager::pushSyncedPbftBlocksIntoChain_() {
     }
     pbft_last_observed_synced_queue_size_ = pbft_synced_queue_size;
   }
-
-  if (updated_vrf_last_pbft_block_hash) {
-    LOG(log_nf_) << "Remove all verified votes. Since new PBFT blocks have synced into chain, last PBFT block hash "
-                    "has changed.";
-    vote_mgr_->removeVerifiedVotes();
-  }
 }
 
-bool PbftManager::pushPbftBlock_(PbftBlockCert const &pbft_block_cert_votes, bool syncing,
-                                 bool &updated_vrf_last_pbft_block_hash) {
+bool PbftManager::pushPbftBlock_(PbftBlockCert const &pbft_block_cert_votes) {
   auto const &pbft_block_hash = pbft_block_cert_votes.pbft_blk->getBlockHash();
   if (db_->pbftBlockInDb(pbft_block_hash)) {
     LOG(log_er_) << "PBFT block: " << pbft_block_hash << " in DB already.";
@@ -1415,15 +1378,6 @@ bool PbftManager::pushPbftBlock_(PbftBlockCert const &pbft_block_cert_votes, boo
   // Add dag_block_period in DB
   for (auto const &blk_hash : finalized_dag_blk_hashes) {
     db_->addDagBlockPeriodToBatch(blk_hash, pbft_period, batch);
-  }
-
-  // Update last PBFT block hash when synced PBFT blocks that is not voted at the current round
-  if (syncing && cert_votes[0].getRound() != getPbftRound()) {
-    db_->addPbftMgrVotedValueToBatch(PbftMgrVotedValue::vrf_pbft_chain_last_block_hash, pbft_block_hash, batch);
-    vrf_pbft_chain_last_block_hash_ = pbft_block_hash;
-    updated_vrf_last_pbft_block_hash = true;
-    LOG(log_nf_) << "Sycned PBFT block. Update last PBFT block hash " << vrf_pbft_chain_last_block_hash_
-                 << " for VRF sortition";
   }
 
   // Commit DB

--- a/src/consensus/pbft_manager.hpp
+++ b/src/consensus/pbft_manager.hpp
@@ -57,8 +57,9 @@ class PbftManager {
   void setTwoTPlusOne(size_t const two_t_plus_one);
   void setPbftStep(size_t const pbft_step);
 
-  Vote generateVote(blk_hash_t const &blockhash, PbftVoteTypes type, uint64_t round, size_t step, size_t weighted_index,
-                    blk_hash_t const &last_pbft_block_hash);
+  Vote generateVote(blk_hash_t const &blockhash, PbftVoteTypes type, uint64_t round, size_t step,
+                    size_t weighted_index);
+
   size_t getDposTotalVotesCount() const;
   size_t getDposWeightedVotesCount() const;
 
@@ -100,7 +101,6 @@ class PbftManager {
 
   std::vector<Vote> getVotesOfTypeFromVotesForRoundAndStep_(PbftVoteTypes vote_type, std::vector<Vote> &votes,
                                                             uint64_t round, size_t step,
-                                                            blk_hash_t const &last_pbft_block_hash,
                                                             std::pair<blk_hash_t, bool> blockhash);
 
   size_t placeVote_(blk_hash_t const &blockhash, PbftVoteTypes vote_type, uint64_t round, size_t step);
@@ -125,7 +125,7 @@ class PbftManager {
 
   void pushSyncedPbftBlocksIntoChain_();
 
-  bool pushPbftBlock_(PbftBlockCert const &pbft_block_cert_votes, bool syncing, bool &updated_vrf_last_pbft_block_hash);
+  bool pushPbftBlock_(PbftBlockCert const &pbft_block_cert_votes);
 
   void updateTwoTPlusOneAndThreshold_();
   bool is_syncing_();
@@ -160,8 +160,6 @@ class PbftManager {
   std::atomic<uint64_t> round_ = 1;
   size_t step_ = 1;
   u_long STEP_4_DELAY = 0;  // constant
-
-  blk_hash_t vrf_pbft_chain_last_block_hash_ = blk_hash_t(0);
 
   blk_hash_t own_starting_value_for_round_ = NULL_BLOCK_HASH;
   // <round, cert_voted_block_hash>

--- a/src/consensus/vote.hpp
+++ b/src/consensus/vote.hpp
@@ -160,6 +160,7 @@ class VoteManager {
 
   // Verified votes
   void addVerifiedVote(Vote const& vote);
+  void removeVerifiedVotes();
   bool voteInVerifiedMap(uint64_t const& pbft_round, vote_hash_t const& vote_hash);
   void clearVerifiedVotesTable();
   std::vector<Vote> getVerifiedVotes();

--- a/src/consensus/vote.hpp
+++ b/src/consensus/vote.hpp
@@ -18,22 +18,20 @@ class PbftManager;
 
 struct VrfPbftMsg {
   VrfPbftMsg() = default;
-  VrfPbftMsg(blk_hash_t const& blk, PbftVoteTypes type, uint64_t round, size_t step, size_t weighted_index)
-      : blk(blk), type(type), round(round), step(step), weighted_index(weighted_index) {}
+  VrfPbftMsg(PbftVoteTypes type, uint64_t round, size_t step, size_t weighted_index)
+      : type(type), round(round), step(step), weighted_index(weighted_index) {}
 
   std::string toString() const {
-    return blk.toString() + "_" + std::to_string(type) + "_" + std::to_string(round) + "_" + std::to_string(step) +
-           "_" + std::to_string(weighted_index);
+    return std::to_string(type) + "_" + std::to_string(round) + "_" + std::to_string(step) + "_" +
+           std::to_string(weighted_index);
   }
 
   bool operator==(VrfPbftMsg const& other) const {
-    return blk == other.blk && type == other.type && round == other.round && step == other.step &&
-           weighted_index == other.weighted_index;
+    return type == other.type && round == other.round && step == other.step && weighted_index == other.weighted_index;
   }
 
   friend std::ostream& operator<<(std::ostream& strm, VrfPbftMsg const& pbft_msg) {
     strm << "  [Vrf Pbft Msg] " << std::endl;
-    strm << "    blk_hash: " << pbft_msg.blk << std::endl;
     strm << "    type: " << pbft_msg.type << std::endl;
     strm << "    round: " << pbft_msg.round << std::endl;
     strm << "    step: " << pbft_msg.step << std::endl;
@@ -43,8 +41,7 @@ struct VrfPbftMsg {
 
   bytes getRlpBytes() const {
     dev::RLPStream s;
-    s.appendList(5);
-    s << blk;
+    s.appendList(4);
     s << type;
     s << round;
     s << step;
@@ -52,7 +49,6 @@ struct VrfPbftMsg {
     return s.out();
   }
 
-  blk_hash_t blk;  // PBFT chain last block hash
   PbftVoteTypes type;
   uint64_t round;
   size_t step;
@@ -113,7 +109,6 @@ class Vote {
   auto getCredential() const { return vrf_sortition_.output; }
   sig_t getVoteSignature() const { return vote_signature_; }
   blk_hash_t getBlockHash() const { return blockhash_; }
-  blk_hash_t getVrfLastPbftBlockHash() const { return vrf_sortition_.pbft_msg.blk; }
   PbftVoteTypes getType() const { return vrf_sortition_.pbft_msg.type; }
   uint64_t getRound() const { return vrf_sortition_.pbft_msg.round; }
   size_t getStep() const { return vrf_sortition_.pbft_msg.step; }
@@ -165,7 +160,6 @@ class VoteManager {
 
   // Verified votes
   void addVerifiedVote(Vote const& vote);
-  void removeVerifiedVotes();
   bool voteInVerifiedMap(uint64_t const& pbft_round, vote_hash_t const& vote_hash);
   void clearVerifiedVotesTable();
   std::vector<Vote> getVerifiedVotes();

--- a/src/storage/db_storage.hpp
+++ b/src/storage/db_storage.hpp
@@ -44,7 +44,6 @@ enum PbftMgrStatus {
 enum PbftMgrVotedValue {
   own_starting_value_in_round = 0,
   soft_voted_block_hash_in_round,
-  vrf_pbft_chain_last_block_hash,
 };
 
 enum DposProposalPeriodLevelsStatus : uint8_t { max_proposal_period = 0 };

--- a/tests/crypto_test.cpp
+++ b/tests/crypto_test.cpp
@@ -96,8 +96,7 @@ TEST_F(CryptoTest, vrf_sortition) {
   vrf_sk_t sk(
       "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
       "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
-  blk_hash_t blk(123);
-  VrfPbftMsg msg(blk, PbftVoteTypes::cert_vote_type, 2, 3, 0);
+  VrfPbftMsg msg(PbftVoteTypes::cert_vote_type, 2, 3, 0);
   VrfPbftSortition sortition(sk, msg);
   VrfPbftSortition sortition2(sk, msg);
 
@@ -267,24 +266,29 @@ TEST_F(CryptoTest, sortition_rate) {
   int sortition_threshold = 5;
   // Test for one player sign round messages to get sortition
   // Sortition rate THRESHOLD / PLAYERS = 5%
+  uint64_t pbft_round;
+  size_t pbft_step = 3;
+  size_t weighted_index;
   for (int i = 0; i < round; i++) {
-    blk_hash_t blk(i);
-    VrfPbftMsg msg(blk, PbftVoteTypes::cert_vote_type, 2, 3, 0);
+    pbft_round = i;
+    weighted_index = i;
+    VrfPbftMsg msg(PbftVoteTypes::cert_vote_type, pbft_round, pbft_step, weighted_index);
     VrfPbftSortition sortition(sk, msg);
     bool win = sortition.canSpeak(sortition_threshold, valid_sortition_players);
     if (win) {
       count++;
     }
   }
-  EXPECT_EQ(count, 44);  // Test experience
+  EXPECT_EQ(count, 54);  // Test experience
 
   count = 0;
   sortition_threshold = valid_sortition_players;
   // Test for one player sign round messages to get sortition
   // Sortition rate THRESHOLD / PLAYERS = 100%
   for (int i = 0; i < round; i++) {
-    blk_hash_t blk(i);
-    VrfPbftMsg msg(blk, PbftVoteTypes::cert_vote_type, 2, 3, 0);
+    pbft_round = i;
+    weighted_index = i;
+    VrfPbftMsg msg(PbftVoteTypes::cert_vote_type, pbft_round, pbft_step, weighted_index);
     VrfPbftSortition sortition(sk, msg);
     bool win = sortition.canSpeak(sortition_threshold, valid_sortition_players);
     if (win) {
@@ -303,8 +307,9 @@ TEST_F(CryptoTest, sortition_rate) {
     dev::KeyPair key_pair = dev::KeyPair::create();
     for (int j = 0; j < round; j++) {
       auto [pk, sk] = getVrfKeyPair();
-      blk_hash_t blk(i);
-      VrfPbftMsg msg(blk, PbftVoteTypes::cert_vote_type, 2, 3, 0);
+      pbft_round = i;
+      weighted_index = i;
+      VrfPbftMsg msg(PbftVoteTypes::cert_vote_type, pbft_round, pbft_step, weighted_index);
       VrfPbftSortition sortition(sk, msg);
       bool win = sortition.canSpeak(sortition_threshold, valid_sortition_players);
       if (win) {

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -166,21 +166,16 @@ TEST_F(FullNodeTest, db_test) {
   // PBFT manager voted value
   EXPECT_EQ(db.getPbftMgrVotedValue(PbftMgrVotedValue::own_starting_value_in_round), nullptr);
   EXPECT_EQ(db.getPbftMgrVotedValue(PbftMgrVotedValue::soft_voted_block_hash_in_round), nullptr);
-  EXPECT_EQ(db.getPbftMgrVotedValue(PbftMgrVotedValue::vrf_pbft_chain_last_block_hash), nullptr);
   db.savePbftMgrVotedValue(PbftMgrVotedValue::own_starting_value_in_round, blk_hash_t(1));
   db.savePbftMgrVotedValue(PbftMgrVotedValue::soft_voted_block_hash_in_round, blk_hash_t(2));
-  db.savePbftMgrVotedValue(PbftMgrVotedValue::vrf_pbft_chain_last_block_hash, blk_hash_t(3));
   EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::own_starting_value_in_round), blk_hash_t(1));
   EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::soft_voted_block_hash_in_round), blk_hash_t(2));
-  EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::vrf_pbft_chain_last_block_hash), blk_hash_t(3));
   batch = db.createWriteBatch();
   db.addPbftMgrVotedValueToBatch(PbftMgrVotedValue::own_starting_value_in_round, blk_hash_t(4), batch);
   db.addPbftMgrVotedValueToBatch(PbftMgrVotedValue::soft_voted_block_hash_in_round, blk_hash_t(5), batch);
-  db.addPbftMgrVotedValueToBatch(PbftMgrVotedValue::vrf_pbft_chain_last_block_hash, blk_hash_t(6), batch);
   db.commitWriteBatch(batch);
   EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::own_starting_value_in_round), blk_hash_t(4));
   EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::soft_voted_block_hash_in_round), blk_hash_t(5));
-  EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::vrf_pbft_chain_last_block_hash), blk_hash_t(6));
 
   // PBFT cert voted block hash
   EXPECT_EQ(db.getPbftCertVotedBlockHash(1), nullptr);
@@ -262,13 +257,12 @@ TEST_F(FullNodeTest, db_test) {
   std::vector<Vote> unverified_votes = db.getUnverifiedVotes();
   EXPECT_TRUE(unverified_votes.empty());
   EXPECT_FALSE(db.unverifiedVoteExist(blk_hash_t(0)));
-  blk_hash_t last_pbft_block_hash(0);
   blk_hash_t voted_pbft_block_hash(1);
   auto weighted_index = 0;
   for (auto i = 0; i < 3; i++) {
     auto round = i;
     auto step = i;
-    VrfPbftMsg msg(last_pbft_block_hash, soft_vote_type, round, step, weighted_index);
+    VrfPbftMsg msg(soft_vote_type, round, step, weighted_index);
     vrf_wrapper::vrf_sk_t vrf_sk(
         "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
         "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
@@ -297,13 +291,12 @@ TEST_F(FullNodeTest, db_test) {
   // Verified votes
   std::vector<Vote> verified_votes = db.getVerifiedVotes();
   EXPECT_TRUE(verified_votes.empty());
-  last_pbft_block_hash = blk_hash_t(1);
   voted_pbft_block_hash = blk_hash_t(2);
   weighted_index = 0;
   for (auto i = 0; i < 3; i++) {
     auto round = i;
     auto step = i;
-    VrfPbftMsg msg(last_pbft_block_hash, next_vote_type, round, step, weighted_index);
+    VrfPbftMsg msg(next_vote_type, round, step, weighted_index);
     vrf_wrapper::vrf_sk_t vrf_sk(
         "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
         "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
@@ -329,11 +322,10 @@ TEST_F(FullNodeTest, db_test) {
   auto round = 1, step = 2;
   std::vector<Vote> soft_votes = db.getSoftVotes(round);
   EXPECT_TRUE(soft_votes.empty());
-  last_pbft_block_hash = blk_hash_t(0);
   weighted_index = 0;
   for (auto i = 0; i < 3; i++) {
     blk_hash_t voted_pbft_block_hash(i);
-    VrfPbftMsg msg(last_pbft_block_hash, soft_vote_type, round, step, weighted_index);
+    VrfPbftMsg msg(soft_vote_type, round, step, weighted_index);
     vrf_wrapper::vrf_sk_t vrf_sk(
         "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
         "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
@@ -347,7 +339,7 @@ TEST_F(FullNodeTest, db_test) {
   EXPECT_EQ(soft_votes_from_db.size(), 3);
   for (auto i = 3; i < 5; i++) {
     blk_hash_t voted_pbft_block_hash(i);
-    VrfPbftMsg msg(last_pbft_block_hash, soft_vote_type, round, step, weighted_index);
+    VrfPbftMsg msg(soft_vote_type, round, step, weighted_index);
     vrf_wrapper::vrf_sk_t vrf_sk(
         "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
         "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
@@ -372,8 +364,8 @@ TEST_F(FullNodeTest, db_test) {
   voted_pbft_block_hash = blk_hash_t(10);
   weighted_index = 0;
   for (auto i = 0; i < 3; i++) {
-    blk_hash_t last_pbft_block_hash(i);
-    VrfPbftMsg msg(last_pbft_block_hash, cert_vote_type, 2, 3, weighted_index);
+    weighted_index = i;
+    VrfPbftMsg msg(cert_vote_type, 2, 3, weighted_index);
     vrf_wrapper::vrf_sk_t vrf_sk(
         "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
         "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
@@ -397,7 +389,7 @@ TEST_F(FullNodeTest, db_test) {
   EXPECT_TRUE(next_votes.empty());
   for (auto i = 0; i < 3; i++) {
     blk_hash_t voted_pbft_block_hash(i);
-    VrfPbftMsg msg(last_pbft_block_hash, next_vote_type, round, step, weighted_index);
+    VrfPbftMsg msg(next_vote_type, round, step, weighted_index);
     vrf_wrapper::vrf_sk_t vrf_sk(
         "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
         "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
@@ -412,7 +404,7 @@ TEST_F(FullNodeTest, db_test) {
   next_votes.clear();
   for (auto i = 3; i < 5; i++) {
     blk_hash_t voted_pbft_block_hash(i);
-    VrfPbftMsg msg(last_pbft_block_hash, next_vote_type, round, step, weighted_index);
+    VrfPbftMsg msg(next_vote_type, round, step, weighted_index);
     vrf_wrapper::vrf_sk_t vrf_sk(
         "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
         "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");

--- a/tests/vote_test.cpp
+++ b/tests/vote_test.cpp
@@ -53,13 +53,12 @@ TEST_F(VoteTest, unverified_votes) {
   clearAllVotes(node);
 
   // Generate a vote
-  blk_hash_t pbft_chain_last_block_hash = node->getPbftChain()->getLastPbftBlockHash();
   blk_hash_t blockhash(1);
   PbftVoteTypes type = propose_vote_type;
   auto round = 1;
   auto step = 1;
   auto weighted_index = 0;
-  Vote vote = pbft_mgr->generateVote(blockhash, type, round, step, weighted_index, pbft_chain_last_block_hash);
+  Vote vote = pbft_mgr->generateVote(blockhash, type, round, step, weighted_index);
 
   auto vote_mgr = node->getVoteManager();
   vote_mgr->addUnverifiedVote(vote);
@@ -70,7 +69,7 @@ TEST_F(VoteTest, unverified_votes) {
   for (auto i = 1; i <= 3; i++) {
     round = i;
     step = i;
-    Vote vote = pbft_mgr->generateVote(blockhash, type, round, step, weighted_index, pbft_chain_last_block_hash);
+    Vote vote = pbft_mgr->generateVote(blockhash, type, round, step, weighted_index);
     unverified_votes.emplace_back(vote);
   }
 
@@ -99,13 +98,12 @@ TEST_F(VoteTest, verified_votes) {
   clearAllVotes(node);
 
   // Generate a vote
-  blk_hash_t pbft_chain_last_block_hash = node->getPbftChain()->getLastPbftBlockHash();
   blk_hash_t blockhash(1);
   PbftVoteTypes type = soft_vote_type;
   auto round = 1;
   auto step = 2;
   auto weighted_index = 0;
-  Vote vote = pbft_mgr->generateVote(blockhash, type, round, step, weighted_index, pbft_chain_last_block_hash);
+  Vote vote = pbft_mgr->generateVote(blockhash, type, round, step, weighted_index);
 
   auto vote_mgr = node->getVoteManager();
   vote_mgr->addVerifiedVote(vote);
@@ -135,13 +133,12 @@ TEST_F(VoteTest, add_cleanup_get_votes) {
   auto vote_mgr = node->getVoteManager();
   blk_hash_t blockhash(1);
   PbftVoteTypes type = propose_vote_type;
-  blk_hash_t pbft_chain_last_block_hash = node->getPbftChain()->getLastPbftBlockHash();
   auto weighted_index = 0;
   for (int i = 1; i <= 3; i++) {
     for (int j = 1; j <= 2; j++) {
       uint64_t round = i;
       size_t step = j;
-      Vote vote = pbft_mgr->generateVote(blockhash, type, round, step, weighted_index, pbft_chain_last_block_hash);
+      Vote vote = pbft_mgr->generateVote(blockhash, type, round, step, weighted_index);
       vote_mgr->addUnverifiedVote(vote);
     }
   }
@@ -174,14 +171,14 @@ TEST_F(VoteTest, reconstruct_votes) {
   public_t pk(12345);
   sig_t sortition_sig(1234567);
   sig_t vote_sig(9878766);
-  blk_hash_t blk_hash(111111);
+  blk_hash_t propose_blk_hash(111111);
   PbftVoteTypes type(propose_vote_type);
   uint64_t round(999);
   size_t step(2);
   size_t weighted_index(0);
-  VrfPbftMsg msg(blk_hash_t(123), type, round, step, weighted_index);
+  VrfPbftMsg msg(type, round, step, weighted_index);
   VrfPbftSortition vrf_sortition(g_vrf_sk, msg);
-  Vote vote1(g_sk, vrf_sortition, blk_hash);
+  Vote vote1(g_sk, vrf_sortition, propose_blk_hash);
   auto rlp = vote1.rlp();
   Vote vote2(rlp);
   EXPECT_EQ(vote1, vote2);
@@ -206,13 +203,12 @@ TEST_F(VoteTest, transfer_vote) {
   clearAllVotes(node2);
 
   // generate vote
-  blk_hash_t blockhash(11);
-  blk_hash_t pbft_blockhash(991);
+  blk_hash_t propose_blockhash(11);
   PbftVoteTypes type = propose_vote_type;
   uint64_t period = 1;
   size_t step = 1;
   auto weighted_index = 0;
-  Vote vote = pbft_mgr2->generateVote(blockhash, type, period, step, weighted_index, pbft_blockhash);
+  Vote vote = pbft_mgr2->generateVote(propose_blockhash, type, period, step, weighted_index);
 
   nw2->sendPbftVote(nw1->getNodeId(), vote);
 
@@ -268,13 +264,12 @@ TEST_F(VoteTest, vote_broadcast) {
   clearAllVotes(node3);
 
   // generate vote
-  blk_hash_t blockhash(1);
-  blk_hash_t pbft_blockhash(1);
+  blk_hash_t propose_block_hash(1);
   PbftVoteTypes type = propose_vote_type;
   uint64_t period = 1;
   size_t step = 1;
   auto weighted_index = 0;
-  Vote vote = pbft_mgr1->generateVote(blockhash, type, period, step, weighted_index, pbft_blockhash);
+  Vote vote = pbft_mgr1->generateVote(propose_block_hash, type, period, step, weighted_index);
 
   nw1->onNewPbftVotes(vector{vote});
 
@@ -317,11 +312,10 @@ TEST_F(VoteTest, previous_round_next_votes) {
 
   // Generate 3 votes voted at NULL_BLOCK_HASH
   std::vector<Vote> next_votes_1;
-  blk_hash_t last_pbft_block_hash(0);
   auto round = 1;
   auto step = 4;
   auto weighted_index = 0;
-  VrfPbftMsg msg(last_pbft_block_hash, next_vote_type, round, step, weighted_index);
+  VrfPbftMsg msg(next_vote_type, round, step, weighted_index);
   VrfPbftSortition vrf_sortition(g_vrf_sk, msg);
   blk_hash_t voted_pbft_block_hash(0);
   for (auto i = 0; i < 3; i++) {


### PR DESCRIPTION
## Purpose

Since cannot guarantee all nodes have same size of PBFT chain when they vote, remove last PBFT block hash for vote VRF sortition 

## For reviewers

<!-- Describe anything you want to call out to the reviewers e.g. areas to focus on, decisions you made, specific feedback you are looking for, etc. -->

## Related Github issues

https://github.com/Taraxa-project/taraxa-node/issues/780

## Changes

<!-- Summary or changes that have been made. -->

## Tests

<!-- Describe what you did to test these changes, including unit tests that have been added or changed. -->

## Deployment Considerations

## Version Notes ##
{ major | minor | patch }

<!--

Decide whether this is a major, minor, or patch version change. Major is for backwards incompatible changes (This is only relevant once the service is live and in production and the major version is at least 1. While the major version is 0, it is ok to have backwards incompatible changes in a minor version.). Minor is for additional features. Patch is for bug fixes.

Describe the changes in this version. This is essentially the details you would include in the squash commit message.
-->

**NOTE: Include the version notes in the squash commit message**
