### PR TITLE
fix(logging): change default log verbosity level to ERROR

### DIFF
--- a/config/_template.json
+++ b/config/_template.json
@@ -35,7 +35,7 @@
       {
         "name": "standard",
         "on": true,
-        "verbosity": "INFO",
+        "verbosity": "ERROR",
         "channels": [
           {
             "name": "SUMMARY",


### PR DESCRIPTION
## Purpose

After #824  to address #822  we didn't change the default verbosity in the template to ERROR as suggested by @MatusKysel.  Now we have way to many INFO logs enabled by default!

## Related Github issues

#822 has the suggestion that we didn't fully carry through on.

## Changes

Changes default logging verbosity level to ERROR

