### PR TITLE
chore(circleci): Removing build of special ctest image, making ctest …

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -422,21 +422,21 @@ jobs:
               command: |
                 docker build -t ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} .
 
-      - docker-cache/with-save-restore-images:
-         repository: gcr.io/${GOOGLE_PROJECT_ID}
-         images: >-
-           ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} 
-           ${IMAGE}-ctest:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}
-           ${IMAGE}-cache:latest
-           ${IMAGE}-cache:${DOCKER_BRANCH_TAG}
-         steps: 
-           - docker-cache/build:
-              command: |
-               docker build -t ${IMAGE}-ctest:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} \
-                 --target build .
-           - docker-cache/tag: 
-               tags: >-
-                  ${IMAGE}-ctest:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} ${IMAGE}-cache:${DOCKER_BRANCH_TAG}
+#      - docker-cache/with-save-restore-images:
+#         repository: gcr.io/${GOOGLE_PROJECT_ID}
+#         images: >-
+#           ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} 
+#           ${IMAGE}-ctest:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}
+#           ${IMAGE}-cache:latest
+#           ${IMAGE}-cache:${DOCKER_BRANCH_TAG}
+#         steps: 
+#           - docker-cache/build:
+#              command: |
+#               docker build -t ${IMAGE}-ctest:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} \
+#                 --target build .
+#           - docker-cache/tag: 
+#               tags: >-
+#                  ${IMAGE}-ctest:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} ${IMAGE}-cache:${DOCKER_BRANCH_TAG}
               
                 
       - run:
@@ -444,7 +444,7 @@ jobs:
          command: |
            docker run  --rm -v $PWD/tmp_docker:/tmp \
                        --name taraxa-node-ctest-${DOCKER_BRANCH_TAG} \
-                       ${IMAGE}-ctest:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}\
+                       ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}\
                         sh -c \
                        'cd cmake-docker-build-debug/bin \
                         && ctest --output-on-failure'


### PR DESCRIPTION
## Purpose

Ctest build takes a long time and is not taking advantage of cache some times, this PR is to try to improve that 

## For reviewers
Ctest image is the one that actually is being used as cache, will try to improve this behaviour
## Related Github issues

<!-- Include related github issues. -->

## Changes

<!-- Summary or changes that have been made. -->

## Tests

<!-- Describe what you did to test these changes, including unit tests that have been added or changed. -->

## Deployment Considerations

## Version Notes ##
{ major | minor | patch }

<!--

Decide whether this is a major, minor, or patch version change. Major is for backwards incompatible changes (This is only relevant once the service is live and in production and the major version is at least 1. While the major version is 0, it is ok to have backwards incompatible changes in a minor version.). Minor is for additional features. Patch is for bug fixes.

Describe the changes in this version. This is essentially the details you would include in the squash commit message.
-->

**NOTE: Include the version notes in the squash commit message**
