### PR TITLE
perf(verification): store verified txs in to the DB with sender add, …

### DIFF
--- a/src/final_chain/final_chain.cpp
+++ b/src/final_chain/final_chain.cpp
@@ -111,7 +111,7 @@ class FinalChainImpl final : public FinalChain {
         }
         // Non-executed trxs
         auto const& trx = to_execute.emplace_back(vector_ref<string::value_type>(trx_db_results[1 + i * 2]).toBytes(),
-                                                  false, h256(db_query.get_key(1 + i * 2)), true);
+                                                  false, h256(db_query.get_key(1 + i * 2)), true, true);
         if (replay_protection_service_ && replay_protection_service_->is_nonce_stale(trx.getSender(), trx.getNonce())) {
           to_execute.pop_back();
         }

--- a/src/storage/db_storage.cpp
+++ b/src/storage/db_storage.cpp
@@ -280,8 +280,8 @@ std::map<blk_hash_t, bool> DbStorage::getAllDagBlockState() {
   return res;
 }
 
-void DbStorage::saveTransaction(Transaction const& trx) {
-  insert(Columns::transactions, toSlice(trx.getHash().asBytes()), toSlice(*trx.rlp()));
+void DbStorage::saveTransaction(Transaction const& trx, bool verified) {
+  insert(Columns::transactions, toSlice(trx.getHash().asBytes()), toSlice(*trx.rlp(false, verified)));
 }
 
 void DbStorage::saveTransactionStatus(trx_hash_t const& trx_hash, TransactionStatus const& status) {
@@ -330,8 +330,9 @@ std::shared_ptr<std::pair<Transaction, taraxa::bytes>> DbStorage::getTransaction
   return nullptr;
 }
 
-void DbStorage::addTransactionToBatch(Transaction const& trx, Batch& write_batch) {
-  insert(write_batch, DbStorage::Columns::transactions, toSlice(trx.getHash().asBytes()), toSlice(*trx.rlp()));
+void DbStorage::addTransactionToBatch(Transaction const& trx, Batch& write_batch, bool verified) {
+  insert(write_batch, DbStorage::Columns::transactions, toSlice(trx.getHash().asBytes()),
+         toSlice(*trx.rlp(false, verified)));
 }
 
 bool DbStorage::transactionInDb(trx_hash_t const& hash) {

--- a/src/storage/db_storage.hpp
+++ b/src/storage/db_storage.hpp
@@ -182,12 +182,12 @@ struct DbStorage {
   std::map<blk_hash_t, bool> getAllDagBlockState();
 
   // Transaction
-  void saveTransaction(Transaction const& trx);
+  void saveTransaction(Transaction const& trx, bool verified = false);
   dev::bytes getTransactionRaw(trx_hash_t const& hash);
   shared_ptr<Transaction> getTransaction(trx_hash_t const& hash);
   shared_ptr<pair<Transaction, taraxa::bytes>> getTransactionExt(trx_hash_t const& hash);
   bool transactionInDb(trx_hash_t const& hash);
-  void addTransactionToBatch(Transaction const& trx, Batch& write_batch);
+  void addTransactionToBatch(Transaction const& trx, Batch& write_batch, bool verified = false);
 
   void saveTransactionStatus(trx_hash_t const& trx, TransactionStatus const& status);
   void addTransactionStatusToBatch(Batch& write_batch, trx_hash_t const& trx, TransactionStatus const& status);

--- a/src/transaction_manager/transaction.hpp
+++ b/src/transaction_manager/transaction.hpp
@@ -34,7 +34,7 @@ struct Transaction {
   mutable std::shared_ptr<bytes> cached_rlp_;
   mutable DefaultConstructCopyableMovable<std::mutex> cached_rlp_mu_;
 
-  template <bool for_signature>
+  template <bool for_signature, bool w_sender>
   void streamRLP(dev::RLPStream &s) const;
   trx_hash_t hash_for_signature() const;
   addr_t const &get_sender_() const;
@@ -44,11 +44,13 @@ struct Transaction {
   Transaction() : is_zero_(true){};
   Transaction(uint64_t nonce, val_t const &value, val_t const &gas_price, uint64_t gas, bytes data, secret_t const &sk,
               std::optional<addr_t> const &receiver = std::nullopt, uint64_t chain_id = 0);
-  explicit Transaction(dev::RLP const &_rlp, bool verify_strict = false, h256 const &hash = {});
+  explicit Transaction(dev::RLP const &_rlp, bool verify_strict = false, h256 const &hash = {},
+                       bool rlp_w_sender = false);
   explicit Transaction(bytes const &_rlp, bool verify_strict = false, h256 const &hash = {})
       : Transaction(dev::RLP(_rlp), verify_strict, hash) {}
-  explicit Transaction(bytes &&_rlp, bool verify_strict = false, h256 const &hash = {}, bool cache_rlp = false)
-      : Transaction(dev::RLP(_rlp), verify_strict, hash) {
+  explicit Transaction(bytes &&_rlp, bool verify_strict = false, h256 const &hash = {}, bool cache_rlp = false,
+                       bool rlp_w_sender = false)
+      : Transaction(dev::RLP(_rlp), verify_strict, hash, rlp_w_sender) {
     if (cache_rlp) {
       cached_rlp_ = std::make_shared<bytes>(std::move(_rlp));
     }
@@ -68,7 +70,7 @@ struct Transaction {
 
   bool operator==(Transaction const &other) const { return getHash() == other.getHash(); }
 
-  std::shared_ptr<bytes> rlp(bool cache = false) const;
+  std::shared_ptr<bytes> rlp(bool cache = false, bool w_sender = false) const;
 
   Json::Value toJSON() const;
 };

--- a/src/transaction_manager/transaction_manager.cpp
+++ b/src/transaction_manager/transaction_manager.cpp
@@ -108,7 +108,7 @@ std::pair<bool, std::string> TransactionManager::insertTransaction(const Transac
   }
 
   status = verify ? TransactionStatus::in_queue_verified : TransactionStatus::in_queue_unverified;
-  db_->saveTransaction(trx);
+  db_->saveTransaction(trx, verify && mode_ != VerifyMode::skip_verify_sig);
   db_->saveTransactionStatus(hash, status);
   trx_qu_.insert(trx, verify);
 
@@ -230,7 +230,7 @@ void TransactionManager::verifyQueuedTrxs() {
       auto status = db_->getTransactionStatus(hash);
       if (status == TransactionStatus::in_queue_unverified) {
         db_->saveTransactionStatus(hash, TransactionStatus::in_queue_verified);
-
+        db_->saveTransaction(*item.second, mode_ != VerifyMode::skip_verify_sig);
         trx_qu_.addTransactionToVerifiedQueue(hash, item.second);
       }
     }
@@ -372,11 +372,9 @@ bool TransactionManager::verifyBlockTransactions(DagBlock const &blk, std::vecto
                      << valid.second;
         return false;
       }
-      if (status == TransactionStatus::not_seen) db_->addTransactionToBatch(trx, trx_batch);
+      db_->addTransactionToBatch(trx, trx_batch, true);
     }
   }
-
-  db_->commitWriteBatch(trx_batch);
 
   bool all_transactions_saved = true;
   trx_hash_t missing_trx;
@@ -393,8 +391,11 @@ bool TransactionManager::verifyBlockTransactions(DagBlock const &blk, std::vecto
                      << valid.second;
         return false;
       }
+      db_->addTransactionToBatch(*tx, trx_batch, true);
     }
   }
+
+  db_->commitWriteBatch(trx_batch);
 
   if (all_transactions_saved) {
     auto trx_batch = db_->createWriteBatch();

--- a/tests/transaction_test.cpp
+++ b/tests/transaction_test.cpp
@@ -28,6 +28,24 @@ auto g_blk_samples = Lazy([] { return samples::createMockDagBlkSamples(0, NUM_BL
 
 struct TransactionTest : BaseTest {};
 
+TEST_F(TransactionTest, double_verification) {
+  DbStorage db(data_dir);
+
+  auto trx_data_ptr = g_signed_trx_samples[0].rlp(false, true);
+  RLP trx_rlp = RLP(*trx_data_ptr);
+  EXPECT_EQ(trx_rlp.itemCount(), 10);  // check if there is sender field
+
+  db.saveTransaction(g_signed_trx_samples[0]);  // save it unverified
+  auto trx_data = db.getTransactionRaw(g_signed_trx_samples[0].getHash());
+  trx_rlp = RLP(trx_data);
+  EXPECT_EQ(trx_rlp.itemCount(), 9);
+
+  db.saveTransaction(g_signed_trx_samples[0], true);  // save it verified
+  trx_data = db.getTransactionRaw(g_signed_trx_samples[0].getHash());
+  trx_rlp = RLP(trx_data);
+  EXPECT_EQ(trx_rlp.itemCount(), 10);
+}
+
 TEST_F(TransactionTest, status_table_lru) {
   using TestStatus = StatusTable<int, int>;
   TestStatus status_table(100);


### PR DESCRIPTION
We were doing double verification on every trx. Once when we stored it and again where we were doing execution.

So my solution is to save sender to DB after verification (has sender ~ verified)

before:
![old](https://user-images.githubusercontent.com/6115866/120634515-a133bf80-c46b-11eb-9229-80d485bc7a81.png)
after:
![new](https://user-images.githubusercontent.com/6115866/120634544-aabd2780-c46b-11eb-8bd9-ba6b06d3b189.png)

this should save 5% of cpu cycles



