### PR TITLE
Added github actions to trigger circleci deploy pr-nets

### DIFF
--- a/.github/actions/prnet/action.yml
+++ b/.github/actions/prnet/action.yml
@@ -1,0 +1,43 @@
+name: 'Trigger Circleci pipelines'
+description: 'Triggers circleci pr nets'
+inputs:
+  action:  # id of input
+    description: 'Pipeline parameter to pass to circleci'
+    required: true
+  circleci_slug:
+    description: 'Slug for the circleci pipeline to trigger'
+    required: true
+  circle_token:
+    description: 'Circleci token'
+    required: true
+  pull_request:
+    description: 'pull request data'
+    required: true
+outputs:
+  status:
+    description: "Api call status"
+    value: ${{ steps.random-number-generator.outputs.status }}
+
+runs:
+  using: "composite"
+  steps:
+      - run: echo ${{ inputs.pull_request.data }}
+        shell: bash
+      - name: Get PR informations
+        id: pr_data
+        run: |
+          echo "::set-output name=branch::${{ fromJson(inputs.pull_request).head.ref }}"
+          echo "::set-output name=number::${{ fromJson(inputs.pull_request).number }}"
+        shell: bash
+      - run: |
+            curl -u ${{ inputs.circle_token}}: -X  POST \
+               -H 'Content-Type: application/json' \
+               -H 'Accept: application/json' \
+               -d "{\"branch\":\"${{ steps.pr_data.outputs.branch }}\", \
+                    \"parameters\": { \
+                       \"${{ inputs.action }}\": true , \
+                       \"pr_number\": \"${{ steps.pr_data.outputs.number }}\"
+                       } \
+                   }" \
+               https://circleci.com/api/v2/project/${{ inputs.circleci_slug }}/pipeline
+        shell: bash

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -90,7 +90,7 @@ jobs:
       - uses: khan/pull-request-comment-trigger@master
         id: check
         with:
-          trigger: '/redeploy'
+          trigger: '/cleanup'
           reaction: rocket
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -17,8 +17,6 @@ jobs:
         env:
           GITHUB_TOKEN: '{{ secrets.GITHUB_TOKEN }}' 
       - uses: actions/checkout@v1
-        with: 
-         ref: develop
         if: steps.check.outputs.triggered == 'true'
       - name: GitHub API Request
         id: request
@@ -47,8 +45,6 @@ jobs:
         env:
           GITHUB_TOKEN: '{{ secrets.GITHUB_TOKEN }}' 
       - uses: actions/checkout@v1
-        with: 
-         ref: develop
         if: steps.check.outputs.triggered == 'true'
       - name: GitHub API Request
         id: request
@@ -77,8 +73,6 @@ jobs:
         env:
           GITHUB_TOKEN: '{{ secrets.GITHUB_TOKEN }}' 
       - uses: actions/checkout@v1
-        with: 
-         ref: develop
         if: steps.check.outputs.triggered == 'true'
       - name: GitHub API Request
         id: request

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -30,7 +30,7 @@ jobs:
         id: trigger
         with:
           action: 'deploy_prnet'
-          circleci_slug: 'gh/Taraxa/taraxa-node'
+          circleci_slug: 'gh/Taraxa-project/taraxa-node'
           circle_token: '${{ secrets.CIRCLE_TOKEN }}'
           pull_request: '${{ steps.request.outputs.data }}'
         if: steps.check.outputs.triggered == 'true'
@@ -58,7 +58,7 @@ jobs:
         id: trigger
         with:
           action: 'redeploy_prnet'
-          circleci_slug: 'gh/Taraxa/taraxa-node'
+          circleci_slug: 'gh/Taraxa-project/taraxa-node'
           circle_token: '${{ secrets.CIRCLE_TOKEN }}'
           pull_request: '${{ steps.request.outputs.data }}'
         if: steps.check.outputs.triggered == 'true'
@@ -86,7 +86,7 @@ jobs:
         id: trigger
         with:
           action: 'cleanup_prnet'
-          circleci_slug: 'gh/Taraxa/taraxa-node'
+          circleci_slug: 'gh/Taraxa-project/taraxa-node'
           circle_token: '${{ secrets.CIRCLE_TOKEN }}'
           pull_request: '${{ steps.request.outputs.data }}'
         if: steps.check.outputs.triggered == 'true'

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -1,7 +1,7 @@
 name: prnet-actions
 on:
   pull_request:
