### PR TITLE
chore(tests): fix async_accept error

### DIFF
--- a/src/network/rpc/RpcServer.cpp
+++ b/src/network/rpc/RpcServer.cpp
@@ -46,6 +46,7 @@ bool RpcServer::StopListening() {
   if (bool b = false; !stopped_.compare_exchange_strong(b, !b)) {
     return true;
   }
+  io_context_.stop();
   acceptor_.close();
   LOG(log_tr_) << "StopListening: ";
   return true;

--- a/src/network/rpc/WSServer.cpp
+++ b/src/network/rpc/WSServer.cpp
@@ -303,6 +303,7 @@ void WSServer::run() { do_accept(); }
 
 WSServer::~WSServer() {
   stopped_ = true;
+  ioc_.stop();
   acceptor_.close();
   boost::unique_lock<boost::shared_mutex> lock(sessions_mtx_);
   for (auto const &session : sessions) {


### PR DESCRIPTION
## Purpose

Added calls of `io_context.stop()` fixed numerous async_accept error logs

