### PR TITLE
chore(ci) fixes trigger for testnet branch with valid branch name

### DIFF
--- a/.github/workflows/trigger-ci-on-branch.yml
+++ b/.github/workflows/trigger-ci-on-branch.yml
@@ -11,9 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Set env
+      run: echo "CIRCLE_BRANCH=$(git symbolic-ref -q --short HEAD)" >> $GITHUB_ENV
     - name: Trigger CircleCI build
       env:
-        CIRCLE_BRANCH: ${{ github.ref }}
         TOKEN: ${{ secrets.CIRCLE_TOKEN }}
       run: |
         curl -X POST \


### PR DESCRIPTION
Fixes trigger for testnet branch with valid branch name.

Right now it's calling the circleci action with `refs/heads/testnet`
This change calls the action just with the branch name