-    types: [opened]
+    types: [opened,reopened]
   issue_comment:
     types: [created]
 

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -15,7 +15,11 @@ jobs:
           trigger: '/deploy'
           reaction: rocket
         env:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          GITHUB_TOKEN: '{{ secrets.GITHUB_TOKEN }}' 
+      - uses: actions/checkout@v1
+        with: 
+         ref: develop
+        if: steps.check.outputs.triggered == 'true'
       - name: GitHub API Request
         id: request
         uses: octokit/request-action@v2.0.0
@@ -24,27 +28,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: steps.check.outputs.triggered == 'true'
-      - name: Get PR informations
-        id: pr_data
-        run: |
-          echo "::set-output name=branch::${{ fromJson(steps.request.outputs.data).head.ref }}"
-          echo "::set-output name=repo_name::${{ fromJson(steps.request.outputs.data).base.repo.full_name }}"
-          echo "::set-output name=repo_clone_url::${{ fromJson(steps.request.outputs.data).base.repo.clone_url }}"
-          echo "::set-output name=repo_ssh_url::${{ fromJson(steps.request.outputs.data).base.repo.ssh_url }}"
+      - uses: ./.github/actions/prnet
+        id: trigger
+        with:
+          action: 'deploy_prnet'
+          circleci_slug: 'gh/Taraxa/taraxa-node'
+          circle_token: '${{ secrets.CIRCLE_TOKEN }}'
+          pull_request: '${{ steps.request.outputs.data }}'
         if: steps.check.outputs.triggered == 'true'
-      - run: |
-            curl -u ${{ secrets.CIRCLE_TOKEN }}: -X  POST \
-               -H 'Content-Type: application/json' \
-               -H 'Accept: application/json' \
-               -d "{\"branch\":\"${{ steps.pr_data.outputs.branch }}\", \
-                    \"parameters\": { \
-                       \"deploy_prnet\": true , \
-                       \"pr_number\": \"${{ github.event.issue.number }}\"
-                       } \
-                   }" \
-               https://circleci.com/api/v2/project/gh/agrebin/taraxa-node/pipeline
-        if: steps.check.outputs.triggered == 'true'
-
   redeploy:
     runs-on: ubuntu-latest
     steps:
@@ -54,7 +45,11 @@ jobs:
           trigger: '/redeploy'
           reaction: rocket
         env:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          GITHUB_TOKEN: '{{ secrets.GITHUB_TOKEN }}' 
+      - uses: actions/checkout@v1
+        with: 
+         ref: develop
+        if: steps.check.outputs.triggered == 'true'
       - name: GitHub API Request
         id: request
         uses: octokit/request-action@v2.0.0
@@ -63,27 +58,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: steps.check.outputs.triggered == 'true'
-      - name: Get PR informations
-        id: pr_data
-        run: |
-          echo "::set-output name=branch::${{ fromJson(steps.request.outputs.data).head.ref }}"
-          echo "::set-output name=repo_name::${{ fromJson(steps.request.outputs.data).base.repo.full_name }}"
-          echo "::set-output name=repo_clone_url::${{ fromJson(steps.request.outputs.data).base.repo.clone_url }}"
-          echo "::set-output name=repo_ssh_url::${{ fromJson(steps.request.outputs.data).base.repo.ssh_url }}"
+      - uses: ./.github/actions/prnet
+        id: trigger
+        with:
+          action: 'redeploy_prnet'
+          circleci_slug: 'gh/Taraxa/taraxa-node'
+          circle_token: '${{ secrets.CIRCLE_TOKEN }}'
+          pull_request: '${{ steps.request.outputs.data }}'
         if: steps.check.outputs.triggered == 'true'
-      - run: |
-            curl -u ${{ secrets.CIRCLE_TOKEN }}: -X  POST \
-               -H 'Content-Type: application/json' \
-               -H 'Accept: application/json' \
-               -d "{\"branch\":\"${{steps.pr_data.outputs.branch}}\", \
-                    \"parameters\": { \
-                       \"redeploy_prnet\": true , \
-                       \"pr_number\": \"${{ github.event.issue.number }}\"
-                       } \
-                   }" \
-               https://circleci.com/api/v2/project/gh/agrebin/taraxa-node/pipeline
-        if: steps.check.outputs.triggered == 'true'
-
   cleanup:
     runs-on: ubuntu-latest
     steps:
