### PR TITLE
perf(votes): rewrite verified votes table

### DIFF
--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -1050,19 +1050,19 @@ void PbftManager::secondFinish_() {
   loop_back_finish_state_ = elapsed_time_in_round_ms_ > end_time_for_step;
 }
 
-std::shared_ptr<Vote> PbftManager::generateVote(blk_hash_t const &blockhash, PbftVoteTypes type, uint64_t round, size_t step,
-                               size_t weighted_index) {
+std::shared_ptr<Vote> PbftManager::generateVote(blk_hash_t const &blockhash, PbftVoteTypes type, uint64_t round,
+                                                size_t step, size_t weighted_index) {
   // sortition proof
   VrfPbftMsg msg(type, round, step, weighted_index);
   VrfPbftSortition vrf_sortition(vrf_sk_, msg);
   Vote vote(node_sk_, vrf_sortition, blockhash);
 
-  return std::shared_ptr<Vote>(vote);
+  return std::make_shared<Vote>(vote);
 }
 
 size_t PbftManager::placeVote_(taraxa::blk_hash_t const &blockhash, PbftVoteTypes vote_type, uint64_t round,
                                size_t step) {
-  vector<Vote> votes;
+  std::vector<std::shared_ptr<Vote>> votes;
 
   for (size_t weighted_index(0); weighted_index < weighted_votes_count_; weighted_index++) {
     if (step == 1 && weighted_index > 0) {
@@ -1394,7 +1394,7 @@ std::pair<vec_blk_t, bool> PbftManager::comparePbftBlockScheduleWithDAGblocks_(P
 }
 
 bool PbftManager::pushCertVotedPbftBlockIntoChain_(taraxa::blk_hash_t const &cert_voted_block_hash,
-                                                   std::vector<Vote> const &cert_votes_for_round) {
+                                                   std::vector<std::shared_ptr<Vote>> const &cert_votes_for_round) {
   auto pbft_block = getUnfinalizedBlock_(cert_voted_block_hash);
   if (!pbft_block) {
     LOG(log_nf_) << "Can not find the cert voted block hash " << cert_voted_block_hash << " in both pbft queue and DB";

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -1796,8 +1796,8 @@ std::optional<SyncBlock> PbftManager::processSyncBlock() {
 
   // Check cert vote matches
   for (auto const &vote : sync_block.first.cert_votes) {
-    if (vote.getBlockHash() != pbft_block_hash) {
-      LOG(log_er_) << "Invalid cert votes block hash " << vote.getBlockHash() << " instead of " << pbft_block_hash
+    if (vote->getBlockHash() != pbft_block_hash) {
+      LOG(log_er_) << "Invalid cert votes block hash " << vote->getBlockHash() << " instead of " << pbft_block_hash
                    << " from peer " << sync_block.second.abridged() << " received, stop syncing.";
       clearSyncBlockQueue();
       net->handleMaliciousSyncPeer(sync_queue_.front().second);

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -1055,9 +1055,8 @@ std::shared_ptr<Vote> PbftManager::generateVote(blk_hash_t const &blockhash, Pbf
   // sortition proof
   VrfPbftMsg msg(type, round, step, weighted_index);
   VrfPbftSortition vrf_sortition(vrf_sk_, msg);
-  Vote vote(node_sk_, vrf_sortition, blockhash);
 
-  return std::make_shared<Vote>(vote);
+  return std::make_shared<Vote>(node_sk_, vrf_sortition, blockhash);
 }
 
 size_t PbftManager::placeVote_(taraxa::blk_hash_t const &blockhash, PbftVoteTypes vote_type, uint64_t round,

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -1267,7 +1267,7 @@ std::vector<std::vector<uint>> PbftManager::createMockTrxSchedule(
   return blocks_trx_modes;
 }
 
-std::pair<blk_hash_t, bool> PbftManager::identifyLeaderBlock_(std::vector<Vote> const &votes) {
+std::pair<blk_hash_t, bool> PbftManager::identifyLeaderBlock_(std::vector<std::shared_ptr<Vote>> votes) {
   auto round = getPbftRound();
   LOG(log_dg_) << "Into identify leader block, in round " << round;
 
@@ -1275,10 +1275,10 @@ std::pair<blk_hash_t, bool> PbftManager::identifyLeaderBlock_(std::vector<Vote> 
   std::vector<std::pair<vrf_output_t, blk_hash_t>> leader_candidates;
 
   for (auto const &v : votes) {
-    if (v.getRound() == round && v.getType() == propose_vote_type) {
+    if (v->getRound() == round && v->getType() == propose_vote_type) {
       // We should not pick any null block as leader (proposed when
       // no new blocks found, or maliciously) if others have blocks.
-      auto proposed_block_hash = v.getBlockHash();
+      auto proposed_block_hash = v->getBlockHash();
 
       // Make sure we don't keep soft voting for soft value we want to give up...
       if (proposed_block_hash == last_soft_voted_value_ && giveUpSoftVotedBlock_()) {
@@ -1287,7 +1287,7 @@ std::pair<blk_hash_t, bool> PbftManager::identifyLeaderBlock_(std::vector<Vote> 
 
       if (round == 1 ||
           (proposed_block_hash != NULL_BLOCK_HASH && !pbft_chain_->findPbftBlockInChain(proposed_block_hash))) {
-        leader_candidates.emplace_back(std::make_pair(v.getCredential(), proposed_block_hash));
+        leader_candidates.emplace_back(std::make_pair(v->getCredential(), proposed_block_hash));
       }
     }
   }

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -690,9 +690,7 @@ bool PbftManager::updateSoftVotedBlockForThisRound_() {
   if (!soft_voted_block_for_this_round_.second) {
     auto round = getPbftRound();
 
-    auto soft_votes = getVotesOfTypeFromVotesForRoundAndStep_(soft_vote_type, votes_, round, 2,
-                                                              std::make_pair(NULL_BLOCK_HASH, false));
-    auto voted_block_hash_with_soft_votes = blockWithEnoughVotes_(soft_votes);
+    auto voted_block_hash_with_soft_votes = vote_mgr_->getVotesBundleByRoundAndStep(round, 2, TWO_T_PLUS_ONE);
 
     auto batch = db_->createWriteBatch();
     db_->addPbftMgrVotedValueToBatch(PbftMgrVotedValue::soft_voted_block_hash_in_round,

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -1703,8 +1703,8 @@ std::shared_ptr<PbftBlock> PbftManager::getUnfinalizedBlock_(blk_hash_t const &b
 void PbftManager::countVotes_() {
   auto round = getPbftRound();
   while (!monitor_stop_) {
-    auto verified_votes = db_->getVerifiedVotes();
-    auto unverified_votes = db_->getUnverifiedVotes();
+    auto verified_votes = vote_mgr_->getVerifiedVotes();
+    auto unverified_votes = vote_mgr_->getUnverifiedVotes();
     std::vector<Vote> votes;
     votes.reserve(verified_votes.size() + unverified_votes.size());
     votes.insert(votes.end(), std::make_move_iterator(verified_votes.begin()),

--- a/src/consensus/pbft_manager.hpp
+++ b/src/consensus/pbft_manager.hpp
@@ -59,8 +59,8 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   void setTwoTPlusOne(size_t const two_t_plus_one);
   void setPbftStep(size_t const pbft_step);
 
-  Vote generateVote(blk_hash_t const &blockhash, PbftVoteTypes type, uint64_t round, size_t step,
-                    size_t weighted_index);
+  std::shared_ptr<Vote> generateVote(blk_hash_t const &blockhash, PbftVoteTypes type, uint64_t round, size_t step,
+                                     size_t weighted_index);
 
   size_t getDposTotalVotesCount() const;
   size_t getDposWeightedVotesCount() const;
@@ -128,7 +128,7 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   std::pair<vec_blk_t, bool> comparePbftBlockScheduleWithDAGblocks_(PbftBlock const &pbft_block);
 
   bool pushCertVotedPbftBlockIntoChain_(blk_hash_t const &cert_voted_block_hash,
-                                        std::vector<Vote> const &cert_votes_for_round);
+                                        std::vector<std::shared_ptr<Vote>> const &cert_votes_for_round);
 
   void pushSyncedPbftBlocksIntoChain_();
 

--- a/src/consensus/pbft_manager.hpp
+++ b/src/consensus/pbft_manager.hpp
@@ -31,16 +31,6 @@ enum PbftSyncRequestReason {
   exceeded_max_steps
 };
 
-struct votesBundle {
-  bool enough;
-  blk_hash_t voted_block_hash;
-  std::vector<Vote> votes;  // exactly 2t+1 votes
-
-  votesBundle() : enough(false), voted_block_hash(NULL_BLOCK_HASH) {}
-  votesBundle(bool const enough_, blk_hash_t const &voted_block_hash_, std::vector<Vote> const &votes_)
-      : enough(enough_), voted_block_hash(voted_block_hash_), votes(votes_) {}
-};
-
 class PbftManager : public std::enable_shared_from_this<PbftManager> {
  public:
   using time_point = std::chrono::system_clock::time_point;
@@ -122,14 +112,6 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   void firstFinish_();
   void secondFinish_();
 
-  uint64_t roundDeterminedFromVotes_();
-
-  votesBundle blockWithEnoughVotes_(std::vector<Vote> const &votes) const;
-
-  std::vector<Vote> getVotesOfTypeFromVotesForRoundAndStep_(PbftVoteTypes vote_type, std::vector<Vote> &votes,
-                                                            uint64_t round, size_t step,
-                                                            std::pair<blk_hash_t, bool> blockhash);
-
   size_t placeVote_(blk_hash_t const &blockhash, PbftVoteTypes vote_type, uint64_t round, size_t step);
 
   std::pair<blk_hash_t, bool> proposeMyPbftBlock_();
@@ -209,8 +191,6 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   blk_hash_t own_starting_value_for_round_ = NULL_BLOCK_HASH;
 
   std::pair<blk_hash_t, bool> soft_voted_block_for_this_round_ = std::make_pair(NULL_BLOCK_HASH, false);
-
-  std::vector<Vote> votes_;
 
   time_point round_clock_initial_datetime_;
   time_point now_;

--- a/src/consensus/pbft_manager.hpp
+++ b/src/consensus/pbft_manager.hpp
@@ -116,7 +116,7 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
 
   std::pair<blk_hash_t, bool> proposeMyPbftBlock_();
 
-  std::pair<blk_hash_t, bool> identifyLeaderBlock_(std::vector<std::shared_ptr<Vote>> votes);
+  std::pair<blk_hash_t, bool> identifyLeaderBlock_();
 
   bool syncRequestedAlreadyThisStep_() const;
 

--- a/src/consensus/pbft_manager.hpp
+++ b/src/consensus/pbft_manager.hpp
@@ -116,7 +116,7 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
 
   std::pair<blk_hash_t, bool> proposeMyPbftBlock_();
 
-  std::pair<blk_hash_t, bool> identifyLeaderBlock_(std::vector<Vote> const &votes);
+  std::pair<blk_hash_t, bool> identifyLeaderBlock_(std::vector<std::shared_ptr<Vote>> votes);
 
   bool syncRequestedAlreadyThisStep_() const;
 

--- a/src/consensus/sync_block.cpp
+++ b/src/consensus/sync_block.cpp
@@ -11,14 +11,14 @@ namespace taraxa {
 
 using namespace std;
 
-SyncBlock::SyncBlock(PbftBlock const& pbft_blk, std::vector<Vote> const& cert_votes)
+SyncBlock::SyncBlock(PbftBlock const& pbft_blk, std::vector<std::shared_ptr<Vote>> const& cert_votes)
     : pbft_blk(new PbftBlock(pbft_blk)), cert_votes(cert_votes) {}
 
 SyncBlock::SyncBlock(dev::RLP const& rlp) {
   auto it = rlp.begin();
-  pbft_blk = make_shared<PbftBlock>(*it++);
+  pbft_blk = std::make_shared<PbftBlock>(*it++);
   for (auto const vote_rlp : *it++) {
-    cert_votes.emplace_back(vote_rlp);
+    cert_votes.emplace_back(std::make_shared<Vote>(vote_rlp));
   }
 
   for (auto const dag_block_rlp : *it++) {
@@ -39,7 +39,7 @@ bytes SyncBlock::rlp() const {
   s.appendRaw(pbft_blk->rlp(true));
   s.appendList(cert_votes.size());
   for (auto const& v : cert_votes) {
-    s.appendRaw(v.rlp(true));
+    s.appendRaw(v->rlp(true));
   }
   s.appendList(dag_blocks.size());
   for (auto const& b : dag_blocks) {

--- a/src/consensus/sync_block.hpp
+++ b/src/consensus/sync_block.hpp
@@ -17,12 +17,12 @@ class DagBlock;
 
 class SyncBlock {
  public:
-  SyncBlock(PbftBlock const& pbft_blk, std::vector<Vote> const& cert_votes);
+  SyncBlock(PbftBlock const& pbft_blk, std::vector<std::shared_ptr<Vote>> const& cert_votes);
   SyncBlock(dev::RLP const& all_rlp);
   SyncBlock(bytes const& all_rlp);
 
   std::shared_ptr<PbftBlock> pbft_blk;
-  std::vector<Vote> cert_votes;
+  std::vector<std::shared_ptr<Vote>> cert_votes;
   std::vector<DagBlock> dag_blocks;
   std::vector<Transaction> transactions;
   bytes rlp() const;

--- a/src/consensus/vote.cpp
+++ b/src/consensus/vote.cpp
@@ -100,47 +100,47 @@ VoteManager::VoteManager(addr_t node_addr, std::shared_ptr<DbStorage> db, std::s
 
 VoteManager::~VoteManager() { daemon_->join(); }
 
-void VoteManager::setNetwork(std::weak_ptr<Network> network) { network_ = move(network); }
+void VoteManager::setNetwork(std::weak_ptr<Network> network) { network_ = std::move(network); }
 
 void VoteManager::retreieveVotes_() {
   LOG(log_si_) << "Retrieve unverified votes from DB";
   auto unverified_votes = db_->getUnverifiedVotes();
   for (auto const& v : unverified_votes) {
-    auto pbft_round = v.getRound();
-    auto hash = v.getHash();
+    auto pbft_round = v->getRound();
+    auto hash = v->getHash();
     {
       uniqueLock_ lock(unverified_votes_access_);
       if (unverified_votes_.count(pbft_round)) {
         unverified_votes_[pbft_round][hash] = v;
       } else {
-        std::unordered_map<vote_hash_t, Vote> votes{std::make_pair(hash, v)};
-        unverified_votes_[pbft_round] = votes;
+        std::unordered_map<vote_hash_t, std::shared_ptr<Vote>> votes{std::make_pair(hash, v)};
+        unverified_votes_[pbft_round] = std::move(votes);
       }
     }
-    LOG(log_dg_) << "Retrieved unverified vote " << v;
+    LOG(log_dg_) << "Retrieved unverified vote " << *v;
   }
 
   LOG(log_si_) << "Retrieve verified votes from DB";
   auto verified_votes = db_->getVerifiedVotes();
   for (auto const& v : verified_votes) {
     // Rebroadcast our own next votes in case we were partitioned...
-    if (v.getVoterAddr() == node_addr_ && v.getStep() >= FIRST_FINISH_STEP &&
+    if (v->getVoterAddr() == node_addr_ && v->getStep() >= FIRST_FINISH_STEP &&
         db_->getPbftMgrField(PbftMgrRoundStep::PbftStep) > EXTENDED_PARTITION_STEPS) {
-      vector<Vote> votes = {v};
+      std::vector<std::shared_ptr<Vote>> votes = {v};
       if (auto net = network_.lock()) {
-        net->onNewPbftVotes(move(votes));
+        net->onNewPbftVotes(std::move(votes));
       }
     }
 
     addVerifiedVote(v);
-    LOG(log_dg_) << "Retrieved verified vote " << v;
+    LOG(log_dg_) << "Retrieved verified vote " << *v;
   }
 }
 
-bool VoteManager::addUnverifiedVote(taraxa::Vote const& vote) {
-  uint64_t pbft_round = vote.getRound();
-  const auto& hash = vote.getHash();
-  vote.getVoterAddr();  // this will cache object variables - speed up
+bool VoteManager::addUnverifiedVote(std::shared_ptr<Vote> const& vote) {
+  uint64_t pbft_round = vote->getRound();
+  const auto& hash = vote->getHash();
+  vote->getVoterAddr();  // this will cache object variables - speed up
 
   {
     uniqueLock_ lock(unverified_votes_access_);
@@ -150,30 +150,30 @@ bool VoteManager::addUnverifiedVote(taraxa::Vote const& vote) {
         return false;
       }
     } else {
-      std::unordered_map<vote_hash_t, Vote> votes{std::make_pair(hash, vote)};
+      std::unordered_map<vote_hash_t, std::shared_ptr<Vote>> votes{std::make_pair(hash, vote)};
       unverified_votes_[pbft_round] = std::move(votes);
     }
 
     // Save vote also in db
     db_->saveUnverifiedVote(vote);
   }
+  LOG(log_nf_) << "Add unverified vote " << vote->getHash().abridged();
 
-  LOG(log_nf_) << "Add unverified vote " << vote.getHash().abridged();
   return true;
 }
 
 void VoteManager::addUnverifiedVotes(std::vector<std::shared_ptr<Vote>> const& votes) {
   for (auto const& v : votes) {
     if (voteInUnverifiedMap(v->getRound(), v->getHash())) {
-      LOG(log_dg_) << "The vote is in unverified queue already " << v;
+      LOG(log_dg_) << "The vote is in unverified queue already " << v->getHash();
       continue;
     }
     if (db_->unverifiedVoteExist(v->getHash())) {
       // Vote in unverified DB but not in unverified queue
-      LOG(log_dg_) << "The vote is in unverified DB already " << v;
+      LOG(log_dg_) << "The vote is in unverified DB already " << v->getHash();
       continue;
     }
-    addUnverifiedVote(*v);
+    addUnverifiedVote(v);
   }
 }
 
@@ -199,9 +199,8 @@ std::vector<std::shared_ptr<Vote>> VoteManager::getUnverifiedVotes() {
 
   sharedLock_ lock(unverified_votes_access_);
   for (auto const& round_votes : unverified_votes_) {
-    std::transform(
-        round_votes.second.begin(), round_votes.second.end(), std::back_inserter(votes),
-        [](std::pair<const taraxa::vote_hash_t, taraxa::Vote> const& v) { return std::make_shared<Vote>(v.second); });
+    std::transform(round_votes.second.begin(), round_votes.second.end(), std::back_inserter(votes),
+                   [](std::pair<const taraxa::vote_hash_t, std::shared_ptr<Vote>> const& v) { return v.second; });
   }
 
   return votes;
@@ -216,8 +215,7 @@ uint64_t VoteManager::getUnverifiedVotesSize() const {
   uint64_t size = 0;
 
   sharedLock_ lock(unverified_votes_access_);
-  std::map<uint64_t, std::unordered_map<vote_hash_t, Vote>>::const_iterator it;
-  for (it = unverified_votes_.begin(); it != unverified_votes_.end(); ++it) {
+  for (auto it = unverified_votes_.begin(); it != unverified_votes_.end(); ++it) {
     size += it->second.size();
   }
 
@@ -232,7 +230,7 @@ std::vector<std::shared_ptr<Vote>> VoteManager::getVerifiedVotes() {
     for (auto const& step : round.second) {
       for (auto const& voted_value : step.second) {
         for (auto const& v : voted_value.second) {
-          votes.emplace_back(std::make_shared<Vote>(v.second));
+          votes.emplace_back(v.second);
         }
       }
     }
@@ -256,11 +254,11 @@ uint64_t VoteManager::getVerifiedVotesSize() const {
   return size;
 }
 
-void VoteManager::addVerifiedVote(Vote const& vote) {
-  auto round = vote.getRound();
-  auto step = vote.getStep();
-  auto voted_value = vote.getBlockHash();
-  auto hash = vote.getHash();
+void VoteManager::addVerifiedVote(std::shared_ptr<Vote> const& vote) {
+  auto round = vote->getRound();
+  auto step = vote->getStep();
+  auto voted_value = vote->getBlockHash();
+  auto hash = vote->getHash();
 
   upgradableLock_ lock(verified_votes_access_);
   auto found_round_it = verified_votes_.find(round);
@@ -284,15 +282,15 @@ void VoteManager::addVerifiedVote(Vote const& vote) {
         }
       } else {
         // Add voted value
-        std::unordered_map<vote_hash_t, Vote> votes{{hash, vote}};
+        std::unordered_map<vote_hash_t, std::shared_ptr<Vote>> votes{{hash, vote}};
 
         upgradeLock_ locked(lock);
         verified_votes_[round][step][voted_value] = std::move(votes);
       }
     } else {
       // Add step
-      std::unordered_map<vote_hash_t, Vote> votes{{hash, vote}};
-      std::unordered_map<blk_hash_t, std::unordered_map<vote_hash_t, Vote>> voted_values{
+      std::unordered_map<vote_hash_t, std::shared_ptr<Vote>> votes{{hash, vote}};
+      std::unordered_map<blk_hash_t, std::unordered_map<vote_hash_t, std::shared_ptr<Vote>>> voted_values{
           {voted_value, std::move(votes)}};
 
       upgradeLock_ locked(lock);
@@ -300,9 +298,10 @@ void VoteManager::addVerifiedVote(Vote const& vote) {
     }
   } else {
     // Add round
-    std::unordered_map<vote_hash_t, Vote> votes{{hash, vote}};
-    std::unordered_map<blk_hash_t, std::unordered_map<vote_hash_t, Vote>> voted_values{{voted_value, std::move(votes)}};
-    std::map<size_t, std::unordered_map<blk_hash_t, std::unordered_map<vote_hash_t, Vote>>> steps{
+    std::unordered_map<vote_hash_t, std::shared_ptr<Vote>> votes{{hash, vote}};
+    std::unordered_map<blk_hash_t, std::unordered_map<vote_hash_t, std::shared_ptr<Vote>>> voted_values{
+        {voted_value, std::move(votes)}};
+    std::map<size_t, std::unordered_map<blk_hash_t, std::unordered_map<vote_hash_t, std::shared_ptr<Vote>>>> steps{
         {step, std::move(voted_values)}};
 
     upgradeLock_ locked(lock);
@@ -310,7 +309,7 @@ void VoteManager::addVerifiedVote(Vote const& vote) {
   }
 
   LOG(log_nf_) << "Added verified vote: " << hash;
-  LOG(log_dg_) << "Added verified vote: " << vote;
+  LOG(log_dg_) << "Added verified vote: " << *vote;
 }
 
 // Move all verified votes back to unverified queue/DB. Since PBFT chain pushed new blocks, that will affect DPOS
@@ -333,11 +332,11 @@ void VoteManager::removeVerifiedVotes() {
   db_->commitWriteBatch(batch);
 }
 
-bool VoteManager::voteInVerifiedMap(Vote const& vote) {
-  auto round = vote.getRound();
-  auto step = vote.getStep();
-  auto voted_value = vote.getBlockHash();
-  auto hash = vote.getHash();
+bool VoteManager::voteInVerifiedMap(std::shared_ptr<Vote> const& vote) {
+  auto round = vote->getRound();
+  auto step = vote->getStep();
+  auto voted_value = vote->getBlockHash();
+  auto hash = vote->getHash();
 
   sharedLock_ lock(verified_votes_access_);
   auto found_round_it = verified_votes_.find(round);
@@ -399,7 +398,7 @@ void VoteManager::verifyVotes(uint64_t pbft_round, size_t sortition_threshold, u
       LOG(log_dg_) << "Account " << voter_account_address << " is not eligible to vote. Vote: " << v;
       vote_is_valid = false;
     } else {
-      vote_is_valid = voteValidation(*v, dpos_total_votes_count, sortition_threshold);
+      vote_is_valid = voteValidation(v, dpos_total_votes_count, sortition_threshold);
     }
 
     if (vote_is_valid) {
@@ -414,7 +413,7 @@ void VoteManager::verifyVotes(uint64_t pbft_round, size_t sortition_threshold, u
 
   auto batch = db_->createWriteBatch();
   for (auto const& v : verified_votes) {
-    db_->addVerifiedVoteToBatch(*v, batch);
+    db_->addVerifiedVoteToBatch(v, batch);
     db_->removeUnverifiedVoteToBatch(v->getHash(), batch);
   }
 
@@ -425,7 +424,7 @@ void VoteManager::verifyVotes(uint64_t pbft_round, size_t sortition_threshold, u
   db_->commitWriteBatch(batch);
 
   for (auto const& v : verified_votes) {
-    addVerifiedVote(*v);
+    addVerifiedVote(v);
     removeUnverifiedVote(v->getRound(), v->getHash());
   }
 
@@ -440,8 +439,8 @@ void VoteManager::cleanupVotes(uint64_t pbft_round) {
   vector<vote_hash_t> remove_unverified_votes_hash;
   {
     upgradableLock_ lock(unverified_votes_access_);
-    std::map<uint64_t, std::unordered_map<vote_hash_t, Vote>>::iterator it = unverified_votes_.begin();
-    std::map<uint64_t, std::unordered_map<vote_hash_t, Vote>>::reverse_iterator rit;
+    std::map<uint64_t, std::unordered_map<vote_hash_t, std::shared_ptr<Vote>>>::iterator it = unverified_votes_.begin();
+    std::map<uint64_t, std::unordered_map<vote_hash_t, std::shared_ptr<Vote>>>::reverse_iterator rit;
 
     upgradeLock_ locked(lock);
     while (it != unverified_votes_.end() && it->first < pbft_round) {
@@ -459,7 +458,7 @@ void VoteManager::cleanupVotes(uint64_t pbft_round) {
       auto v = rit->second.begin();
       while (v != rit->second.end()) {
         // Check if vote is a stale vote for given address...
-        addr_t voter_account_address = v->second.getVoterAddr();
+        addr_t voter_account_address = v->second->getVoterAddr();
         auto found_in_map = max_received_round_for_address_.find(voter_account_address);
         if (found_in_map == max_received_round_for_address_.end()) {
           max_received_round_for_address_[voter_account_address] = vote_round;
@@ -520,18 +519,19 @@ void VoteManager::cleanupVotes(uint64_t pbft_round) {
   db_->commitWriteBatch(batch);
 }
 
-bool VoteManager::voteValidation(taraxa::Vote& vote, size_t dpos_total_votes_count, size_t sortition_threshold) const {
-  if (!vote.verifyVrfSortition()) {
+bool VoteManager::voteValidation(std::shared_ptr<Vote>& vote, size_t dpos_total_votes_count,
+                                 size_t sortition_threshold) const {
+  if (!vote->verifyVrfSortition()) {
     LOG(log_er_) << "Invalid vrf proof. " << vote;
     return false;
   }
 
-  if (!vote.verifyVote()) {
+  if (!vote->verifyVote()) {
     LOG(log_er_) << "Invalid vote signature. " << vote;
     return false;
   }
 
-  if (!vote.verifyCanSpeak(sortition_threshold, dpos_total_votes_count)) {
+  if (!vote->verifyCanSpeak(sortition_threshold, dpos_total_votes_count)) {
     LOG(log_er_) << "Vote sortition failed. Sortition threshold " << sortition_threshold << ", DPOS total votes count "
                  << dpos_total_votes_count << vote;
     return false;
@@ -548,27 +548,27 @@ bool VoteManager::pbftBlockHasEnoughValidCertVotes(SyncBlock& pbft_block_and_vot
     return false;
   }
 
-  std::vector<Vote> valid_votes;
-  auto first_cert_vote_round = pbft_block_and_votes.cert_votes[0].getRound();
+  std::vector<std::shared_ptr<Vote>> valid_votes;
+  auto first_cert_vote_round = pbft_block_and_votes.cert_votes[0]->getRound();
 
   for (auto& v : pbft_block_and_votes.cert_votes) {
     // Any info is wrong that can determine the synced PBFT block comes from a malicious player
-    if (v.getType() != cert_vote_type) {
+    if (v->getType() != cert_vote_type) {
       LOG(log_er_) << "For PBFT block " << pbft_block_and_votes.pbft_blk->getBlockHash() << ", cert vote "
-                   << v.getHash() << " has wrong vote type " << v.getType();
+                   << v->getHash() << " has wrong vote type " << v->getType();
       break;
-    } else if (v.getRound() != first_cert_vote_round) {
+    } else if (v->getRound() != first_cert_vote_round) {
       LOG(log_er_) << "For PBFT block " << pbft_block_and_votes.pbft_blk->getBlockHash() << ", cert vote "
-                   << v.getHash() << " has a different vote round " << v.getRound() << ", compare to first cert vote "
-                   << pbft_block_and_votes.cert_votes[0].getHash() << " has vote round " << first_cert_vote_round;
+                   << v->getHash() << " has a different vote round " << v->getRound() << ", compare to first cert vote "
+                   << pbft_block_and_votes.cert_votes[0]->getHash() << " has vote round " << first_cert_vote_round;
       break;
-    } else if (v.getStep() != 3) {
+    } else if (v->getStep() != 3) {
       LOG(log_er_) << "For PBFT block " << pbft_block_and_votes.pbft_blk->getBlockHash() << ", cert vote "
-                   << v.getHash() << " has wrong vote step " << v.getStep();
+                   << v->getHash() << " has wrong vote step " << v->getStep();
       break;
-    } else if (v.getBlockHash() != pbft_block_and_votes.pbft_blk->getBlockHash()) {
+    } else if (v->getBlockHash() != pbft_block_and_votes.pbft_blk->getBlockHash()) {
       LOG(log_er_) << "For PBFT block " << pbft_block_and_votes.pbft_blk->getBlockHash() << ", cert vote "
-                   << v.getHash() << " has wrong vote block hash " << v.getBlockHash();
+                   << v->getHash() << " has wrong vote block hash " << v->getBlockHash();
       break;
     }
 
@@ -576,7 +576,7 @@ bool VoteManager::pbftBlockHasEnoughValidCertVotes(SyncBlock& pbft_block_and_vot
       valid_votes.emplace_back(v);
     } else {
       LOG(log_wr_) << "For PBFT block " << pbft_block_and_votes.pbft_blk->getBlockHash() << ", cert vote "
-                   << v.getHash() << " failed validation";
+                   << v->getHash() << " failed validation";
     }
   }
 
@@ -617,7 +617,7 @@ std::vector<std::shared_ptr<Vote>> VoteManager::getProposalVotes(uint64_t pbft_r
   sharedLock_ lock(verified_votes_access_);
   for (auto const& voted_value : verified_votes_[pbft_round][1]) {
     for (auto const& v : voted_value.second) {
-      proposal_votes.emplace_back(std::make_shared<Vote>(v.second));
+      proposal_votes.emplace_back(v.second);
     }
   }
 
@@ -625,7 +625,7 @@ std::vector<std::shared_ptr<Vote>> VoteManager::getProposalVotes(uint64_t pbft_r
 }
 
 VotesBundle VoteManager::getVotesBundleByRoundAndStep(uint64_t round, size_t step, size_t two_t_plus_one) {
-  std::vector<Vote> votes;
+  std::vector<std::shared_ptr<Vote>> votes;
 
   sharedLock_ lock(verified_votes_access_);
   auto found_round_it = verified_votes_.find(round);
@@ -688,7 +688,7 @@ uint64_t VoteManager::roundDeterminedFromVotes(size_t two_t_plus_one) {
 }
 
 NextVotesForPreviousRound::NextVotesForPreviousRound(addr_t node_addr, std::shared_ptr<DbStorage> db)
-    : db_(db), enough_votes_for_null_block_hash_(false), voted_value_(NULL_BLOCK_HASH), next_votes_size_(0) {
+    : db_(std::move(db)), enough_votes_for_null_block_hash_(false), voted_value_(NULL_BLOCK_HASH), next_votes_size_(0) {
   LOG_OBJECTS_CREATE("NEXT_VOTES");
 }
 
@@ -721,8 +721,8 @@ blk_hash_t NextVotesForPreviousRound::getVotedValue() const {
   return voted_value_;
 }
 
-std::vector<Vote> NextVotesForPreviousRound::getNextVotes() {
-  std::vector<Vote> next_votes_bundle;
+std::vector<std::shared_ptr<Vote>> NextVotesForPreviousRound::getNextVotes() {
+  std::vector<std::shared_ptr<Vote>> next_votes_bundle;
 
   sharedLock_ lock(access_);
   for (auto const& blk_hash_nv : next_votes_) {
@@ -741,7 +741,8 @@ size_t NextVotesForPreviousRound::getNextVotesSize() const {
 // Assumption is that all votes are validated, in next voting phase, in the same round.
 // Votes for same voted value are in the same step
 // Voted values have maximum 2 PBFT block hashes, NULL_BLOCK_HASH and a non NULL_BLOCK_HASH
-void NextVotesForPreviousRound::addNextVotes(std::vector<Vote> const& next_votes, size_t pbft_2t_plus_1) {
+void NextVotesForPreviousRound::addNextVotes(std::vector<std::shared_ptr<Vote>> const& next_votes,
+                                             size_t pbft_2t_plus_1) {
   if (next_votes.empty()) {
     return;
   }
@@ -752,9 +753,9 @@ void NextVotesForPreviousRound::addNextVotes(std::vector<Vote> const& next_votes
   }
 
   auto own_votes = getNextVotes();
-  const auto sync_voted_round = next_votes[0].getRound();
+  const auto sync_voted_round = next_votes[0]->getRound();
   if (!own_votes.empty()) {
-    auto own_previous_round = own_votes[0].getRound();
+    auto own_previous_round = own_votes[0]->getRound();
     if (own_previous_round != sync_voted_round) {
       LOG(log_dg_) << "Drop it. The previous PBFT round has been at " << own_previous_round
                    << ", syncing next votes voted at round " << sync_voted_round;
@@ -770,9 +771,9 @@ void NextVotesForPreviousRound::addNextVotes(std::vector<Vote> const& next_votes
   // Add all next votes
   std::unordered_set<blk_hash_t> voted_values;
   for (auto const& v : next_votes) {
-    LOG(log_dg_) << "Add next vote: " << v;
+    LOG(log_dg_) << "Add next vote: " << *v;
 
-    auto vote_hash = v.getHash();
+    auto vote_hash = v->getHash();
     if (next_votes_set_.count(vote_hash)) {
       continue;
     }
@@ -794,7 +795,7 @@ void NextVotesForPreviousRound::addNextVotes(std::vector<Vote> const& next_votes
   // Update list of next votes in database by new unique votes
   db_->saveNextVotes(sync_voted_round, next_votes_in_db);
 
-  LOG(log_dg_) << "PBFT 2t+1 is " << pbft_2t_plus_1 << " in round " << next_votes[0].getRound();
+  LOG(log_dg_) << "PBFT 2t+1 is " << pbft_2t_plus_1 << " in round " << next_votes[0]->getRound();
   for (auto const& voted_value : voted_values) {
     auto const& voted_value_next_votes_size = next_votes_.at(voted_value).size();
     if (voted_value_next_votes_size >= pbft_2t_plus_1) {
@@ -815,7 +816,7 @@ void NextVotesForPreviousRound::addNextVotes(std::vector<Vote> const& next_votes
       LOG(log_dg_) << "Shoud not happen here. Voted PBFT block hash " << voted_value << " has "
                    << voted_value_next_votes_size << " next votes. Not enough, removed!";
       for (auto const& v : next_votes_.at(voted_value)) {
-        next_votes_set_.erase(v.getHash());
+        next_votes_set_.erase(v->getHash());
       }
       next_votes_size_ -= voted_value_next_votes_size;
       next_votes_.erase(voted_value);
@@ -837,7 +838,8 @@ void NextVotesForPreviousRound::addNextVotes(std::vector<Vote> const& next_votes
 }
 
 // Assumption is that all votes are validated, in next voting phase, in the same round and step
-void NextVotesForPreviousRound::updateNextVotes(std::vector<Vote> const& next_votes, size_t pbft_2t_plus_1) {
+void NextVotesForPreviousRound::updateNextVotes(std::vector<std::shared_ptr<Vote>> const& next_votes,
+                                                size_t pbft_2t_plus_1) {
   LOG(log_nf_) << "There are " << next_votes.size() << " next votes for updating.";
   if (next_votes.empty()) {
     return;
@@ -849,21 +851,21 @@ void NextVotesForPreviousRound::updateNextVotes(std::vector<Vote> const& next_vo
 
   // Copy all next votes
   for (auto const& v : next_votes) {
-    LOG(log_dg_) << "Add next vote: " << v;
+    LOG(log_dg_) << "Add next vote: " << *v;
 
-    next_votes_set_.insert(v.getHash());
-    auto voted_block_hash = v.getBlockHash();
+    next_votes_set_.insert(v->getHash());
+    auto voted_block_hash = v->getBlockHash();
     if (next_votes_.count(voted_block_hash)) {
       next_votes_[voted_block_hash].emplace_back(v);
     } else {
-      std::vector<Vote> votes{v};
-      next_votes_[voted_block_hash] = votes;
+      std::vector<std::shared_ptr<Vote>> votes{v};
+      next_votes_[voted_block_hash] = std::move(votes);
     }
   }
 
   // Protect for malicious players. If no malicious players, will include either/both NULL BLOCK HASH and a non NULL
   // BLOCK HASH
-  LOG(log_nf_) << "PBFT 2t+1 is " << pbft_2t_plus_1 << " in round " << next_votes[0].getRound();
+  LOG(log_nf_) << "PBFT 2t+1 is " << pbft_2t_plus_1 << " in round " << next_votes[0]->getRound();
   auto next_votes_size = next_votes.size();
 
   auto it = next_votes_.begin();
@@ -886,7 +888,7 @@ void NextVotesForPreviousRound::updateNextVotes(std::vector<Vote> const& next_vo
       LOG(log_dg_) << "Voted PBFT block hash " << it->first << " has " << it->second.size()
                    << " next votes. Not enough, removed!";
       for (auto const& v : it->second) {
-        next_votes_set_.erase(v.getHash());
+        next_votes_set_.erase(v->getHash());
       }
       next_votes_size -= it->second.size();
       it = next_votes_.erase(it);
@@ -911,7 +913,8 @@ void NextVotesForPreviousRound::updateNextVotes(std::vector<Vote> const& next_vo
 
 // Assumption is that all synced votes are in next voting phase, in the same round.
 // Valid voted values have maximum 2 block hash, NULL_BLOCK_HASH and a non NULL_BLOCK_HASH
-void NextVotesForPreviousRound::updateWithSyncedVotes(std::vector<Vote> const& next_votes, size_t pbft_2t_plus_1) {
+void NextVotesForPreviousRound::updateWithSyncedVotes(std::vector<std::shared_ptr<Vote>> const& next_votes,
+                                                      size_t pbft_2t_plus_1) {
   // TODO: need do vote verificaton
   if (next_votes.empty()) {
     LOG(log_er_) << "Synced next votes is empty.";
@@ -923,7 +926,7 @@ void NextVotesForPreviousRound::updateWithSyncedVotes(std::vector<Vote> const& n
     return;
   }
 
-  std::unordered_map<blk_hash_t, std::vector<Vote>> own_votes_map;
+  std::unordered_map<blk_hash_t, std::vector<std::shared_ptr<Vote>>> own_votes_map;
   {
     sharedLock_ lock(access_);
     own_votes_map = next_votes_;
@@ -935,23 +938,23 @@ void NextVotesForPreviousRound::updateWithSyncedVotes(std::vector<Vote> const& n
     return;
   }
 
-  std::unordered_map<blk_hash_t, std::vector<Vote>> synced_next_votes;
+  std::unordered_map<blk_hash_t, std::vector<std::shared_ptr<Vote>>> synced_next_votes;
   // All next votes should be in the next voting phase and in the same voted round
   for (size_t i = 0; i < next_votes.size(); i++) {
-    if (next_votes[i].getType() != next_vote_type) {
-      LOG(log_er_) << "Synced next vote is not at next voting phase. Vote " << next_votes[i];
+    if (next_votes[i]->getType() != next_vote_type) {
+      LOG(log_er_) << "Synced next vote is not at next voting phase. Vote " << *next_votes[i];
       return;
-    } else if (next_votes[i].getRound() != next_votes[0].getRound()) {
-      LOG(log_er_) << "Synced next votes have a different voted PBFT round. Vote1 " << next_votes[0] << ", Vote2 "
-                   << next_votes[i];
+    } else if (next_votes[i]->getRound() != next_votes[0]->getRound()) {
+      LOG(log_er_) << "Synced next votes have a different voted PBFT round. Vote1 " << *next_votes[0] << ", Vote2 "
+                   << *next_votes[i];
       return;
     }
 
-    auto voted_block_hash = next_votes[i].getBlockHash();
+    auto voted_block_hash = next_votes[i]->getBlockHash();
     if (synced_next_votes.count(voted_block_hash)) {
       synced_next_votes[voted_block_hash].emplace_back(next_votes[i]);
     } else {
-      std::vector<Vote> votes{next_votes[i]};
+      std::vector<std::shared_ptr<Vote>> votes{next_votes[i]};
       synced_next_votes[voted_block_hash] = std::move(votes);
     }
   }
@@ -959,11 +962,11 @@ void NextVotesForPreviousRound::updateWithSyncedVotes(std::vector<Vote> const& n
   // Next votes for same voted value should be in the same step
   for (auto const& voted_value_and_votes : synced_next_votes) {
     auto votes = voted_value_and_votes.second;
-    auto voted_step = votes[0].getStep();
+    auto voted_step = votes[0]->getStep();
     for (size_t i = 1; i < votes.size(); i++) {
-      if (votes[i].getStep() != voted_step) {
-        LOG(log_er_) << "Synced next votes have a different voted PBFT step. Vote1 " << votes[0] << ", Vote2 "
-                     << votes[i];
+      if (votes[i]->getStep() != voted_step) {
+        LOG(log_er_) << "Synced next votes have a different voted PBFT step. Vote1 " << *votes[0] << ", Vote2 "
+                     << *votes[i];
         return;
       }
     }
@@ -977,24 +980,24 @@ void NextVotesForPreviousRound::updateWithSyncedVotes(std::vector<Vote> const& n
     return;
   }
 
-  std::vector<Vote> update_votes;
+  std::vector<std::shared_ptr<Vote>> update_votes;
   // Don't update votes for same valid voted value that >= 2t+1
   for (auto const& voted_value_and_votes : synced_next_votes) {
     if (own_votes_map.count(voted_value_and_votes.first)) {
       continue;
     }
-
+    
     if (voted_value_and_votes.second.size() >= pbft_2t_plus_1) {
       LOG(log_nf_) << "Don't have the voted value " << voted_value_and_votes.first << " for previous round. Add votes";
       for (auto const& v : voted_value_and_votes.second) {
-        LOG(log_dg_) << "Add next vote " << v;
+        LOG(log_dg_) << "Add next vote " << *v;
         update_votes.emplace_back(v);
       }
     } else {
       LOG(log_dg_) << "Voted value " << voted_value_and_votes.first
                    << " doesn't have enough next votes. Size of syncing next votes "
                    << voted_value_and_votes.second.size() << ", PBFT 2t+1 is " << pbft_2t_plus_1 << " for round "
-                   << voted_value_and_votes.second[0].getRound();
+                   << voted_value_and_votes.second[0]->getRound();
     }
   }
 
@@ -1002,20 +1005,21 @@ void NextVotesForPreviousRound::updateWithSyncedVotes(std::vector<Vote> const& n
   addNextVotes(update_votes, pbft_2t_plus_1);
 }
 
-void NextVotesForPreviousRound::assertError_(std::vector<Vote> next_votes_1, std::vector<Vote> next_votes_2) const {
+void NextVotesForPreviousRound::assertError_(std::vector<std::shared_ptr<Vote>> next_votes_1,
+                                             std::vector<std::shared_ptr<Vote>> next_votes_2) const {
   if (next_votes_1.empty() || next_votes_2.empty()) {
     return;
   }
 
   LOG(log_er_) << "There are more than one voted values on non NULL_BLOCK_HASH have 2t+1 next votes.";
 
-  LOG(log_er_) << "Voted value " << next_votes_1[0].getBlockHash();
+  LOG(log_er_) << "Voted value " << next_votes_1[0]->getBlockHash();
   for (auto const& v : next_votes_1) {
-    LOG(log_er_) << v;
+    LOG(log_er_) << *v;
   }
-  LOG(log_er_) << "Voted value " << next_votes_2[0].getBlockHash();
+  LOG(log_er_) << "Voted value " << next_votes_2[0]->getBlockHash();
   for (auto const& v : next_votes_2) {
-    LOG(log_er_) << v;
+    LOG(log_er_) << *v;
   }
 
   assert(false);

--- a/src/consensus/vote.cpp
+++ b/src/consensus/vote.cpp
@@ -644,7 +644,8 @@ votesBundle VoteManager::getVotesBundleByRoundAndStep(uint64_t const& round, siz
     LOG(log_nf_) << "Found enough " << votes_hash.size() << " votes at voted value " << voted_block_hash
                  << " for round " << round << " step " << step;
 
-    std::vector<Vote> votes(two_t_plus_one);
+    std::vector<Vote> votes;
+    votes.reserve(two_t_plus_one);
     for (auto const& v_hash : votes_hash) {
       auto vote = db_->getVerifiedVote(v_hash);
       assert(vote);

--- a/src/consensus/vote.cpp
+++ b/src/consensus/vote.cpp
@@ -614,10 +614,10 @@ std::string VoteManager::getJsonStr(std::vector<std::shared_ptr<Vote>> const& vo
 
 std::vector<std::shared_ptr<Vote>> VoteManager::getProposalVotes(uint64_t pbft_round) {
   std::vector<std::shared_ptr<Vote>> proposal_votes;
-  // For each proposed value should only have one vote(except NULL_BLOCK_HASH)
-  proposal_votes.reserve(verified_votes_[pbft_round][1].size());
 
   sharedLock_ lock(verified_votes_access_);
+  // For each proposed value should only have one vote(except NULL_BLOCK_HASH)
+  proposal_votes.reserve(verified_votes_[pbft_round][1].size());
   for (auto const& voted_value : verified_votes_[pbft_round][1]) {
     for (auto const& v : voted_value.second) {
       proposal_votes.emplace_back(v.second);

--- a/src/consensus/vote.cpp
+++ b/src/consensus/vote.cpp
@@ -174,7 +174,7 @@ void VoteManager::addUnverifiedVotes(std::vector<Vote> const& votes) {
   }
 }
 
-void VoteManager::removeUnverifiedVote(uint64_t const& pbft_round, vote_hash_t const& vote_hash) {
+void VoteManager::removeUnverifiedVote(uint64_t const pbft_round, vote_hash_t const& vote_hash) {
   upgradableLock_ lock(unverified_votes_access_);
   if (unverified_votes_.count(pbft_round)) {
     upgradeLock_ locked(lock);
@@ -182,7 +182,7 @@ void VoteManager::removeUnverifiedVote(uint64_t const& pbft_round, vote_hash_t c
   }
 }
 
-bool VoteManager::voteInUnverifiedMap(uint64_t const& pbft_round, vote_hash_t const& vote_hash) {
+bool VoteManager::voteInUnverifiedMap(uint64_t const pbft_round, vote_hash_t const& vote_hash) {
   sharedLock_ lock(unverified_votes_access_);
   if (unverified_votes_.count(pbft_round)) {
     return unverified_votes_[pbft_round].count(vote_hash);
@@ -336,8 +336,8 @@ void VoteManager::clearVerifiedVotesTable() {
 }
 
 // Verify all unverified votes >= pbft_round
-void VoteManager::verifyVotes(uint64_t const& pbft_round, size_t const& sortition_threshold,
-                              uint64_t const& dpos_total_votes_count,
+void VoteManager::verifyVotes(uint64_t const pbft_round, size_t const sortition_threshold,
+                              uint64_t const dpos_total_votes_count,
                               std::function<size_t(addr_t const&)> const& dpos_eligible_vote_count) {
   // Cleanup votes for previous rounds
   cleanupVotes(pbft_round);
@@ -412,7 +412,7 @@ void VoteManager::verifyVotes(uint64_t const& pbft_round, size_t const& sortitio
 }
 
 // cleanup votes < pbft_round
-void VoteManager::cleanupVotes(uint64_t const& pbft_round) {
+void VoteManager::cleanupVotes(uint64_t const pbft_round) {
   // Remove unverified votes
   vector<vote_hash_t> remove_unverified_votes_hash;
   {
@@ -497,8 +497,8 @@ void VoteManager::cleanupVotes(uint64_t const& pbft_round) {
   db_->commitWriteBatch(batch);
 }
 
-bool VoteManager::voteValidation(taraxa::Vote& vote, size_t const& dpos_total_votes_count,
-                                 size_t const& sortition_threshold) const {
+bool VoteManager::voteValidation(taraxa::Vote& vote, size_t const dpos_total_votes_count,
+                                 size_t const sortition_threshold) const {
   if (!vote.verifyVrfSortition()) {
     LOG(log_er_) << "Invalid vrf proof. " << vote;
     return false;
@@ -589,7 +589,7 @@ std::string VoteManager::getJsonStr(std::vector<Vote> const& votes) {
   return ptroot.toStyledString();
 }
 
-std::vector<Vote> VoteManager::getProposalVotes(uint64_t const& pbft_round) {
+std::vector<Vote> VoteManager::getProposalVotes(uint64_t const pbft_round) {
   std::unordered_map<blk_hash_t, std::unordered_set<vote_hash_t>> proposal_voted_value_map;
   {
     sharedLock_ lock(verified_votes_access_);
@@ -611,8 +611,8 @@ std::vector<Vote> VoteManager::getProposalVotes(uint64_t const& pbft_round) {
   return proposal_votes;
 }
 
-votesBundle VoteManager::getVotesBundleByRoundAndStep(uint64_t const& round, size_t const& step,
-                                                      size_t const& two_t_plus_one) {
+votesBundle VoteManager::getVotesBundleByRoundAndStep(uint64_t const round, size_t const step,
+                                                      size_t const two_t_plus_one) {
   blk_hash_t voted_block_hash;
   std::vector<vote_hash_t> votes_hash;
 
@@ -658,7 +658,7 @@ votesBundle VoteManager::getVotesBundleByRoundAndStep(uint64_t const& round, siz
   return votesBundle();
 }
 
-uint64_t VoteManager::roundDeterminedFromVotes(size_t const& two_t_plus_one) {
+uint64_t VoteManager::roundDeterminedFromVotes(size_t const two_t_plus_one) {
   sharedLock_ lock(verified_votes_access_);
   for (auto rit = verified_votes_.rbegin(); rit != verified_votes_.rend(); ++rit) {
     for (auto const& step : rit->second) {

--- a/src/consensus/vote.cpp
+++ b/src/consensus/vote.cpp
@@ -613,8 +613,14 @@ std::string VoteManager::getJsonStr(std::vector<std::shared_ptr<Vote>> const& vo
 
 std::vector<std::shared_ptr<Vote>> VoteManager::getProposalVotes(uint64_t pbft_round) {
   std::vector<std::shared_ptr<Vote>> proposal_votes;
+  auto size = 0;
 
   sharedLock_ lock(verified_votes_access_);
+  for (auto const& voted_value : verified_votes_[pbft_round][1]) {
+    size += voted_value.second.size();
+  }
+  proposal_votes.reserve(size);
+
   for (auto const& voted_value : verified_votes_[pbft_round][1]) {
     for (auto const& v : voted_value.second) {
       proposal_votes.emplace_back(v.second);

--- a/src/consensus/vote.cpp
+++ b/src/consensus/vote.cpp
@@ -497,9 +497,9 @@ void VoteManager::cleanupVotes(uint64_t const& pbft_round) {
   db_->commitWriteBatch(batch);
 }
 
-bool VoteManager::voteValidation(taraxa::Vote const& vote, size_t const& dpos_total_votes_count,
+bool VoteManager::voteValidation(taraxa::Vote& vote, size_t const& dpos_total_votes_count,
                                  size_t const& sortition_threshold) const {
-  if (!vote.getVrfSortition()) {
+  if (!vote.verifyVrfSortition()) {
     LOG(log_er_) << "Invalid vrf proof. " << vote;
     return false;
   }

--- a/src/consensus/vote.cpp
+++ b/src/consensus/vote.cpp
@@ -782,7 +782,7 @@ void NextVotesForPreviousRound::addNextVotes(std::vector<std::shared_ptr<Vote>> 
     }
 
     next_votes_set_.insert(vote_hash);
-    auto voted_block_hash = v.getBlockHash();
+    auto voted_block_hash = v->getBlockHash();
     next_votes_[voted_block_hash].emplace_back(v);
 
     next_votes_size_++;
@@ -989,7 +989,7 @@ void NextVotesForPreviousRound::updateWithSyncedVotes(std::vector<std::shared_pt
     if (own_votes_map.count(voted_value_and_votes.first)) {
       continue;
     }
-    
+
     if (voted_value_and_votes.second.size() >= pbft_2t_plus_1) {
       LOG(log_nf_) << "Don't have the voted value " << voted_value_and_votes.first << " for previous round. Add votes";
       for (auto const& v : voted_value_and_votes.second) {

--- a/src/consensus/vote.cpp
+++ b/src/consensus/vote.cpp
@@ -224,6 +224,7 @@ uint64_t VoteManager::getUnverifiedVotesSize() const {
 
 std::vector<std::shared_ptr<Vote>> VoteManager::getVerifiedVotes() {
   std::vector<std::shared_ptr<Vote>> votes;
+  votes.reserve(getVerifiedVotesSize());
 
   sharedLock_ lock(verified_votes_access_);
   for (auto const& round : verified_votes_) {
@@ -613,14 +614,10 @@ std::string VoteManager::getJsonStr(std::vector<std::shared_ptr<Vote>> const& vo
 
 std::vector<std::shared_ptr<Vote>> VoteManager::getProposalVotes(uint64_t pbft_round) {
   std::vector<std::shared_ptr<Vote>> proposal_votes;
-  auto size = 0;
+  // For each proposed value should only have one vote(except NULL_BLOCK_HASH)
+  proposal_votes.reserve(verified_votes_[pbft_round][1].size());
 
   sharedLock_ lock(verified_votes_access_);
-  for (auto const& voted_value : verified_votes_[pbft_round][1]) {
-    size += voted_value.second.size();
-  }
-  proposal_votes.reserve(size);
-
   for (auto const& voted_value : verified_votes_[pbft_round][1]) {
     for (auto const& v : voted_value.second) {
       proposal_votes.emplace_back(v.second);

--- a/src/consensus/vote.cpp
+++ b/src/consensus/vote.cpp
@@ -131,7 +131,7 @@ void VoteManager::retreieveVotes_() {
         net->onNewPbftVotes(move(votes));
       }
     }
-    
+
     addVerifiedVote(v);
     LOG(log_dg_) << "Retrieved verified vote " << v;
   }

--- a/src/consensus/vote.cpp
+++ b/src/consensus/vote.cpp
@@ -610,17 +610,13 @@ std::string VoteManager::getJsonStr(std::vector<Vote> const& votes) {
   return ptroot.toStyledString();
 }
 
-std::vector<Vote> VoteManager::getProposalVotes(uint64_t pbft_round) {
-  std::unordered_map<blk_hash_t, std::unordered_map<vote_hash_t, Vote>> proposal_voted_value_map;
-  {
-    sharedLock_ lock(verified_votes_access_);
-    proposal_voted_value_map = verified_votes_[pbft_round][1];
-  }
+std::vector<std::shared_ptr<Vote>> VoteManager::getProposalVotes(uint64_t pbft_round) {
+  std::vector<std::shared_ptr<Vote>> proposal_votes;
 
-  std::vector<Vote> proposal_votes;
-  for (auto const& voted_value : proposal_voted_value_map) {
+  sharedLock_ lock(verified_votes_access_);
+  for (auto const& voted_value : verified_votes_[pbft_round][1]) {
     for (auto const& v : voted_value.second) {
-      proposal_votes.emplace_back(v.second);
+      proposal_votes.emplace_back(std::make_shared<Vote>(v.second));
     }
   }
 

--- a/src/consensus/vote.hpp
+++ b/src/consensus/vote.hpp
@@ -145,75 +145,6 @@ class Vote {
   mutable addr_t cached_voter_addr_;
 };
 
-class VoteManager {
- public:
-  VoteManager(addr_t node_addr, std::shared_ptr<DbStorage> db, std::shared_ptr<FinalChain> final_chain,
-              std::shared_ptr<PbftChain> pbft_chain);
-  ~VoteManager();
-
-  void setNetwork(std::weak_ptr<Network> network);
-
-  // Unverified votes
-  bool addUnverifiedVote(Vote const& vote);
-  void addUnverifiedVotes(std::vector<Vote> const& votes);
-  void removeUnverifiedVote(uint64_t const& pbft_round, vote_hash_t const& vote_hash);
-  bool voteInUnverifiedMap(uint64_t const& pbft_round, vote_hash_t const& vote_hash);
-  std::vector<Vote> getUnverifiedVotes();
-  void clearUnverifiedVotesTable();
-  uint64_t getUnverifiedVotesSize() const;
-  uint64_t getVerifiedVotesSize() const;
-
-  // Verified votes
-  void addVerifiedVote(Vote const& vote);
-  void removeVerifiedVotes();
-  bool voteInVerifiedMap(uint64_t const& pbft_round, vote_hash_t const& vote_hash);
-  void clearVerifiedVotesTable();
-  std::vector<Vote> getVerifiedVotes();
-
-  std::vector<Vote> getVerifiedVotes(uint64_t const pbft_round, size_t const sortition_threshold,
-                                     uint64_t dpos_total_votes_count,
-                                     std::function<size_t(addr_t const&)> const& dpos_eligible_vote_count);
-
-  void cleanupVotes(uint64_t pbft_round);
-
-  bool voteValidation(Vote& vote, size_t const valid_sortition_players, size_t const sortition_threshold) const;
-
-  bool pbftBlockHasEnoughValidCertVotes(SyncBlock& pbft_block_and_votes, size_t valid_sortition_players,
-                                        size_t sortition_threshold, size_t pbft_2t_plus_1) const;
-
-  std::string getJsonStr(std::vector<Vote> const& votes);
-
- private:
-  void retreieveVotes_();
-
-  using uniqueLock_ = boost::unique_lock<boost::shared_mutex>;
-  using sharedLock_ = boost::shared_lock<boost::shared_mutex>;
-  using upgradableLock_ = boost::upgrade_lock<boost::shared_mutex>;
-  using upgradeLock_ = boost::upgrade_to_unique_lock<boost::shared_mutex>;
-
-  // <pbft_round, <vote_hash, vote>>
-  std::map<uint64_t, std::unordered_map<vote_hash_t, Vote>> unverified_votes_;
-  std::map<uint64_t, std::unordered_map<vote_hash_t, Vote>> verified_votes_;
-
-  std::unordered_set<vote_hash_t> votes_invalid_in_current_final_chain_period_;
-  h256 current_period_final_chain_block_hash_;
-  std::map<addr_t, uint64_t> max_received_round_for_address_;
-
-  std::unique_ptr<std::thread> daemon_;
-
-  mutable boost::shared_mutex unverified_votes_access_;
-  mutable boost::shared_mutex verified_votes_access_;
-
-  addr_t node_addr_;
-
-  std::shared_ptr<DbStorage> db_;
-  std::shared_ptr<PbftChain> pbft_chain_;
-  std::shared_ptr<FinalChain> final_chain_;
-  std::weak_ptr<Network> network_;
-
-  LOG_OBJECTS_DEFINE
-};
-
 class NextVotesForPreviousRound {
  public:
   NextVotesForPreviousRound(addr_t node_addr, std::shared_ptr<DbStorage> db);
@@ -257,6 +188,93 @@ class NextVotesForPreviousRound {
   // only save votes >= 2t+1 voted at same value in map and set
   std::unordered_map<blk_hash_t, std::vector<Vote>> next_votes_;
   std::unordered_set<vote_hash_t> next_votes_set_;
+
+  LOG_OBJECTS_DEFINE
+};
+
+struct votesBundle {
+  bool enough;
+  blk_hash_t voted_block_hash;
+  std::vector<Vote> votes;  // exactly 2t+1 votes
+
+  votesBundle() : enough(false), voted_block_hash(blk_hash_t(0)) {}
+  votesBundle(bool const enough_, blk_hash_t const& voted_block_hash_, std::vector<Vote> const& votes_)
+      : enough(enough_), voted_block_hash(voted_block_hash_), votes(votes_) {}
+};
+
+class VoteManager {
+ public:
+  VoteManager(addr_t node_addr, std::shared_ptr<DbStorage> db, std::shared_ptr<FinalChain> final_chain,
+              std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<NextVotesForPreviousRound> next_votes_mgr);
+  ~VoteManager() {}
+
+  void setNetwork(std::weak_ptr<Network> network);
+
+  // Unverified votes
+  bool addUnverifiedVote(Vote const& vote);
+  void addUnverifiedVotes(std::vector<Vote> const& votes);
+  void removeUnverifiedVote(uint64_t const& pbft_round, vote_hash_t const& vote_hash);
+  bool voteInUnverifiedMap(uint64_t const& pbft_round, vote_hash_t const& vote_hash);
+  std::vector<Vote> getUnverifiedVotes();
+  void clearUnverifiedVotesTable();
+  uint64_t getUnverifiedVotesSize() const;
+  uint64_t getVerifiedVotesSize() const;
+
+  // Verified votes
+  void addVerifiedVote(Vote const& vote);
+  void removeVerifiedVotes();
+  bool voteInVerifiedMap(Vote const& vote);
+  void clearVerifiedVotesTable();
+
+  void verifyVotes(uint64_t const& pbft_round, size_t const& sortition_threshold,
+                   uint64_t const& dpos_total_votes_count,
+                   std::function<size_t(addr_t const&)> const& dpos_eligible_vote_count);
+
+  void cleanupVotes(uint64_t const& pbft_round);
+
+  bool voteValidation(Vote const& vote, size_t const& valid_sortition_players, size_t const& sortition_threshold) const;
+
+  bool pbftBlockHasEnoughValidCertVotes(SyncBlock& pbft_block_and_votes, size_t valid_sortition_players,
+                                        size_t sortition_threshold, size_t pbft_2t_plus_1) const;
+
+  std::string getJsonStr(std::vector<Vote> const& votes);
+
+  std::vector<Vote> getProposalVotes(uint64_t const& pbft_round);
+
+  votesBundle getVotesBundleByRoundAndStep(uint64_t const& round, size_t const& step, size_t const& two_t_plus_one);
+
+  uint64_t roundDeterminedFromVotes(size_t const& two_t_plus_one);
+
+ private:
+  void retreieveVotes_();
+
+  using uniqueLock_ = boost::unique_lock<boost::shared_mutex>;
+  using sharedLock_ = boost::shared_lock<boost::shared_mutex>;
+  using upgradableLock_ = boost::upgrade_lock<boost::shared_mutex>;
+  using upgradeLock_ = boost::upgrade_to_unique_lock<boost::shared_mutex>;
+
+  // <pbft_round, <vote_hash, vote>>
+  std::map<uint64_t, std::unordered_map<vote_hash_t, Vote>> unverified_votes_;
+
+  // <PBFT round, <PBFT step, <voted value, <vote hash list>>>>
+  std::map<uint64_t, std::map<size_t, std::unordered_map<blk_hash_t, std::unordered_set<vote_hash_t>>>> verified_votes_;
+
+  std::unordered_set<vote_hash_t> votes_invalid_in_current_final_chain_period_;
+  h256 current_period_final_chain_block_hash_;
+  std::map<addr_t, uint64_t> max_received_round_for_address_;
+
+  std::unique_ptr<std::thread> daemon_;
+
+  mutable boost::shared_mutex unverified_votes_access_;
+  mutable boost::shared_mutex verified_votes_access_;
+
+  addr_t node_addr_;
+
+  std::shared_ptr<DbStorage> db_;
+  std::shared_ptr<PbftChain> pbft_chain_;
+  std::shared_ptr<FinalChain> final_chain_;
+  std::shared_ptr<NextVotesForPreviousRound> previous_round_next_votes_;
+  std::weak_ptr<Network> network_;
 
   LOG_OBJECTS_DEFINE
 };

--- a/src/consensus/vote.hpp
+++ b/src/consensus/vote.hpp
@@ -232,7 +232,7 @@ class VoteManager {
 
   void cleanupVotes(uint64_t const& pbft_round);
 
-  bool voteValidation(Vote const& vote, size_t const& valid_sortition_players, size_t const& sortition_threshold) const;
+  bool voteValidation(Vote& vote, size_t const& valid_sortition_players, size_t const& sortition_threshold) const;
 
   bool pbftBlockHasEnoughValidCertVotes(SyncBlock& pbft_block_and_votes, size_t valid_sortition_players,
                                         size_t sortition_threshold, size_t pbft_2t_plus_1) const;

--- a/src/consensus/vote.hpp
+++ b/src/consensus/vote.hpp
@@ -245,7 +245,7 @@ class VoteManager {
 
   std::string getJsonStr(std::vector<Vote> const& votes);
 
-  std::vector<Vote> getProposalVotes(uint64_t pbft_round);
+  std::vector<std::shared_ptr<Vote>> getProposalVotes(uint64_t pbft_round);
 
   VotesBundle getVotesBundleByRoundAndStep(uint64_t round, size_t step, size_t two_t_plus_one);
 

--- a/src/consensus/vote.hpp
+++ b/src/consensus/vote.hpp
@@ -213,8 +213,8 @@ class VoteManager {
   // Unverified votes
   bool addUnverifiedVote(Vote const& vote);
   void addUnverifiedVotes(std::vector<Vote> const& votes);
-  void removeUnverifiedVote(uint64_t const& pbft_round, vote_hash_t const& vote_hash);
-  bool voteInUnverifiedMap(uint64_t const& pbft_round, vote_hash_t const& vote_hash);
+  void removeUnverifiedVote(uint64_t const pbft_round, vote_hash_t const& vote_hash);
+  bool voteInUnverifiedMap(uint64_t const pbft_round, vote_hash_t const& vote_hash);
   std::vector<Vote> getUnverifiedVotes();
   void clearUnverifiedVotesTable();
   uint64_t getUnverifiedVotesSize() const;
@@ -227,24 +227,23 @@ class VoteManager {
 
   void removeVerifiedVotes();
 
-  void verifyVotes(uint64_t const& pbft_round, size_t const& sortition_threshold,
-                   uint64_t const& dpos_total_votes_count,
+  void verifyVotes(uint64_t const pbft_round, size_t const sortition_threshold, uint64_t const dpos_total_votes_count,
                    std::function<size_t(addr_t const&)> const& dpos_eligible_vote_count);
 
-  void cleanupVotes(uint64_t const& pbft_round);
+  void cleanupVotes(uint64_t const pbft_round);
 
-  bool voteValidation(Vote& vote, size_t const& valid_sortition_players, size_t const& sortition_threshold) const;
+  bool voteValidation(Vote& vote, size_t const valid_sortition_players, size_t const sortition_threshold) const;
 
   bool pbftBlockHasEnoughValidCertVotes(SyncBlock& pbft_block_and_votes, size_t valid_sortition_players,
                                         size_t sortition_threshold, size_t pbft_2t_plus_1) const;
 
   std::string getJsonStr(std::vector<Vote> const& votes);
 
-  std::vector<Vote> getProposalVotes(uint64_t const& pbft_round);
+  std::vector<Vote> getProposalVotes(uint64_t const pbft_round);
 
-  votesBundle getVotesBundleByRoundAndStep(uint64_t const& round, size_t const& step, size_t const& two_t_plus_one);
+  votesBundle getVotesBundleByRoundAndStep(uint64_t const round, size_t const step, size_t const two_t_plus_one);
 
-  uint64_t roundDeterminedFromVotes(size_t const& two_t_plus_one);
+  uint64_t roundDeterminedFromVotes(size_t const two_t_plus_one);
 
  private:
   void retreieveVotes_();

--- a/src/consensus/vote.hpp
+++ b/src/consensus/vote.hpp
@@ -211,7 +211,7 @@ class VoteManager {
  public:
   VoteManager(addr_t node_addr, std::shared_ptr<DbStorage> db, std::shared_ptr<FinalChain> final_chain,
               std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<NextVotesForPreviousRound> next_votes_mgr);
-  ~VoteManager() {}
+  ~VoteManager();
 
   void setNetwork(std::weak_ptr<Network> network);
 

--- a/src/consensus/vote.hpp
+++ b/src/consensus/vote.hpp
@@ -216,11 +216,11 @@ class VoteManager {
   void setNetwork(std::weak_ptr<Network> network);
 
   // Unverified votes
-  bool addUnverifiedVote(Vote const& vote);
-  void addUnverifiedVotes(std::vector<Vote> const& votes);
+  bool addUnverifiedVote(std::shared_ptr<Vote> const& vote);
+  void addUnverifiedVotes(std::vector<std::shared_ptr<Vote>> const& votes);
   void removeUnverifiedVote(uint64_t pbft_round, vote_hash_t const& vote_hash);
   bool voteInUnverifiedMap(uint64_t pbft_round, vote_hash_t const& vote_hash);
-  std::vector<Vote> getUnverifiedVotes();
+  std::vector<std::shared_ptr<Vote>> getUnverifiedVotes();
   void clearUnverifiedVotesTable();
   uint64_t getUnverifiedVotesSize() const;
 
@@ -228,7 +228,7 @@ class VoteManager {
   void addVerifiedVote(Vote const& vote);
   bool voteInVerifiedMap(Vote const& vote);
   void clearVerifiedVotesTable();
-  std::vector<Vote> getVerifiedVotes();
+  std::vector<std::shared_ptr<Vote>> getVerifiedVotes();
   uint64_t getVerifiedVotesSize() const;
 
   void removeVerifiedVotes();
@@ -243,7 +243,7 @@ class VoteManager {
   bool pbftBlockHasEnoughValidCertVotes(SyncBlock& pbft_block_and_votes, size_t valid_sortition_players,
                                         size_t sortition_threshold, size_t pbft_2t_plus_1) const;
 
-  std::string getJsonStr(std::vector<Vote> const& votes);
+  std::string getJsonStr(std::vector<std::shared_ptr<Vote>> const& votes);
 
   std::vector<std::shared_ptr<Vote>> getProposalVotes(uint64_t pbft_round);
 

--- a/src/consensus/vote.hpp
+++ b/src/consensus/vote.hpp
@@ -163,11 +163,11 @@ class NextVotesForPreviousRound {
 
   size_t getNextVotesSize() const;
 
-  void addNextVotes(std::vector<Vote> const& next_votes, size_t const pbft_2t_plus_1);
+  void addNextVotes(std::vector<Vote> const& next_votes, size_t pbft_2t_plus_1);
 
-  void updateNextVotes(std::vector<Vote> const& next_votes, size_t const pbft_2t_plus_1);
+  void updateNextVotes(std::vector<Vote> const& next_votes, size_t pbft_2t_plus_1);
 
-  void updateWithSyncedVotes(std::vector<Vote> const& votes, size_t const pbft_2t_plus_1);
+  void updateWithSyncedVotes(std::vector<Vote> const& votes, size_t pbft_2t_plus_1);
 
  private:
   using uniqueLock_ = boost::unique_lock<boost::shared_mutex>;
@@ -192,14 +192,14 @@ class NextVotesForPreviousRound {
   LOG_OBJECTS_DEFINE
 };
 
-struct votesBundle {
+struct VotesBundle {
   bool enough;
   blk_hash_t voted_block_hash;
   std::vector<Vote> votes;  // exactly 2t+1 votes
 
-  votesBundle() : enough(false), voted_block_hash(blk_hash_t(0)) {}
-  votesBundle(bool const enough_, blk_hash_t const& voted_block_hash_, std::vector<Vote> const& votes_)
-      : enough(enough_), voted_block_hash(voted_block_hash_), votes(votes_) {}
+  VotesBundle() : enough(false), voted_block_hash(blk_hash_t(0)) {}
+  VotesBundle(bool enough, blk_hash_t const& voted_block_hash, std::vector<Vote> const& votes)
+      : enough(enough), voted_block_hash(voted_block_hash), votes(votes) {}
 };
 
 class VoteManager {
@@ -213,8 +213,8 @@ class VoteManager {
   // Unverified votes
   bool addUnverifiedVote(Vote const& vote);
   void addUnverifiedVotes(std::vector<Vote> const& votes);
-  void removeUnverifiedVote(uint64_t const pbft_round, vote_hash_t const& vote_hash);
-  bool voteInUnverifiedMap(uint64_t const pbft_round, vote_hash_t const& vote_hash);
+  void removeUnverifiedVote(uint64_t pbft_round, vote_hash_t const& vote_hash);
+  bool voteInUnverifiedMap(uint64_t pbft_round, vote_hash_t const& vote_hash);
   std::vector<Vote> getUnverifiedVotes();
   void clearUnverifiedVotesTable();
   uint64_t getUnverifiedVotesSize() const;
@@ -227,23 +227,23 @@ class VoteManager {
 
   void removeVerifiedVotes();
 
-  void verifyVotes(uint64_t const pbft_round, size_t const sortition_threshold, uint64_t const dpos_total_votes_count,
+  void verifyVotes(uint64_t pbft_round, size_t sortition_threshold, uint64_t dpos_total_votes_count,
                    std::function<size_t(addr_t const&)> const& dpos_eligible_vote_count);
 
-  void cleanupVotes(uint64_t const pbft_round);
+  void cleanupVotes(uint64_t pbft_round);
 
-  bool voteValidation(Vote& vote, size_t const valid_sortition_players, size_t const sortition_threshold) const;
+  bool voteValidation(Vote& vote, size_t valid_sortition_players, size_t sortition_threshold) const;
 
   bool pbftBlockHasEnoughValidCertVotes(SyncBlock& pbft_block_and_votes, size_t valid_sortition_players,
                                         size_t sortition_threshold, size_t pbft_2t_plus_1) const;
 
   std::string getJsonStr(std::vector<Vote> const& votes);
 
-  std::vector<Vote> getProposalVotes(uint64_t const pbft_round);
+  std::vector<Vote> getProposalVotes(uint64_t pbft_round);
 
-  votesBundle getVotesBundleByRoundAndStep(uint64_t const round, size_t const step, size_t const two_t_plus_one);
+  VotesBundle getVotesBundleByRoundAndStep(uint64_t round, size_t step, size_t two_t_plus_one);
 
-  uint64_t roundDeterminedFromVotes(size_t const two_t_plus_one);
+  uint64_t roundDeterminedFromVotes(size_t two_t_plus_one);
 
  private:
   void retreieveVotes_();

--- a/src/consensus/vote.hpp
+++ b/src/consensus/vote.hpp
@@ -192,6 +192,11 @@ class NextVotesForPreviousRound {
   LOG_OBJECTS_DEFINE
 };
 
+class VoteHash {
+ public:
+  vote_hash_t operator()(const Vote& vote) const { return vote.getHash(); }
+};
+
 struct VotesBundle {
   bool enough;
   blk_hash_t voted_block_hash;
@@ -223,6 +228,7 @@ class VoteManager {
   void addVerifiedVote(Vote const& vote);
   bool voteInVerifiedMap(Vote const& vote);
   void clearVerifiedVotesTable();
+  std::vector<Vote> getVerifiedVotes();
   uint64_t getVerifiedVotesSize() const;
 
   void removeVerifiedVotes();
@@ -253,11 +259,12 @@ class VoteManager {
   using upgradableLock_ = boost::upgrade_lock<boost::shared_mutex>;
   using upgradeLock_ = boost::upgrade_to_unique_lock<boost::shared_mutex>;
 
-  // <pbft_round, <vote_hash, vote>>
+  // <pbft round, <vote hash, vote>>
   std::map<uint64_t, std::unordered_map<vote_hash_t, Vote>> unverified_votes_;
 
-  // <PBFT round, <PBFT step, <voted value, <vote hash list>>>>
-  std::map<uint64_t, std::map<size_t, std::unordered_map<blk_hash_t, std::unordered_set<vote_hash_t>>>> verified_votes_;
+  // <PBFT round, <PBFT step, <voted value, <vote hash, vote>>>>
+  std::map<uint64_t, std::map<size_t, std::unordered_map<blk_hash_t, std::unordered_map<vote_hash_t, Vote>>>>
+      verified_votes_;
 
   std::unordered_set<vote_hash_t> votes_invalid_in_current_final_chain_period_;
   h256 current_period_final_chain_block_hash_;

--- a/src/consensus/vote.hpp
+++ b/src/consensus/vote.hpp
@@ -218,13 +218,14 @@ class VoteManager {
   std::vector<Vote> getUnverifiedVotes();
   void clearUnverifiedVotesTable();
   uint64_t getUnverifiedVotesSize() const;
-  uint64_t getVerifiedVotesSize() const;
 
   // Verified votes
   void addVerifiedVote(Vote const& vote);
-  void removeVerifiedVotes();
   bool voteInVerifiedMap(Vote const& vote);
   void clearVerifiedVotesTable();
+  uint64_t getVerifiedVotesSize() const;
+
+  void removeVerifiedVotes();
 
   void verifyVotes(uint64_t const& pbft_round, size_t const& sortition_threshold,
                    uint64_t const& dpos_total_votes_count,

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -106,9 +106,9 @@ uint64_t Network::syncTimeSeconds() const { return taraxa_capability_->getNodeSt
 
 void Network::handleMaliciousSyncPeer(dev::p2p::NodeID const &id) { taraxa_capability_->handleMaliciousSyncPeer({id}); }
 
-void Network::onNewPbftVotes(std::vector<Vote> votes) {
+void Network::onNewPbftVotes(std::vector<std::shared_ptr<Vote>> votes) {
   for (auto const &vote : votes) {
-    LOG(log_dg_) << "Network broadcast PBFT vote: " << vote.getHash();
+    LOG(log_dg_) << "Network broadcast PBFT vote: " << vote->getHash();
     taraxa_capability_->onNewPbftVote(vote);
   }
 }
@@ -162,8 +162,8 @@ void Network::sendPbftBlock(dev::p2p::NodeID const &id, PbftBlock const &pbft_bl
   taraxa_capability_->sendPbftBlock(id, pbft_block, pbft_chain_size);
 }
 
-void Network::sendPbftVote(dev::p2p::NodeID const &id, Vote const &vote) {
-  LOG(log_dg_) << "Network sent PBFT vote: " << vote.getHash() << " to: " << id;
+void Network::sendPbftVote(dev::p2p::NodeID const &id, std::shared_ptr<Vote> const &vote) {
+  LOG(log_dg_) << "Network sent PBFT vote: " << vote->getHash() << " to: " << id;
   taraxa_capability_->sendPbftVote(id, vote);
 }
 

--- a/src/network/network.hpp
+++ b/src/network/network.hpp
@@ -55,7 +55,7 @@ class Network {
 
   void handleMaliciousSyncPeer(dev::p2p::NodeID const &id);
 
-  void onNewPbftVotes(std::vector<Vote> votes);
+  void onNewPbftVotes(std::vector<std::shared_ptr<Vote>> votes);
   void broadcastPreviousRoundNextVotesBundle();
 
   // METHODS USED IN TESTS ONLY
@@ -70,7 +70,7 @@ class Network {
 
   // PBFT
   void sendPbftBlock(dev::p2p::NodeID const &id, PbftBlock const &pbft_block, uint64_t const &pbft_chain_size);
-  void sendPbftVote(dev::p2p::NodeID const &id, Vote const &vote);
+  void sendPbftVote(dev::p2p::NodeID const &id, std::shared_ptr<Vote> const &vote);
   // END METHODS USED IN TESTS ONLY
 
  private:

--- a/src/network/rpc/Test.cpp
+++ b/src/network/rpc/Test.cpp
@@ -319,7 +319,7 @@ Json::Value Test::get_votes(const Json::Value & /*param1*/) {
 
       auto verified_votes = vote_mgr->getVerifiedVotes();
       auto unverified_votes = vote_mgr->getUnverifiedVotes();
-      std::vector<Vote> votes;
+      std::vector<std::shared_ptr<Vote>> votes;
       votes.reserve(verified_votes.size() + unverified_votes.size());
       votes.insert(votes.end(), verified_votes.begin(), verified_votes.end());
       votes.insert(votes.end(), unverified_votes.begin(), unverified_votes.end());

--- a/src/network/rpc/Test.cpp
+++ b/src/network/rpc/Test.cpp
@@ -315,16 +315,15 @@ Json::Value Test::get_votes(const Json::Value & /*param1*/) {
   Json::Value res;
   try {
     if (auto node = full_node_.lock()) {
-      auto db = node->getDB();
+      auto vote_mgr = node->getVoteManager();
 
-      auto verified_votes = db->getVerifiedVotes();
-      auto unverified_votes = db->getUnverifiedVotes();
+      auto verified_votes = vote_mgr->getVerifiedVotes();
+      auto unverified_votes = vote_mgr->getUnverifiedVotes();
       std::vector<Vote> votes;
       votes.reserve(verified_votes.size() + unverified_votes.size());
       votes.insert(votes.end(), verified_votes.begin(), verified_votes.end());
       votes.insert(votes.end(), unverified_votes.begin(), unverified_votes.end());
 
-      auto vote_mgr = node->getVoteManager();
       res = vote_mgr->getJsonStr(votes);
     }
   } catch (std::exception &e) {

--- a/src/network/rpc/Test.cpp
+++ b/src/network/rpc/Test.cpp
@@ -315,15 +315,16 @@ Json::Value Test::get_votes(const Json::Value & /*param1*/) {
   Json::Value res;
   try {
     if (auto node = full_node_.lock()) {
-      std::shared_ptr<VoteManager> vote_mgr = node->getVoteManager();
+      auto db = node->getDB();
 
-      auto verified_votes = vote_mgr->getVerifiedVotes();
-      auto unverified_votes = vote_mgr->getUnverifiedVotes();
+      auto verified_votes = db->getVerifiedVotes();
+      auto unverified_votes = db->getUnverifiedVotes();
       std::vector<Vote> votes;
       votes.reserve(verified_votes.size() + unverified_votes.size());
       votes.insert(votes.end(), verified_votes.begin(), verified_votes.end());
       votes.insert(votes.end(), unverified_votes.begin(), unverified_votes.end());
 
+      auto vote_mgr = node->getVoteManager();
       res = vote_mgr->getJsonStr(votes);
     }
   } catch (std::exception &e) {

--- a/src/network/tarcap/packets_handlers/vote_packets_handler.hpp
+++ b/src/network/tarcap/packets_handlers/vote_packets_handler.hpp
@@ -21,9 +21,10 @@ class VotePacketsHandler : public PacketHandler {
 
   virtual ~VotePacketsHandler() = default;
 
-  void sendPbftVote(dev::p2p::NodeID const& peer_id, Vote const& vote);
-  void onNewPbftVote(Vote const& vote);
-  void sendPbftNextVotes(dev::p2p::NodeID const& peer_id, std::vector<Vote> const& send_next_votes_bundle);
+  void sendPbftVote(dev::p2p::NodeID const& peer_id, std::shared_ptr<Vote> const& vote);
+  void onNewPbftVote(std::shared_ptr<Vote> const& vote);
+  void sendPbftNextVotes(dev::p2p::NodeID const& peer_id,
+                         std::vector<std::shared_ptr<Vote>> const& send_next_votes_bundle);
   void broadcastPreviousRoundNextVotesBundle();
 
  private:

--- a/src/network/tarcap/taraxa_capability.cpp
+++ b/src/network/tarcap/taraxa_capability.cpp
@@ -378,7 +378,7 @@ void TaraxaCapability::onNewPbftBlock(std::shared_ptr<PbftBlock> const &pbft_blo
       ->onNewPbftBlock(*pbft_block);
 }
 
-void TaraxaCapability::onNewPbftVote(const Vote &vote) {
+void TaraxaCapability::onNewPbftVote(const std::shared_ptr<Vote> &vote) {
   std::static_pointer_cast<VotePacketsHandler>(
       packets_handlers_->getSpecificHandler(PriorityQueuePacketType::kPqPbftVotePacket))
       ->onNewPbftVote(vote);
@@ -433,7 +433,7 @@ void TaraxaCapability::sendPbftBlock(dev::p2p::NodeID const &id, PbftBlock const
       ->sendPbftBlock(id, pbft_block, pbft_chain_size);
 }
 
-void TaraxaCapability::sendPbftVote(dev::p2p::NodeID const &id, Vote const &vote) {
+void TaraxaCapability::sendPbftVote(dev::p2p::NodeID const &id, std::shared_ptr<Vote> const &vote) {
   std::static_pointer_cast<VotePacketsHandler>(
       packets_handlers_->getSpecificHandler(PriorityQueuePacketType::kPqPbftVotePacket))
       ->sendPbftVote(id, vote);

--- a/src/network/tarcap/taraxa_capability.hpp
+++ b/src/network/tarcap/taraxa_capability.hpp
@@ -74,7 +74,7 @@ class TaraxaCapability : public dev::p2p::CapabilityFace {
   void onNewBlockVerified(std::shared_ptr<DagBlock> const &blk, bool proposed);
   void onNewTransactions(const std::vector<Transaction> &transactions);
   void onNewPbftBlock(std::shared_ptr<PbftBlock> const &pbft_block);
-  void onNewPbftVote(const Vote &vote);
+  void onNewPbftVote(const std::shared_ptr<Vote> &vote);
   void broadcastPreviousRoundNextVotesBundle();
   void sendTransactions(dev::p2p::NodeID const &id, std::vector<taraxa::bytes> const &transactions);
   void handleMaliciousSyncPeer(dev::p2p::NodeID const &id);
@@ -92,7 +92,7 @@ class TaraxaCapability : public dev::p2p::CapabilityFace {
 
   // PBFT
   void sendPbftBlock(dev::p2p::NodeID const &id, PbftBlock const &pbft_block, uint64_t pbft_chain_size);
-  void sendPbftVote(dev::p2p::NodeID const &id, Vote const &vote);
+  void sendPbftVote(dev::p2p::NodeID const &id, std::shared_ptr<Vote> const &vote);
   // END METHODS USED IN TESTS ONLY
 
  private:

--- a/src/node/full_node.cpp
+++ b/src/node/full_node.cpp
@@ -93,14 +93,14 @@ void FullNode::init() {
                  << dag_genesis_hash_from_db << " in DB";
     assert(false);
   }
-
+  
   pbft_chain_ = std::make_shared<PbftChain>(genesis_hash, node_addr, db_);
   next_votes_mgr_ = std::make_shared<NextVotesForPreviousRound>(node_addr, db_);
   dag_blk_mgr_ = std::make_shared<DagBlockManager>(node_addr, conf_.chain.vdf, conf_.chain.final_chain.state.dpos,
                                                    4 /* verifer thread*/, db_, trx_mgr_, final_chain_, pbft_chain_,
                                                    log_time_, conf_.test_params.max_block_queue_warn);
   dag_mgr_ = std::make_shared<DagManager>(genesis_hash, node_addr, trx_mgr_, pbft_chain_, dag_blk_mgr_, db_, log_time_);
-  vote_mgr_ = std::make_shared<VoteManager>(node_addr, db_, final_chain_, pbft_chain_);
+  vote_mgr_ = std::make_shared<VoteManager>(node_addr, db_, final_chain_, pbft_chain_, next_votes_mgr_);
   trx_order_mgr_ = std::make_shared<TransactionOrderManager>(node_addr, db_);
   pbft_mgr_ = std::make_shared<PbftManager>(conf_.chain.pbft, genesis_hash, node_addr, db_, pbft_chain_, vote_mgr_,
                                             next_votes_mgr_, dag_mgr_, dag_blk_mgr_, trx_mgr_, final_chain_,

--- a/src/node/full_node.cpp
+++ b/src/node/full_node.cpp
@@ -93,7 +93,7 @@ void FullNode::init() {
                  << dag_genesis_hash_from_db << " in DB";
     assert(false);
   }
-  
+
   pbft_chain_ = std::make_shared<PbftChain>(genesis_hash, node_addr, db_);
   next_votes_mgr_ = std::make_shared<NextVotesForPreviousRound>(node_addr, db_);
   dag_blk_mgr_ = std::make_shared<DagBlockManager>(node_addr, conf_.chain.vdf, conf_.chain.final_chain.state.dpos,

--- a/src/storage/db_storage.hpp
+++ b/src/storage/db_storage.hpp
@@ -240,33 +240,35 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   void addStatusFieldToBatch(StatusDbField const& field, uint64_t value, Batch& write_batch);
 
   // Unverified votes
-  std::vector<Vote> getUnverifiedVotes();
-  shared_ptr<Vote> getUnverifiedVote(vote_hash_t const& vote_hash);
+  std::vector<std::shared_ptr<Vote>> getUnverifiedVotes();
+  std::shared_ptr<Vote> getUnverifiedVote(vote_hash_t const& vote_hash);
   bool unverifiedVoteExist(vote_hash_t const& vote_hash);
-  void saveUnverifiedVote(Vote const& vote);
-  void addUnverifiedVoteToBatch(Vote const& vote, Batch& write_batch);
+  void saveUnverifiedVote(std::shared_ptr<Vote> const& vote);
+  void addUnverifiedVoteToBatch(std::shared_ptr<Vote> const& vote, Batch& write_batch);
   void removeUnverifiedVoteToBatch(vote_hash_t const& vote_hash, Batch& write_batch);
 
   // Verified votes
-  std::vector<Vote> getVerifiedVotes();
-  shared_ptr<Vote> getVerifiedVote(vote_hash_t const& vote_hash);
-  void saveVerifiedVote(Vote const& vote);
-  void addVerifiedVoteToBatch(Vote const& vote, Batch& write_batch);
+  std::vector<std::shared_ptr<Vote>> getVerifiedVotes();
+  std::shared_ptr<Vote> getVerifiedVote(vote_hash_t const& vote_hash);
+  void saveVerifiedVote(std::shared_ptr<Vote> const& vote);
+  void addVerifiedVoteToBatch(std::shared_ptr<Vote> const& vote, Batch& write_batch);
   void removeVerifiedVoteToBatch(vote_hash_t const& vote_hash, Batch& write_batch);
 
   // Soft votes
-  std::vector<Vote> getSoftVotes(uint64_t pbft_round);
-  void saveSoftVotes(uint64_t pbft_round, std::vector<Vote> const& soft_votes);
-  void addSoftVotesToBatch(uint64_t pbft_round, std::vector<Vote> const& soft_votes, Batch& write_batch);
+  std::vector<std::shared_ptr<Vote>> getSoftVotes(uint64_t pbft_round);
+  void saveSoftVotes(uint64_t pbft_round, std::vector<std::shared_ptr<Vote>> const& soft_votes);
+  void addSoftVotesToBatch(uint64_t pbft_round, std::vector<std::shared_ptr<Vote>> const& soft_votes,
+                           Batch& write_batch);
   void removeSoftVotesToBatch(uint64_t pbft_round, Batch& write_batch);
 
   // Certified votes
-  std::vector<Vote> getCertVotes(uint64_t period);
+  std::vector<std::shared_ptr<Vote>> getCertVotes(uint64_t period);
 
   // Next votes
-  std::vector<Vote> getNextVotes(uint64_t pbft_round);
-  void saveNextVotes(uint64_t pbft_round, std::vector<Vote> const& next_votes);
-  void addNextVotesToBatch(uint64_t pbft_round, std::vector<Vote> const& next_votes, Batch& write_batch);
+  std::vector<std::shared_ptr<Vote>> getNextVotes(uint64_t pbft_round);
+  void saveNextVotes(uint64_t pbft_round, std::vector<std::shared_ptr<Vote>> const& next_votes);
+  void addNextVotesToBatch(uint64_t pbft_round, std::vector<std::shared_ptr<Vote>> const& next_votes,
+                           Batch& write_batch);
   void removeNextVotesToBatch(uint64_t pbft_round, Batch& write_batch);
 
   // period_pbft_block

--- a/tests/final_chain_test.cpp
+++ b/tests/final_chain_test.cpp
@@ -48,7 +48,7 @@ struct FinalChainTest : WithDataDir {
     DagBlock dag_blk({}, {}, {}, trx_hashes, {}, secret_t::random());
     db->saveDagBlock(dag_blk);
     PbftBlock pbft_block(blk_hash_t(), blk_hash_t(), blk_hash_t(), 1, addr_t(1), KeyPair::create().secret());
-    std::vector<Vote> votes;
+    std::vector<std::shared_ptr<Vote>> votes;
     SyncBlock sync_block(pbft_block, votes);
     sync_block.dag_blocks.push_back(dag_blk);
     sync_block.transactions = trxs;

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -402,7 +402,7 @@ TEST_F(NetworkTest, node_pbft_sync) {
                         node1->getSecretKey());
   db1->putFinalizedDagBlockHashesByAnchor(batch, pbft_block1.getPivotDagBlockHash(),
                                           {pbft_block1.getPivotDagBlockHash()});
-  std::vector<Vote> votes_for_pbft_blk1;
+  std::vector<std::shared_ptr<Vote>> votes_for_pbft_blk1;
   votes_for_pbft_blk1.emplace_back(
       node1->getPbftManager()->generateVote(pbft_block1.getBlockHash(), cert_vote_type, 1, 3, 0));
   std::cout << "Generate 1 vote for first PBFT block" << std::endl;
@@ -451,7 +451,7 @@ TEST_F(NetworkTest, node_pbft_sync) {
   db1->putFinalizedDagBlockHashesByAnchor(batch, pbft_block2.getPivotDagBlockHash(),
                                           {pbft_block2.getPivotDagBlockHash()});
 
-  std::vector<Vote> votes_for_pbft_blk2;
+  std::vector<std::shared_ptr<Vote>> votes_for_pbft_blk2;
   votes_for_pbft_blk2.emplace_back(
       node1->getPbftManager()->generateVote(pbft_block2.getBlockHash(), cert_vote_type, 2, 3, 0));
   std::cout << "Generate 1 vote for second PBFT block" << std::endl;
@@ -548,7 +548,7 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
                         node1->getSecretKey());
   db1->putFinalizedDagBlockHashesByAnchor(batch, pbft_block1.getPivotDagBlockHash(),
                                           {pbft_block1.getPivotDagBlockHash()});
-  std::vector<Vote> votes_for_pbft_blk1;
+  std::vector<std::shared_ptr<Vote>> votes_for_pbft_blk1;
   votes_for_pbft_blk1.emplace_back(
       node1->getPbftManager()->generateVote(pbft_block1.getBlockHash(), cert_vote_type, 1, 3, 0));
   std::cout << "Generate 1 vote for first PBFT block" << std::endl;
@@ -662,7 +662,7 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_behind_round) {
   pbft_mgr1->stop();
 
   // Generate 3 next votes
-  std::vector<Vote> next_votes;
+  std::vector<std::shared_ptr<Vote>> next_votes;
   PbftVoteTypes type = next_vote_type;
   uint64_t round = 1;
   size_t step = 5;
@@ -670,7 +670,7 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_behind_round) {
   for (auto i = 0; i < 3; i++) {
     blk_hash_t voted_pbft_block_hash(i % 2);  // Next votes could vote on 2 values
     weighted_index = i;
-    Vote vote = pbft_mgr1->generateVote(voted_pbft_block_hash, type, round, step, weighted_index);
+    auto vote = pbft_mgr1->generateVote(voted_pbft_block_hash, type, round, step, weighted_index);
     next_votes.emplace_back(vote);
   }
 
@@ -717,7 +717,7 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_1) {
   auto& node2 = nodes[1];
 
   // Generate 4 next votes for noode1
-  std::vector<Vote> next_votes1;
+  std::vector<std::shared_ptr<Vote>> next_votes1;
   uint64_t round = 0;
   size_t step = 5;
   PbftVoteTypes type = next_vote_type;
@@ -725,7 +725,7 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_1) {
   for (auto i = 0; i < 4; i++) {
     blk_hash_t voted_pbft_block_hash1(i % 2);  // Next votes could vote on 2 values
     weighted_index = i;
-    Vote vote = node1->getPbftManager()->generateVote(voted_pbft_block_hash1, type, round, step, weighted_index);
+    auto vote = node1->getPbftManager()->generateVote(voted_pbft_block_hash1, type, round, step, weighted_index);
     next_votes1.emplace_back(vote);
   }
 
@@ -736,10 +736,10 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_1) {
 
   // Generate 2 same next votes with node1, voted same value on NULL_BLOCK_HASH
   blk_hash_t voted_pbft_block_hash2(0);
-  std::vector<Vote> next_votes2;
+  std::vector<std::shared_ptr<Vote>> next_votes2;
   for (auto i = 0; i < 2; i++) {
     weighted_index = i * 2;  // NULL_BLOCK_HASH is weighted_index at 0 and 2
-    Vote vote = node1->getPbftManager()->generateVote(voted_pbft_block_hash2, type, round, step, weighted_index);
+    auto vote = node1->getPbftManager()->generateVote(voted_pbft_block_hash2, type, round, step, weighted_index);
     next_votes2.emplace_back(vote);
   }
 
@@ -775,7 +775,7 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_2) {
   auto& node2 = nodes[1];
 
   // Generate 3 next votes for node1
-  std::vector<Vote> next_votes1;
+  std::vector<std::shared_ptr<Vote>> next_votes1;
   blk_hash_t voted_pbft_block_hash1(blk_hash_t(0));
   PbftVoteTypes type = next_vote_type;
   uint64_t round = 0;
@@ -783,7 +783,7 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_2) {
   size_t weighted_index;
   for (auto i = 0; i < 3; i++) {
     weighted_index = i;
-    Vote vote = node1->getPbftManager()->generateVote(voted_pbft_block_hash1, type, round, step, weighted_index);
+    auto vote = node1->getPbftManager()->generateVote(voted_pbft_block_hash1, type, round, step, weighted_index);
     next_votes1.emplace_back(vote);
   }
 
@@ -793,12 +793,12 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_2) {
   EXPECT_EQ(next_votes_mgr1->getNextVotesSize(), next_votes1.size());
 
   // Generate 3 different next votes with node1
-  std::vector<Vote> next_votes2;
+  std::vector<std::shared_ptr<Vote>> next_votes2;
   step = 6;
   blk_hash_t voted_pbft_block_hash2(blk_hash_t(2));
   for (auto i = 0; i < 3; i++) {
     weighted_index = i;
-    Vote vote = node2->getPbftManager()->generateVote(voted_pbft_block_hash2, type, round, step, weighted_index);
+    auto vote = node2->getPbftManager()->generateVote(voted_pbft_block_hash2, type, round, step, weighted_index);
     next_votes2.emplace_back(vote);
   }
 

--- a/tests/pbft_chain_test.cpp
+++ b/tests/pbft_chain_test.cpp
@@ -68,7 +68,7 @@ TEST_F(PbftChainTest, pbft_db_test) {
   // put into pbft chain and store into DB
   auto batch = db->createWriteBatch();
   // Add PBFT block in DB
-  std::vector<Vote> votes;
+  std::vector<std::shared_ptr<Vote>> votes;
 
   SyncBlock sync_block(pbft_block, votes);
   sync_block.dag_blocks.push_back(blk1);
@@ -154,7 +154,7 @@ TEST_F(PbftChainTest, block_broadcast) {
   auto db1 = node1->getDB();
   auto batch = db1->createWriteBatch();
   // Add PBFT block in DB
-  std::vector<Vote> votes;
+  std::vector<std::shared_ptr<Vote>> votes;
   SyncBlock sync_block(*pbft_block, votes);
   sync_block.dag_blocks.push_back(blk1);
   db1->savePeriodData(sync_block, batch);

--- a/tests/pbft_manager_test.cpp
+++ b/tests/pbft_manager_test.cpp
@@ -200,10 +200,13 @@ TEST_F(PbftManagerTest, terminate_soft_voting_pbft_block) {
   auto alternate_propose_block_hash = blk_hash_t("0000000200000000000000000000000000000000000000000000000000000000");
   auto prev_round_next_vote = pbft_mgr->generateVote(stale_block_hash, next_vote_type, 1, 4, weighted_index);
   vote_mgr->addVerifiedVote(prev_round_next_vote);
+  db->saveVerifiedVote(prev_round_next_vote);
   auto propose_vote = pbft_mgr->generateVote(stale_block_hash, propose_vote_type, 2, 1, weighted_index);
   vote_mgr->addVerifiedVote(propose_vote);
+  db->saveVerifiedVote(propose_vote);
   propose_vote = pbft_mgr->generateVote(alternate_propose_block_hash, propose_vote_type, 2, 1, weighted_index);
   vote_mgr->addVerifiedVote(propose_vote);
+  db->saveVerifiedVote(propose_vote);
 
   pbft_mgr->setLastSoftVotedValue(stale_block_hash);
 
@@ -280,6 +283,7 @@ TEST_F(PbftManagerTest, terminate_bogus_dag_anchor) {
   auto weighted_index = 0;
   auto propose_vote = pbft_mgr->generateVote(pbft_block_hash, next_vote_type, round, step, weighted_index);
   vote_mgr->addVerifiedVote(propose_vote);
+  db->saveVerifiedVote(propose_vote);
 
   pbft_mgr->start();
 
@@ -344,6 +348,7 @@ TEST_F(PbftManagerTest, terminate_missing_proposed_pbft_block) {
   auto pbft_block_hash = blk_hash_t("0000000100000000000000000000000000000000000000000000000000000000");
   auto propose_vote = pbft_mgr->generateVote(pbft_block_hash, next_vote_type, round, step, weighted_index);
   vote_mgr->addVerifiedVote(propose_vote);
+  db->saveVerifiedVote(propose_vote);
 
   pbft_mgr->start();
 

--- a/tests/pbft_manager_test.cpp
+++ b/tests/pbft_manager_test.cpp
@@ -366,10 +366,10 @@ TEST_F(PbftManagerTest, terminate_missing_proposed_pbft_block) {
     auto votes = vote_mgr->getVerifiedVotes();
 
     for (auto const &v : votes) {
-      if (propose_vote_type == v.getType() && v.getBlockHash() == NULL_BLOCK_HASH) {
+      if (propose_vote_type == v->getType() && v->getBlockHash() == NULL_BLOCK_HASH) {
         auto soft_voted_from_db = *db->getPbftMgrVotedValue(PbftMgrVotedValue::soft_voted_block_hash_in_round);
         if (soft_voted_from_db == NULL_BLOCK_HASH) {
-          soft_vote_value = v.getBlockHash();
+          soft_vote_value = v->getBlockHash();
           break;
         }
       }

--- a/tests/pbft_manager_test.cpp
+++ b/tests/pbft_manager_test.cpp
@@ -229,11 +229,11 @@ TEST_F(PbftManagerTest, terminate_soft_voting_pbft_block) {
   bool skipped_soft_voting = true;
   auto votes = vote_mgr->getVerifiedVotes();
   for (auto const &v : votes) {
-    if (soft_vote_type == v.getType()) {
-      if (v.getBlockHash() == stale_block_hash) {
+    if (soft_vote_type == v->getType()) {
+      if (v->getBlockHash() == stale_block_hash) {
         skipped_soft_voting = false;
       }
-      cout << "Found soft voted value of " << v.getBlockHash().abridged() << " in round 2" << endl;
+      cout << "Found soft voted value of " << v->getBlockHash().abridged() << " in round 2" << endl;
     }
   }
   EXPECT_EQ(skipped_soft_voting, true);
@@ -286,8 +286,8 @@ TEST_F(PbftManagerTest, terminate_bogus_dag_anchor) {
     auto soft_vote_value = blk_hash_t(0);
     auto votes = vote_mgr->getVerifiedVotes();
     for (auto const &v : votes) {
-      if (soft_vote_type == v.getType() && v.getBlockHash() == pbft_block_hash) {
-        soft_vote_value = v.getBlockHash();
+      if (soft_vote_type == v->getType() && v->getBlockHash() == pbft_block_hash) {
+        soft_vote_value = v->getBlockHash();
         break;
       }
     }

--- a/tests/vote_test.cpp
+++ b/tests/vote_test.cpp
@@ -64,20 +64,20 @@ TEST_F(VoteTest, unverified_votes) {
   EXPECT_TRUE(vote_mgr->voteInUnverifiedMap(vote.getRound(), vote.getHash()));
 
   // Generate 3 votes, (round = 1, step = 1) is duplicate
-  std::vector<Vote> unverified_votes;
+  std::vector<std::shared_ptr<Vote>> unverified_votes;
   for (auto i = 1; i <= 3; i++) {
     round = i;
     step = i;
     Vote vote = pbft_mgr->generateVote(blockhash, type, round, step, weighted_index);
-    unverified_votes.emplace_back(vote);
+    unverified_votes.emplace_back(std::make_shared<Vote>(vote));
   }
 
   vote_mgr->addUnverifiedVotes(unverified_votes);
   EXPECT_EQ(vote_mgr->getUnverifiedVotes().size(), unverified_votes.size());
   EXPECT_EQ(vote_mgr->getUnverifiedVotesSize(), unverified_votes.size());
 
-  vote_mgr->removeUnverifiedVote(unverified_votes[0].getRound(), unverified_votes[0].getHash());
-  EXPECT_FALSE(vote_mgr->voteInUnverifiedMap(unverified_votes[0].getRound(), unverified_votes[0].getHash()));
+  vote_mgr->removeUnverifiedVote(unverified_votes[0]->getRound(), unverified_votes[0]->getHash());
+  EXPECT_FALSE(vote_mgr->voteInUnverifiedMap(unverified_votes[0]->getRound(), unverified_votes[0]->getHash()));
   EXPECT_EQ(vote_mgr->getUnverifiedVotes().size(), unverified_votes.size() - 1);
   EXPECT_EQ(vote_mgr->getUnverifiedVotesSize(), unverified_votes.size() - 1);
 
@@ -196,8 +196,8 @@ TEST_F(VoteTest, add_cleanup_get_votes) {
   EXPECT_EQ(verified_votes_size, 4);
   auto votes = vote_mgr->getVerifiedVotes();
   EXPECT_EQ(votes.size(), 4);
-  for (Vote const &v : votes) {
-    EXPECT_GT(v.getRound(), 1);
+  for (auto const &v : votes) {
+    EXPECT_GT(v->getRound(), 1);
   }
 
   // Test cleanup votes

--- a/tests/vote_test.cpp
+++ b/tests/vote_test.cpp
@@ -119,8 +119,7 @@ TEST_F(VoteTest, verified_votes) {
 
 // Test moving all verified votes to unverified table/DB
 TEST_F(VoteTest, remove_verified_votes) {
-  auto node_cfgs = make_node_cfgs(1);
-  FullNode::Handle node(node_cfgs[0]);
+  auto node = create_nodes(1, true /*start*/).front();
 
   // stop PBFT manager, that will place vote
   auto pbft_mgr = node->getPbftManager();
@@ -209,8 +208,7 @@ TEST_F(VoteTest, add_cleanup_get_votes) {
 }
 
 TEST_F(VoteTest, round_determine_from_next_votes) {
-  auto node_cfgs = make_node_cfgs(1);
-  FullNode::Handle node(node_cfgs[0]);
+  auto node = create_nodes(1, true /*start*/).front();
 
   // stop PBFT manager, that will place vote
   auto pbft_mgr = node->getPbftManager();


### PR DESCRIPTION
## Purpose

Fix verified votes consume lots of memory issue when PBFT cannot make consensus on voting

## For reviewers

1. Only save verified votes hash in verified table
2. PBFT manager will not get all verified votes for current round, only get number of votes 

## Related Github issues

<!-- Include related github issues. -->

## Changes

<!-- Summary or changes that have been made. -->

## Tests

<!-- Describe what you did to test these changes, including unit tests that have been added or changed. -->

## Deployment Considerations

## Version Notes ##
{ major | minor | patch }

<!--

Decide whether this is a major, minor, or patch version change. Major is for backwards incompatible changes (This is only relevant once the service is live and in production and the major version is at least 1. While the major version is 0, it is ok to have backwards incompatible changes in a minor version.). Minor is for additional features. Patch is for bug fixes.

Describe the changes in this version. This is essentially the details you would include in the squash commit message.
-->

**NOTE: Include the version notes in the squash commit message**
