### PR TITLE
chore(cmake): make clang-tidy optional as it is not used at the moment

### DIFF
--- a/CMakeModules/clang_tidy.cmake
+++ b/CMakeModules/clang_tidy.cmake
@@ -3,7 +3,6 @@
 find_program(CLANG_TIDY_EXE
         NAMES clang-tidy-${LLVM_VERSION} clang-tidy
         DOC "Path to clang-tidy executable"
-        REQUIRED
         )
 
 set(taraxa_LINT_LEVEL "OFF" CACHE STRING "Lint level during taraxa build (FULL, HIGH, LOW, OFF)")


### PR DESCRIPTION
## Purpose

clang-tidy is not properly configured and used at the moment. No need to require it until we properly set it up to be used during building ALL...
