### PR TITLE
fix(pbft): make sure don't give up a cert voted value

### DIFF
--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -1650,8 +1650,11 @@ bool PbftManager::giveUpNextVotedBlock_() {
     return true;
   }
 
+  // Check previous round cert voted value to make sure we don't give up
+  // on a previously cert voted (but unpushed) block...
   if (previous_round_next_voted_value_ == last_soft_voted_value_ && giveUpSoftVotedBlock_() &&
-      cert_voted_values_for_round_.find(getPbftRound()) == cert_voted_values_for_round_.end()) {
+      cert_voted_values_for_round_.find(getPbftRound()) == cert_voted_values_for_round_.end() &&
+      cert_voted_values_for_round_.find(getPbftRound() - 1) == cert_voted_values_for_round_.end()) {
     LOG(log_tr_) << "Giving up next voted value " << previous_round_next_voted_value_
                  << " because giving up soft voted value.";
 

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -915,22 +915,18 @@ void PbftManager::certifyBlock_() {
 
       if (executed_soft_voted_block_for_this_round || unverified_soft_vote_block_for_this_round_is_valid) {
         // generate cert vote
+        // comparePbftBlockScheduleWithDAGblocks_ has checked the cert voted block exist
+        auto cert_voted_block = pbft_chain_->getUnverifiedPbftBlock(soft_voted_block_for_this_round_.first);
+        auto batch = db_->createWriteBatch();
+        db_->addPbftCertVotedBlockHashToBatch(round, soft_voted_block_for_this_round_.first, batch);
+        db_->addPbftCertVotedBlockToBatch(*cert_voted_block, batch);
+        db_->commitWriteBatch(batch);
+        cert_voted_values_for_round_[round] = soft_voted_block_for_this_round_.first;
+        should_have_cert_voted_in_this_round_ = true;
         auto place_votes = placeVote_(soft_voted_block_for_this_round_.first, cert_vote_type, round, step_);
         if (place_votes) {
           LOG(log_nf_) << "Cert votes " << place_votes << " voting " << soft_voted_block_for_this_round_.first
                        << " in round " << round;
-
-          // comparePbftBlockScheduleWithDAGblocks_ has checked the cert voted block exist
-          auto cert_voted_block = pbft_chain_->getUnverifiedPbftBlock(soft_voted_block_for_this_round_.first);
-
-          auto batch = db_->createWriteBatch();
-          db_->addPbftCertVotedBlockHashToBatch(round, soft_voted_block_for_this_round_.first, batch);
-          db_->addPbftCertVotedBlockToBatch(*cert_voted_block, batch);
-          db_->commitWriteBatch(batch);
-
-          cert_voted_values_for_round_[round] = soft_voted_block_for_this_round_.first;
-
-          should_have_cert_voted_in_this_round_ = true;
         }
       }
     }
@@ -982,25 +978,23 @@ void PbftManager::secondFinish_() {
 
   if (!next_voted_soft_value_ && soft_voted_block_for_this_round_.second &&
       soft_voted_block_for_this_round_.first != NULL_BLOCK_HASH) {
+    db_->savePbftMgrStatus(PbftMgrStatus::next_voted_soft_value, true);
+    next_voted_soft_value_ = true;
     auto place_votes = placeVote_(soft_voted_block_for_this_round_.first, next_vote_type, round, step_);
     if (place_votes) {
       LOG(log_nf_) << "Next votes " << place_votes << " voting " << soft_voted_block_for_this_round_.first
                    << " for round " << round << ", at step " << step_;
-
-      db_->savePbftMgrStatus(PbftMgrStatus::next_voted_soft_value, true);
-      next_voted_soft_value_ = true;
     }
   }
 
   if (!next_voted_null_block_hash_ && round >= 2 &&
       (giveUpNextVotedBlock_() || step_ > MAX_WAIT_FOR_NEXT_VOTED_BLOCK_STEPS) &&
       (cert_voted_values_for_round_.find(round) == cert_voted_values_for_round_.end())) {
+    db_->savePbftMgrStatus(PbftMgrStatus::next_voted_null_block_hash, true);
+    next_voted_null_block_hash_ = true;
     auto place_votes = placeVote_(NULL_BLOCK_HASH, next_vote_type, round, step_);
     if (place_votes) {
       LOG(log_nf_) << "Next votes " << place_votes << " voting NULL BLOCK for round " << round << ", at step " << step_;
-
-      db_->savePbftMgrStatus(PbftMgrStatus::next_voted_null_block_hash, true);
-      next_voted_null_block_hash_ = true;
     }
   }
 


### PR DESCRIPTION
## Purpose

Introduced a consensus error where could give up on previously cert voted (but not pushed) value in giveUpNextVotedBlock_()

## For reviewers

<!-- Describe anything you want to call out to the reviewers e.g. areas to focus on, decisions you made, specific feedback you are looking for, etc. -->

## Related Github issues

<!-- Include related github issues. -->

## Changes

<!-- Summary or changes that have been made. -->

## Tests

<!-- Describe what you did to test these changes, including unit tests that have been added or changed. -->

## Deployment Considerations

## Version Notes ##
{ major | minor | patch }

<!--

Decide whether this is a major, minor, or patch version change. Major is for backwards incompatible changes (This is only relevant once the service is live and in production and the major version is at least 1. While the major version is 0, it is ok to have backwards incompatible changes in a minor version.). Minor is for additional features. Patch is for bug fixes.

Describe the changes in this version. This is essentially the details you would include in the squash commit message.
-->

**NOTE: Include the version notes in the squash commit message**
