### PR TITLE
fix: CPU intensive loop when syncing in block proposer

### DIFF
--- a/src/consensus/block_proposer.cpp
+++ b/src/consensus/block_proposer.cpp
@@ -100,10 +100,9 @@ void BlockProposer::start() {
       if (auto net = network_.lock()) {
         syncing = net->pbft_syncing();
       }
-      if (syncing) {
-        continue;
+      if (!syncing) {
+        propose_model_->propose();
       }
-      propose_model_->propose();
       thisThreadSleepForMilliSeconds(min_proposal_delay);
     }
   });


### PR DESCRIPTION
## Purpose

Block proposer thread would get into CPU intensive loop without any sleep when node syncing

## For reviewers

<!-- Describe anything you want to call out to the reviewers e.g. areas to focus on, decisions you made, specific feedback you are looking for, etc. -->

## Related Github issues

<!-- Include related github issues. -->

## Changes

<!-- Summary or changes that have been made. -->

## Tests

<!-- Describe what you did to test these changes, including unit tests that have been added or changed. -->

## Deployment Considerations

## Version Notes ##
{ major | minor | patch }

<!--

Decide whether this is a major, minor, or patch version change. Major is for backwards incompatible changes (This is only relevant once the service is live and in production and the major version is at least 1. While the major version is 0, it is ok to have backwards incompatible changes in a minor version.). Minor is for additional features. Patch is for bug fixes.

Describe the changes in this version. This is essentially the details you would include in the squash commit message.
-->

**NOTE: Include the version notes in the squash commit message**
