### PR TITLE
fix: protect non finalized block map

### DIFF
--- a/src/dag/dag.cpp
+++ b/src/dag/dag.cpp
@@ -635,7 +635,7 @@ void DagManager::recoverDag() {
   }
 }
 
-const std::map<uint64_t, std::vector<std::string>> &DagManager::getNonFinalizedBlocks() const {
+const std::map<uint64_t, std::vector<std::string>> DagManager::getNonFinalizedBlocks() const {
   sharedLock lock(mutex_);
   return non_finalized_blks_;
 }

--- a/src/dag/dag.hpp
+++ b/src/dag/dag.hpp
@@ -167,7 +167,7 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
     return std::make_pair(old_anchor_, anchor_);
   }
 
-  const std::map<uint64_t, std::vector<std::string>> &getNonFinalizedBlocks() const;
+  const std::map<uint64_t, std::vector<std::string>> getNonFinalizedBlocks() const;
 
   DagFrontier getDagFrontier();
 

--- a/src/network/taraxa_capability.cpp
+++ b/src/network/taraxa_capability.cpp
@@ -414,7 +414,12 @@ void TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
         for (auto &block : level_blocks.second) {
           auto hash = blk_hash_t(block);
           if (known_non_finalized_blocks.count(hash) == 0) {
-            dag_blocks.emplace_back(db_->getDagBlock(hash));
+            if (auto blk = db_->getDagBlock(hash); blk) {
+              dag_blocks.emplace_back(blk);
+            } else {
+              LOG(log_er_dag_sync_) << "NonFinalizedBlock " << hash << " not in DB";
+              assert(false);
+            }
           }
         }
       }


### PR DESCRIPTION
## Purpose

Non finalized blocks were retrieved with reference which means is was accessed without any lock protection. Returning a copy instead

## For reviewers

<!-- Describe anything you want to call out to the reviewers e.g. areas to focus on, decisions you made, specific feedback you are looking for, etc. -->

## Related Github issues

<!-- Include related github issues. -->

## Changes

<!-- Summary or changes that have been made. -->

## Tests

<!-- Describe what you did to test these changes, including unit tests that have been added or changed. -->

## Deployment Considerations

## Version Notes ##
{ major | minor | patch }

<!--

Decide whether this is a major, minor, or patch version change. Major is for backwards incompatible changes (This is only relevant once the service is live and in production and the major version is at least 1. While the major version is 0, it is ok to have backwards incompatible changes in a minor version.). Minor is for additional features. Patch is for bug fixes.

Describe the changes in this version. This is essentially the details you would include in the squash commit message.
-->

**NOTE: Include the version notes in the squash commit message**
