### PR TITLE
fix(network): add network protocol version in status packet

### DIFF
--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -242,11 +242,11 @@ void PbftManager::setPbftStep(size_t const pbft_step) {
   if (step_ > MAX_STEPS && LAMBDA_backoff_multiple < 8) {
     // Note: We calculate the lambda for a step independently of prior steps
     //       in case missed earlier steps.
-    //std::uniform_int_distribution<u_long> distribution(0, step_ - MAX_STEPS);
-    //auto lambda_random_count = distribution(random_engine_);
-    //LAMBDA_backoff_multiple = 2 * LAMBDA_backoff_multiple;
-    //LAMBDA_ms = LAMBDA_ms_MIN * (LAMBDA_backoff_multiple + lambda_random_count);
-    //LOG(log_si_) << "Surpassed max steps, exponentially backing off lambda to " << LAMBDA_ms << " ms in round "
+    // std::uniform_int_distribution<u_long> distribution(0, step_ - MAX_STEPS);
+    // auto lambda_random_count = distribution(random_engine_);
+    // LAMBDA_backoff_multiple = 2 * LAMBDA_backoff_multiple;
+    // LAMBDA_ms = LAMBDA_ms_MIN * (LAMBDA_backoff_multiple + lambda_random_count);
+    // LOG(log_si_) << "Surpassed max steps, exponentially backing off lambda to " << LAMBDA_ms << " ms in round "
     //             << getPbftRound() << ", step " << step_;
   } else {
     LAMBDA_ms = LAMBDA_ms_MIN;

--- a/src/node/full_node.hpp
+++ b/src/node/full_node.hpp
@@ -169,7 +169,7 @@ class FullNode : public std::enable_shared_from_this<FullNode> {
   static constexpr uint16_t c_node_minor_version = 8;
 
   // Any time a change in the network protocol is introduced this version should be increased
-  static constexpr uint16_t c_network_protocol_version = 9;
+  static constexpr uint16_t c_network_protocol_version = 10;
 
   // Major version is modified when DAG blocks, pbft blocks and any basic building blocks of our blockchan is modified
   // in the db


### PR DESCRIPTION
## Purpose

Bump up network protocol version should prevent nodes connecting to old version nodes

## For reviewers

Protocol version c_network_protocol_version is not in status packet. Status packet is include network_id only, and network_id is chain_id actually. When receive status packet only check network_id, don’t check any protocol version. So bump up  c_network_protocol_version cannot prevent connecting to old nodes.

## Related Github issues

<!-- Include related github issues. -->

## Changes

<!-- Summary or changes that have been made. -->

## Tests

<!-- Describe what you did to test these changes, including unit tests that have been added or changed. -->

## Deployment Considerations

## Version Notes ##
{ major | minor | patch }

<!--

Decide whether this is a major, minor, or patch version change. Major is for backwards incompatible changes (This is only relevant once the service is live and in production and the major version is at least 1. While the major version is 0, it is ok to have backwards incompatible changes in a minor version.). Minor is for additional features. Patch is for bug fixes.

Describe the changes in this version. This is essentially the details you would include in the squash commit message.
-->

**NOTE: Include the version notes in the squash commit message**
