### PR TITLE
fix(eth-jsonrpc-subscriptions): various fixes in ethereum json-rpc subscription module

### DIFF
--- a/src/dag/dag_block.hpp
+++ b/src/dag/dag_block.hpp
@@ -16,11 +16,11 @@ class DagBlock {
   vec_trx_t trxs_;  // transactions
   sig_t sig_;
   mutable blk_hash_t hash_;
-  mutable DefaultConstructCopyableMovable<std::mutex> hash_mu_;
+  mutable util::DefaultConstructCopyableMovable<std::mutex> hash_mu_;
   uint64_t timestamp_ = 0;
   vdf_sortition::VdfSortition vdf_;
   mutable addr_t cached_sender_;  // block creater
-  mutable DefaultConstructCopyableMovable<std::mutex> cached_sender_mu_;
+  mutable util::DefaultConstructCopyableMovable<std::mutex> cached_sender_mu_;
 
  public:
   DagBlock() = default;

--- a/src/network/rpc/eth/Eth.cpp
+++ b/src/network/rpc/eth/Eth.cpp
@@ -350,12 +350,15 @@ class EthImpl : public Eth, EthParams {
     return ret ? *ret : final_chain->last_block_number();
   }
 
-  static LogFilter parse_log_filter(Json::Value const& json) {
-    optional<EthBlockNumber> from_block, to_block;
+  LogFilter parse_log_filter(Json::Value const& json) {
+    EthBlockNumber from_block;
+    optional<EthBlockNumber> to_block;
     AddressSet addresses;
     LogFilter::Topics topics;
     if (auto const& fromBlock = json["fromBlock"]; !fromBlock.empty()) {
-      from_block = parse_blk_num_specific(fromBlock.asString());
+      from_block = parse_blk_num(fromBlock.asString());
+    } else {
+      from_block = final_chain->last_block_number();
     }
     if (auto const& toBlock = json["toBlock"]; !toBlock.empty()) {
       to_block = parse_blk_num_specific(toBlock.asString());

--- a/src/network/rpc/eth/LogFilter.hpp
+++ b/src/network/rpc/eth/LogFilter.hpp
@@ -9,14 +9,14 @@ struct LogFilter {
   using Topics = array<unordered_set<h256>, 4>;
 
  private:
-  optional<EthBlockNumber> from_block_;
+  EthBlockNumber from_block_;
   optional<EthBlockNumber> to_block_;
   AddressSet addresses_;
   Topics topics_;
   bool is_range_only_ = false;
 
  public:
-  LogFilter(optional<EthBlockNumber> from_block, optional<EthBlockNumber> to_block, AddressSet addresses,
+  LogFilter(EthBlockNumber from_block, optional<EthBlockNumber> to_block, AddressSet addresses,
             LogFilter::Topics topics);
 
   vector<LogBloom> bloomPossibilities() const;

--- a/src/network/rpc/eth/watches.hpp
+++ b/src/network/rpc/eth/watches.hpp
@@ -49,6 +49,7 @@ class WatchGroup {
     Params params;
     time_point last_touched{};
     vector<OutputType> updates{};
+    mutable util::DefaultConstructCopyableMovable<std::shared_mutex> mu{};
   };
 
  private:
@@ -63,9 +64,11 @@ class WatchGroup {
       : cfg_(cfg[type]), updater_(move(updater)) {
     assert(cfg_.idle_timeout.count() != 0);
     if constexpr (is_same_v<InputType, OutputType>) {
-      if (!updater) {
-        updater = [](auto const&, auto const& input, auto const& do_update) { do_update(input); };
+      if (!updater_) {
+        updater_ = [](auto const&, auto const& input, auto const& do_update) { do_update(input); };
       }
+    } else {
+      assert(updater_);
     }
   }
 
@@ -112,7 +115,10 @@ class WatchGroup {
     shared_lock l(watches_mu_);
     for (auto& entry : watches_) {
       auto& watch = entry.second;
-      updater_(watch.params, obj_in, [&](auto const& obj_out) { watch.updates.push_back(obj_out); });
+      updater_(watch.params, obj_in, [&](auto const& obj_out) {
+        std::unique_lock l(watch.mu.val);
+        watch.updates.push_back(obj_out);
+      });
     }
   }
 
@@ -121,6 +127,7 @@ class WatchGroup {
     shared_lock l(watches_mu_);
     if (auto entry = watches_.find(watch_id); entry != watches_.end()) {
       auto& watch = entry->second;
+      std::unique_lock l(watch.mu.val);
       swap(ret, watch.updates);
       watch.last_touched = high_resolution_clock::now();
     }

--- a/src/node/full_node.hpp
+++ b/src/node/full_node.hpp
@@ -112,14 +112,14 @@ class FullNode : public std::enable_shared_from_this<FullNode> {
   }
 
   template <typename T, typename... ConstructorParams>
-  auto &emplace(std::shared_ptr<T> &ptr, ConstructorParams &&...ctor_params) {
+  auto &emplace(std::shared_ptr<T> &ptr, ConstructorParams &&... ctor_params) {
     ptr = std::make_shared<T>(std::forward<ConstructorParams>(ctor_params)...);
     register_s_ptr(ptr);
     return ptr;
   }
 
   template <typename T, typename... ConstructorParams>
-  static auto &emplace(std::unique_ptr<T> &ptr, ConstructorParams &&...ctor_params) {
+  static auto &emplace(std::unique_ptr<T> &ptr, ConstructorParams &&... ctor_params) {
     return ptr = std::make_unique<T>(std::forward<ConstructorParams>(ctor_params)...);
   }
 

--- a/src/transaction_manager/transaction.hpp
+++ b/src/transaction_manager/transaction.hpp
@@ -26,13 +26,13 @@ struct Transaction {
   mutable trx_hash_t hash_;
   mutable bool hash_initialized_ = false;
   bool is_zero_ = false;
-  mutable DefaultConstructCopyableMovable<std::mutex> hash_mu_;
+  mutable util::DefaultConstructCopyableMovable<std::mutex> hash_mu_;
   mutable bool sender_initialized_ = false;
   mutable bool sender_valid_ = false;
   mutable addr_t sender_;
-  mutable DefaultConstructCopyableMovable<std::mutex> sender_mu_;
+  mutable util::DefaultConstructCopyableMovable<std::mutex> sender_mu_;
   mutable std::shared_ptr<bytes> cached_rlp_;
-  mutable DefaultConstructCopyableMovable<std::mutex> cached_rlp_mu_;
+  mutable util::DefaultConstructCopyableMovable<std::mutex> cached_rlp_mu_;
 
   template <bool for_signature, bool w_sender>
   void streamRLP(dev::RLPStream &s) const;

--- a/src/util/default_construct_copyable_movable.hpp
+++ b/src/util/default_construct_copyable_movable.hpp
@@ -7,6 +7,8 @@
 // This basically captures a common work-around pattern for classes that contain fields of this kind of types
 // - a famous example would be a mutex type
 
+namespace taraxa::util {
+
 template <typename T>
 struct DefaultConstructCopyableMovable {
   T val;
@@ -20,3 +22,5 @@ struct DefaultConstructCopyableMovable {
   auto& operator=(DefaultConstructCopyableMovable const&) { return *this; }
   auto& operator=(DefaultConstructCopyableMovable&&) { return *this; }
 };
+
+}  // namespace taraxa::util

--- a/src/util/util.hpp
+++ b/src/util/util.hpp
@@ -215,7 +215,7 @@ class StatusTable {
 };  // namespace taraxa
 
 template <typename... TS>
-std::string fmt(const std::string &pattern, const TS &...args) {
+std::string fmt(const std::string &pattern, const TS &... args) {
   return (boost::format(pattern) % ... % args).str();
 }
 


### PR DESCRIPTION
1) Fixed the data race on the state of a filter (aka watch)
2) Emitted new pending transaction event in the place which is more likely to yield the desired exactly-once semantics: it is now emitted under the same conditions when we increment the debugging transaction counter that we also depend upon in the existing tests (we assume it is incremented in exactly-once fashion).
3) Fixed parsing/calculating `fromBlock` field of `LogFilter`