### PR TITLE
fix(pbft): terminate PBFT soft voted value after some rounds 

### DIFF
--- a/src/consensus/pbft_manager.hpp
+++ b/src/consensus/pbft_manager.hpp
@@ -78,6 +78,9 @@ class PbftManager {
       std::shared_ptr<std::vector<std::pair<blk_hash_t, std::vector<bool>>>> trx_overlap_table);
   size_t getPbftCommitteeSize() const { return COMMITTEE_SIZE; }
   u_long getPbftInitialLambda() const { return LAMBDA_ms_MIN; }
+  void setLastSoftVotedValueSinceRound(blk_hash_t const voted_value, uint64_t const round) {
+    last_soft_voted_value_since_round_ = std::make_pair(voted_value, round);
+  }
 
  private:
   // DPOS
@@ -117,7 +120,7 @@ class PbftManager {
 
   std::pair<blk_hash_t, bool> proposeMyPbftBlock_();
 
-  std::pair<blk_hash_t, bool> identifyLeaderBlock_(std::vector<Vote> const &votes);
+  blk_hash_t identifyLeaderBlock_(std::vector<Vote> const &votes);
 
   bool checkPbftBlockValid_(blk_hash_t const &block_hash) const;
 
@@ -196,7 +199,7 @@ class PbftManager {
   bool next_voted_null_block_hash_ = false;
   bool go_finish_state_ = false;
   bool loop_back_finish_state_ = false;
-  bool reset_own_value_to_null_block_hash_in_this_round_ = false;
+  bool reset_own_starting_value_in_this_round_ = false;
 
   size_t const max_wait_rounds_for_proposal_block_ = 5;
   uint64_t round_began_wait_proposal_block_ = 0;

--- a/src/consensus/pbft_manager.hpp
+++ b/src/consensus/pbft_manager.hpp
@@ -198,8 +198,8 @@ class PbftManager {
   bool loop_back_finish_state_ = false;
   bool reset_own_value_to_null_block_hash_in_this_round_ = false;
 
+  size_t const max_wait_rounds_for_proposal_block_ = 5;
   uint64_t round_began_wait_proposal_block_ = 0;
-  size_t max_wait_rounds_for_proposal_block_ = 5;
   uint64_t round_began_wait_voted_block_ = 0;
 
   uint64_t pbft_round_last_requested_sync_ = 0;

--- a/src/consensus/pbft_manager.hpp
+++ b/src/consensus/pbft_manager.hpp
@@ -113,6 +113,7 @@ class PbftManager {
                                                             std::pair<blk_hash_t, bool> blockhash);
 
   size_t placeVote_(blk_hash_t const &blockhash, PbftVoteTypes vote_type, uint64_t round, size_t step);
+  void placeVoteForNewLeaderBlock_();
 
   std::pair<blk_hash_t, bool> proposeMyPbftBlock_();
 
@@ -176,9 +177,9 @@ class PbftManager {
   size_t step_ = 1;
 
   blk_hash_t own_starting_value_for_round_ = NULL_BLOCK_HASH;
-  // <round, cert_voted_block_hash>
-  std::unordered_map<size_t, blk_hash_t> cert_voted_values_for_round_;
+
   std::pair<blk_hash_t, bool> soft_voted_block_for_this_round_ = std::make_pair(NULL_BLOCK_HASH, false);
+  std::pair<blk_hash_t, uint64_t> last_soft_voted_value_since_round_ = std::make_pair(NULL_BLOCK_HASH, 0);
 
   std::vector<Vote> votes_;
 
@@ -190,7 +191,7 @@ class PbftManager {
 
   bool executed_pbft_block_ = false;
   bool have_executed_this_round_ = false;
-  bool should_have_cert_voted_in_this_round_ = false;
+  bool have_cert_voted_in_this_round_ = false;
   bool next_voted_soft_value_ = false;
   bool next_voted_null_block_hash_ = false;
   bool go_finish_state_ = false;

--- a/src/storage/db_storage.cpp
+++ b/src/storage/db_storage.cpp
@@ -431,24 +431,6 @@ void DbStorage::addPbftMgrVotedValueToBatch(PbftMgrVotedValue const& field, blk_
   insert(write_batch, Columns::pbft_mgr_voted_value, toSlice((uint8_t)field), toSlice(value.asBytes()));
 }
 
-shared_ptr<blk_hash_t> DbStorage::getPbftCertVotedBlockHash(uint64_t const& pbft_round) {
-  auto hash = asBytes(lookup(toSlice(pbft_round), Columns::pbft_cert_voted_block_hash));
-  if (hash.size() > 0) {
-    return make_shared<blk_hash_t>(hash);
-  }
-  return nullptr;
-}
-
-void DbStorage::savePbftCertVotedBlockHash(uint64_t const& pbft_round, blk_hash_t const& cert_voted_block_hash) {
-  insert(Columns::pbft_cert_voted_block_hash, toSlice(pbft_round), toSlice(cert_voted_block_hash.asBytes()));
-}
-
-void DbStorage::addPbftCertVotedBlockHashToBatch(uint64_t const& pbft_round, blk_hash_t const& cert_voted_block_hash,
-                                                 Batch& write_batch) {
-  insert(write_batch, Columns::pbft_cert_voted_block_hash, toSlice(pbft_round),
-         toSlice(cert_voted_block_hash.asBytes()));
-}
-
 shared_ptr<PbftBlock> DbStorage::getPbftCertVotedBlock(blk_hash_t const& block_hash) {
   auto block = lookup(toSlice(block_hash.asBytes()), Columns::pbft_cert_voted_block);
   if (!block.empty()) {

--- a/src/storage/db_storage.hpp
+++ b/src/storage/db_storage.hpp
@@ -36,6 +36,7 @@ enum StatusDbField : uint8_t {
 enum PbftMgrRoundStep : uint8_t { PbftRound = 0, PbftStep };
 enum PbftMgrStatus {
   soft_voted_block_in_round = 0,
+  cert_voted_block_in_round,
   executed_block,
   executed_in_round,
   next_voted_soft_value,
@@ -98,7 +99,6 @@ struct DbStorage {
     COLUMN(pbft_round_2t_plus_1);
     COLUMN(pbft_mgr_status);
     COLUMN(pbft_mgr_voted_value);
-    COLUMN(pbft_cert_voted_block_hash);
     COLUMN(pbft_cert_voted_block);
     COLUMN(pbft_head);
     COLUMN(pbft_blocks);
@@ -210,11 +210,6 @@ struct DbStorage {
   shared_ptr<blk_hash_t> getPbftMgrVotedValue(PbftMgrVotedValue const& field);
   void savePbftMgrVotedValue(PbftMgrVotedValue const& field, blk_hash_t const& value);
   void addPbftMgrVotedValueToBatch(PbftMgrVotedValue const& field, blk_hash_t const& value, Batch& write_batch);
-
-  shared_ptr<blk_hash_t> getPbftCertVotedBlockHash(uint64_t const& pbft_round);
-  void savePbftCertVotedBlockHash(uint64_t const& pbft_round, blk_hash_t const& cert_voted_block_hash);
-  void addPbftCertVotedBlockHashToBatch(uint64_t const& pbft_round, blk_hash_t const& cert_voted_block_hash,
-                                        Batch& write_batch);
 
   shared_ptr<PbftBlock> getPbftCertVotedBlock(blk_hash_t const& block_hash);
   void savePbftCertVotedBlock(PbftBlock const& pbft_block);

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -136,28 +136,33 @@ TEST_F(FullNodeTest, db_test) {
 
   // PBFT manager status
   EXPECT_FALSE(db.getPbftMgrStatus(PbftMgrStatus::soft_voted_block_in_round));
+  EXPECT_FALSE(db.getPbftMgrStatus(PbftMgrStatus::cert_voted_block_in_round));
   EXPECT_FALSE(db.getPbftMgrStatus(PbftMgrStatus::executed_block));
   EXPECT_FALSE(db.getPbftMgrStatus(PbftMgrStatus::executed_in_round));
   EXPECT_FALSE(db.getPbftMgrStatus(PbftMgrStatus::next_voted_soft_value));
   EXPECT_FALSE(db.getPbftMgrStatus(PbftMgrStatus::next_voted_null_block_hash));
   db.savePbftMgrStatus(PbftMgrStatus::soft_voted_block_in_round, true);
+  db.savePbftMgrStatus(PbftMgrStatus::cert_voted_block_in_round, true);
   db.savePbftMgrStatus(PbftMgrStatus::executed_block, true);
   db.savePbftMgrStatus(PbftMgrStatus::executed_in_round, true);
   db.savePbftMgrStatus(PbftMgrStatus::next_voted_soft_value, true);
   db.savePbftMgrStatus(PbftMgrStatus::next_voted_null_block_hash, true);
   EXPECT_TRUE(db.getPbftMgrStatus(PbftMgrStatus::soft_voted_block_in_round));
+  EXPECT_TRUE(db.getPbftMgrStatus(PbftMgrStatus::cert_voted_block_in_round));
   EXPECT_TRUE(db.getPbftMgrStatus(PbftMgrStatus::executed_block));
   EXPECT_TRUE(db.getPbftMgrStatus(PbftMgrStatus::executed_in_round));
   EXPECT_TRUE(db.getPbftMgrStatus(PbftMgrStatus::next_voted_soft_value));
   EXPECT_TRUE(db.getPbftMgrStatus(PbftMgrStatus::next_voted_null_block_hash));
   batch = db.createWriteBatch();
   db.addPbftMgrStatusToBatch(PbftMgrStatus::soft_voted_block_in_round, false, batch);
+  db.addPbftMgrStatusToBatch(PbftMgrStatus::cert_voted_block_in_round, false, batch);
   db.addPbftMgrStatusToBatch(PbftMgrStatus::executed_block, false, batch);
   db.addPbftMgrStatusToBatch(PbftMgrStatus::executed_in_round, false, batch);
   db.addPbftMgrStatusToBatch(PbftMgrStatus::next_voted_soft_value, false, batch);
   db.addPbftMgrStatusToBatch(PbftMgrStatus::next_voted_null_block_hash, false, batch);
   db.commitWriteBatch(batch);
   EXPECT_FALSE(db.getPbftMgrStatus(PbftMgrStatus::soft_voted_block_in_round));
+  EXPECT_FALSE(db.getPbftMgrStatus(PbftMgrStatus::cert_voted_block_in_round));
   EXPECT_FALSE(db.getPbftMgrStatus(PbftMgrStatus::executed_block));
   EXPECT_FALSE(db.getPbftMgrStatus(PbftMgrStatus::executed_in_round));
   EXPECT_FALSE(db.getPbftMgrStatus(PbftMgrStatus::next_voted_soft_value));
@@ -176,17 +181,6 @@ TEST_F(FullNodeTest, db_test) {
   db.commitWriteBatch(batch);
   EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::own_starting_value_in_round), blk_hash_t(4));
   EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::soft_voted_block_hash_in_round), blk_hash_t(5));
-
-  // PBFT cert voted block hash
-  EXPECT_EQ(db.getPbftCertVotedBlockHash(1), nullptr);
-  db.savePbftCertVotedBlockHash(1, blk_hash_t(1));
-  EXPECT_EQ(*db.getPbftCertVotedBlockHash(1), blk_hash_t(1));
-  batch = db.createWriteBatch();
-  db.addPbftCertVotedBlockHashToBatch(1, blk_hash_t(2), batch);
-  db.addPbftCertVotedBlockHashToBatch(2, blk_hash_t(3), batch);
-  db.commitWriteBatch(batch);
-  EXPECT_EQ(*db.getPbftCertVotedBlockHash(1), blk_hash_t(2));
-  EXPECT_EQ(*db.getPbftCertVotedBlockHash(2), blk_hash_t(3));
 
   // PBFT cert voted block
   auto pbft_block1 = make_simple_pbft_block(blk_hash_t(1), 1);


### PR DESCRIPTION
## Purpose

Malicious player could propose a PBFT block that include a bogus DAG anchor, that will have a chance cause PBFT stalled. 

## For reviewers

1. Terminate PBFT soft voted value after some(5) rounds
2. Since only need record the current round cert vote status. Remove PBFT cert voted value for all rounds, use have_cert_voted_in_this_round_ for the current round.

## Related Github issues

<!-- Include related github issues. -->

## Changes

<!-- Summary or changes that have been made. -->

## Tests

<!-- Describe what you did to test these changes, including unit tests that have been added or changed. -->

## Deployment Considerations

## Version Notes ##
{ major | minor | patch }

<!--

Decide whether this is a major, minor, or patch version change. Major is for backwards incompatible changes (This is only relevant once the service is live and in production and the major version is at least 1. While the major version is 0, it is ok to have backwards incompatible changes in a minor version.). Minor is for additional features. Patch is for bug fixes.

Describe the changes in this version. This is essentially the details you would include in the squash commit message.
-->

**NOTE: Include the version notes in the squash commit message**
