### PR TITLE
Increase circleci no_output_timeout and decrease helm install/test timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,7 @@ jobs:
            fi
       - run:
          name: Install/configure helm and chart
+         no_output_timeout: 15m
          command: |
             if [[ ${PR} != "false" ]];then
               docker push ${GCP_IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}
@@ -151,7 +152,7 @@ jobs:
               helm install  ${HELM_TEST_NAME:0:40} taraxa-node \
                 --wait \
                 --atomic \
-                --timeout 1200s \
+                --timeout 600s \
                 --create-namespace \
                 --namespace ${HELM_TEST_NAME} \
                 --set replicaCount=5 \
@@ -162,10 +163,11 @@ jobs:
             fi
       - run:
          name: Run helm test
+         no_output_timeout: 15m
          command: |
             if [[ ${PR} != "false" ]];then
               helm test ${HELM_TEST_NAME} \
-                --timeout 3600s \
+                --timeout 600s \
                 --namespace ${HELM_TEST_NAME}
               ./scripts/kibana-url.sh || true
             fi


### PR DESCRIPTION
## Purpose

Fix circleci stopping the process before the helm test/install has time to fail.
Also, decrease the timeout for the helm commands as they were too long for the current usage.

