### PR TITLE
fix: optimize vote processing

### DIFF
--- a/src/consensus/vote.cpp
+++ b/src/consensus/vote.cpp
@@ -12,15 +12,14 @@ VrfPbftSortition::VrfPbftSortition(bytes const& b) {
   if (!rlp.isList()) {
     throw std::invalid_argument("VrfPbftSortition RLP must be a list");
   }
+  auto it = rlp.begin();
 
-  pk = rlp[0].toHash<vrf_pk_t>();
-  pbft_msg.type = PbftVoteTypes(rlp[1].toInt<uint>());
-  pbft_msg.round = rlp[2].toInt<uint64_t>();
-  pbft_msg.step = rlp[3].toInt<size_t>();
-  pbft_msg.weighted_index = rlp[4].toInt<size_t>();
-  proof = rlp[5].toHash<vrf_proof_t>();
-
-  verify();
+  pk = (*it++).toHash<vrf_pk_t>();
+  pbft_msg.type = PbftVoteTypes((*it++).toInt<uint>());
+  pbft_msg.round = (*it++).toInt<uint64_t>();
+  pbft_msg.step = (*it++).toInt<size_t>();
+  pbft_msg.weighted_index = (*it++).toInt<size_t>();
+  proof = (*it++).toHash<vrf_proof_t>();
 }
 
 bytes VrfPbftSortition::getRlpBytes() const {
@@ -51,9 +50,11 @@ bool VrfPbftSortition::canSpeak(size_t threshold, size_t dpos_total_votes_count)
 
 Vote::Vote(dev::RLP const& rlp) {
   if (!rlp.isList()) throw std::invalid_argument("vote RLP must be a list");
-  blockhash_ = rlp[0].toHash<blk_hash_t>();
-  vrf_sortition_ = VrfPbftSortition(rlp[1].toBytes());
-  vote_signature_ = rlp[2].toHash<sig_t>();
+  auto it = rlp.begin();
+
+  blockhash_ = (*it++).toHash<blk_hash_t>();
+  vrf_sortition_ = VrfPbftSortition((*it++).toBytes());
+  vote_signature_ = (*it++).toHash<sig_t>();
   vote_hash_ = sha3(true);
 }
 

--- a/src/consensus/vote.hpp
+++ b/src/consensus/vote.hpp
@@ -64,7 +64,7 @@ struct VrfPbftSortition : public vrf_wrapper::VrfSortitionBase {
   VrfPbftSortition() = default;
   VrfPbftSortition(vrf_sk_t const& sk, VrfPbftMsg const& pbft_msg)
       : VrfSortitionBase(sk, pbft_msg.getRlpBytes()), pbft_msg(pbft_msg) {}
-  explicit VrfPbftSortition(bytes const& rlp);
+  explicit VrfPbftSortition(bytes const& rlp, bool verify_vrf = true);
   bytes getRlpBytes() const;
   bool verify() { return VrfSortitionBase::verify(pbft_msg.getRlpBytes()); }
   bool operator==(VrfPbftSortition const& other) const {
@@ -89,8 +89,8 @@ class Vote {
   Vote() = default;
   Vote(secret_t const& node_sk, VrfPbftSortition const& vrf_sortition, blk_hash_t const& blockhash);
 
-  explicit Vote(dev::RLP const& rlp);
-  explicit Vote(bytes const& rlp);
+  explicit Vote(dev::RLP const& rlp, bool verify_vrf = true);
+  explicit Vote(bytes const& rlp, bool verify_vrf = true);
   bool operator==(Vote const& other) const { return rlp() == other.rlp(); }
   ~Vote() {}
 
@@ -104,6 +104,7 @@ class Vote {
     return cached_voter_addr_;
   }
 
+  bool verifyVrfSortition() { return vrf_sortition_.verify(); }
   auto getVrfSortition() const { return vrf_sortition_; }
   auto getSortitionProof() const { return vrf_sortition_.proof; }
   auto getCredential() const { return vrf_sortition_.output; }
@@ -172,9 +173,9 @@ class VoteManager {
 
   void cleanupVotes(uint64_t pbft_round);
 
-  bool voteValidation(Vote const& vote, size_t const valid_sortition_players, size_t const sortition_threshold) const;
+  bool voteValidation(Vote& vote, size_t const valid_sortition_players, size_t const sortition_threshold) const;
 
-  bool pbftBlockHasEnoughValidCertVotes(PbftBlockCert const& pbft_block_and_votes, size_t valid_sortition_players,
+  bool pbftBlockHasEnoughValidCertVotes(PbftBlockCert& pbft_block_and_votes, size_t valid_sortition_players,
                                         size_t sortition_threshold, size_t pbft_2t_plus_1) const;
 
   std::string getJsonStr(std::vector<Vote> const& votes);

--- a/src/network/taraxa_capability.cpp
+++ b/src/network/taraxa_capability.cpp
@@ -486,7 +486,7 @@ void TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
     case PbftVotePacket: {
       LOG(log_dg_vote_prp_) << "In PbftVotePacket";
 
-      Vote vote(_r[0].toBytes());
+      Vote vote(_r[0].toBytes(), false);
       auto vote_hash = vote.getHash();
       LOG(log_dg_vote_prp_) << "Received PBFT vote " << vote_hash;
       peer->markVoteAsKnown(vote_hash);


### PR DESCRIPTION
## Purpose

Optimized RLP votes processing.
Removed verify method in VrfPbftSortition which actually did not do anything since there was no check for return value.

These changes significantly reduce time of processing vote packets

## For reviewers

<!-- Describe anything you want to call out to the reviewers e.g. areas to focus on, decisions you made, specific feedback you are looking for, etc. -->

## Related Github issues

<!-- Include related github issues. -->

## Changes

<!-- Summary or changes that have been made. -->

## Tests

<!-- Describe what you did to test these changes, including unit tests that have been added or changed. -->

## Deployment Considerations

## Version Notes ##
{ major | minor | patch }

<!--

Decide whether this is a major, minor, or patch version change. Major is for backwards incompatible changes (This is only relevant once the service is live and in production and the major version is at least 1. While the major version is 0, it is ok to have backwards incompatible changes in a minor version.). Minor is for additional features. Patch is for bug fixes.

Describe the changes in this version. This is essentially the details you would include in the squash commit message.
-->

**NOTE: Include the version notes in the squash commit message**
