### PR TITLE
chore(unit test): Add waiting nodes initial status packets passed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,7 +404,7 @@ workflows:
           context: taraxa-node
           attach-workspace: true
           replace: true
-#          workspace-root: cmake-docker-build-debug
+          workspace-root: release
           path: release
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,8 +299,8 @@ jobs:
         - store_artifacts:
            path: /Users/distiller/project/cmake-build/bin/release/
         - persist_to_workspace:
-           root: cmake-build
-           paths: [ bin ]
+           root: cmake-build/bin
+           paths: [ release ]
    build-linux:
      environment:
         BUILD_OUTPUT_DIR: "cmake-docker-build-debug"
@@ -365,8 +365,8 @@ jobs:
         - store_artifacts:
            path: /root/project/cmake-docker-build-debug/bin/release
         - persist_to_workspace:
-           root: cmake-docker-build-debug
-           paths: [ bin ]
+           root: cmake-docker-build-debug/bin/
+           paths: [ release ]
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,21 +404,7 @@ workflows:
           attach-workspace: true
           replace: true
           workspace-root: cmake-docker-build-debug
-          path: cmake-docker-build-debug/bin_install/taraxad-x86_64
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v\d+\.\d+\.\d+$/
-          requires:
-            - build-linux
-            - build-mac
-      - github-release/create:
-          context: taraxa-node
-          attach-workspace: true
-          replace: true
-          workspace-root: cmake-build
-          path: cmake-build/bin/taraxad-macos
+          path: cmake-docker-build-debug/bin_install/
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,14 +289,15 @@ jobs:
                export CPATH=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include &&
                cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DSYSTEM_HOME_OVERRIDE=/Users/root/project/cmake-build  ../ &&
                make -j 6  &&
-               cp bin/taraxad bin/taraxad-macos
+               mkdir bin/release/
+               cp bin/taraxad bin/release/taraxad-macos
         - run:
            name: Execute ctest
            command: |
              ulimit -n 1024
              cd cmake-build/tests && ctest --output-on-failure
         - store_artifacts:
-           path: /Users/distiller/project/cmake-build/bin/taraxad-macos
+           path: /Users/distiller/project/cmake-build/bin/release/
         - persist_to_workspace:
            root: cmake-build
            paths: [ bin ]
@@ -355,17 +356,17 @@ jobs:
            command: cd $BUILD_OUTPUT_DIR && make install
         - run:
            name: strip binary
-           command: cd $BUILD_OUTPUT_DIR && strip bin_install/taraxad && cp bin_install/taraxad bin_install/taraxad-x86_64
+           command: cd $BUILD_OUTPUT_DIR && strip bin_install/taraxad && mkdir -p bin/release/ && cp bin_install/taraxad bin/release/taraxad-x86_64
         - run:
            name: Execute ctest
            command: |
             ulimit -n 1024
             cd $BUILD_OUTPUT_DIR/tests && ctest --output-on-failure
         - store_artifacts:
-           path: /root/project/cmake-docker-build-debug/bin_install/taraxad
+           path: /root/project/cmake-docker-build-debug/bin/release
         - persist_to_workspace:
            root: cmake-docker-build-debug
-           paths: [ bin_install ]
+           paths: [ bin ]
 
 
 workflows:
@@ -404,7 +405,7 @@ workflows:
           attach-workspace: true
           replace: true
           workspace-root: cmake-docker-build-debug
-          path: cmake-docker-build-debug/bin_install/
+          path: cmake-docker-build-debug/bin/release
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,18 +289,18 @@ jobs:
                export CPATH=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include &&
                cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DSYSTEM_HOME_OVERRIDE=/Users/root/project/cmake-build  ../ &&
                make -j 6  &&
-               mkdir bin/release/
-               cp bin/taraxad bin/release/taraxad-macos
+               mkdir /Users/distiller/project/release &&
+               cp bin/taraxad /Users/distiller/project/release/taraxad-macos
         - run:
            name: Execute ctest
            command: |
              ulimit -n 1024
              cd cmake-build/tests && ctest --output-on-failure
         - store_artifacts:
