### PR TITLE
perf(dag): use interal dag block cache instead of db

### DIFF
--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -1541,7 +1541,7 @@ void PbftManager::finalize_(PbftBlock const &pbft_block, vector<h256> finalized_
       },
       [this, anchor_hash = pbft_block.getPivotDagBlockHash()](auto const &, auto &batch) {
         // Update proposal period DAG levels map
-        auto anchor = db_->getDagBlock(anchor_hash);
+        auto anchor = dag_blk_mgr_->getDagBlock(anchor_hash);
         if (!anchor) {
           LOG(log_er_) << "DB corrupted - Cannot find anchor block: " << anchor_hash << " in DB.";
           assert(false);

--- a/src/dag/dag.hpp
+++ b/src/dag/dag.hpp
@@ -23,6 +23,7 @@
 
 #include "common/types.hpp"
 #include "consensus/pbft_chain.hpp"
+#include "dag/dag_block_manager.hpp"
 #include "dag_block.hpp"
 #include "storage/db_storage.hpp"
 #include "transaction_manager/transaction_manager.hpp"
@@ -120,14 +121,14 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
   using sharedLock = boost::shared_lock<boost::shared_mutex>;
 
   explicit DagManager(blk_hash_t const &genesis, addr_t node_addr, std::shared_ptr<TransactionManager> trx_mgr,
-                      std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<DbStorage> db);
+                      std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<DagBlockManager> dag_blk_mgr,
+                      std::shared_ptr<DbStorage> db);
   virtual ~DagManager() = default;
   std::shared_ptr<DagManager> getShared();
   void stop();
 
   blk_hash_t const &get_genesis() { return genesis_; }
 
-  bool pivotAndTipsAvailable(DagBlock const &blk);
   void addDagBlock(DagBlock const &blk, bool finalized = false,
                    bool save = true);  // insert to buffer if fail
 
@@ -191,6 +192,7 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
   std::shared_ptr<Dag> total_dag_;         // contains both pivot and tips
   std::shared_ptr<TransactionManager> trx_mgr_;
   std::shared_ptr<PbftChain> pbft_chain_;
+  std::shared_ptr<DagBlockManager> dag_blk_mgr_;
   std::shared_ptr<DbStorage> db_;
   blk_hash_t anchor_;      // anchor of the last period
   blk_hash_t old_anchor_;  // anchor of the second to last period

--- a/src/dag/dag_block_manager.cpp
+++ b/src/dag/dag_block_manager.cpp
@@ -88,6 +88,25 @@ bool DagBlockManager::pivotAndTipsValid(DagBlock const &blk) {
   return true;
 }
 
+bool DagBlockManager::pivotAndTipsAvailable(DagBlock const &blk) {
+  auto dag_blk_hash = blk.getHash();
+  auto dag_blk_pivot = blk.getPivot();
+
+  if (getDagBlock(dag_blk_pivot) == nullptr) {
+    LOG(log_dg_) << "DAG Block " << dag_blk_hash << " pivot " << dag_blk_pivot << " unavailable";
+    return false;
+  }
+
+  for (auto const &t : blk.getTips()) {
+    if (getDagBlock(t) == nullptr) {
+      LOG(log_dg_) << "DAG Block " << dag_blk_hash << " tip " << t << " unavailable";
+      return false;
+    }
+  }
+
+  return true;
+}
+
 level_t DagBlockManager::getMaxDagLevelInQueue() const {
   level_t max_level = 0;
   {

--- a/src/dag/dag_block_manager.hpp
+++ b/src/dag/dag_block_manager.hpp
@@ -43,6 +43,7 @@ class DagBlockManager {
   std::shared_ptr<DagBlock> getDagBlock(blk_hash_t const &hash) const;
   void clearBlockStatausTable() { blk_status_.clear(); }
   bool pivotAndTipsValid(DagBlock const &blk);
+  bool pivotAndTipsAvailable(DagBlock const &blk);
   uint64_t getCurrentMaxProposalPeriod() const;
   uint64_t getLastProposalPeriod() const;
   void setLastProposalPeriod(uint64_t const period);

--- a/src/network/taraxa_capability.cpp
+++ b/src/network/taraxa_capability.cpp
@@ -423,7 +423,7 @@ void TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
       LOG(log_dg_dag_prp_) << "Received GetNewBlockPacket" << hash.toString();
 
       if (dag_blk_mgr_) {
-        auto block = db_->getDagBlock(hash);
+        auto block = dag_blk_mgr_->getDagBlock(hash);
         if (block) {
           sendBlock(_nodeID, *block);
         } else
@@ -454,7 +454,7 @@ void TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
           auto hash = block;
           if (mode == MissingHashes) {
             if (blocks_hashes.count(hash) == 1) {
-              if (auto blk = db_->getDagBlock(hash); blk) {
+              if (auto blk = dag_blk_mgr_->getDagBlock(hash); blk) {
                 dag_blocks.emplace_back(blk);
               } else {
                 LOG(log_er_dag_sync_) << "NonFinalizedBlock " << hash << " not in DB";
@@ -463,7 +463,7 @@ void TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
             }
           } else if (mode == KnownHashes) {
             if (blocks_hashes.count(hash) == 0) {
-              if (auto blk = db_->getDagBlock(hash); blk) {
+              if (auto blk = dag_blk_mgr_->getDagBlock(hash); blk) {
                 dag_blocks.emplace_back(blk);
               } else {
                 LOG(log_er_dag_sync_) << "NonFinalizedBlock " << hash << " not in DB";

--- a/src/node/full_node.cpp
+++ b/src/node/full_node.cpp
@@ -93,9 +93,9 @@ void FullNode::init() {
 
   emplace(pbft_chain_, genesis_hash, node_addr, db_);
   emplace(next_votes_mgr_, node_addr, db_);
-  emplace(dag_mgr_, genesis_hash, node_addr, trx_mgr_, pbft_chain_, db_);
   emplace(dag_blk_mgr_, node_addr, conf_.chain.vdf, conf_.chain.final_chain.state.dpos, 4 /* verifer thread*/, db_,
           trx_mgr_, final_chain_, pbft_chain_, log_time_, conf_.test_params.max_block_queue_warn);
+  emplace(dag_mgr_, genesis_hash, node_addr, trx_mgr_, pbft_chain_, dag_blk_mgr_, db_);
   emplace(vote_mgr_, node_addr, db_, final_chain_, pbft_chain_);
   emplace(trx_order_mgr_, node_addr, db_);
   emplace(pbft_mgr_, conf_.chain.pbft, genesis_hash, node_addr, db_, pbft_chain_, vote_mgr_, next_votes_mgr_, dag_mgr_,
@@ -220,7 +220,7 @@ void FullNode::start() {
         received_blocks_++;
       }
 
-      if (dag_mgr_->pivotAndTipsAvailable(blk)) {
+      if (dag_blk_mgr_->pivotAndTipsAvailable(blk)) {
         dag_mgr_->addDagBlock(blk);
         if (jsonrpc_ws_) {
           jsonrpc_ws_->newDagBlock(blk);

--- a/src/node/full_node.hpp
+++ b/src/node/full_node.hpp
@@ -67,9 +67,9 @@ class FullNode : public std::enable_shared_from_this<FullNode> {
   // components
   std::shared_ptr<DbStorage> db_;
   std::shared_ptr<DbStorage> old_db_;
-  std::shared_ptr<DagManager> dag_mgr_;
-  std::shared_ptr<DagBlockManager> dag_blk_mgr_;
   std::shared_ptr<TransactionManager> trx_mgr_;
+  std::shared_ptr<DagBlockManager> dag_blk_mgr_;
+  std::shared_ptr<DagManager> dag_mgr_;
   std::shared_ptr<Network> network_;
   std::shared_ptr<TransactionOrderManager> trx_order_mgr_;
   std::shared_ptr<BlockProposer> blk_proposer_;

--- a/tests/dag_test.cpp
+++ b/tests/dag_test.cpp
@@ -9,6 +9,9 @@
 
 namespace taraxa::core_tests {
 
+const auto node_cfgs = make_node_cfgs(1);
+const auto time_log = logger::createLogger(logger::Verbosity::Info, "TMSTM", addr_t());
+
 struct DagTest : BaseTest {};
 
 TEST_F(DagTest, build_dag) {
@@ -134,7 +137,11 @@ TEST_F(DagTest, genesis_get_pivot) {
 TEST_F(DagTest, compute_epoch) {
   const blk_hash_t GENESIS("0000000000000000000000000000000000000000000000000000000000000001");
   auto db_ptr = std::make_shared<DbStorage>(data_dir / "db");
-  auto mgr = std::make_shared<DagManager>(GENESIS, addr_t(), nullptr, nullptr, db_ptr);
+  auto mgr = std::make_shared<DagManager>(
+      GENESIS, addr_t(), nullptr, nullptr,
+      std::make_shared<DagBlockManager>(addr_t(), node_cfgs[0].chain.vdf, node_cfgs[0].chain.final_chain.state.dpos, 1,
+                                        db_ptr, nullptr, nullptr, nullptr, time_log),
+      db_ptr);
   DagBlock blkA(blk_hash_t(1), 0, {}, {trx_hash_t(2)}, sig_t(1), blk_hash_t(2), addr_t(1));
   DagBlock blkB(blk_hash_t(1), 0, {}, {trx_hash_t(3), trx_hash_t(4)}, sig_t(1), blk_hash_t(3), addr_t(1));
   DagBlock blkC(blk_hash_t(2), 0, {blk_hash_t(3)}, {}, sig_t(1), blk_hash_t(4), addr_t(1));
@@ -216,8 +223,12 @@ TEST_F(DagTest, compute_epoch) {
 
 TEST_F(DagTest, receive_block_in_order) {
   const blk_hash_t GENESIS("000000000000000000000000000000000000000000000000000000000000000a");
-  auto mgr =
-      std::make_shared<DagManager>(GENESIS, addr_t(), nullptr, nullptr, std::make_shared<DbStorage>(data_dir / "db"));
+  auto db_ptr = std::make_shared<DbStorage>(data_dir / "db");
+  auto mgr = std::make_shared<DagManager>(
+      GENESIS, addr_t(), nullptr, nullptr,
+      std::make_shared<DagBlockManager>(addr_t(), node_cfgs[0].chain.vdf, node_cfgs[0].chain.final_chain.state.dpos, 1,
+                                        db_ptr, nullptr, nullptr, nullptr, time_log),
+      db_ptr);
   // mgr.setVerbose(true);
   DagBlock genesis_block(blk_hash_t(0), 0, {}, {}, sig_t(777), blk_hash_t(10), addr_t(15));
   DagBlock blk1(blk_hash_t(10), 0, {}, {}, sig_t(777), blk_hash_t(1), addr_t(15));
@@ -250,7 +261,11 @@ TEST_F(DagTest, receive_block_in_order) {
 TEST_F(DagTest, compute_epoch_2) {
   const blk_hash_t GENESIS("0000000000000000000000000000000000000000000000000000000000000001");
   auto db_ptr = std::make_shared<DbStorage>(data_dir / "db");
-  auto mgr = std::make_shared<DagManager>(GENESIS, addr_t(), nullptr, nullptr, db_ptr);
+  auto mgr = std::make_shared<DagManager>(
+      GENESIS, addr_t(), nullptr, nullptr,
+      std::make_shared<DagBlockManager>(addr_t(), node_cfgs[0].chain.vdf, node_cfgs[0].chain.final_chain.state.dpos, 1,
+                                        db_ptr, nullptr, nullptr, nullptr, time_log),
+      db_ptr);
   DagBlock blkA(blk_hash_t(1), 0, {}, {trx_hash_t(2)}, sig_t(1), blk_hash_t(2), addr_t(1));
   DagBlock blkB(blk_hash_t(1), 0, {}, {trx_hash_t(3), trx_hash_t(4)}, sig_t(1), blk_hash_t(3), addr_t(1));
   DagBlock blkC(blk_hash_t(2), 0, {blk_hash_t(3)}, {}, sig_t(1), blk_hash_t(4), addr_t(1));
@@ -333,8 +348,12 @@ TEST_F(DagTest, compute_epoch_2) {
 
 TEST_F(DagTest, get_latest_pivot_tips) {
   const blk_hash_t GENESIS("0000000000000000000000000000000000000000000000000000000000000001");
-  auto mgr =
-      std::make_shared<DagManager>(GENESIS, addr_t(), nullptr, nullptr, std::make_shared<DbStorage>(data_dir / "db"));
+  auto db_ptr = std::make_shared<DbStorage>(data_dir / "db");
+  auto mgr = std::make_shared<DagManager>(
+      GENESIS, addr_t(), nullptr, nullptr,
+      std::make_shared<DagBlockManager>(addr_t(), node_cfgs[0].chain.vdf, node_cfgs[0].chain.final_chain.state.dpos, 1,
+                                        db_ptr, nullptr, nullptr, nullptr, time_log),
+      db_ptr);
 
   // mgr.setVerbose(true);
   DagBlock blk1(blk_hash_t(0), 0, {}, {}, sig_t(0), blk_hash_t(1), addr_t(15));


### PR DESCRIPTION
## Purpose

We already have internal cache for DAG blocks, but we do not use it and get them all the time from DB. With this approach we use it as much as possible 
