### PR TITLE
chore(tests): fix network_test/sync_large_pbft_block

### DIFF
--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -190,6 +190,11 @@ TEST_F(NetworkTest, sync_large_pbft_block) {
   auto pbft_blocks1 = nodes[0]->getPbftChain()->getPbftBlocks(1, 1);
   auto pbft_blocks2 = nodes2[0]->getPbftChain()->getPbftBlocks(1, 1);
   EXPECT_EQ(pbft_blocks1[0].rlp(), pbft_blocks2[0].rlp());
+
+  // this sleep is needed to process all remaining packets and destruct all network stuff
+  // on removal will cause next tests in the suite to fail because p2p port left binded
+  // see https://github.com/Taraxa-project/taraxa-node/issues/977 for more info
+  this_thread::sleep_for(1s);
 }
 
 // Test creates two Network setup and verifies sending transaction


### PR DESCRIPTION
## Purpose

Added sleep fixes the issue during destruction that caused a crash

## For reviewers

Have commits from https://github.com/Taraxa-project/taraxa-node/pull/1046 and https://github.com/Taraxa-project/taraxa-node/pull/1048. Them would be removed after merging