-           path: /Users/distiller/project/cmake-build/bin/release/
+           path: /Users/distiller/project/release/taraxad-macos
         - persist_to_workspace:
-           root: cmake-build/bin
-           paths: [ release ]
+           root: release
+           paths: [ taraxad-macos ]
    build-linux:
      environment:
         BUILD_OUTPUT_DIR: "cmake-docker-build-debug"
@@ -356,17 +356,17 @@ jobs:
            command: cd $BUILD_OUTPUT_DIR && make install
         - run:
            name: strip binary
-           command: cd $BUILD_OUTPUT_DIR && strip bin_install/taraxad && mkdir -p bin/release/ && cp bin_install/taraxad bin/release/taraxad-x86_64
+           command: cd $BUILD_OUTPUT_DIR && strip bin_install/taraxad && mkdir -p /root/project/release && cp bin_install/taraxad /root/project/release/taraxad-x86_64
         - run:
            name: Execute ctest
            command: |
             ulimit -n 1024
             cd $BUILD_OUTPUT_DIR/tests && ctest --output-on-failure
         - store_artifacts:
-           path: /root/project/cmake-docker-build-debug/bin/release
+           path: /root/project/release/taraxad-x86_64
         - persist_to_workspace:
-           root: cmake-docker-build-debug/bin/
-           paths: [ release ]
+           root: release
+           paths: [ taraxad-x86_64 ]
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -402,6 +402,7 @@ workflows:
       - github-release/create:
           context: taraxa-node
           attach-workspace: true
+          replace: true
           workspace-root: cmake-docker-build-debug
           path: cmake-docker-build-debug/bin_install/taraxad-x86_64
           filters:
@@ -415,6 +416,7 @@ workflows:
       - github-release/create:
           context: taraxa-node
           attach-workspace: true
+          replace: true
           workspace-root: cmake-build
           path: cmake-build/bin/taraxad-macos
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,8 +404,8 @@ workflows:
           context: taraxa-node
           attach-workspace: true
           replace: true
-          workspace-root: cmake-docker-build-debug
-          path: cmake-docker-build-debug/bin/release
+#          workspace-root: cmake-docker-build-debug
+          path: release
           filters:
             branches:
               ignore: /.*/

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -183,14 +183,11 @@ TEST_F(NetworkTest, save_network) {
     nw2->start();
     nw3->start();
 
-    for (int i = 0; i < 45; i++) {
-      taraxa::thisThreadSleepForSeconds(1);
-      if (2 == nw1->getPeerCount() && 2 == nw2->getPeerCount() && 2 == nw3->getPeerCount()) break;
-    }
-
-    ASSERT_EQ(2, nw1->getPeerCount());
-    ASSERT_EQ(2, nw2->getPeerCount());
-    ASSERT_EQ(2, nw3->getPeerCount());
+    EXPECT_HAPPENS({120s, 500ms}, [&](auto& ctx) {
+      WAIT_EXPECT_EQ(ctx, nw1->getPeerCount(), 2)
+      WAIT_EXPECT_EQ(ctx, nw2->getPeerCount(), 2)
+      WAIT_EXPECT_EQ(ctx, nw3->getPeerCount(), 2)
+    });
   }
 
   std::shared_ptr<Network> nw2(new taraxa::Network(g_conf2->network, "/tmp/nw2", key2));
