### PR TITLE
Rework final chain executor

### DIFF
--- a/src/util/thread_pool.cpp
+++ b/src/util/thread_pool.cpp
@@ -12,7 +12,6 @@ ThreadPool::ThreadPool(size_t num_threads, bool _start)
 }
 
 void ThreadPool::start() {
-  std::unique_lock l(threads_mu_);
   if (!threads_.empty()) {
     return;
   }
@@ -21,13 +20,9 @@ void ThreadPool::start() {
   }
 }
 
-bool ThreadPool::is_running() const {
-  std::shared_lock l(threads_mu_);
-  return !threads_.empty();
-}
+bool ThreadPool::is_running() const { return !threads_.empty(); }
 
 void ThreadPool::stop() {
-  std::unique_lock l(threads_mu_);
   ioc_.stop();
   for (auto &th : threads_) {
     th.join();

--- a/src/util/thread_pool.hpp
+++ b/src/util/thread_pool.hpp
@@ -13,7 +13,6 @@ class ThreadPool : std::enable_shared_from_this<ThreadPool> {
   boost::asio::io_context ioc_;
   boost::asio::executor_work_guard<decltype(ioc_)::executor_type> ioc_work_;
   std::vector<std::thread> threads_;
-  mutable std::shared_mutex threads_mu_;
 
   std::atomic<uint64_t> num_pending_tasks_ = 0;
 

--- a/src/util/thread_pool.hpp
+++ b/src/util/thread_pool.hpp
@@ -49,10 +49,6 @@ class ThreadPool : std::enable_shared_from_this<ThreadPool> {
   operator task_executor_t() {
     return [this](auto &&task) { post(std::forward<task_t>(task)); };
   }
-
-  task_executor_t strand() {
-    return [s = boost::asio::make_strand(ioc_)](auto &&task) { boost::asio::post(s, std::forward<task_t>(task)); };
-  }
 };
 
 }  // namespace taraxa::util


### PR DESCRIPTION
## Purpose

1. Remove unnecessary mutex from thread_pool and it locks
2. Remove `executor_` field from `FinalChain` and replace it with direct `executor_thread_.post`. We don't need `strand` here and executor implementation caused some side-effects that caused tests failing

## For reviewers

<!-- Describe anything you want to call out to the reviewers e.g. areas to focus on, decisions you made, specific feedback you are looking for, etc. -->

## Related Github issues

<!-- Include related github issues. -->

## Changes

<!-- Summary or changes that have been made. -->

## Tests

<!-- Describe what you did to test these changes, including unit tests that have been added or changed. -->

## Deployment Considerations

## Version Notes ##
{ major | minor | patch }

<!--

Decide whether this is a major, minor, or patch version change. Major is for backwards incompatible changes (This is only relevant once the service is live and in production and the major version is at least 1. While the major version is 0, it is ok to have backwards incompatible changes in a minor version.). Minor is for additional features. Patch is for bug fixes.

Describe the changes in this version. This is essentially the details you would include in the squash commit message.
-->

**NOTE: Include the version notes in the squash commit message**
