### PR TITLE
Followup on PR #843

### DIFF
--- a/src/node/full_node.cpp
+++ b/src/node/full_node.cpp
@@ -163,12 +163,12 @@ void FullNode::start() {
     }
     final_chain_->block_finalized_.subscribe(
         [eth_json_rpc = weak_ptr(eth_json_rpc), ws = weak_ptr(jsonrpc_ws_), db = weak_ptr(db_)](auto const &res) {
-          if (auto _eth_json_rpc = eth_json_rpc.lock(); _eth_json_rpc) {
+          if (auto _eth_json_rpc = eth_json_rpc.lock()) {
             _eth_json_rpc->note_block_executed(*res->final_chain_blk, res->trxs, res->trx_receipts);
           }
-          if (auto _ws = ws.lock(); _ws) {
+          if (auto _ws = ws.lock()) {
             _ws->newEthBlock(*res->final_chain_blk);
-            if (auto _db = db.lock(); _db) {
+            if (auto _db = db.lock()) {
               auto pbft_blk = _db->getPbftBlock(res->hash);
               _ws->newDagBlockFinalized(pbft_blk->getPivotDagBlockHash(), pbft_blk->getPeriod());
               _ws->newPbftBlockExecuted(*pbft_blk, res->dag_blk_hashes);
@@ -178,10 +178,10 @@ void FullNode::start() {
         *rpc_thread_pool_);
     trx_mgr_->transaction_accepted_.subscribe(
         [eth_json_rpc = weak_ptr(eth_json_rpc), ws = weak_ptr(jsonrpc_ws_)](auto const &trx_hash) {
-          if (auto _eth_json_rpc = eth_json_rpc.lock(); _eth_json_rpc) {
+          if (auto _eth_json_rpc = eth_json_rpc.lock()) {
             _eth_json_rpc->note_pending_transaction(trx_hash);
           }
-          if (auto _ws = ws.lock(); _ws) {
+          if (auto _ws = ws.lock()) {
             _ws->newPendingTransaction(trx_hash);
           }
         },

--- a/src/node/full_node.cpp
+++ b/src/node/full_node.cpp
@@ -162,7 +162,7 @@ void FullNode::start() {
       jsonrpc_ws_->run();
     }
     final_chain_->block_finalized_.subscribe(
-        [eth_json_rpc = weak_ptr(eth_json_rpc), ws = weak_ptr(jsonrpc_ws_), db = weak_ptr(db_)](auto const &res) {
+        [eth_json_rpc = as_weak(eth_json_rpc), ws = as_weak(jsonrpc_ws_), db = as_weak(db_)](auto const &res) {
           if (auto _eth_json_rpc = eth_json_rpc.lock()) {
             _eth_json_rpc->note_block_executed(*res->final_chain_blk, res->trxs, res->trx_receipts);
           }
@@ -177,7 +177,7 @@ void FullNode::start() {
         },
         *rpc_thread_pool_);
     trx_mgr_->transaction_accepted_.subscribe(
-        [eth_json_rpc = weak_ptr(eth_json_rpc), ws = weak_ptr(jsonrpc_ws_)](auto const &trx_hash) {
+        [eth_json_rpc = as_weak(eth_json_rpc), ws = as_weak(jsonrpc_ws_)](auto const &trx_hash) {
           if (auto _eth_json_rpc = eth_json_rpc.lock()) {
             _eth_json_rpc->note_pending_transaction(trx_hash);
           }

--- a/src/node/full_node.hpp
+++ b/src/node/full_node.hpp
@@ -112,14 +112,14 @@ class FullNode : public std::enable_shared_from_this<FullNode> {
   }
 
   template <typename T, typename... ConstructorParams>
-  auto &emplace(std::shared_ptr<T> &ptr, ConstructorParams &&... ctor_params) {
+  auto &emplace(std::shared_ptr<T> &ptr, ConstructorParams &&...ctor_params) {
     ptr = std::make_shared<T>(std::forward<ConstructorParams>(ctor_params)...);
     register_s_ptr(ptr);
     return ptr;
   }
 
   template <typename T, typename... ConstructorParams>
-  static auto &emplace(std::unique_ptr<T> &ptr, ConstructorParams &&... ctor_params) {
+  static auto &emplace(std::unique_ptr<T> &ptr, ConstructorParams &&...ctor_params) {
     return ptr = std::make_unique<T>(std::forward<ConstructorParams>(ctor_params)...);
   }
 

--- a/src/node/full_node.hpp
+++ b/src/node/full_node.hpp
@@ -112,14 +112,14 @@ class FullNode : public std::enable_shared_from_this<FullNode> {
   }
 
   template <typename T, typename... ConstructorParams>
-  auto &emplace(std::shared_ptr<T> &ptr, ConstructorParams &&...ctor_params) {
+  auto &emplace(std::shared_ptr<T> &ptr, ConstructorParams &&... ctor_params) {
     ptr = std::make_shared<T>(std::forward<ConstructorParams>(ctor_params)...);
     register_s_ptr(ptr);
     return ptr;
   }
 
   template <typename T, typename... ConstructorParams>
-  static auto &emplace(std::unique_ptr<T> &ptr, ConstructorParams &&...ctor_params) {
+  static auto &emplace(std::unique_ptr<T> &ptr, ConstructorParams &&... ctor_params) {
     return ptr = std::make_unique<T>(std::forward<ConstructorParams>(ctor_params)...);
   }
 

--- a/src/transaction_manager/transaction.hpp
+++ b/src/transaction_manager/transaction.hpp
@@ -10,12 +10,6 @@
 namespace taraxa {
 
 struct Transaction {
-  struct InvalidChainID : std::invalid_argument {
-    InvalidChainID() : invalid_argument("eip-155 chain id must be > 0") {}
-  };
-  struct InvalidEncodingSize : std::invalid_argument {
-    InvalidEncodingSize() : invalid_argument("transaction rlp must be a list of 9 elements") {}
-  };
   struct InvalidSignature : std::runtime_error {
     explicit InvalidSignature(std::string const &msg) : runtime_error("invalid signature:\n" + msg) {}
   };

--- a/src/util/util.hpp
+++ b/src/util/util.hpp
@@ -24,6 +24,11 @@
 
 namespace taraxa {
 
+template <typename T>
+std::weak_ptr<T> as_weak(std::shared_ptr<T> sp) {
+  return std::weak_ptr<T>(sp);
+}
+
 template <typename Int1, typename Int2>
 auto int_pow(Int1 x, Int2 y) {
   if (!y) {
@@ -210,7 +215,7 @@ class StatusTable {
 };  // namespace taraxa
 
 template <typename... TS>
-std::string fmt(const std::string &pattern, const TS &... args) {
+std::string fmt(const std::string &pattern, const TS &...args) {
   return (boost::format(pattern) % ... % args).str();
 }
 

--- a/src/util/util.hpp
+++ b/src/util/util.hpp
@@ -215,7 +215,7 @@ class StatusTable {
 };  // namespace taraxa
 
 template <typename... TS>
-std::string fmt(const std::string &pattern, const TS &...args) {
+std::string fmt(const std::string &pattern, const TS &... args) {
   return (boost::format(pattern) % ... % args).str();
 }
 

--- a/src/util/util.hpp
+++ b/src/util/util.hpp
@@ -215,7 +215,7 @@ class StatusTable {
 };  // namespace taraxa
 
 template <typename... TS>
-std::string fmt(const std::string &pattern, const TS &... args) {
+std::string fmt(const std::string &pattern, const TS &...args) {
   return (boost::format(pattern) % ... % args).str();
 }
 

--- a/src/util/util.hpp
+++ b/src/util/util.hpp
@@ -210,7 +210,7 @@ class StatusTable {
 };  // namespace taraxa
 
 template <typename... TS>
-std::string fmt(const std::string &pattern, const TS &...args) {
+std::string fmt(const std::string &pattern, const TS &... args) {
   return (boost::format(pattern) % ... % args).str();
 }
 

--- a/tests/transaction_test.cpp
+++ b/tests/transaction_test.cpp
@@ -73,7 +73,7 @@ TEST_F(TransactionTest, sig) {
   ASSERT_THROW(Transaction(dev::jsToBytes("0xf84980808080808024a01404adc97c8b58fef303b2862d0e72378"
                                           "4fb635e7237e0e8d3ea33bbea19c36ca0229e80d57ba91a0f347686"
                                           "30fd21ad86e4c403b307de9ac4550d0ccc81c90fe3")),
-               Transaction::InvalidChainID);
+               Transaction::InvalidSignature);
   vector<pair<uint64_t, string>> valid_cases{
       {0, "0xf647d1d47ce927ce2fb9f57e4e2a3c32b037c5e544b44611077f5cc6980b0bc2"},
       {1, "0x49c1cb845df5d3ed238ca37ad25ca96f417e4f22d7911224cf3c2a725985e7ff"},


### PR DESCRIPTION
1) Fixed a bug in transaction rlp parsing. We used to require v, r, s signature fields to be full-sized, but actually it's okay by the standard for them to be not full-sized due to leading zeroes trimming.
2) Simplified and cleaned up the code in some places
3) Fixed inconsistent formatting by running clang-format
4)  fixed failure to deduce weak_ptr constructor template arguments on some macos compilers