### PR TITLE
chore(tests): fix fix_pbft_chain/pbft_db_test

### DIFF
--- a/tests/pbft_chain_test.cpp
+++ b/tests/pbft_chain_test.cpp
@@ -33,7 +33,8 @@ TEST_F(PbftChainTest, serialize_desiriablize_pbft_block) {
 
 TEST_F(PbftChainTest, pbft_db_test) {
   auto node_cfgs = make_node_cfgs(1);
-  auto node = create_nodes(node_cfgs, true /*start*/).front();
+  // There is no need to start a node for that db test
+  auto node = create_nodes(node_cfgs).front();
   auto db = node->getDB();
   std::shared_ptr<PbftChain> pbft_chain = node->getPbftChain();
   blk_hash_t pbft_chain_head_hash = pbft_chain->getHeadHash();


### PR DESCRIPTION
## Purpose

Because of not full data that was written to a db we get errors when node starting a `run` that we actually don't need