### PR TITLE
[REPLACED BY PR 965] fix(pbft): refactor the way we opt to give up on non-received next voted pbft block

### DIFF
--- a/src/cli/testnet_config.hpp
+++ b/src/cli/testnet_config.hpp
@@ -86,14 +86,14 @@ const char *testnet_json = R"foo({
       "level": "0x0",
       "pivot": "0x0000000000000000000000000000000000000000000000000000000000000000",
       "sig": "0xb7e22d46c1ba94d5e8347b01d137b5c428fcbbeaf0a77fb024cbbf1517656ff00d04f7f25be608c321b0d7483c402c294ff46c49b265305d046a52236c0a363701",
-      "timestamp": "0x60b03286",
+      "timestamp": "0x60b03287",
       "tips": [],
       "transactions": []
     },
     "final_chain": {
       "genesis_block_fields": {
         "author": "0x0000000000000000000000000000000000000000",
-        "timestamp": "0x60b03286"
+        "timestamp": "0x60b03287"
       },
       "state": {
         "disable_block_rewards": true,

--- a/src/cli/testnet_config.hpp
+++ b/src/cli/testnet_config.hpp
@@ -86,14 +86,14 @@ const char *testnet_json = R"foo({
       "level": "0x0",
       "pivot": "0x0000000000000000000000000000000000000000000000000000000000000000",
       "sig": "0xb7e22d46c1ba94d5e8347b01d137b5c428fcbbeaf0a77fb024cbbf1517656ff00d04f7f25be608c321b0d7483c402c294ff46c49b265305d046a52236c0a363701",
-      "timestamp": "0x60b03287",
+      "timestamp": "0x60b03288",
       "tips": [],
       "transactions": []
     },
     "final_chain": {
       "genesis_block_fields": {
         "author": "0x0000000000000000000000000000000000000000",
-        "timestamp": "0x60b03287"
+        "timestamp": "0x60b03288"
       },
       "state": {
         "disable_block_rewards": true,

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -379,11 +379,14 @@ void PbftManager::initialState_() {
     }
     previous_round_next_votes_->updateNextVotes(next_votes_in_previous_round, previous_round_2t_plus_1);
   }
+
+  next_voted_value_ = previous_round_next_votes_->getVotedValue();
+  time_began_waiting_next_voted_block_ = std::chrono::system_clock::now();
+
   LOG(log_nf_) << "Node initialize at round " << round << " step " << step
                << ". Previous round has enough next votes for NULL_BLOCK_HASH: " << std::boolalpha
-               << previous_round_next_votes_->haveEnoughVotesForNullBlockHash() << ", voted value "
-               << previous_round_next_votes_->getVotedValue() << ", next votes size in previous round is "
-               << previous_round_next_votes_->getNextVotesSize();
+               << previous_round_next_votes_->haveEnoughVotesForNullBlockHash() << ", voted value " << next_voted_value_
+               << ", next votes size in previous round is " << previous_round_next_votes_->getNextVotesSize();
 
   // Initial last sync request
   pbft_round_last_requested_sync_ = 0;
@@ -532,6 +535,8 @@ void PbftManager::loopBackFinishState_() {
 bool PbftManager::stateOperations_() {
   pushSyncedPbftBlocksIntoChain_();
 
+  updateNextVotedValue_();
+
   now_ = std::chrono::system_clock::now();
   duration_ = now_ - round_clock_initial_datetime_;
   elapsed_time_in_round_ms_ = std::chrono::duration_cast<std::chrono::milliseconds>(duration_).count();
@@ -575,17 +580,26 @@ bool PbftManager::stateOperations_() {
   return resetRound_();
 }
 
+void PbftManager::updateNextVotedValue_() {
+  auto latest_next_voted_value = previous_round_next_votes_->getVotedValue();
+
+  if (latest_next_voted_value != next_voted_value_) {
+    time_began_waiting_next_voted_block_ = std::chrono::system_clock::now();
+  }
+
+  next_voted_value_ = latest_next_voted_value;
+}
+
 void PbftManager::proposeBlock_() {
   // Value Proposal
   auto round = getPbftRound();
-  auto voted_value = previous_round_next_votes_->getVotedValue();
 
   LOG(log_tr_) << "PBFT value proposal state in round " << round;
   if (round > 1) {
     if (previous_round_next_votes_->haveEnoughVotesForNullBlockHash()) {
       LOG(log_nf_) << "Previous round " << round - 1 << " next voted block is NULL_BLOCK_HASH";
-    } else if (voted_value != NULL_BLOCK_HASH) {
-      LOG(log_nf_) << "Previous round " << round - 1 << " next voted block is " << voted_value;
+    } else if (next_voted_value_ != NULL_BLOCK_HASH) {
+      LOG(log_nf_) << "Previous round " << round - 1 << " next voted block is " << next_voted_value_;
     } else {
       LOG(log_er_) << "Previous round " << round - 1 << " doesn't have enough next votes";
       assert(false);
@@ -598,7 +612,7 @@ void PbftManager::proposeBlock_() {
       LOG(log_nf_) << "Proposing " << place_votes << " values of NULL_BLOCK_HASH " << NULL_BLOCK_HASH
                    << " for round 1 by protocol";
     }
-  } else if (round >= 2 && giveUpVotedBlock_(voted_value)) {
+  } else if (round >= 2 && giveUpNextVotedBlock_()) {
     // PBFT block only be proposed once in one period
     if (!proposed_block_hash_.second || proposed_block_hash_.first == NULL_BLOCK_HASH) {
       // Propose value...
@@ -614,9 +628,9 @@ void PbftManager::proposeBlock_() {
                      << " for round " << round;
       }
     }
-  } else if (round >= 2 && voted_value != NULL_BLOCK_HASH) {
-    db_->savePbftMgrVotedValue(PbftMgrVotedValue::own_starting_value_in_round, voted_value);
-    own_starting_value_for_round_ = voted_value;
+  } else if (round >= 2 && next_voted_value_ != NULL_BLOCK_HASH) {
+    db_->savePbftMgrVotedValue(PbftMgrVotedValue::own_starting_value_in_round, next_voted_value_);
+    own_starting_value_for_round_ = next_voted_value_;
 
     auto pbft_block = pbft_chain_->getUnverifiedPbftBlock(own_starting_value_for_round_);
     if (!pbft_block) {
@@ -645,10 +659,9 @@ void PbftManager::proposeBlock_() {
 void PbftManager::identifyBlock_() {
   // The Filtering Step
   auto round = getPbftRound();
-  auto voted_value = previous_round_next_votes_->getVotedValue();
   LOG(log_tr_) << "PBFT filtering state in round " << round;
 
-  if (round == 1 || (round >= 2 && giveUpVotedBlock_(voted_value))) {
+  if (round == 1 || (round >= 2 && giveUpNextVotedBlock_())) {
     // Identity leader
     std::pair<blk_hash_t, bool> leader_block = identifyLeaderBlock_(votes_);
     if (leader_block.second) {
@@ -661,10 +674,10 @@ void PbftManager::identifyBlock_() {
         LOG(log_nf_) << "Soft votes " << place_votes << " voting block " << leader_block.first << " at round " << round;
       }
     }
-  } else if (round >= 2 && voted_value != NULL_BLOCK_HASH) {
-    auto place_votes = placeVote_(voted_value, soft_vote_type, round, step_);
+  } else if (round >= 2 && next_voted_value_ != NULL_BLOCK_HASH) {
+    auto place_votes = placeVote_(next_voted_value_, soft_vote_type, round, step_);
     if (place_votes) {
-      LOG(log_nf_) << "Soft votes " << place_votes << " voting block " << voted_value
+      LOG(log_nf_) << "Soft votes " << place_votes << " voting block " << next_voted_value_
                    << " from previous round. In round " << round;
     }
   }
@@ -769,24 +782,23 @@ void PbftManager::firstFinish_() {
   auto round = getPbftRound();
   LOG(log_tr_) << "PBFT first finishing state at step " << step_ << " in round " << round;
 
-  auto voted_value = previous_round_next_votes_->getVotedValue();
   if (cert_voted_values_for_round_.find(round) != cert_voted_values_for_round_.end()) {
     auto place_votes = placeVote_(cert_voted_values_for_round_[round], next_vote_type, round, step_);
     if (place_votes) {
       LOG(log_nf_) << "Next votes " << place_votes << " voting cert voted value " << cert_voted_values_for_round_[round]
                    << " for round " << round << " , step " << step_;
     }
-  } else if (round >= 2 && giveUpVotedBlock_(voted_value)) {
+  } else if (round >= 2 && giveUpNextVotedBlock_()) {
     auto place_votes = placeVote_(NULL_BLOCK_HASH, next_vote_type, round, step_);
     if (place_votes) {
       LOG(log_nf_) << "Next votes " << place_votes << " voting NULL BLOCK for round " << round << ", at step " << step_;
     }
   } else {
     if (own_starting_value_for_round_ == NULL_BLOCK_HASH) {
-      if (voted_value != NULL_BLOCK_HASH && !reset_own_value_to_null_block_hash_in_this_round_) {
-        db_->savePbftMgrVotedValue(PbftMgrVotedValue::own_starting_value_in_round, voted_value);
-        own_starting_value_for_round_ = voted_value;
-        LOG(log_dg_) << "Updating own starting to previous round next voted value of " << voted_value;
+      if (next_voted_value_ != NULL_BLOCK_HASH && !reset_own_value_to_null_block_hash_in_this_round_) {
+        db_->savePbftMgrVotedValue(PbftMgrVotedValue::own_starting_value_in_round, next_voted_value_);
+        own_starting_value_for_round_ = next_voted_value_;
+        LOG(log_dg_) << "Updating own starting to previous round next voted value of " << next_voted_value_;
       }
     }
     auto place_votes = placeVote_(own_starting_value_for_round_, next_vote_type, round, step_);
@@ -841,8 +853,7 @@ void PbftManager::secondFinish_() {
     }
   }
 
-  auto voted_value = previous_round_next_votes_->getVotedValue();
-  if (!next_voted_null_block_hash_ && round >= 2 && giveUpVotedBlock_(voted_value) &&
+  if (!next_voted_null_block_hash_ && round >= 2 && giveUpNextVotedBlock_() &&
       (cert_voted_values_for_round_.find(round) == cert_voted_values_for_round_.end())) {
     auto place_votes = placeVote_(NULL_BLOCK_HASH, next_vote_type, round, step_);
     if (place_votes) {
@@ -1471,7 +1482,8 @@ void PbftManager::updateTwoTPlusOneAndThreshold_() {
                << ". Update 2t+1 " << TWO_T_PLUS_ONE << ", Threshold " << sortition_threshold_;
 }
 
-bool PbftManager::giveUpVotedBlock_(blk_hash_t const &block_hash) {
+bool PbftManager::giveUpNextVotedBlock_() {
+  blk_hash_t const &block_hash = next_voted_value_;
   if (block_hash == NULL_BLOCK_HASH) {
     // Have received 2t+1 next votes for NULL_BLOCK_HASH for previous round
     return true;
@@ -1489,27 +1501,24 @@ bool PbftManager::giveUpVotedBlock_(blk_hash_t const &block_hash) {
     pbft_block = db_->getPbftCertVotedBlock(block_hash);
     if (!pbft_block) {
       LOG(log_dg_) << "Cannot find PBFT block " << block_hash << " in both queue and DB, have not got yet";
-      auto round = getPbftRound();
-      if (!round_began_wait_voted_block_) {
-        round_began_wait_voted_block_ = round;
-        LOG(log_dg_) << "Set began waiting voted block " << block_hash << " at round " << round_began_wait_voted_block_;
-      } else if (round > round_began_wait_voted_block_) {
-        auto wait_voted_block_rounds = round - round_began_wait_voted_block_;
-        if (wait_voted_block_rounds < max_wait_rounds_for_proposal_block_) {
-          LOG(log_dg_) << "Have been waiting " << wait_voted_block_rounds << " rounds for voted block " << block_hash;
-        } else {
-          LOG(log_dg_) << "Have been waiting " << wait_voted_block_rounds << " rounds for voted block " << block_hash
-                       << ", give up voted value.";
-          return true;
-        }
+
+      auto now = std::chrono::system_clock::now();
+      auto next_voted_block_wait_duration = now - time_began_waiting_next_voted_block_;
+      auto elapsed_wait_next_voted_block_in_ms =
+          std::chrono::duration_cast<std::chrono::milliseconds>(next_voted_block_wait_duration).count();
+      if (elapsed_wait_next_voted_block_in_ms > MAX_WAIT_FOR_NEXT_VOTED_BLOCK_MS) {
+        LOG(log_dg_) << "Have been waiting " << elapsed_wait_next_voted_block_in_ms << "ms for next voted block "
+                     << block_hash << ", giving up now on this value.";
+        return true;
+      } else {
+        LOG(log_tr_) << "Have been waiting " << elapsed_wait_next_voted_block_in_ms << "ms for next voted block "
+                     << block_hash;
       }
       return false;
     }
     // Read from DB pushing into unverified queue
     pbft_chain_->pushUnverifiedPbftBlock(pbft_block);
   }
-  // Back to zero to signify no longer waiting...
-  round_began_wait_voted_block_ = 0;
 
   if (pbft_block) {
     if (!checkPbftBlockValid_(block_hash)) {

--- a/src/consensus/pbft_manager.hpp
+++ b/src/consensus/pbft_manager.hpp
@@ -16,6 +16,7 @@
 #define NULL_BLOCK_HASH blk_hash_t(0)
 #define POLLING_INTERVAL_ms 100  // milliseconds...
 #define MAX_STEPS 13
+#define MAX_WAIT_FOR_NEXT_VOTED_BLOCK_MS 30000
 
 namespace taraxa {
 class FullNode;
@@ -140,7 +141,8 @@ class PbftManager {
   void updateTwoTPlusOneAndThreshold_();
   bool is_syncing_();
 
-  bool giveUpVotedBlock_(blk_hash_t const &block_hash);
+  bool giveUpNextVotedBlock_();
+  void updateNextVotedValue_();
 
   std::atomic<bool> stopped_ = true;
   // Using to check if PBFT block has been proposed already in one period
@@ -184,6 +186,10 @@ class PbftManager {
 
   time_point round_clock_initial_datetime_;
   time_point now_;
+
+  time_point time_began_waiting_next_voted_block_;
+  blk_hash_t next_voted_value_;
+
   std::chrono::duration<double> duration_;
   u_long next_step_time_ms_ = 0;
   u_long elapsed_time_in_round_ms_ = 0;
@@ -198,8 +204,7 @@ class PbftManager {
   bool reset_own_value_to_null_block_hash_in_this_round_ = false;
 
   uint64_t round_began_wait_proposal_block_ = 0;
-  size_t max_wait_rounds_for_proposal_block_ = 5;
-  uint64_t round_began_wait_voted_block_ = 0;
+  size_t max_wait_rounds_for_proposal_block_ = 2;
 
   uint64_t pbft_round_last_requested_sync_ = 0;
   size_t pbft_step_last_requested_sync_ = 0;

--- a/src/network/taraxa_capability.hpp
+++ b/src/network/taraxa_capability.hpp
@@ -86,7 +86,8 @@ class TaraxaPeer : public boost::noncopyable {
 
   void setAlive() { alive_check_count_ = 0; }
 
-  bool passed_initial_ = false;
+  bool received_initial_status_ = false;
+  bool sent_initial_status_ = false;
   bool syncing_ = false;
   uint64_t dag_level_ = 0;
   uint64_t pbft_chain_size_ = 0;
@@ -187,7 +188,7 @@ struct TaraxaCapability : virtual CapabilityFace {
   std::shared_ptr<TaraxaPeer> getPeer(NodeID const &node_id);
   unsigned int getPeersCount();
   void erasePeer(NodeID const &node_id);
-  void insertPeer(NodeID const &node_id);
+  std::shared_ptr<TaraxaPeer> insertPeer(NodeID const &node_id);
 
  private:
   void handle_read_exception(weak_ptr<Session> session, unsigned _id);

--- a/tests/util_test/util.hpp
+++ b/tests/util_test/util.hpp
@@ -177,7 +177,7 @@ inline auto wait_inital_status_packet_passed(vector<FullNode::Handle> const& nod
       auto peers = nodes[i]->getNetwork()->getAllPeers();
       for (size_t j = 0; j < peers.size(); j++) {
         auto peer = nodes[i]->getNetwork()->getPeer(peers[j]);
-        if (ctx.fail_if(!peer->passed_initial_)) {
+        if (ctx.fail_if(!peer->received_initial_status_)) {
           return;
         }
       }


### PR DESCRIPTION
## Purpose

Currently we had a fatal flaw in doing this based on round.   But in certain circumstances we could violate ability to make consensus for next voting if partitioning of the count of rounds have been waiting occurred.   Now we do it based on time, so that after some point in time > 2t+1 nodes will have timedout. 

## For reviewers

<!-- Describe anything you want to call out to the reviewers e.g. areas to focus on, decisions you made, specific feedback you are looking for, etc. -->

## Related Github issues

<!-- Include related github issues. -->

## Changes

<!-- Summary or changes that have been made. -->

## Tests

<!-- Describe what you did to test these changes, including unit tests that have been added or changed. -->

## Deployment Considerations

## Version Notes ##
{ major | minor | patch }

<!--

Decide whether this is a major, minor, or patch version change. Major is for backwards incompatible changes (This is only relevant once the service is live and in production and the major version is at least 1. While the major version is 0, it is ok to have backwards incompatible changes in a minor version.). Minor is for additional features. Patch is for bug fixes.

Describe the changes in this version. This is essentially the details you would include in the squash commit message.
-->

**NOTE: Include the version notes in the squash commit message**
