### PR TITLE
fix(networking): redefine where we mark peer as active & missing lock

### DIFF
--- a/src/dag/dag_block_manager.hpp
+++ b/src/dag/dag_block_manager.hpp
@@ -16,10 +16,9 @@ using BlockStatusTable = ExpirationCacheMap<blk_hash_t, BlockStatus>;
 class DagBlockManager {
  public:
   DagBlockManager(addr_t node_addr, vdf_sortition::VdfConfig const &vdf_config,
-                  optional<state_api::DPOSConfig> dpos_config, unsigned verify_threads,
-                  std::shared_ptr<DbStorage> db, std::shared_ptr<TransactionManager> trx_mgr,
-                  std::shared_ptr<FinalChain> final_chain, std::shared_ptr<PbftChain> pbft_chain,
-                  logger::Logger log_time_, uint32_t queue_limit = 0);
+                  optional<state_api::DPOSConfig> dpos_config, unsigned verify_threads, std::shared_ptr<DbStorage> db,
+                  std::shared_ptr<TransactionManager> trx_mgr, std::shared_ptr<FinalChain> final_chain,
+                  std::shared_ptr<PbftChain> pbft_chain, logger::Logger log_time_, uint32_t queue_limit = 0);
   ~DagBlockManager();
   void insertBlock(DagBlock const &blk);
   // Only used in initial syncs when blocks are received with full list of transactions

--- a/src/network/taraxa_capability.cpp
+++ b/src/network/taraxa_capability.cpp
@@ -213,8 +213,8 @@ void TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
   if (dag_mgr_ && !peer->passed_initial_ && _id != StatusPacket) {
     return;
   }