@@ -93,7 +75,11 @@ jobs:
           trigger: '/cleanup'
           reaction: rocket
         env:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          GITHUB_TOKEN: '{{ secrets.GITHUB_TOKEN }}' 
+      - uses: actions/checkout@v1
+        with: 
+         ref: develop
+        if: steps.check.outputs.triggered == 'true'
       - name: GitHub API Request
         id: request
         uses: octokit/request-action@v2.0.0
@@ -102,23 +88,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: steps.check.outputs.triggered == 'true'
-      - name: Get PR informations
-        id: pr_data
-        run: |
-          echo "::set-output name=branch::${{ fromJson(steps.request.outputs.data).head.ref }}"
-          echo "::set-output name=repo_name::${{ fromJson(steps.request.outputs.data).base.repo.full_name }}"
-          echo "::set-output name=repo_clone_url::${{ fromJson(steps.request.outputs.data).base.repo.clone_url }}"
-          echo "::set-output name=repo_ssh_url::${{ fromJson(steps.request.outputs.data).base.repo.ssh_url }}"
-        if: steps.check.outputs.triggered == 'true'
-      - run: |
-            curl -u ${{ secrets.CIRCLE_TOKEN }}: -X  POST \
-               -H 'Content-Type: application/json' \
-               -H 'Accept: application/json' \
-               -d "{\"branch\":\"${{ steps.pr_data.outputs.branch }}\", \
-                    \"parameters\": { \
-                       \"cleanup_prnet\": true , \
-                       \"pr_number\": \"${{ github.event.issue.number }}\"
-                       } \
-                   }" \
-               https://circleci.com/api/v2/project/gh/agrebin/taraxa-node/pipeline
+      - uses: ./.github/actions/prnet
+        id: trigger
+        with:
+          action: 'cleanup_prnet'
+          circleci_slug: 'gh/Taraxa/taraxa-node'
+          circle_token: '${{ secrets.CIRCLE_TOKEN }}'
+          pull_request: '${{ steps.request.outputs.data }}'
         if: steps.check.outputs.triggered == 'true'

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -1,0 +1,124 @@
+name: prnet-actions
+on:
+  pull_request:
+    types: [opened]
+  issue_comment:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: khan/pull-request-comment-trigger@master
+        id: check
+        with:
+          trigger: '/deploy'
+          reaction: rocket
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+      - name: GitHub API Request
+        id: request
+        uses: octokit/request-action@v2.0.0
+        with:
+          route: ${{ github.event.issue.pull_request.url }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: steps.check.outputs.triggered == 'true'
+      - name: Get PR informations
+        id: pr_data
+        run: |
+          echo "::set-output name=branch::${{ fromJson(steps.request.outputs.data).head.ref }}"
+          echo "::set-output name=repo_name::${{ fromJson(steps.request.outputs.data).base.repo.full_name }}"
+          echo "::set-output name=repo_clone_url::${{ fromJson(steps.request.outputs.data).base.repo.clone_url }}"
+          echo "::set-output name=repo_ssh_url::${{ fromJson(steps.request.outputs.data).base.repo.ssh_url }}"
+        if: steps.check.outputs.triggered == 'true'
+      - run: |
+            curl -u ${{ secrets.CIRCLE_TOKEN }}: -X  POST \
+               -H 'Content-Type: application/json' \
+               -H 'Accept: application/json' \
+               -d "{\"branch\":\"${{ steps.pr_data.outputs.branch }}\", \
+                    \"parameters\": { \
+                       \"deploy_prnet\": true , \
+                       \"pr_number\": \"${{ github.event.issue.number }}\"
+                       } \
+                   }" \
+               https://circleci.com/api/v2/project/gh/agrebin/taraxa-node/pipeline
+        if: steps.check.outputs.triggered == 'true'
+
+  redeploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: khan/pull-request-comment-trigger@master
+        id: check
+        with:
+          trigger: '/redeploy'
+          reaction: rocket
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+      - name: GitHub API Request
+        id: request
+        uses: octokit/request-action@v2.0.0
+        with:
+          route: ${{ github.event.issue.pull_request.url }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: steps.check.outputs.triggered == 'true'
+      - name: Get PR informations
+        id: pr_data
+        run: |
+          echo "::set-output name=branch::${{ fromJson(steps.request.outputs.data).head.ref }}"
+          echo "::set-output name=repo_name::${{ fromJson(steps.request.outputs.data).base.repo.full_name }}"
+          echo "::set-output name=repo_clone_url::${{ fromJson(steps.request.outputs.data).base.repo.clone_url }}"
+          echo "::set-output name=repo_ssh_url::${{ fromJson(steps.request.outputs.data).base.repo.ssh_url }}"
+        if: steps.check.outputs.triggered == 'true'
+      - run: |
+            curl -u ${{ secrets.CIRCLE_TOKEN }}: -X  POST \
+               -H 'Content-Type: application/json' \
+               -H 'Accept: application/json' \
+               -d "{\"branch\":\"${{steps.pr_data.outputs.branch}}\", \
+                    \"parameters\": { \
+                       \"redeploy_prnet\": true , \
+                       \"pr_number\": \"${{ github.event.issue.number }}\"
+                       } \
+                   }" \
+               https://circleci.com/api/v2/project/gh/agrebin/taraxa-node/pipeline
+        if: steps.check.outputs.triggered == 'true'
+
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: khan/pull-request-comment-trigger@master
+        id: check
+        with:
+          trigger: '/redeploy'
+          reaction: rocket
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+      - name: GitHub API Request
+        id: request
+        uses: octokit/request-action@v2.0.0
+        with:
+          route: ${{ github.event.issue.pull_request.url }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: steps.check.outputs.triggered == 'true'
+      - name: Get PR informations
+        id: pr_data
+        run: |
+          echo "::set-output name=branch::${{ fromJson(steps.request.outputs.data).head.ref }}"
+          echo "::set-output name=repo_name::${{ fromJson(steps.request.outputs.data).base.repo.full_name }}"
+          echo "::set-output name=repo_clone_url::${{ fromJson(steps.request.outputs.data).base.repo.clone_url }}"
+          echo "::set-output name=repo_ssh_url::${{ fromJson(steps.request.outputs.data).base.repo.ssh_url }}"
+        if: steps.check.outputs.triggered == 'true'
+      - run: |
+            curl -u ${{ secrets.CIRCLE_TOKEN }}: -X  POST \
+               -H 'Content-Type: application/json' \
+               -H 'Accept: application/json' \
+               -d "{\"branch\":\"${{ steps.pr_data.outputs.branch }}\", \
+                    \"parameters\": { \
+                       \"cleanup_prnet\": true , \
+                       \"pr_number\": \"${{ github.event.issue.number }}\"
+                       } \
+                   }" \
+               https://circleci.com/api/v2/project/gh/agrebin/taraxa-node/pipeline
+        if: steps.check.outputs.triggered == 'true'

