### PR TITLE
fix(RLP): do not log corrupted RLP as it can cause crash

### DIFF
--- a/src/dag/dag.cpp
+++ b/src/dag/dag.cpp
@@ -635,7 +635,7 @@ void DagManager::recoverDag() {
   }
 }
 
-const std::map<uint64_t, std::vector<std::string>>& DagManager::getNonFinalizedBlocks() const {
+const std::map<uint64_t, std::vector<std::string>> &DagManager::getNonFinalizedBlocks() const {
   sharedLock lock(mutex_);
   return non_finalized_blks_;
 }

--- a/src/dag/dag.hpp
+++ b/src/dag/dag.hpp
@@ -167,7 +167,7 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
     return std::make_pair(old_anchor_, anchor_);
   }
 
-  const std::map<uint64_t, std::vector<std::string>>& getNonFinalizedBlocks() const;
+  const std::map<uint64_t, std::vector<std::string>> &getNonFinalizedBlocks() const;
 
   DagFrontier getDagFrontier();
 

--- a/src/network/taraxa_capability.cpp
+++ b/src/network/taraxa_capability.cpp
@@ -192,7 +192,7 @@ void TaraxaCapability::interpretCapabilityPacket(weak_ptr<Session> session, unsi
     try {
       interpretCapabilityPacketImpl(_nodeID, _id, r, packet_stats);
     } catch (...) {
-      handle_read_exception(session, _id, r);
+      handle_read_exception(session, _id);
     }
     auto duration = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - begin);
     packet_stats.total_duration_ = duration;
@@ -406,7 +406,7 @@ void TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
         known_non_finalized_blocks.insert(blk_hash_t(hash));
       }
       std::vector<std::shared_ptr<DagBlock>> dag_blocks;
-      const auto& blocks = dag_mgr_->getNonFinalizedBlocks();
+      const auto &blocks = dag_mgr_->getNonFinalizedBlocks();
       for (auto &level_blocks : blocks) {
         for (auto &block : level_blocks.second) {
           auto hash = blk_hash_t(block);
@@ -770,13 +770,13 @@ void TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
   };
 }
 
-void TaraxaCapability::handle_read_exception(weak_ptr<Session> session, unsigned _packetType, RLP const &_r) {
+void TaraxaCapability::handle_read_exception(weak_ptr<Session> session, unsigned _packetType) {
   try {
     throw;
   } catch (std::exception const &_e) {
     // TODO be more precise about the error handling
     LOG(log_er_) << "Read exception: " << _e.what() << ". PacketType: " << packetTypeToString(_packetType) << " ("
-                 << _packetType << "). RLP: " << _r;
+                 << _packetType << ")";
     if (auto session_p = session.lock()) {
       session_p->disconnect(BadProtocol);
     }

--- a/src/network/taraxa_capability.hpp
+++ b/src/network/taraxa_capability.hpp
@@ -190,7 +190,7 @@ struct TaraxaCapability : virtual CapabilityFace {
   void insertPeer(NodeID const &node_id);
 
  private:
-  void handle_read_exception(weak_ptr<Session> session, unsigned _id, RLP const &_r);
+  void handle_read_exception(weak_ptr<Session> session, unsigned _id);
 
   weak_ptr<Host> host_;
   NodeID node_id_;


### PR DESCRIPTION
## Purpose

In case we receive corrupted RLP let's not log content of that RLP as it can cause crash of whole app