-  //Any packet means that we are comunicating so let's not disconnect
-  //e.g. we could sned a lot of data and status packet can be in send queue
+  // Any packet means that we are comunicating so let's not disconnect
+  // e.g. we could sned a lot of data and status packet can be in send queue
   peer->setAlive();
 
   switch (_id) {
@@ -772,7 +772,7 @@ void TaraxaCapability::restartSyncingPbft(bool force) {
   uint64_t max_node_dag_level = 0;
   {
     boost::shared_lock<boost::shared_mutex> lock(peers_mutex_);
-    for (auto const& peer : peers_) {
+    for (auto const &peer : peers_) {
       if (peer.second->pbft_chain_size_ > max_pbft_chain_size) {
         max_pbft_chain_size = peer.second->pbft_chain_size_;
         max_pbft_chain_nodeID = peer.first;
@@ -1041,8 +1041,8 @@ void TaraxaCapability::sendBlocks(NodeID const &_id, std::vector<std::shared_ptr
 
     // Split packet into multiple smaller ones if total size is > MAX_PACKET_SIZE
     if (packet_bytes.size() > MAX_PACKET_SIZE) {
-      LOG(log_dg_dag_sync_) << "Sending partial BlocksPacket due tu MAX_PACKET_SIZE limit. "
-                            << blocks_counter << " blocks out of " << blocks.size() << " PbftBlockPacketsent.";
+      LOG(log_dg_dag_sync_) << "Sending partial BlocksPacket due tu MAX_PACKET_SIZE limit. " << blocks_counter
+                            << " blocks out of " << blocks.size() << " PbftBlockPacketsent.";
 
       taraxa::bytes removed_bytes;
       std::copy(packet_bytes.begin() + previous_block_packet_size, packet_bytes.end(),
@@ -1160,7 +1160,8 @@ void TaraxaCapability::checkLiveness() {
     for (auto const &peer : peers_) {
       // Disconnect any node that did not send any message for 3 status intervals
       if (!peer.second->isAlive(MAX_CHECK_ALIVE_COUNT)) {
-        LOG(log_nf_) << "Host disconnected, no status message in " << MAX_CHECK_ALIVE_COUNT * check_alive_interval_ << " ms" << peer.first;
+        LOG(log_nf_) << "Host disconnected, no status message in " << MAX_CHECK_ALIVE_COUNT * check_alive_interval_
+                     << " ms" << peer.first;
         host->disconnect(peer.first, p2p::PingTimeout);
       }
       // Send status message
@@ -1187,7 +1188,7 @@ void TaraxaCapability::logNodeStats() {
   {
     boost::shared_lock<boost::shared_mutex> lock(peers_mutex_);
     peers_size = peers_.size();
-    for (auto const& peer : peers_) {
+    for (auto const &peer : peers_) {
       // Find max pbft chain size
       if (peer.second->pbft_chain_size_ > peer_max_pbft_chain_size) {
         peer_max_pbft_chain_size = peer.second->pbft_chain_size_;
@@ -1470,10 +1471,10 @@ void TaraxaCapability::sendPbftBlocks(NodeID const &_id, size_t height_to_sync, 
   auto transactions = db_query.execute();
 
   // Creates final packet out of provided pbft blocks rlp representations
-  auto create_packet = [_id](std::vector<dev::bytes>&& pbft_blocks) -> RLPStream {
+  auto create_packet = [_id](std::vector<dev::bytes> &&pbft_blocks) -> RLPStream {
     RLPStream packet_rlp;
     packet_rlp.appendList(pbft_blocks.size());
-    for (const dev::bytes& block_rlp : pbft_blocks) {
+    for (const dev::bytes &block_rlp : pbft_blocks) {
       packet_rlp.appendRaw(std::move(block_rlp));
     }
 
@@ -1489,7 +1490,7 @@ void TaraxaCapability::sendPbftBlocks(NodeID const &_id, size_t height_to_sync, 
     auto start_1 = dag_blocks_indexes[pbft_block_idx];
     auto end_1 = dag_blocks_indexes[pbft_block_idx + 1];
 
-    pbft_block_rlp.appendList(2); // item #1 - pbft block rlp, item #2 - list of dag blocks
+    pbft_block_rlp.appendList(2);  // item #1 - pbft block rlp, item #2 - list of dag blocks
     pbft_block_rlp.appendRaw(pbft_blocks[pbft_block_idx].rlp());
     pbft_block_rlp.appendList(end_1 - start_1);
 
@@ -1498,7 +1499,7 @@ void TaraxaCapability::sendPbftBlocks(NodeID const &_id, size_t height_to_sync, 
       auto start_2 = transactions_indexes[dag_block_idx];
       auto end_2 = transactions_indexes[dag_block_idx + 1];
 
-      pbft_block_rlp.appendList(2); // item #1 - dag block rlp, item #2 - list of dag block transactions
+      pbft_block_rlp.appendList(2);  // item #1 - dag block rlp, item #2 - list of dag block transactions
       pbft_block_rlp.appendRaw(dag_blocks[dag_block_idx]);
       pbft_block_rlp.appendList(end_2 - start_2);
 
@@ -1522,8 +1523,8 @@ void TaraxaCapability::sendPbftBlocks(NodeID const &_id, size_t height_to_sync, 
         continue;
       }
 
-      LOG(log_dg_dag_sync_) << "Sending partial PbftBlockPacket due tu MAX_PACKET_SIZE limit. "
-                            << pbft_block_idx + 1 << " blocks out of " << pbft_blocks.size() << " sent.";
+      LOG(log_dg_dag_sync_) << "Sending partial PbftBlockPacket due tu MAX_PACKET_SIZE limit. " << pbft_block_idx + 1
+                            << " blocks out of " << pbft_blocks.size() << " sent.";
 
       // Send partial packet
       sealAndSend(_id, PbftBlockPacket, create_packet(std::move(pbft_blocks_rlps)));

--- a/src/network/taraxa_capability.cpp
+++ b/src/network/taraxa_capability.cpp
@@ -1159,8 +1159,8 @@ void TaraxaCapability::checkLiveness() {
     boost::shared_lock<boost::shared_mutex> lock(peers_mutex_);
     for (auto const &peer : peers_) {
       // Disconnect any node that did not send any message for 3 status intervals
-      if (!peer.second->isAlive(5)) {
-        LOG(log_nf_) << "Host disconnected, no status message in " << 5 * check_alive_interval_ << " ms" << peer.first;
+      if (!peer.second->isAlive(MAX_CHECK_ALIVE_COUNT)) {
+        LOG(log_nf_) << "Host disconnected, no status message in " << MAX_CHECK_ALIVE_COUNT * check_alive_interval_ << " ms" << peer.first;
         host->disconnect(peer.first, p2p::PingTimeout);
       }
       // Send status message

--- a/src/network/taraxa_capability.cpp
+++ b/src/network/taraxa_capability.cpp
@@ -214,7 +214,7 @@ void TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
     return;
   }
   // Any packet means that we are comunicating so let's not disconnect
-  // e.g. we could sned a lot of data and status packet can be in send queue
+  // e.g. we could send a lot of data and status packet can be in send queue
   peer->setAlive();
 
   switch (_id) {

--- a/src/network/taraxa_capability.hpp
+++ b/src/network/taraxa_capability.hpp
@@ -241,6 +241,7 @@ struct TaraxaCapability : virtual CapabilityFace {
   PacketsStats received_packets_stats_;
 
   const uint32_t MAX_PACKET_SIZE = 15 * 1024 * 1024;  // 15 MB -> 15 * 1024 * 1024 B
+  const uint16_t MAX_CHECK_ALIVE_COUNT = 5;
 
   LOG_OBJECTS_DEFINE
   LOG_OBJECTS_DEFINE_SUB(pbft_sync)

--- a/src/network/taraxa_capability.hpp
+++ b/src/network/taraxa_capability.hpp
@@ -79,12 +79,12 @@ class TaraxaPeer : public boost::noncopyable {
   bool isPbftBlockKnown(blk_hash_t const &_hash) const { return known_pbft_blocks_.count(_hash); }
   void markPbftBlockAsKnown(blk_hash_t const &_hash) { known_pbft_blocks_.insert(_hash); }
 
-  bool checkStatus(uint16_t max_check_count) {
-    status_check_count_++;
-    return status_check_count_ <= max_check_count;
+  bool isAlive(uint16_t max_check_count) {
+    alive_check_count_++;
+    return alive_check_count_ <= max_check_count;
   }
 
-  void statusReceived() { status_check_count_ = 0; }
+  void setAlive() { alive_check_count_ = 0; }
 
   bool passed_initial_ = false;
   bool syncing_ = false;
@@ -102,7 +102,7 @@ class TaraxaPeer : public boost::noncopyable {
   ExpirationCache<blk_hash_t> known_pbft_blocks_;
   ExpirationCache<vote_hash_t> known_votes_;  // for peers
 
-  uint16_t status_check_count_ = 0;
+  std::atomic<uint16_t> alive_check_count_ = 0;
 };
 
 struct TaraxaCapability : virtual CapabilityFace {
@@ -158,7 +158,7 @@ struct TaraxaCapability : virtual CapabilityFace {
 
   uint64_t getSimulatedNetworkDelay(const RLP &packet_rlp, const NodeID &nodeID);
 
-  void doBackgroundWork();
+  void checkLiveness();
   void logNodeStats();
   void logPacketsStats();
   void sendTransactions();
@@ -221,7 +221,7 @@ struct TaraxaCapability : virtual CapabilityFace {
   mutable std::mt19937_64 urng_;  // Mersenne Twister psuedo-random number generator
   std::mt19937 delay_rng_;
   std::uniform_int_distribution<std::mt19937::result_type> random_dist_;
-  uint16_t check_status_interval_ = 0;
+  uint16_t check_alive_interval_ = 0;
 
   uint64_t received_trx_count = 0;
   uint64_t unique_received_trx_count = 0;

--- a/src/node/full_node.cpp
+++ b/src/node/full_node.cpp
@@ -95,9 +95,8 @@ void FullNode::init() {
   emplace(pbft_chain_, genesis_hash, node_addr, db_);
   emplace(next_votes_mgr_, node_addr, db_);
   emplace(dag_mgr_, genesis_hash, node_addr, trx_mgr_, pbft_chain_, db_);
-  emplace(dag_blk_mgr_, node_addr, conf_.chain.vdf, conf_.chain.final_chain.state.dpos,
-          4 /* verifer thread*/, db_, trx_mgr_, final_chain_, pbft_chain_, log_time_,
-          conf_.test_params.max_block_queue_warn);
+  emplace(dag_blk_mgr_, node_addr, conf_.chain.vdf, conf_.chain.final_chain.state.dpos, 4 /* verifer thread*/, db_,
+          trx_mgr_, final_chain_, pbft_chain_, log_time_, conf_.test_params.max_block_queue_warn);
   emplace(vote_mgr_, node_addr, db_, final_chain_, pbft_chain_);
   emplace(trx_order_mgr_, node_addr, db_);
   emplace(executor_, node_addr, db_, dag_mgr_, trx_mgr_, dag_blk_mgr_, final_chain_, pbft_chain_,


### PR DESCRIPTION
## Purpose
- add missing lock
- change when we mark that peer is active

## For reviewers
What I have noticed, is that sometimes e.g. right now on testnet peer is trying to send my node a lot of missing DAG blocks (10k),
so peer splits those to multiple packets, but it takes while to process it. Meanwhile he is trying to send me status back, but is somewhere deep down in send/write queue and it will not be send in time. Then  we disconnect each other, because we did not get status packet.
One of the solutions is mark all incoming packet as some kind of activity between us, so we do not disconnect