### PR TITLE
fix: optimize block queue processing

### DIFF
--- a/src/dag/dag_block_manager.cpp
+++ b/src/dag/dag_block_manager.cpp
@@ -172,10 +172,16 @@ std::pair<size_t, size_t> DagBlockManager::getDagBlockQueueSize() const {
   return res;
 }
 
-DagBlock DagBlockManager::popVerifiedBlock() {
+DagBlock DagBlockManager::popVerifiedBlock(bool level_limit, uint64_t level) {
   uLock lock(shared_mutex_for_verified_qu_);
-  while (verified_qu_.empty() && !stopped_) {
-    cond_for_verified_qu_.wait(lock);
+  if (level_limit) {
+    while ((verified_qu_.empty() || verified_qu_.begin()->first >= level) && !stopped_) {
+      cond_for_verified_qu_.wait(lock);
+    }
+  } else {
+    while (verified_qu_.empty() && !stopped_) {
+      cond_for_verified_qu_.wait(lock);
+    }
   }
   if (stopped_) return DagBlock();
 

--- a/src/dag/dag_block_manager.hpp
+++ b/src/dag/dag_block_manager.hpp
@@ -26,8 +26,8 @@ class DagBlockManager {
   void pushUnverifiedBlock(DagBlock const &block,
                            bool critical);  // add to unverified queue
   void pushUnverifiedBlock(DagBlock const &block, std::vector<Transaction> const &transactions,
-                           bool critical);  // add to unverified queue
-  DagBlock popVerifiedBlock();              // get one verified block and pop
+                           bool critical);                                  // add to unverified queue
+  DagBlock popVerifiedBlock(bool level_limit = false, uint64_t level = 0);  // get one verified block and pop
   void pushVerifiedBlock(DagBlock const &blk);
   std::pair<size_t, size_t> getDagBlockQueueSize() const;
   level_t getMaxDagLevelInQueue() const;


### PR DESCRIPTION
## Purpose

When DAG block is missing a tip or pivot there was a state in which we got in an endless loop maxing out CPU on checking the same block over and over again. Now the check is only done when we receive another block with smaller level

## For reviewers

<!-- Describe anything you want to call out to the reviewers e.g. areas to focus on, decisions you made, specific feedback you are looking for, etc. -->

## Related Github issues

<!-- Include related github issues. -->

## Changes

<!-- Summary or changes that have been made. -->

## Tests

<!-- Describe what you did to test these changes, including unit tests that have been added or changed. -->

## Deployment Considerations

## Version Notes ##
{ major | minor | patch }

<!--

Decide whether this is a major, minor, or patch version change. Major is for backwards incompatible changes (This is only relevant once the service is live and in production and the major version is at least 1. While the major version is 0, it is ok to have backwards incompatible changes in a minor version.). Minor is for additional features. Patch is for bug fixes.

Describe the changes in this version. This is essentially the details you would include in the squash commit message.
-->

**NOTE: Include the version notes in the squash commit message**
