### PR TITLE
implemented external caching with cci-x/docker-registry-image-cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,7 @@ jobs:
          repository: gcr.io/${GOOGLE_PROJECT_ID}
          images: >-
            ${IMAGE}-ctest:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}
+           ${IMAGE}-cache:latest
            ${IMAGE}-cache:${DOCKER_BRANCH_TAG}
          steps: 
            - docker-cache/build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,6 @@ jobs:
             echo ${GCLOUD_SERVICE_KEY} | docker login -u _json_key --password-stdin https://gcr.io
 
       - docker-cache/with-save-restore-images:
-         name: Build main image with external cache
          repository: gcr.io/${GOOGLE_PROJECT_ID}
          images: >-
            ${IMAGE}-cache:${DOCKER_BRANCH_TAG}
@@ -67,7 +66,6 @@ jobs:
                 docker build -t ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} .
 
       - docker-cache/with-save-restore-images:
-         name: Build cache image with eternal caching
          repository: gcr.io/${GOOGLE_PROJECT_ID}
          images: >-
            ${IMAGE}-ctest:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,14 +12,15 @@ parameters:
 orbs:
   git: opuscapita/git@0.0.3
   github-release: izumin5210/github-release@0.1.1
-
   gcp-gcr: circleci/gcp-gcr@0.13.0
+  docker-cache: cci-x/docker-registry-image-cache@0.2.12
 
 
 jobs:
    build-and-push-docker-image:
     environment:
       - IMAGE: taraxa-node
+      - CONAN_REVISIONS_ENABLED: 1
     machine:
       image: ubuntu-2004:202010-01
       docker_layer_caching: false
@@ -43,19 +44,52 @@ jobs:
            echo "export START_TIME=$(date +%Y%m%d-%Hh%Mm%Ss)" >>$BASH_ENV
            echo "export GCP_IMAGE=gcr.io/${GOOGLE_PROJECT_ID}/${IMAGE}" >> $BASH_ENV
            echo "export PR=$( [[ -z ${CIRCLE_PULL_REQUEST+x} ]] && echo false || echo $(basename ${CIRCLE_PULL_REQUEST}) )" >>$BASH_ENV
-           #echo "export HELM_TEST_NAME=$(echo $CIRCLE_BRANCH | sed 's/[^A-Za-z0-9\\-]*//g' | tr '[:upper:]' '[:lower:]')" >>$BASH_ENV
            export PR=$( [[ -z ${CIRCLE_PULL_REQUEST+x} ]] && echo false || echo $(basename ${CIRCLE_PULL_REQUEST}) )           
            echo "export HELM_TEST_NAME=pr-${PR}" >> $BASH_ENV
            sudo service apport stop
+
       - run:
-         name: Docker Build taraxa-node
+         name: Login into gcr
          command: |
-           docker build -t ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} .
-      - run:
-         name: Docker Build taraxa-node-ctest
-         command: |
-          docker build -t ${IMAGE}-ctest:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} \
-            --target build .
+            echo ${GCLOUD_SERVICE_KEY} | docker login -u _json_key --password-stdin https://gcr.io
+ 
+#      - run:
+#         name: Docker Build taraxa-node
+#         command: |
+#           docker build -t ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} .
+
+      - docker-cache/with-save-restore-images:
+         repository: gcr.io/${GOOGLE_PROJECT_ID}
+         images: >-
+           ${IMAGE}:${DOCKER_BRANCH_TAG}
+           ${IMAGE}-cache:${DOCKER_BRANCH_TAG}
+           ${IMAGE}-cache:latest
+           ${IMAGE}-develop:latest
+         steps:
+           - docker-cache/build:
+              command: |
+                docker build -t ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} .
+                 
+#      - run:
+#         name: Docker Build taraxa-node-ctest\
+#         command: |
+#          docker build -t ${IMAGE}-ctest:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} \
+#            --target build .
+      - docker-cache/with-save-restore-images:
+         repository: gcr.io/${GOOGLE_PROJECT_ID}
+         images: >-
+           ${IMAGE}-ctest:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}
+           ${IMAGE}-cache:${DOCKER_BRANCH_TAG}
+         steps: 
+           - docker-cache/build:
+              command: |
+               docker build -t ${IMAGE}-ctest:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} \
+                 --target build .
+           - docker-cache/tag: 
+               tags: >-
+                  ${IMAGE}-ctest:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} ${IMAGE}-cache:${DOCKER_BRANCH_TAG}
+              
+                
       - run:
          name: Run Ctest
          command: |
@@ -130,6 +164,7 @@ jobs:
            docker tag ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} ${GCP_IMAGE}:${START_TIME}
            docker tag ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} ${GCP_IMAGE}:${START_TIME}-${CIRCLE_SHA1}
            docker tag ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} ${GCP_IMAGE}:latest
+           
            docker tag ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} taraxa/${IMAGE}:${CIRCLE_SHA1}
            docker tag ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} taraxa/${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}
            docker tag ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} taraxa/${IMAGE}:${START_TIME}
@@ -138,6 +173,7 @@ jobs:
            if [[ ${PR} != "false" ]];then
               docker tag ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} ${GCP_IMAGE}:pr-${PR}-${CIRCLE_BUILD_NUM}
            fi
+           docker tag ${GCP_IMAGE}-cache:${DOCKER_BRANCH_TAG} ${GCP_IMAGE}-cache:latest
       - run:
          name: Install/configure helm and chart
          no_output_timeout: 15m
