### PR TITLE
optimize syncing non finalized dag blocks

### DIFF
--- a/src/network/taraxa_capability.cpp
+++ b/src/network/taraxa_capability.cpp
@@ -401,7 +401,7 @@ void TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
     }
     case GetBlocksPacket: {
       LOG(log_dg_dag_sync_) << "Received GetBlocksPacket with " << _r.itemCount() << " known blocks";
-      set<blk_hash_t> known_non_finalized_blocks;
+      std::unordered_set<blk_hash_t> known_non_finalized_blocks;
       for (auto hash : _r) {
         known_non_finalized_blocks.insert(blk_hash_t(hash));
       }

--- a/src/network/taraxa_capability.cpp
+++ b/src/network/taraxa_capability.cpp
@@ -400,12 +400,19 @@ void TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
       break;
     }
     case GetBlocksPacket: {
-      LOG(log_dg_dag_sync_) << "Received GetBlocksPacket";
+      LOG(log_dg_dag_sync_) << "Received GetBlocksPacket with " << _r.itemCount() << " known blocks";
+      set<blk_hash_t> known_non_finalized_blocks;
+      for (auto hash : _r) {
+        known_non_finalized_blocks.insert(blk_hash_t(hash));
+      }
       std::vector<std::shared_ptr<DagBlock>> dag_blocks;
       auto blocks = dag_mgr_->getNonFinalizedBlocks();
       for (auto &level_blocks : blocks) {
         for (auto &block : level_blocks.second) {
-          dag_blocks.emplace_back(db_->getDagBlock(blk_hash_t(block)));
+          auto hash = blk_hash_t(block);
+          if (known_non_finalized_blocks.count(hash) == 0) {
+            dag_blocks.emplace_back(db_->getDagBlock(hash));
+          }
         }
       }
       sendBlocks(_nodeID, dag_blocks);
@@ -1057,10 +1064,6 @@ void TaraxaCapability::sendBlocks(NodeID const &_id, std::vector<std::shared_ptr
   if (!peer) return;
 
   for (auto &block : blocks) {
-    if (peer->isBlockKnown(block->getHash())) {
-      continue;
-    }
-
     size_t dag_block_items_count = 0;
     size_t previous_block_packet_size = packet_bytes.size();
 
@@ -1171,7 +1174,19 @@ void TaraxaCapability::requestPbftBlocks(NodeID const &_id, size_t height_to_syn
 
 void TaraxaCapability::requestPendingDagBlocks(NodeID const &_id) {
   LOG(log_nf_dag_sync_) << "Sending GetBlocksPacket";
-  sealAndSend(_id, GetBlocksPacket, RLPStream(0));
+  vector<blk_hash_t> known_non_finalized_blocks;
+  auto blocks = dag_mgr_->getNonFinalizedBlocks();
+  for (auto &level_blocks : blocks) {
+    for (auto &block : level_blocks.second) {
+      known_non_finalized_blocks.emplace_back(blk_hash_t(block));
+    }
+  }
+  RLPStream s(known_non_finalized_blocks.size());
+
+  for (auto blk : known_non_finalized_blocks) {
+    s << blk;
+  }
+  sealAndSend(_id, GetBlocksPacket, s);
 }
 
 std::pair<int, int> TaraxaCapability::retrieveTestData(NodeID const &_id) {

--- a/src/node/full_node.hpp
+++ b/src/node/full_node.hpp
@@ -169,7 +169,7 @@ class FullNode : public std::enable_shared_from_this<FullNode> {
   static constexpr uint16_t c_node_minor_version = 8;
 
   // Any time a change in the network protocol is introduced this version should be increased
-  static constexpr uint16_t c_network_protocol_version = 7;
+  static constexpr uint16_t c_network_protocol_version = 8;
 
   // Major version is modified when DAG blocks, pbft blocks and any basic building blocks of our blockchan is modified
   // in the db


### PR DESCRIPTION
## Purpose

optimize syncing non finalized dag blocks

## For reviewers

Sending hashes with the getBlocksPacket to only retrieve non finalized blocks not yet known by the requesting node

## Related Github issues

<!-- Include related github issues. -->

## Changes

<!-- Summary or changes that have been made. -->

## Tests

<!-- Describe what you did to test these changes, including unit tests that have been added or changed. -->

## Deployment Considerations

## Version Notes ##
{ major | minor | patch }

<!--

Decide whether this is a major, minor, or patch version change. Major is for backwards incompatible changes (This is only relevant once the service is live and in production and the major version is at least 1. While the major version is 0, it is ok to have backwards incompatible changes in a minor version.). Minor is for additional features. Patch is for bug fixes.

Describe the changes in this version. This is essentially the details you would include in the squash commit message.
-->

**NOTE: Include the version notes in the squash commit message**
