### PR TITLE
fix(peer): remove deadlock

### DIFF
--- a/src/network/taraxa_capability.cpp
+++ b/src/network/taraxa_capability.cpp
@@ -1021,10 +1021,11 @@ void TaraxaCapability::restartSyncingPbft(bool force) {
 }
 
 void TaraxaCapability::onDisconnect(NodeID const &_nodeID) {
-  LOG(log_nf_) << "Node " << _nodeID << " disconnected";
-  erasePeer(_nodeID);
-
   tp_.post([=] {
+    LOG(log_nf_) << "Node " << _nodeID << " disconnected";
+    // DO NOT MOVE THIS OUTSIDE THE TP, IT CAN CAUSE DEADLOCK
+    // CHECK checkLiveness() -> erasePeer()
+    erasePeer(_nodeID);
     cnt_received_messages_.erase(_nodeID);
     test_sums_.erase(_nodeID);
 


### PR DESCRIPTION
## Purpose

Deadlock was happening in this order:

we executed `checkLiveness()` if condition was met we went for disconnect here https://github.com/Taraxa-project/taraxa-node/blob/develop/src/network/taraxa_capability.cpp#L1418 
which will call `onDisconnect()` and then -> `erasePeer()`

in `checkLiveness` we are creating shared_lock https://github.com/Taraxa-project/taraxa-node/blob/develop/src/network/taraxa_capability.cpp#L1412 and then later in `erasePeer` we are creating uniqe_lock https://github.com/Taraxa-project/taraxa-node/blob/develop/src/network/taraxa_capability.cpp#L84 

so in this order it will cause deadlock