@@ -185,6 +221,7 @@ jobs:
          name: Push Images
          command: |
            if [[ ${CIRCLE_BRANCH} == "develop"   ]];then
+              docker push ${GCP_IMAGE}-cache:latest
               docker push ${GCP_IMAGE}-develop:latest
               docker push ${GCP_IMAGE}-develop:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}
               docker push ${GCP_IMAGE}-develop:${START_TIME}
@@ -195,6 +232,7 @@ jobs:
               docker push ${GCP_IMAGE}:pr-${PR}-${CIRCLE_BUILD_NUM}
            fi
            if [[ ${CIRCLE_BRANCH} == "master" ]];then
+              docker push ${GCP_IMAGE}-cache:latest
               docker push ${GCP_IMAGE}:latest
               docker push ${GCP_IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}
               docker push ${GCP_IMAGE}:${START_TIME}
@@ -397,6 +435,10 @@ workflows:
     jobs:
       - build-and-push-docker-image:
          context: taraxa-node
+         filters:
+           branches: 
+             only: 
+              - speedup-docker-build 
 
   create-builder-image:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,7 @@ jobs:
       - docker-cache/with-save-restore-images:
          repository: gcr.io/${GOOGLE_PROJECT_ID}
          images: >-
+           ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} 
            ${IMAGE}-ctest:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}
            ${IMAGE}-cache:latest
            ${IMAGE}-cache:${DOCKER_BRANCH_TAG}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,6 @@ jobs:
       - run:
          name: Tag images
          command: |
-           echo ${GCLOUD_SERVICE_KEY} | docker login -u _json_key --password-stdin https://gcr.io
            if [[ ${CIRCLE_BRANCH} == "develop" ]]; then
               docker tag ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} ${GCP_IMAGE}-develop:${CIRCLE_SHA1}
               docker tag ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} ${GCP_IMAGE}-develop:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,6 @@ jobs:
            ${IMAGE}-develop:latest
          steps:
            - docker-cache/build:
-              name: docker build
               command: |
                 docker build -t ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} .
 
@@ -72,12 +71,10 @@ jobs:
            ${IMAGE}-cache:${DOCKER_BRANCH_TAG}
          steps: 
            - docker-cache/build:
-              name: docker build
               command: |
                docker build -t ${IMAGE}-ctest:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} \
                  --target build .
            - docker-cache/tag: 
-               name: Tag cache image
                tags: >-
                   ${IMAGE}-ctest:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} ${IMAGE}-cache:${DOCKER_BRANCH_TAG}
               

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,40 +52,34 @@ jobs:
          name: Login into gcr
          command: |
             echo ${GCLOUD_SERVICE_KEY} | docker login -u _json_key --password-stdin https://gcr.io
- 
-#      - run:
-#         name: Docker Build taraxa-node
-#         command: |
-#           docker build -t ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} .
 
       - docker-cache/with-save-restore-images:
+         name: Build main image with external cache
          repository: gcr.io/${GOOGLE_PROJECT_ID}
          images: >-
-           ${IMAGE}:${DOCKER_BRANCH_TAG}
            ${IMAGE}-cache:${DOCKER_BRANCH_TAG}
            ${IMAGE}-cache:latest
            ${IMAGE}-develop:latest
          steps:
            - docker-cache/build:
+              name: docker build
               command: |
                 docker build -t ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} .
-                 
-#      - run:
-#         name: Docker Build taraxa-node-ctest\
-#         command: |
-#          docker build -t ${IMAGE}-ctest:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} \
-#            --target build .
+
       - docker-cache/with-save-restore-images:
+         name: Build cache image with eternal caching
          repository: gcr.io/${GOOGLE_PROJECT_ID}
          images: >-
            ${IMAGE}-ctest:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}
            ${IMAGE}-cache:${DOCKER_BRANCH_TAG}
          steps: 
            - docker-cache/build:
+              name: docker build
               command: |
                docker build -t ${IMAGE}-ctest:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} \
                  --target build .
            - docker-cache/tag: 
+               name: Tag cache image
                tags: >-
                   ${IMAGE}-ctest:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} ${IMAGE}-cache:${DOCKER_BRANCH_TAG}
               
@@ -435,10 +429,6 @@ workflows:
     jobs:
       - build-and-push-docker-image:
          context: taraxa-node
-         filters:
-           branches: 
-             only: 
-              - speedup-docker-build 
 
   create-builder-image:
     jobs:


### PR DESCRIPTION
## Purpose

This PR is to speedup docker image builds via implementing external cache method.

## For reviewers

i have performed may tests, trying to cover most of the variants that i was able to reproduce.
it costs about 10' downloading two cache images, one for current branch and one to be the latest, but overall i think it lowers the built time at least to half.
i have discovered that cacheable layers are all on the actual ctest image, since the taraxad image gets most of the stuff removed, so i retag ctest image to be the caching image.

## Related Github issues

<!-- Include related github issues. -->

## Changes

<!-- Summary or changes that have been made. -->

## Tests

<!-- Describe what you did to test these changes, including unit tests that have been added or changed. -->

## Deployment Considerations

## Version Notes ##
{ major | minor | patch }

<!--

Decide whether this is a major, minor, or patch version change. Major is for backwards incompatible changes (This is only relevant once the service is live and in production and the major version is at least 1. While the major version is 0, it is ok to have backwards incompatible changes in a minor version.). Minor is for additional features. Patch is for bug fixes.

Describe the changes in this version. This is essentially the details you would include in the squash commit message.
-->

**NOTE: Include the version notes in the squash commit message**
