### PR TITLE
Splitting PbftBlockPacket if over max size of 15MB

### DIFF
--- a/src/network/taraxa_capability.cpp
+++ b/src/network/taraxa_capability.cpp
@@ -1528,9 +1528,15 @@ void TaraxaCapability::sendPbftBlocks(NodeID const &_id, size_t height_to_sync, 
         dag_rlp.appendRaw(transactions[trx_idx]);
       }
 
+      // When checking if size limit exceeds MAX_PACKET_SIZE there are few bytes or rlp structure that is added
+      // for the pbft block and dag block. This should be just a couple of bytes but we enforece even stricter 128 limit
+      static const int RLP_OVERHEAD = 128;
+
       // Check if PBFT blocks need to be split and sent in multiple packets so we dont exceed
       // MAX_PACKET_SIZE (15 MB) limit
-      if (act_packet_size + dag_blocks_size + dag_rlp.out().size() > MAX_PACKET_SIZE) {
+      if (act_packet_size + dag_blocks_size + dag_rlp.out().size() + pbft_blocks[pbft_block_idx].rlp().size() +
+              RLP_OVERHEAD >
+          MAX_PACKET_SIZE) {
         LOG(log_dg_dag_sync_) << "Sending partial PbftBlockPacket due tu MAX_PACKET_SIZE limit. " << pbft_block_idx + 1
                               << " blocks out of " << pbft_blocks.size() << " sent.";
 

--- a/src/network/taraxa_capability.cpp
+++ b/src/network/taraxa_capability.cpp
@@ -607,44 +607,10 @@ void TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
 
       auto pbft_sync_period = pbft_chain_->pbftSyncingPeriod();
       for (auto const pbft_blk_tuple : _r) {
-        PbftBlockCert pbft_blk_and_votes(pbft_blk_tuple[0]);
-        auto pbft_blk_hash = pbft_blk_and_votes.pbft_blk->getBlockHash();
-        peer->markPbftBlockAsKnown(pbft_blk_hash);
-        LOG(log_nf_pbft_sync_) << "Received pbft block: " << pbft_blk_and_votes.pbft_blk->getBlockHash();
-
-        if (pbft_chain_->isKnownPbftBlockForSyncing(pbft_blk_hash)) {
-          // Already have this block...
-          return;
-        } else {
-          blk_hash_t last_local_pbft_blockhash;
-          if (pbft_chain_->pbftSyncedQueueEmpty()) {
-            // Look at the chain...
-            last_local_pbft_blockhash = pbft_chain_->getLastPbftBlockHash();
-          } else {
-            last_local_pbft_blockhash = pbft_chain_->pbftSyncedQueueBack().pbft_blk->getBlockHash();
-          }
-
-          if (last_local_pbft_blockhash != pbft_blk_and_votes.pbft_blk->getPrevBlockHash()) {
-            // This block is out of order...
-            if (_nodeID == peer_syncing_pbft_) {
-              LOG(log_si_pbft_sync_) << "PBFT SYNC ERROR, UNEXPECTED PBFT BLOCK HEIGHT: "
-                                     << pbft_blk_and_votes.pbft_blk->getPeriod()
-                                     << ", has synced period: " << pbft_sync_period
-                                     << ", PBFT chain size: " << pbft_chain_->getPbftChainSize()
-                                     << ", synced queue size : " << pbft_chain_->pbftSyncedQueueSize();
-              syncing_ = false;
-            }
-            return;
-          }
-        }
-
-        if (peer->pbft_chain_size_ < pbft_blk_and_votes.pbft_blk->getPeriod()) {
-          peer->pbft_chain_size_ = pbft_blk_and_votes.pbft_blk->getPeriod();
-        }
-
+        dev::RLP dag_blocks_rlp = pbft_blk_tuple[0];
         string received_dag_blocks_str;
         map<uint64_t, map<blk_hash_t, pair<DagBlock, vector<Transaction>>>> dag_blocks_per_level;
-        for (auto const dag_blk_struct : pbft_blk_tuple[1]) {
+        for (auto const dag_blk_struct : dag_blocks_rlp) {
           DagBlock dag_blk(dag_blk_struct[0]);
           auto const &dag_blk_h = dag_blk.getHash();
           peer->markBlockAsKnown(dag_blk_h);
@@ -663,9 +629,7 @@ void TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
             auto status = checkDagBlockValidation(block.second.first);
             if (!status.first) {
               if (peer_syncing_pbft_ == _nodeID) {
-                LOG(log_si_pbft_sync_) << "PBFT SYNC ERROR, DAG missing a tip/pivot in period "
-                                       << pbft_blk_and_votes.pbft_blk->getPeriod()
-                                       << ", has synced period: " << pbft_sync_period
+                LOG(log_si_pbft_sync_) << "PBFT SYNC ERROR, DAG missing a tip/pivot"
                                        << ", PBFT chain size: " << pbft_chain_->getPbftChainSize()
                                        << ", synced queue size: " << pbft_chain_->pbftSyncedQueueSize();
                 syncing_ = false;
@@ -681,24 +645,60 @@ void TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
           }
         }
 
-        // Check the PBFT block whether in the chain or in the synced queue
-        if (!pbft_chain_->isKnownPbftBlockForSyncing(pbft_blk_hash)) {
-          // Check the PBFT block validation
-          if (pbft_chain_->checkPbftBlockValidationFromSyncing(*pbft_blk_and_votes.pbft_blk)) {
-            // Notice: cannot verify 2t+1 cert votes here. Since don't
-            // have correct account status for nodes which after the
-            // first synced one.
-            pbft_chain_->setSyncedPbftBlockIntoQueue(pbft_blk_and_votes);
-            pbft_sync_period = pbft_chain_->pbftSyncingPeriod();
-            LOG(log_nf_pbft_sync_) << "Synced PBFT block hash " << pbft_blk_hash << " with "
-                                   << pbft_blk_and_votes.cert_votes.size() << " cert votes";
-            LOG(log_dg_pbft_sync_) << "Synced PBFT block " << pbft_blk_and_votes;
+        if (pbft_blk_tuple.itemCount() == 2) {
+          PbftBlockCert pbft_blk_and_votes(pbft_blk_tuple[1]);
+          auto pbft_blk_hash = pbft_blk_and_votes.pbft_blk->getBlockHash();
+          peer->markPbftBlockAsKnown(pbft_blk_hash);
+          LOG(log_nf_pbft_sync_) << "Received pbft block: " << pbft_blk_and_votes.pbft_blk->getBlockHash();
+
+          if (pbft_chain_->isKnownPbftBlockForSyncing(pbft_blk_hash)) {
+            // Already have this block...
+            return;
           } else {
-            LOG(log_er_pbft_sync_) << "The PBFT block " << pbft_blk_hash << " failed validation. Drop it!";
+            blk_hash_t last_local_pbft_blockhash;
+            if (pbft_chain_->pbftSyncedQueueEmpty()) {
+              // Look at the chain...
+              last_local_pbft_blockhash = pbft_chain_->getLastPbftBlockHash();
+            } else {
+              last_local_pbft_blockhash = pbft_chain_->pbftSyncedQueueBack().pbft_blk->getBlockHash();
+            }
+
+            if (last_local_pbft_blockhash != pbft_blk_and_votes.pbft_blk->getPrevBlockHash()) {
+              // This block is out of order...
+              if (_nodeID == peer_syncing_pbft_) {
+                LOG(log_si_pbft_sync_) << "PBFT SYNC ERROR, UNEXPECTED PBFT BLOCK HEIGHT: "
+                                       << pbft_blk_and_votes.pbft_blk->getPeriod()
+                                       << ", has synced period: " << pbft_sync_period
+                                       << ", PBFT chain size: " << pbft_chain_->getPbftChainSize()
+                                       << ", synced queue size : " << pbft_chain_->pbftSyncedQueueSize();
+                syncing_ = false;
+              }
+              return;
+            }
+          }
+
+          if (peer->pbft_chain_size_ < pbft_blk_and_votes.pbft_blk->getPeriod()) {
+            peer->pbft_chain_size_ = pbft_blk_and_votes.pbft_blk->getPeriod();
+          }
+
+          // Check the PBFT block whether in the chain or in the synced queue
+          if (!pbft_chain_->isKnownPbftBlockForSyncing(pbft_blk_hash)) {
+            // Check the PBFT block validation
+            if (pbft_chain_->checkPbftBlockValidationFromSyncing(*pbft_blk_and_votes.pbft_blk)) {
+              // Notice: cannot verify 2t+1 cert votes here. Since don't
+              // have correct account status for nodes which after the
+              // first synced one.
+              pbft_chain_->setSyncedPbftBlockIntoQueue(pbft_blk_and_votes);
+              pbft_sync_period = pbft_chain_->pbftSyncingPeriod();
+              LOG(log_nf_pbft_sync_) << "Synced PBFT block hash " << pbft_blk_hash << " with "
+                                     << pbft_blk_and_votes.cert_votes.size() << " cert votes";
+              LOG(log_dg_pbft_sync_) << "Synced PBFT block " << pbft_blk_and_votes;
+            } else {
+              LOG(log_er_pbft_sync_) << "The PBFT block " << pbft_blk_hash << " failed validation. Drop it!";
+            }
           }
         }
       }
-
       if (pbft_blk_count > 0) {
         if (syncing_) {
           if (pbft_sync_period > pbft_chain_->getPbftChainSize() + (10 * conf_.network_sync_level_size)) {
@@ -724,7 +724,6 @@ void TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
           sendSyncedMessage();
         }
       }
-
       break;
     }
     case TestPacket: {
@@ -1511,48 +1510,55 @@ void TaraxaCapability::sendPbftBlocks(NodeID const &_id, size_t height_to_sync, 
     auto start_1 = dag_blocks_indexes[pbft_block_idx];
     auto end_1 = dag_blocks_indexes[pbft_block_idx + 1];
 
-    pbft_block_rlp.appendList(2);  // item #1 - pbft block rlp, item #2 - list of dag blocks
-    pbft_block_rlp.appendRaw(pbft_blocks[pbft_block_idx].rlp());
-    pbft_block_rlp.appendList(end_1 - start_1);
+    std::vector<dev::bytes> dag_blocks_rlps;
+    uint64_t dag_blocks_size = 0;
 
     // Iterate through dag blocks blocks / per pbft block
     for (uint dag_block_idx = start_1; dag_block_idx < end_1; ++dag_block_idx) {
       auto start_2 = transactions_indexes[dag_block_idx];
       auto end_2 = transactions_indexes[dag_block_idx + 1];
 
-      pbft_block_rlp.appendList(2);  // item #1 - dag block rlp, item #2 - list of dag block transactions
-      pbft_block_rlp.appendRaw(dag_blocks[dag_block_idx]);
-      pbft_block_rlp.appendList(end_2 - start_2);
+      RLPStream dag_rlp;
+      dag_rlp.appendList(2);  // item #1 - dag block rlp, item #2 - list of dag block transactions
+      dag_rlp.appendRaw(dag_blocks[dag_block_idx]);
+      dag_rlp.appendList(end_2 - start_2);
 
       // Iterate through txs / per dag block
       for (uint trx_idx = start_2; trx_idx < end_2; ++trx_idx) {
-        pbft_block_rlp.appendRaw(transactions[trx_idx]);
-      }
-    }
-
-    // Check if PBFT blocks need to be split and sent in multiple packets so we dont exceed
-    // MAX_PACKET_SIZE (15 MB) limit
-    if (act_packet_size + pbft_block_rlp.out().size() > MAX_PACKET_SIZE) {
-      if (pbft_blocks_rlps.empty()) {
-        // If this log is present in log, it means there was created such big pbft block, that we are not able to send
-        // it through network
-        // This situation should never ever happen !!!
-        LOG(log_er_) << "Unable to send pbft block: " << pbft_blocks[pbft_block_idx].pbft_blk->getBlockHash().abridged()
-                     << " due to MAX_PACKET_SIZE(" << MAX_PACKET_SIZE << ") limit. "
-                     << "Block size: " << pbft_block_rlp.out().size() << " [B]";
-        // Skip this block as it would not go through network anyway
-        continue;
+        dag_rlp.appendRaw(transactions[trx_idx]);
       }
 
-      LOG(log_dg_dag_sync_) << "Sending partial PbftBlockPacket due tu MAX_PACKET_SIZE limit. " << pbft_block_idx + 1
-                            << " blocks out of " << pbft_blocks.size() << " sent.";
+      // Check if PBFT blocks need to be split and sent in multiple packets so we dont exceed
+      // MAX_PACKET_SIZE (15 MB) limit
+      if (act_packet_size + dag_blocks_size + dag_rlp.out().size() > MAX_PACKET_SIZE) {
+        LOG(log_dg_dag_sync_) << "Sending partial PbftBlockPacket due tu MAX_PACKET_SIZE limit. " << pbft_block_idx + 1
+                              << " blocks out of " << pbft_blocks.size() << " sent.";
 
-      // Send partial packet
-      sealAndSend(_id, PbftBlockPacket, create_packet(std::move(pbft_blocks_rlps)));
+        pbft_block_rlp.appendList(1);  // Only list of dag blocks and no pbft block rlp for incomplete packet
+        pbft_block_rlp.appendList(dag_blocks_rlps.size());
 
-      act_packet_size = 0;
-      pbft_blocks_rlps.clear();
+        for (auto &dag_block : dag_blocks_rlps) pbft_block_rlp.appendRaw(dag_block);
+
+        pbft_blocks_rlps.emplace_back(pbft_block_rlp.invalidate());
+
+        // Send partial packet
+        sealAndSend(_id, PbftBlockPacket, create_packet(std::move(pbft_blocks_rlps)));
+
+        act_packet_size = 0;
+        pbft_blocks_rlps.clear();
+        dag_blocks_size = 0;
+        dag_blocks_rlps.clear();
+      }
+
+      dag_blocks_rlps.push_back(dag_rlp.out());
+      dag_blocks_size += dag_rlp.out().size();
     }
+    pbft_block_rlp.appendList(2);  // item #1 - list of dag blocks, item #2 pbft block rlp
+    pbft_block_rlp.appendList(dag_blocks_rlps.size());
+
+    for (auto &dag_block : dag_blocks_rlps) pbft_block_rlp.appendRaw(dag_block);
+
+    pbft_block_rlp.appendRaw(pbft_blocks[pbft_block_idx].rlp());
 
     act_packet_size += pbft_block_rlp.out().size();
     pbft_blocks_rlps.emplace_back(pbft_block_rlp.invalidate());

--- a/src/node/full_node.hpp
+++ b/src/node/full_node.hpp
@@ -169,7 +169,7 @@ class FullNode : public std::enable_shared_from_this<FullNode> {
   static constexpr uint16_t c_node_minor_version = 8;
 
   // Any time a change in the network protocol is introduced this version should be increased
-  static constexpr uint16_t c_network_protocol_version = 6;
+  static constexpr uint16_t c_network_protocol_version = 7;
 
   // Major version is modified when DAG blocks, pbft blocks and any basic building blocks of our blockchan is modified
   // in the db

--- a/tests/util_test/samples.hpp
+++ b/tests/util_test/samples.hpp
@@ -131,13 +131,13 @@ inline std::vector<Transaction> createMockTrxSamples(unsigned start, unsigned nu
   return trxs;
 }
 
-inline std::vector<Transaction> createSignedTrxSamples(unsigned start, unsigned num, secret_t const &sk) {
+inline std::vector<Transaction> createSignedTrxSamples(unsigned start, unsigned num, secret_t const &sk,
+                                                       bytes data = str2bytes("00FEDCBA9876543210000000")) {
   assert(start + num < std::numeric_limits<unsigned>::max());
   std::vector<Transaction> trxs;
   for (auto i = start; i < num; ++i) {
     blk_hash_t hash(i);
-    trxs.emplace_back(
-        Transaction(i, i * 100, 0, 1000000, str2bytes("00FEDCBA9876543210000000"), sk, addr_t((i + 1) * 100)));
+    trxs.emplace_back(Transaction(i, i * 100, 0, 1000000, data, sk, addr_t((i + 1) * 100)));
   }
   return trxs;
 }


### PR DESCRIPTION
## Purpose

Splitting PbftBlockPacket if over max size of 15MB

## For reviewers

PbftBlockPacket which can contain multiple pbft packets together with the dag blocks and transactions was previously only split by pbft packets meaning that any pbft block packet over 15MB could not be split. With the changes in this PR splitting is done on the dag block level. This still means that no DAG block over 15MB can be sent.

## Related Github issues

<!-- Include related github issues. -->

## Changes

Changes in taraxa capability on sending and processing PBFT packet. Format is changed for any packet with pbft and dag blocks changing order in the packet. Pbft block is only sent once all dag blocks are sent

## Tests

Unit test added which tests syncing of large pbft block

## Deployment Considerations

## Version Notes ##
{ major | minor | patch }

<!--

Decide whether this is a major, minor, or patch version change. Major is for backwards incompatible changes (This is only relevant once the service is live and in production and the major version is at least 1. While the major version is 0, it is ok to have backwards incompatible changes in a minor version.). Minor is for additional features. Patch is for bug fixes.

Describe the changes in this version. This is essentially the details you would include in the squash commit message.
-->

**NOTE: Include the version notes in the squash commit message**
