### PR TITLE
chore(gitmodules): change taraxa submodule paths to relative

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,17 +4,17 @@
 	ignore = dirty
 [submodule "submodules/taraxa-evm"]
 	path = submodules/taraxa-evm
-	url = https://github.com/Taraxa-project/taraxa-evm.git
+	url = ../taraxa-evm.git
 	ignore = dirty
 [submodule "submodules/taraxa-vdf"]
 	path = submodules/taraxa-vdf
-	url = https://github.com/Taraxa-project/taraxa-vdf.git
+	url = ../taraxa-vdf.git
 	ignore = dirty
 [submodule "submodules/taraxa-vrf"]
 	path = submodules/taraxa-vrf
-	url = https://github.com/Taraxa-project/taraxa-vrf.git
+	url = ../taraxa-vrf.git
 	ignore = dirty
 [submodule "submodules/taraxa-aleth"]
 	path = submodules/taraxa-aleth
-	url = https://github.com/Taraxa-project/taraxa-aleth.git
+	url = ../taraxa-aleth.git
 	ignore = dirty


### PR DESCRIPTION
## Purpose

Make taraxa submodules paths relative. After that change on submodules initialization it will make a url from that one you used for the main repo saving a scheme. So if you clones a repo with `ssh` it will be also used for all submodules 