### PR TITLE
fix: prevent gossiping new blocks while syncing

### DIFF
--- a/src/network/taraxa_capability.cpp
+++ b/src/network/taraxa_capability.cpp
@@ -338,6 +338,8 @@ void TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
     // Means a new block is proposed, full block body and all transaction
     // are received.
     case NewBlockPacket: {
+      // Ignore new block packets when syncing
+      if (syncing_) break;
       DagBlock block(_r[0].data().toBytes());
 
       if (dag_blk_mgr_) {
@@ -983,6 +985,10 @@ void TaraxaCapability::sendSyncedMessage() {
 }
 
 void TaraxaCapability::onNewBlockVerified(DagBlock const &block) {
+  // If node is syncing this is an old block that has been verified - no block goosip is needed
+  if (syncing_) {
+    return;
+  }
   LOG(log_dg_dag_prp_) << "Verified NewBlock " << block.getHash().toString();
   auto const peersWithoutBlock =
       selectPeers([&](TaraxaPeer const &_peer) { return !_peer.isBlockKnown(block.getHash()); });


### PR DESCRIPTION
## Purpose

Prevent gossiping new blocks while syncing

## For reviewers

While node is syncing, OnBlockVerified was called for each of the old DAG block that was verified. This was gossiped to all other nodes as if it is a completely new block. This is now prevented.

## Related Github issues

<!-- Include related github issues. -->

## Changes

<!-- Summary or changes that have been made. -->

## Tests

<!-- Describe what you did to test these changes, including unit tests that have been added or changed. -->

## Deployment Considerations

## Version Notes ##
{ major | minor | patch }

<!--

Decide whether this is a major, minor, or patch version change. Major is for backwards incompatible changes (This is only relevant once the service is live and in production and the major version is at least 1. While the major version is 0, it is ok to have backwards incompatible changes in a minor version.). Minor is for additional features. Patch is for bug fixes.

Describe the changes in this version. This is essentially the details you would include in the squash commit message.
-->

**NOTE: Include the version notes in the squash commit message**
