### PR TITLE
fix(peer): creating PeersState so there will be no deadlocks on peer_…

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,7 @@ set(SOURCES
         final_chain/final_chain.hpp
         logger/log.hpp
         logger/logger_config.hpp
+        network/peers_state.hpp
         network/taraxa_capability.hpp
         network/taraxa_peer.hpp
         network/syncing_state.hpp
@@ -107,6 +108,7 @@ set(SOURCES
         network/rpc/eth/Eth.cpp
         network/network.cpp
         network/packets_stats.cpp
+        network/peers_state.cpp
         network/taraxa_capability.cpp
         network/syncing_state.cpp
         node/full_node.cpp

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -81,7 +81,7 @@ Network::Network(NetworkConfig const &config, std::filesystem::path const &netwo
   diagnostic_thread_.post_loop({30000},
                                [this] { LOG(log_nf_) << "NET_TP_NUM_PENDING_TASKS=" << tp_.num_pending_tasks(); });
   diagnostic_thread_.post_loop({30000}, [this] {
-    auto peers = getAllPeers();
+    auto peers = getAllPeersIDs();
     LOG(log_nf_) << "There are " << peers.size() << " peers connected";
     for (auto const &peer : peers) {
       LOG(log_nf_) << "Connected with peer " << peer;
@@ -107,13 +107,13 @@ bool Network::isStarted() { return tp_.is_running(); }
 
 std::list<NodeEntry> Network::getAllNodes() const { return host_->getNodes(); }
 
-unsigned Network::getPeerCount() { return taraxa_capability_->getPeersCount(); }
+size_t Network::getPeerCount() { return taraxa_capability_->getPeersCount(); }
 
 unsigned Network::getNodeCount() { return host_->getNodeCount(); }
 
 Json::Value Network::getStatus() { return taraxa_capability_->getStatus(); }
 
-std::vector<NodeID> Network::getAllPeers() const { return taraxa_capability_->getAllPeers(); }
+std::vector<NodeID> Network::getAllPeersIDs() const { return taraxa_capability_->getAllPeersIDs(); }
 
 void Network::onNewBlockVerified(shared_ptr<DagBlock> const &blk) {
   tp_.post([=] {

--- a/src/network/network.hpp
+++ b/src/network/network.hpp
@@ -42,10 +42,10 @@ class Network {
   void start();
   bool isStarted();
   std::list<NodeEntry> getAllNodes() const;
-  unsigned getPeerCount();
+  size_t getPeerCount();
   unsigned getNodeCount();
   Json::Value getStatus();
-  std::vector<NodeID> getAllPeers() const;
+  std::vector<NodeID> getAllPeersIDs() const;
   void onNewBlockVerified(shared_ptr<DagBlock> const &blk);
   void onNewTransactions(std::vector<taraxa::bytes> transactions);
   void restartSyncingPbft(bool force = false);

--- a/src/network/peers_state.cpp
+++ b/src/network/peers_state.cpp
@@ -1,0 +1,114 @@
+#include "peers_state.hpp"
+
+namespace taraxa {
+
+std::mt19937_64 PeersState::urng_{std::random_device()()};
+
+std::shared_ptr<TaraxaPeer> PeersState::getPeer(dev::p2p::NodeID const &node_id) const {
+  std::shared_lock lock(peers_mutex_);
+  auto itPeer = peers_.find(node_id);
+  if (itPeer != peers_.end()) {
+    return itPeer->second;
+  }
+  return nullptr;
+}
+
+std::shared_ptr<TaraxaPeer> PeersState::getPendingPeer(dev::p2p::NodeID const &node_id) const {
+  std::shared_lock lock(peers_mutex_);
+  auto itPeer = pending_peers_.find(node_id);
+  if (itPeer != pending_peers_.end()) {
+    return itPeer->second;
+  }
+  return nullptr;
+}
+
+size_t PeersState::getPeersCount() const {
+  std::shared_lock lock(peers_mutex_);
+  return peers_.size();
+}
+
+void PeersState::erasePeer(dev::p2p::NodeID const &node_id) {
+  std::unique_lock lock(peers_mutex_);
+  pending_peers_.erase(node_id);
+  peers_.erase(node_id);
+}
+
+std::shared_ptr<TaraxaPeer> PeersState::addPendingPeer(dev::p2p::NodeID const &node_id) {
+  std::unique_lock lock(peers_mutex_);
+  auto ret = pending_peers_.emplace(node_id, std::make_shared<TaraxaPeer>(node_id));
+  if (!ret.second) {
+    // TODO: keep error level until we know exactly when and why is this happening
+    LOG(log_er_) << "Peer " << node_id.abridged() << " is already in pending peers list";
+  }
+
+  return ret.first->second;
+}
+
+std::shared_ptr<TaraxaPeer> PeersState::setPeerAsReadyToSendMessages(dev::p2p::NodeID const &node_id,
+                                                                     std::shared_ptr<TaraxaPeer> peer) {
+  std::unique_lock lock(peers_mutex_);
+  pending_peers_.erase(node_id);
+  auto ret = peers_.emplace(node_id, peer);
+  if (!ret.second) {
+    // TODO: keep error level until we know exactly when and why is this happening
+    LOG(log_er_) << "Peer " << node_id.abridged() << " is already in peers list";
+  }
+
+  return ret.first->second;
+}
+
+std::vector<dev::p2p::NodeID> PeersState::selectPeers(std::function<bool(TaraxaPeer const &)> const &_predicate) const {
+  std::vector<dev::p2p::NodeID> allowed;
+  std::shared_lock lock(peers_mutex_);
+  for (auto const &peer : peers_) {
+    if (_predicate(*peer.second)) allowed.push_back(peer.first);
+  }
+  return allowed;
+}
+
+std::vector<dev::p2p::NodeID> PeersState::getAllPeersIDs() const {
+  std::vector<dev::p2p::NodeID> peers;
+
+  std::shared_lock lock(peers_mutex_);
+  peers.reserve(peers_.size());
+  std::transform(
+      peers_.begin(), peers_.end(), std::back_inserter(peers),
+      [](std::pair<const dev::p2p::NodeID, std::shared_ptr<taraxa::TaraxaPeer>> const &peer) { return peer.first; });
+
+  return peers;
+}
+
+std::unordered_map<dev::p2p::NodeID, std::shared_ptr<TaraxaPeer>> PeersState::getAllPeers() const {
+  std::shared_lock lock(peers_mutex_);
+  return std::unordered_map<dev::p2p::NodeID, std::shared_ptr<TaraxaPeer>>(peers_.begin(), peers_.end());
+}
+
+std::vector<dev::p2p::NodeID> PeersState::getAllPendingPeers() const {
+  std::vector<dev::p2p::NodeID> peers;
+
+  std::shared_lock lock(peers_mutex_);
+  peers.reserve(pending_peers_.size());
+  std::transform(
+      pending_peers_.begin(), pending_peers_.end(), std::back_inserter(peers),
+      [](std::pair<const dev::p2p::NodeID, std::shared_ptr<taraxa::TaraxaPeer>> const &peer) { return peer.first; });
+
+  return peers;
+}
+
+std::pair<std::vector<dev::p2p::NodeID>, std::vector<dev::p2p::NodeID>> PeersState::randomPartitionPeers(
+    std::vector<dev::p2p::NodeID> const &_peers, std::size_t _number) {
+  std::vector<dev::p2p::NodeID> part1(_peers);
+  std::vector<dev::p2p::NodeID> part2;
+
+  if (_number >= _peers.size()) return std::make_pair(part1, part2);
+
+  std::shuffle(part1.begin(), part1.end(), urng_);
+
+  // Remove elements from the end of the shuffled part1 vector and move
+  // them to part2.
+  std::move(part1.begin() + _number, part1.end(), std::back_inserter(part2));
+  part1.erase(part1.begin() + _number, part1.end());
+  return std::make_pair(move(part1), move(part2));
+}
+
+}  // namespace taraxa

--- a/src/network/peers_state.hpp
+++ b/src/network/peers_state.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <libp2p/Common.h>
+
+#include <shared_mutex>
+
+#include "logger/log.hpp"
+#include "taraxa_peer.hpp"
+
+namespace taraxa {
+
+class PeersState {
+ public:
+  PeersState(addr_t const &node_addr) { LOG_OBJECTS_CREATE("PEERS"); }
+
+  std::shared_ptr<TaraxaPeer> getPeer(dev::p2p::NodeID const &node_id) const;
+  std::shared_ptr<TaraxaPeer> getPendingPeer(dev::p2p::NodeID const &node_id) const;
+  size_t getPeersCount() const;
+  std::unordered_map<dev::p2p::NodeID, std::shared_ptr<TaraxaPeer>> getAllPeers() const;
+  std::vector<dev::p2p::NodeID> getAllPeersIDs() const;
+  std::vector<dev::p2p::NodeID> getAllPendingPeers() const;
+
+  void erasePeer(dev::p2p::NodeID const &node_id);
+  std::shared_ptr<TaraxaPeer> addPendingPeer(dev::p2p::NodeID const &node_id);
+  std::shared_ptr<TaraxaPeer> setPeerAsReadyToSendMessages(dev::p2p::NodeID const &node_id,
+                                                           std::shared_ptr<TaraxaPeer> peer);
+
+  std::vector<dev::p2p::NodeID> selectPeers(std::function<bool(TaraxaPeer const &)> const &_predicate) const;
+  static std::pair<std::vector<dev::p2p::NodeID>, std::vector<dev::p2p::NodeID>> randomPartitionPeers(
+      std::vector<dev::p2p::NodeID> const &_peers, std::size_t _number);
+
+ private:
+  std::unordered_map<dev::p2p::NodeID, std::shared_ptr<TaraxaPeer>> peers_;
+  std::unordered_map<dev::p2p::NodeID, std::shared_ptr<TaraxaPeer>> pending_peers_;
+
+  static std::mt19937_64 urng_;  // Mersenne Twister psuedo-random number generator
+
+  mutable std::shared_mutex peers_mutex_;
+
+  LOG_OBJECTS_DEFINE
+};
+
+}  // namespace taraxa

--- a/src/network/rpc/Test.cpp
+++ b/src/network/rpc/Test.cpp
@@ -256,7 +256,7 @@ Json::Value Test::get_all_peers() {
   Json::Value res;
   try {
     if (auto node = full_node_.lock()) {
-      auto peers = node->getNetwork()->getAllPeers();
+      auto peers = node->getNetwork()->getAllPeersIDs();
       for (auto const &peer : peers) {
         res = res.asString() + peer.toString() + "\n";
       }


### PR DESCRIPTION
…mutex

## Purpose
So this should resolve all issues with deadlocks on `peers_mutex_`. Main issue was that we locked for reading `peers_mutex_` and then called sealAndSend that is also trying to lock for reading that mutex. This should work, but in case another thread try to lock for wrting `peers_mutex_` in between those two shared_locks we end up with deadlock as unique_lock has priority and when anything try's lock after unique_lock it needs to wait.

So basic concept what was happening:
```
Execution                                T1                          T2
    |                                    |                            |
    |             std::shared_lock lock1(peers_mutex_)                |
    |                                    |              std::unique_lock lock2(peers_mutex_)   <--waitng for lock1
    |             std::shared_lock lock3(peers_mutex_) <--waitng for lock2               
    V                                    -                            - 
```

resloves https://github.com/Taraxa-project/taraxa-node/issues/1029
 





