### PR TITLE
fix: ensure status message is sent first

### DIFF
--- a/src/network/taraxa_capability.hpp
+++ b/src/network/taraxa_capability.hpp
@@ -86,7 +86,8 @@ class TaraxaPeer : public boost::noncopyable {
 
   void setAlive() { alive_check_count_ = 0; }
 
-  bool passed_initial_ = false;
+  bool received_initial_status_ = false;
+  bool sent_initial_status_ = false;
   bool syncing_ = false;
   uint64_t dag_level_ = 0;
   uint64_t pbft_chain_size_ = 0;
@@ -187,7 +188,7 @@ struct TaraxaCapability : virtual CapabilityFace {
   std::shared_ptr<TaraxaPeer> getPeer(NodeID const &node_id);
   unsigned int getPeersCount();
   void erasePeer(NodeID const &node_id);
-  void insertPeer(NodeID const &node_id);
+  std::shared_ptr<TaraxaPeer> insertPeer(NodeID const &node_id);
 
  private:
   void handle_read_exception(weak_ptr<Session> session, unsigned _id);

--- a/tests/util_test/util.hpp
+++ b/tests/util_test/util.hpp
@@ -177,7 +177,7 @@ inline auto wait_inital_status_packet_passed(vector<FullNode::Handle> const& nod
       auto peers = nodes[i]->getNetwork()->getAllPeers();
       for (size_t j = 0; j < peers.size(); j++) {
         auto peer = nodes[i]->getNetwork()->getPeer(peers[j]);
-        if (ctx.fail_if(!peer->passed_initial_)) {
+        if (ctx.fail_if(!peer->received_initial_status_)) {
           return;
         }
       }


### PR DESCRIPTION
## Purpose

Transactions that are sent on short intervals might get sent to the node before the status message. This will cause the node to ignore the packet and transactions but at the same time transactions would incorrectly be marked as known. The fix ensures status message is sent before sending the transactions

## For reviewers

<!-- Describe anything you want to call out to the reviewers e.g. areas to focus on, decisions you made, specific feedback you are looking for, etc. -->

## Related Github issues

<!-- Include related github issues. -->

## Changes

<!-- Summary or changes that have been made. -->

## Tests

<!-- Describe what you did to test these changes, including unit tests that have been added or changed. -->

## Deployment Considerations

## Version Notes ##
{ major | minor | patch }

<!--

Decide whether this is a major, minor, or patch version change. Major is for backwards incompatible changes (This is only relevant once the service is live and in production and the major version is at least 1. While the major version is 0, it is ok to have backwards incompatible changes in a minor version.). Minor is for additional features. Patch is for bug fixes.

Describe the changes in this version. This is essentially the details you would include in the squash commit message.
-->

**NOTE: Include the version notes in the squash commit message**