--- a/.github/workflows/pr-net-cleanup-on-close.yml
+++ b/.github/workflows/pr-net-cleanup-on-close.yml
@@ -1,0 +1,28 @@
+name: prnet-actions
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+        with: 
+        if: github.event.pull_request.merged == false
+      - name: GitHub API Request
+        id: request
+        uses: octokit/request-action@v2.0.0
+        with:
+          route: ${{ github.event.issue.pull_request.url }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: github.event.pull_request.merged == false
+      - uses: ./.github/actions/prnet
+        id: trigger
+        with:
+          action: 'cleanup_prnet'
+          circleci_slug: 'gh/Taraxa/taraxa-node'
+          circle_token: '${{ secrets.CIRCLE_TOKEN }}'
+          pull_request: '${{ steps.request.outputs.data }}'
+        if: github.event.pull_request.merged == false


### PR DESCRIPTION
## Purpose

This pull request contains the github actions to trigger circleci jobs to deploy / redeploy / cleanup pr-nets

## For reviewers

This pr just contains the github actions, but not the circleci config

## Related Github issues

<!-- Include related github issues. -->

## Changes

<!-- Summary or changes that have been made. -->

## Tests

<!-- Describe what you did to test these changes, including unit tests that have been added or changed. -->

## Deployment Considerations

## Version Notes ##
{ major | minor | patch }

<!--

Decide whether this is a major, minor, or patch version change. Major is for backwards incompatible changes (This is only relevant once the service is live and in production and the major version is at least 1. While the major version is 0, it is ok to have backwards incompatible changes in a minor version.). Minor is for additional features. Patch is for bug fixes.

Describe the changes in this version. This is essentially the details you would include in the squash commit message.
-->

**NOTE: Include the version notes in the squash commit message**
