### PR TITLE
perf(vdf): remove logging vdfsortition class

### DIFF
--- a/src/consensus/block_proposer.cpp
+++ b/src/consensus/block_proposer.cpp
@@ -33,7 +33,7 @@ bool SortitionPropose::propose() {
   }
 
   // get sortition
-  vdf_sortition::VdfSortition vdf(vdf_config_, node_addr_, vrf_sk_, getRlpBytes(propose_level));
+  vdf_sortition::VdfSortition vdf(vdf_config_, vrf_sk_, getRlpBytes(propose_level));
   if (vdf.isStale(vdf_config_)) {
     if (propose_level == last_propose_level_ && num_tries_ < max_num_tries_) {
       LOG(log_dg_) << "Will not propose DAG block. Get difficulty at stale, last propose level " << last_propose_level_

--- a/src/dag/dag_block.cpp
+++ b/src/dag/dag_block.cpp
@@ -55,7 +55,7 @@ DagBlock::DagBlock(Json::Value const &doc) {
 
   // Allow vdf not to be present for genesis
   if (level_ > 0) {
-    vdf_ = VdfSortition(addr_t(), doc["vdf"]);
+    vdf_ = VdfSortition(doc["vdf"]);
   }
 }
 
@@ -72,7 +72,7 @@ DagBlock::DagBlock(dev::RLP const &rlp) {
     } else if (field_n == 2) {
       timestamp_ = el.toInt<uint64_t>();
     } else if (field_n == 3) {
-      vdf_ = vdf_sortition::VdfSortition(addr_t(), el.toBytes());
+      vdf_ = vdf_sortition::VdfSortition(el.toBytes());
     } else if (field_n == 4) {
       tips_ = el.toVector<trx_hash_t>();
     } else if (field_n == 5) {

--- a/src/dag/dag_block_manager.cpp
+++ b/src/dag/dag_block_manager.cpp
@@ -221,9 +221,11 @@ void DagBlockManager::verifyBlock() {
 
       // Verify VDF solution
       vdf_sortition::VdfSortition vdf = blk.first.getVdf();
-      if (!vdf.verifyVdf(vdf_config_, getRlpBytes(blk.first.getLevel()), blk.first.getPivot().asBytes())) {
+      try {
+        vdf.verifyVdf(vdf_config_, getRlpBytes(blk.first.getLevel()), blk.first.getPivot().asBytes());
+      } catch (vdf_sortition::VdfSortition::InvalidVdfSortition const &e) {
         LOG(log_er_) << "DAG block " << blk.first.getHash() << " failed on VDF verification with pivot hash "
-                     << blk.first.getPivot();
+                     << blk.first.getPivot() << " reason " << e.what();
         blk_status_.update(blk.first.getHash(), BlockStatus::invalid);
         continue;
       }

--- a/src/dag/vdf_sortition.hpp
+++ b/src/dag/vdf_sortition.hpp
@@ -60,13 +60,17 @@ void dec_json(Json::Value const& json, VdfConfig& obj);
 // It includes a vrf for difficulty adjustment
 class VdfSortition : public vrf_wrapper::VrfSortitionBase {
  public:
+  struct InvalidVdfSortition : std::runtime_error {
+    explicit InvalidVdfSortition(std::string const& msg) : runtime_error("Invalid VdfSortition: " + msg) {}
+  };
+
   VdfSortition() = default;
-  explicit VdfSortition(VdfConfig const& config, addr_t node_addr, vrf_sk_t const& sk, bytes const& msg);
-  explicit VdfSortition(addr_t node_addr, bytes const& b);
-  explicit VdfSortition(addr_t node_addr, Json::Value const& json);
+  explicit VdfSortition(VdfConfig const& config, vrf_sk_t const& sk, bytes const& msg);
+  explicit VdfSortition(bytes const& b);
+  explicit VdfSortition(Json::Value const& json);
 
   void computeVdfSolution(VdfConfig const& config, dev::bytes const& msg);
-  bool verifyVdf(VdfConfig const& config, bytes const& vrf_input, bytes const& vdf_input);
+  void verifyVdf(VdfConfig const& config, bytes const& vrf_input, bytes const& vdf_input);
 
   bytes rlp() const;
   bool operator==(VdfSortition const& other) const {
@@ -103,8 +107,6 @@ class VdfSortition : public vrf_wrapper::VrfSortitionBase {
   std::pair<bytes, bytes> vdf_sol_;
   unsigned long vdf_computation_time_ = 0;
   uint16_t difficulty_ = 0;
-
-  LOG_OBJECTS_DEFINE
 };
 
 }  // namespace taraxa::vdf_sortition

--- a/tests/crypto_test.cpp
+++ b/tests/crypto_test.cpp
@@ -115,13 +115,13 @@ TEST_F(CryptoTest, vdf_sortition) {
       "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
   level_t level = 3;
   blk_hash_t vdf_input = blk_hash_t(200);
-  VdfSortition vdf(vdf_config, node_key.address(), sk, getRlpBytes(level));
-  VdfSortition vdf2(vdf_config, node_key.address(), sk, getRlpBytes(level));
+  VdfSortition vdf(vdf_config, sk, getRlpBytes(level));
+  VdfSortition vdf2(vdf_config, sk, getRlpBytes(level));
   vdf.computeVdfSolution(vdf_config, vdf_input.asBytes());
   vdf2.computeVdfSolution(vdf_config, vdf_input.asBytes());
   auto b = vdf.rlp();
-  VdfSortition vdf3(node_key.address(), b);
-  EXPECT_TRUE(vdf3.verifyVdf(vdf_config, getRlpBytes(level), vdf_input.asBytes()));
+  VdfSortition vdf3(b);
+  EXPECT_NO_THROW(vdf3.verifyVdf(vdf_config, getRlpBytes(level), vdf_input.asBytes()));
   EXPECT_EQ(vdf, vdf2);
   EXPECT_EQ(vdf, vdf3);
 
@@ -146,8 +146,8 @@ TEST_F(CryptoTest, vdf_solution) {
       "90f59a7ee7a392c811c5d299b557a4e09e610de7d109d6b3fcb19ab8d51c9a0d931f5e7d"
       "b07c9969e438db7e287eabbaaca49ca414f5f3a402ea6997ade40081");
   level_t level = 1;
-  VdfSortition vdf(vdf_config, node_key.address(), sk, getRlpBytes(level));
-  VdfSortition vdf2(vdf_config, node_key.address(), sk2, getRlpBytes(level));
+  VdfSortition vdf(vdf_config, sk, getRlpBytes(level));
+  VdfSortition vdf2(vdf_config, sk2, getRlpBytes(level));
   blk_hash_t vdf_input = blk_hash_t(200);
 
   std::thread th1([&vdf, vdf_input, vdf_config]() { vdf.computeVdfSolution(vdf_config, vdf_input.asBytes()); });
@@ -165,13 +165,13 @@ TEST_F(CryptoTest, vdf_proof_verify) {
       "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
       "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
   level_t level = 1;
-  VdfSortition vdf(vdf_config, node_key.address(), sk, getRlpBytes(level));
+  VdfSortition vdf(vdf_config, sk, getRlpBytes(level));
   blk_hash_t vdf_input = blk_hash_t(200);
 
   vdf.computeVdfSolution(vdf_config, vdf_input.asBytes());
-  EXPECT_TRUE(vdf.verifyVdf(vdf_config, getRlpBytes(level), vdf_input.asBytes()));
-  VdfSortition vdf2(vdf_config, node_key.address(), sk, getRlpBytes(level));
-  EXPECT_FALSE(vdf2.verifyVdf(vdf_config, getRlpBytes(level), vdf_input.asBytes()));
+  EXPECT_NO_THROW(vdf.verifyVdf(vdf_config, getRlpBytes(level), vdf_input.asBytes()));
+  VdfSortition vdf2(vdf_config, sk, getRlpBytes(level));
+  EXPECT_THROW(vdf2.verifyVdf(vdf_config, getRlpBytes(level), vdf_input.asBytes()), VdfSortition::InvalidVdfSortition);
 }
 
 TEST_F(CryptoTest, DISABLED_compute_vdf_solution_cost_time) {
@@ -195,7 +195,7 @@ TEST_F(CryptoTest, DISABLED_compute_vdf_solution_cost_time) {
     std::cout << "Start at difficulty " << difficulty_stale << " :" << std::endl;
     vdf_sortition::VdfConfig vdf_config(threshold_selection, threshold_vdf_omit, difficulty_min, difficulty_max,
                                         difficulty_stale, lambda_bound);
-    VdfSortition vdf(vdf_config, node_key.address(), sk, getRlpBytes(level));
+    VdfSortition vdf(vdf_config, sk, getRlpBytes(level));
     vdf.computeVdfSolution(vdf_config, proposal_dag_block_pivot_hash1.asBytes());
     vdf_computation_time = vdf.getComputationTime();
     std::cout << "VDF message " << proposal_dag_block_pivot_hash1 << ", lambda bits " << lambda_bound << ", difficulty "
@@ -215,7 +215,7 @@ TEST_F(CryptoTest, DISABLED_compute_vdf_solution_cost_time) {
     std::cout << "Start at lambda " << lambda << " :" << std::endl;
     vdf_sortition::VdfConfig vdf_config(threshold_selection, threshold_vdf_omit, difficulty_min, difficulty_max,
                                         difficulty_stale, lambda);
-    VdfSortition vdf(vdf_config, node_key.address(), sk, getRlpBytes(level));
+    VdfSortition vdf(vdf_config, sk, getRlpBytes(level));
     vdf.computeVdfSolution(vdf_config, proposal_dag_block_pivot_hash1.asBytes());
     vdf_computation_time = vdf.getComputationTime();
     std::cout << "VDF message " << proposal_dag_block_pivot_hash1 << ", lambda bits " << lambda << ", difficulty "
@@ -231,7 +231,7 @@ TEST_F(CryptoTest, DISABLED_compute_vdf_solution_cost_time) {
   }
 
   vdf_sortition::VdfConfig vdf_config(32768, 29184, 16, 21, 22, 100);
-  VdfSortition vdf(vdf_config, node_key.address(), sk, getRlpBytes(level));
+  VdfSortition vdf(vdf_config, sk, getRlpBytes(level));
   std::cout << "output " << vdf.output << std::endl;
   int i = 0;
   for (; i < vdf.output.size; i++) {

--- a/tests/dag_block_test.cpp
+++ b/tests/dag_block_test.cpp
@@ -44,7 +44,7 @@ TEST_F(DagBlockTest, serialize_deserialize) {
       "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
       "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
   level_t level = 3;
-  VdfSortition vdf(vdf_config, g_key_pair.address(), sk, getRlpBytes(level));
+  VdfSortition vdf(vdf_config, sk, getRlpBytes(level));
   blk_hash_t vdf_input(200);
   vdf.computeVdfSolution(vdf_config, vdf_input.asBytes());
   DagBlock blk1(blk_hash_t(1), 2, {}, {}, vdf, secret_t::random());

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -103,7 +103,7 @@ TEST_F(NetworkTest, transfer_lot_of_blocks) {
   // add one valid as last
   auto dag_genesis = nodes[1]->getConfig().chain.dag_genesis_block.getHash();
   vdf_sortition::VdfConfig vdf_config(node_cfgs[1].chain.vdf);
-  vdf_sortition::VdfSortition vdf(vdf_config, node_key.address(), nodes[1]->getVrfSecretKey(), getRlpBytes(1));
+  vdf_sortition::VdfSortition vdf(vdf_config, nodes[1]->getVrfSecretKey(), getRlpBytes(1));
   vdf.computeVdfSolution(vdf_config, dag_genesis.asBytes());
   DagBlock blk(dag_genesis, 1, {}, {samples::createSignedTrxSamples(0, 1, g_secret)[0].getHash()}, vdf,
                nodes[1]->getSecretKey());
@@ -250,32 +250,32 @@ TEST_F(NetworkTest, node_sync) {
   vdf_sortition::VdfConfig vdf_config(node_cfgs[0].chain.vdf);
 
   auto propose_level = 1;
-  vdf_sortition::VdfSortition vdf1(vdf_config, node_key.address(), vrf_sk, getRlpBytes(propose_level));
+  vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk, getRlpBytes(propose_level));
   vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes());
   DagBlock blk1(dag_genesis, propose_level, {}, {}, vdf1, sk);
 
   propose_level = 2;
-  vdf_sortition::VdfSortition vdf2(vdf_config, node_key.address(), vrf_sk, getRlpBytes(propose_level));
+  vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk, getRlpBytes(propose_level));
   vdf2.computeVdfSolution(vdf_config, blk1.getHash().asBytes());
   DagBlock blk2(blk1.getHash(), propose_level, {}, {}, vdf2, sk);
 
   propose_level = 3;
-  vdf_sortition::VdfSortition vdf3(vdf_config, node_key.address(), vrf_sk, getRlpBytes(propose_level));
+  vdf_sortition::VdfSortition vdf3(vdf_config, vrf_sk, getRlpBytes(propose_level));
   vdf3.computeVdfSolution(vdf_config, blk2.getHash().asBytes());
   DagBlock blk3(blk2.getHash(), propose_level, {}, {}, vdf3, sk);
 
   propose_level = 4;
-  vdf_sortition::VdfSortition vdf4(vdf_config, node_key.address(), vrf_sk, getRlpBytes(propose_level));
+  vdf_sortition::VdfSortition vdf4(vdf_config, vrf_sk, getRlpBytes(propose_level));
   vdf4.computeVdfSolution(vdf_config, blk3.getHash().asBytes());
   DagBlock blk4(blk3.getHash(), propose_level, {}, {}, vdf4, sk);
 
   propose_level = 5;
-  vdf_sortition::VdfSortition vdf5(vdf_config, node_key.address(), vrf_sk, getRlpBytes(propose_level));
+  vdf_sortition::VdfSortition vdf5(vdf_config, vrf_sk, getRlpBytes(propose_level));
   vdf5.computeVdfSolution(vdf_config, blk4.getHash().asBytes());
   DagBlock blk5(blk4.getHash(), propose_level, {}, {}, vdf5, sk);
 
   propose_level = 6;
-  vdf_sortition::VdfSortition vdf6(vdf_config, node_key.address(), vrf_sk, getRlpBytes(propose_level));
+  vdf_sortition::VdfSortition vdf6(vdf_config, vrf_sk, getRlpBytes(propose_level));
   vdf6.computeVdfSolution(vdf_config, blk5.getHash().asBytes());
   DagBlock blk6(blk5.getHash(), propose_level, {blk4.getHash(), blk3.getHash()}, {}, vdf6, sk);
 
@@ -332,7 +332,7 @@ TEST_F(NetworkTest, node_pbft_sync) {
   addr_t beneficiary(987);
 
   level_t level = 1;
-  vdf_sortition::VdfSortition vdf1(vdf_config, node_key.address(), vrf_sk, getRlpBytes(level));
+  vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk, getRlpBytes(level));
   vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes());
   DagBlock blk1(dag_genesis, 1, {}, {}, vdf1, sk);
   node1->getDagBlockManager()->insertBlock(blk1);
@@ -364,7 +364,7 @@ TEST_F(NetworkTest, node_pbft_sync) {
   prev_block_hash = pbft_block1.getBlockHash();
 
   level = 2;
-  vdf_sortition::VdfSortition vdf2(vdf_config, node_key.address(), vrf_sk, getRlpBytes(level));
+  vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk, getRlpBytes(level));
   vdf2.computeVdfSolution(vdf_config, blk1.getHash().asBytes());
   DagBlock blk2(blk1.getHash(), 2, {}, {}, vdf2, sk);
   node1->getDagBlockManager()->insertBlock(blk2);
@@ -454,7 +454,7 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   uint64_t period = 1;
   addr_t beneficiary(876);
   level_t level = 1;
-  vdf_sortition::VdfSortition vdf1(vdf_config, node_key.address(), vrf_sk, getRlpBytes(level));
+  vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk, getRlpBytes(level));
   vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes());
   DagBlock blk1(dag_genesis, 1, {}, {}, vdf1, sk);
   node1->getDagBlockManager()->insertBlock(blk1);
@@ -487,7 +487,7 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   period = 2;
   beneficiary = addr_t(543);
   level = 2;
-  vdf_sortition::VdfSortition vdf2(vdf_config, node_key.address(), vrf_sk, getRlpBytes(level));
+  vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk, getRlpBytes(level));
   vdf2.computeVdfSolution(vdf_config, blk1.getHash().asBytes());
   DagBlock blk2(blk1.getHash(), 2, {}, {}, vdf2, sk);
   node1->getDagBlockManager()->insertBlock(blk2);
@@ -815,33 +815,33 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
   auto vrf_sk = node1->getVrfSecretKey();
   vdf_sortition::VdfConfig vdf_config(node_cfgs[0].chain.vdf);
   auto propose_level = 1;
-  vdf_sortition::VdfSortition vdf1(vdf_config, node_key.address(), vrf_sk, getRlpBytes(propose_level));
+  vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk, getRlpBytes(propose_level));
   vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes());
   DagBlock blk1(dag_genesis, propose_level, {}, {g_signed_trx_samples[0].getHash(), g_signed_trx_samples[1].getHash()},
                 vdf1, sk);
   std::vector<Transaction> tr1({g_signed_trx_samples[0], g_signed_trx_samples[1]});
 
   propose_level = 2;
-  vdf_sortition::VdfSortition vdf2(vdf_config, node_key.address(), vrf_sk, getRlpBytes(propose_level));
+  vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk, getRlpBytes(propose_level));
   vdf2.computeVdfSolution(vdf_config, blk1.getHash().asBytes());
   DagBlock blk2(blk1.getHash(), propose_level, {}, {g_signed_trx_samples[2].getHash()}, vdf2, sk);
   std::vector<Transaction> tr2({g_signed_trx_samples[2]});
 
   propose_level = 3;
-  vdf_sortition::VdfSortition vdf3(vdf_config, node_key.address(), vrf_sk, getRlpBytes(propose_level));
+  vdf_sortition::VdfSortition vdf3(vdf_config, vrf_sk, getRlpBytes(propose_level));
   vdf3.computeVdfSolution(vdf_config, blk2.getHash().asBytes());
   DagBlock blk3(blk2.getHash(), propose_level, {}, {}, vdf3, sk);
   std::vector<Transaction> tr3;
 
   propose_level = 4;
-  vdf_sortition::VdfSortition vdf4(vdf_config, node_key.address(), vrf_sk, getRlpBytes(propose_level));
+  vdf_sortition::VdfSortition vdf4(vdf_config, vrf_sk, getRlpBytes(propose_level));
   vdf4.computeVdfSolution(vdf_config, blk3.getHash().asBytes());
   DagBlock blk4(blk3.getHash(), propose_level, {},
                 {g_signed_trx_samples[3].getHash(), g_signed_trx_samples[4].getHash()}, vdf4, sk);
   std::vector<Transaction> tr4({g_signed_trx_samples[3], g_signed_trx_samples[4]});
 
   propose_level = 5;
-  vdf_sortition::VdfSortition vdf5(vdf_config, node_key.address(), vrf_sk, getRlpBytes(propose_level));
+  vdf_sortition::VdfSortition vdf5(vdf_config, vrf_sk, getRlpBytes(propose_level));
   vdf5.computeVdfSolution(vdf_config, blk4.getHash().asBytes());
   DagBlock blk5(blk4.getHash(), propose_level, {},
                 {g_signed_trx_samples[5].getHash(), g_signed_trx_samples[6].getHash(),
@@ -851,7 +851,7 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
       {g_signed_trx_samples[5], g_signed_trx_samples[6], g_signed_trx_samples[7], g_signed_trx_samples[8]});
 
   propose_level = 6;
-  vdf_sortition::VdfSortition vdf6(vdf_config, node_key.address(), vrf_sk, getRlpBytes(propose_level));
+  vdf_sortition::VdfSortition vdf6(vdf_config, vrf_sk, getRlpBytes(propose_level));
   vdf6.computeVdfSolution(vdf_config, blk5.getHash().asBytes());
   DagBlock blk6(blk5.getHash(), propose_level, {blk4.getHash(), blk3.getHash()}, {g_signed_trx_samples[9].getHash()},
                 vdf6, sk);
@@ -902,76 +902,76 @@ TEST_F(NetworkTest, node_sync2) {
   auto transactions = samples::createSignedTrxSamples(0, NUM_TRX2, sk);
   // DAG block1
   auto propose_level = 1;
-  vdf_sortition::VdfSortition vdf1(vdf_config, node_key.address(), vrf_sk, getRlpBytes(propose_level));
+  vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk, getRlpBytes(propose_level));
   vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes());
   DagBlock blk1(dag_genesis, propose_level, {}, {transactions[0].getHash(), transactions[1].getHash()}, vdf1, sk);
   std::vector<Transaction> tr1({transactions[0], transactions[1]});
   // DAG block2
   propose_level = 1;
-  vdf_sortition::VdfSortition vdf2(vdf_config, node_key.address(), vrf_sk, getRlpBytes(propose_level));
+  vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk, getRlpBytes(propose_level));
   vdf2.computeVdfSolution(vdf_config, dag_genesis.asBytes());
   DagBlock blk2(dag_genesis, propose_level, {}, {transactions[2].getHash(), transactions[3].getHash()}, vdf2, sk);
   std::vector<Transaction> tr2({transactions[2], transactions[3]});
   // DAG block3
   propose_level = 2;
-  vdf_sortition::VdfSortition vdf3(vdf_config, node_key.address(), vrf_sk, getRlpBytes(propose_level));
+  vdf_sortition::VdfSortition vdf3(vdf_config, vrf_sk, getRlpBytes(propose_level));
   vdf3.computeVdfSolution(vdf_config, blk1.getHash().asBytes());
   DagBlock blk3(blk1.getHash(), propose_level, {}, {transactions[4].getHash(), transactions[5].getHash()}, vdf3, sk);
   std::vector<Transaction> tr3({transactions[4], transactions[5]});
   // DAG block4
   propose_level = 3;
-  vdf_sortition::VdfSortition vdf4(vdf_config, node_key.address(), vrf_sk, getRlpBytes(propose_level));
+  vdf_sortition::VdfSortition vdf4(vdf_config, vrf_sk, getRlpBytes(propose_level));
   vdf4.computeVdfSolution(vdf_config, blk3.getHash().asBytes());
   DagBlock blk4(blk3.getHash(), propose_level, {}, {transactions[6].getHash(), transactions[7].getHash()}, vdf4, sk);
   std::vector<Transaction> tr4({transactions[6], transactions[7]});
   // DAG block5
   propose_level = 2;
-  vdf_sortition::VdfSortition vdf5(vdf_config, node_key.address(), vrf_sk, getRlpBytes(propose_level));
+  vdf_sortition::VdfSortition vdf5(vdf_config, vrf_sk, getRlpBytes(propose_level));
   vdf5.computeVdfSolution(vdf_config, blk2.getHash().asBytes());
   DagBlock blk5(blk2.getHash(), propose_level, {}, {transactions[8].getHash(), transactions[9].getHash()}, vdf5, sk);
   std::vector<Transaction> tr5({transactions[8], transactions[9]});
   // DAG block6
   propose_level = 2;
-  vdf_sortition::VdfSortition vdf6(vdf_config, node_key.address(), vrf_sk, getRlpBytes(propose_level));
+  vdf_sortition::VdfSortition vdf6(vdf_config, vrf_sk, getRlpBytes(propose_level));
   vdf6.computeVdfSolution(vdf_config, blk1.getHash().asBytes());
   DagBlock blk6(blk1.getHash(), propose_level, {}, {transactions[10].getHash(), transactions[11].getHash()}, vdf6, sk);
   std::vector<Transaction> tr6({transactions[10], transactions[11]});
   // DAG block7
   propose_level = 3;
-  vdf_sortition::VdfSortition vdf7(vdf_config, node_key.address(), vrf_sk, getRlpBytes(propose_level));
+  vdf_sortition::VdfSortition vdf7(vdf_config, vrf_sk, getRlpBytes(propose_level));
   vdf7.computeVdfSolution(vdf_config, blk6.getHash().asBytes());
   DagBlock blk7(blk6.getHash(), propose_level, {}, {transactions[12].getHash(), transactions[13].getHash()}, vdf7, sk);
   std::vector<Transaction> tr7({transactions[12], transactions[13]});
   // DAG block8
   propose_level = 4;
-  vdf_sortition::VdfSortition vdf8(vdf_config, node_key.address(), vrf_sk, getRlpBytes(propose_level));
+  vdf_sortition::VdfSortition vdf8(vdf_config, vrf_sk, getRlpBytes(propose_level));
   vdf8.computeVdfSolution(vdf_config, blk1.getHash().asBytes());
   DagBlock blk8(blk1.getHash(), propose_level, {blk7.getHash()},
                 {transactions[14].getHash(), transactions[15].getHash()}, vdf8, sk);
   std::vector<Transaction> tr8({transactions[14], transactions[15]});
   // DAG block9
   propose_level = 2;
-  vdf_sortition::VdfSortition vdf9(vdf_config, node_key.address(), vrf_sk, getRlpBytes(propose_level));
+  vdf_sortition::VdfSortition vdf9(vdf_config, vrf_sk, getRlpBytes(propose_level));
   vdf9.computeVdfSolution(vdf_config, blk1.getHash().asBytes());
   DagBlock blk9(blk1.getHash(), propose_level, {}, {transactions[16].getHash(), transactions[17].getHash()}, vdf9, sk);
   std::vector<Transaction> tr9({transactions[16], transactions[17]});
   // DAG block10
   propose_level = 5;
-  vdf_sortition::VdfSortition vdf10(vdf_config, node_key.address(), vrf_sk, getRlpBytes(propose_level));
+  vdf_sortition::VdfSortition vdf10(vdf_config, vrf_sk, getRlpBytes(propose_level));
   vdf10.computeVdfSolution(vdf_config, blk8.getHash().asBytes());
   DagBlock blk10(blk8.getHash(), propose_level, {}, {transactions[18].getHash(), transactions[19].getHash()}, vdf10,
                  sk);
   std::vector<Transaction> tr10({transactions[18], transactions[19]});
   // DAG block11
   propose_level = 3;
-  vdf_sortition::VdfSortition vdf11(vdf_config, node_key.address(), vrf_sk, getRlpBytes(propose_level));
+  vdf_sortition::VdfSortition vdf11(vdf_config, vrf_sk, getRlpBytes(propose_level));
   vdf11.computeVdfSolution(vdf_config, blk3.getHash().asBytes());
   DagBlock blk11(blk3.getHash(), propose_level, {}, {transactions[20].getHash(), transactions[21].getHash()}, vdf11,
                  sk);
   std::vector<Transaction> tr11({transactions[20], transactions[21]});
   // DAG block12
   propose_level = 3;
-  vdf_sortition::VdfSortition vdf12(vdf_config, node_key.address(), vrf_sk, getRlpBytes(propose_level));
+  vdf_sortition::VdfSortition vdf12(vdf_config, vrf_sk, getRlpBytes(propose_level));
   vdf12.computeVdfSolution(vdf_config, blk5.getHash().asBytes());
   DagBlock blk12(blk5.getHash(), propose_level, {}, {transactions[22].getHash(), transactions[23].getHash()}, vdf12,
                  sk);


### PR DESCRIPTION
## Purpose
Removed VDF logs, that were created for each instance of vdfsortition and we used it only in case of invalid VDF or VRF