@@ -198,13 +195,10 @@ TEST_F(NetworkTest, save_network) {
   nw2->start();
   nw3->start();
 
-  for (int i = 0; i < 20; i++) {
-    taraxa::thisThreadSleepForSeconds(1);
-    if (1 == nw2->getPeerCount() && 1 == nw3->getPeerCount()) break;
-  }
-
-  ASSERT_EQ(1, nw2->getPeerCount());
-  ASSERT_EQ(1, nw3->getPeerCount());
+  EXPECT_HAPPENS({120s, 500ms}, [&](auto& ctx) {
+    WAIT_EXPECT_EQ(ctx, nw2->getPeerCount(), 1)
+    WAIT_EXPECT_EQ(ctx, nw3->getPeerCount(), 1)
+  });
 }
 
 // Test creates one node with testnet network ID and one node with main ID and verifies that connection fails

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -122,7 +122,7 @@ TEST_F(NetworkTest, transfer_lot_of_blocks) {
 
 TEST_F(NetworkTest, send_pbft_block) {
   auto node_cfgs = make_node_cfgs<5>(2);
-  auto nodes = launch_nodes(node_cfgs, 1);
+  auto nodes = launch_nodes(node_cfgs);
   auto nw1 = nodes[0]->getNetwork();
   auto nw2 = nodes[1]->getNetwork();
 

--- a/tests/vote_test.cpp
+++ b/tests/vote_test.cpp
@@ -202,13 +202,13 @@ TEST_F(VoteTest, transfer_vote) {
   clearAllVotes(node1);
   clearAllVotes(node2);
 
-  // generate vote
-  blk_hash_t propose_blockhash(11);
-  PbftVoteTypes type = propose_vote_type;
-  uint64_t period = 1;
-  size_t step = 1;
-  auto weighted_index = 0;
-  Vote vote = pbft_mgr2->generateVote(propose_blockhash, type, period, step, weighted_index);
+  // generate a vote far ahead (never exist in PBFT manager)
+  blk_hash_t propose_block_hash(11);
+  PbftVoteTypes type = next_vote_type;
+  uint64_t period = 999;
+  size_t step = 1000;
+  auto weighted_index = 10;
+  Vote vote = pbft_mgr2->generateVote(propose_block_hash, type, period, step, weighted_index);
 
   nw2->sendPbftVote(nw1->getNodeId(), vote);
 
@@ -237,12 +237,12 @@ TEST_F(VoteTest, vote_broadcast) {
   clearAllVotes(node2);
   clearAllVotes(node3);
 
-  // generate vote
-  blk_hash_t propose_block_hash(1);
-  PbftVoteTypes type = propose_vote_type;
-  uint64_t period = 1;
-  size_t step = 1;
-  auto weighted_index = 0;
+  // generate a vote far ahead (never exist in PBFT manager)
+  blk_hash_t propose_block_hash(111);
+  PbftVoteTypes type = next_vote_type;
+  uint64_t period = 1000;
+  size_t step = 1002;
+  auto weighted_index = 100;
   Vote vote = pbft_mgr1->generateVote(propose_block_hash, type, period, step, weighted_index);
 
   node1->getNetwork()->onNewPbftVotes(vector{vote});


### PR DESCRIPTION
## Purpose
In CircleCI build, there are unit tests failed intermittently at Mac machine, works in Linux machine. And cannot reproduce in local.
So far, all of the intermittently failed unit tests are related to count object(tansactions, votes, blocks) number. I doubt there is an race condition may fail at here:
https://github.com/Taraxa-project/taraxa-node/blob/develop/src/network/taraxa_capability.cpp#L213

## For reviewers

<!-- Describe anything you want to call out to the reviewers e.g. areas to focus on, decisions you made, specific feedback you are looking for, etc. -->

## Related Github issues

<!-- Include related github issues. -->

## Changes
1. Remove minimum peers connection, since no one use that
2. Add waiting nodes initial status packets passed when launch nodes
3. Improve vote unit tests

## Tests
Will trigger CircleCI build in Mac machine for testing

## Deployment Considerations

## Version Notes ##
{ major | minor | patch }

<!--

Decide whether this is a major, minor, or patch version change. Major is for backwards incompatible changes (This is only relevant once the service is live and in production and the major version is at least 1. While the major version is 0, it is ok to have backwards incompatible changes in a minor version.). Minor is for additional features. Patch is for bug fixes.

Describe the changes in this version. This is essentially the details you would include in the squash commit message.
-->

**NOTE: Include the version notes in the squash commit message**
