### PR TITLE
chore(docker) adds curl and jq to final image in order to be used for…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,6 +107,11 @@ RUN mkdir $BUILD_OUTPUT_DIR && cd $BUILD_OUTPUT_DIR \
 ###############################################################################
 FROM ubuntu:20.04
 
+# Install curl and jq
+RUN apt-get update \
+    && apt-get install -y curl jq \
+    && rm -rf /var/lib/apt/lists/*
+
 ARG BUILD_OUTPUT_DIR
 WORKDIR /root/.taraxa
 


### PR DESCRIPTION
… configuring the node and for k8s probes
