### PR TITLE
Optimize storing blocks to improve syncing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.16)
 # Set current version of the project
 set(TARAXA_MAJOR_VERSION 1)
 set(TARAXA_MINOR_VERSION 11)
-set(TARAXA_PATCH_VERSION 4)
+set(TARAXA_PATCH_VERSION 0)
 set(TARAXA_VERSION ${TARAXA_MAJOR_VERSION}.${TARAXA_MINOR_VERSION}.${TARAXA_PATCH_VERSION})
 
 # Any time a change in the network protocol is introduced this version should be increased

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,18 +2,18 @@ cmake_minimum_required(VERSION 3.16)
 
 # Set current version of the project
 set(TARAXA_MAJOR_VERSION 1)
-set(TARAXA_MINOR_VERSION 10)
+set(TARAXA_MINOR_VERSION 11)
 set(TARAXA_PATCH_VERSION 4)
 set(TARAXA_VERSION ${TARAXA_MAJOR_VERSION}.${TARAXA_MINOR_VERSION}.${TARAXA_PATCH_VERSION})
 
 # Any time a change in the network protocol is introduced this version should be increased
-set(TARAXA_NET_VERSION 14)
+set(TARAXA_NET_VERSION 15)
 # Major version is modified when DAG blocks, pbft blocks and any basic building blocks of our blockchan is modified
 # in the db
-set(TARAXA_DB_MAJOR_VERSION 1)
+set(TARAXA_DB_MAJOR_VERSION 2)
 # Minor version should be modified when changes to the database are made in the tables that can be rebuilt from the
 # basic tables
-set(TARAXA_DB_MINOR_VERSION 2)
+set(TARAXA_DB_MINOR_VERSION 1)
 
 # Defines Taraxa library target.
 project(taraxa-node VERSION ${TARAXA_VERSION})

--- a/src/consensus/pbft_chain.cpp
+++ b/src/consensus/pbft_chain.cpp
@@ -111,7 +111,7 @@ PbftBlockCert::PbftBlockCert(PbftBlock const& pbft_blk, std::vector<Vote> const&
 
 PbftBlockCert::PbftBlockCert(dev::RLP const& rlp) {
   auto it = rlp.begin();
-  pbft_blk.reset(new PbftBlock(*it++));
+  pbft_blk = make_shared<PbftBlock>(*it++);
   for (auto const vote_rlp : *it++) {
     cert_votes.emplace_back(vote_rlp);
   }
@@ -221,7 +221,7 @@ std::vector<std::string> PbftChain::getPbftBlocksStr(size_t period, size_t count
   for (auto i = period; i < period + count; i++) {
     auto pbft_block = db_->getPbftBlock(i);
     if (pbft_block == nullptr) {
-      LOG(log_er_) << "PBFT block period " << i << " is not exist in blocks order DB.";
+      LOG(log_er_) << "PBFT block period " << i << " does not exist in blocks order DB.";
       break;
     }
     if (hash)

--- a/src/consensus/pbft_chain.hpp
+++ b/src/consensus/pbft_chain.hpp
@@ -24,6 +24,8 @@ namespace taraxa {
 struct DbStorage;
 class FullNode;
 class Vote;
+class DagBlock;
+class Transaction;
 
 enum PbftVoteTypes : uint8_t { propose_vote_type = 0, soft_vote_type, cert_vote_type, next_vote_type };
 
@@ -70,8 +72,9 @@ struct PbftBlockCert {
 
   std::shared_ptr<PbftBlock> pbft_blk;
   std::vector<Vote> cert_votes;
+  std::map<uint64_t, std::vector<DagBlock>> dag_blocks_per_level;
+  std::vector<Transaction> transactions;
   bytes rlp() const;
-  static void encode_raw(dev::RLPStream& rlp, PbftBlock const& pbft_blk, dev::bytesConstRef votes_raw);
 };
 std::ostream& operator<<(std::ostream& strm, PbftBlockCert const& b);
 

--- a/src/consensus/pbft_chain.hpp
+++ b/src/consensus/pbft_chain.hpp
@@ -85,7 +85,6 @@ class PbftChain {
 
   PbftBlock getPbftBlockInChain(blk_hash_t const& pbft_block_hash);
   std::shared_ptr<PbftBlock> getUnverifiedPbftBlock(blk_hash_t const& pbft_block_hash);
-  std::vector<std::pair<PbftBlock, bytes>> getPbftBlocks(size_t period, size_t count);
   std::vector<std::string> getPbftBlocksStr(size_t period, size_t count, bool hash) const;  // Remove
   std::string getJsonStr() const;
 

--- a/src/consensus/pbft_chain.hpp
+++ b/src/consensus/pbft_chain.hpp
@@ -25,7 +25,7 @@ struct DbStorage;
 class FullNode;
 class Vote;
 class DagBlock;
-class Transaction;
+struct Transaction;
 
 enum PbftVoteTypes : uint8_t { propose_vote_type = 0, soft_vote_type, cert_vote_type, next_vote_type };
 

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -103,12 +103,11 @@ void PbftManager::run() {
        ++period) {
     auto pbft_block = db_->getPbftBlock(period);
     if (!pbft_block) {
-      LOG(log_er_) << "DB corrupted - Cannot find PBFT block hash " << pbft_block->getBlockHash()
-                   << " in PBFT chain DB pbft_blocks.";
+      LOG(log_er_) << "DB corrupted - Cannot find PBFT block in period " << period << " in PBFT chain DB pbft_blocks.";
       assert(false);
     }
     if (pbft_block->getPeriod() != period) {
-      LOG(log_er_) << "DB corrupted - PBFT block hash " << pbft_block->getBlockHash() << "has different period "
+      LOG(log_er_) << "DB corrupted - PBFT block hash " << pbft_block->getBlockHash() << " has different period "
                    << pbft_block->getPeriod() << " in block data than in block order db: " << period;
       assert(false);
     }
@@ -1598,6 +1597,7 @@ bool PbftManager::pushPbftBlock_(PbftBlockCert const &pbft_block_cert_votes, vec
   auto dag_blocks_res = db_query.execute();
 
   std::vector<DagBlock> dag_blocks;
+  dag_blocks.reserve(dag_blocks_res.size());
 
   for (auto const &dag_blk_raw : dag_blocks_res) {
     dag_blocks.emplace_back(asBytes(dag_blk_raw));
@@ -1617,6 +1617,7 @@ bool PbftManager::pushPbftBlock_(PbftBlockCert const &pbft_block_cert_votes, vec
   auto transactions_res = db_query.execute();
 
   std::vector<Transaction> transactions;
+  transactions.reserve(transactions_res.size());
   for (auto const &trx_raw : transactions_res) {
     if (trx_raw.size() > 0) transactions.emplace_back(asBytes(trx_raw));
   }

--- a/src/dag/dag.cpp
+++ b/src/dag/dag.cpp
@@ -444,6 +444,7 @@ void DagManager::getGhostPath(std::vector<blk_hash_t> &ghost) const {
 // return {period, block order}, for pbft-pivot-blk proposing
 std::pair<uint64_t, std::shared_ptr<vec_blk_t>> DagManager::getDagBlockOrder(blk_hash_t const &anchor) {
   sharedLock lock(mutex_);
+
   // TODO: need to check if the anchor already processed
   // if the period already processed
   vec_blk_t orders;

--- a/src/dag/dag_block_manager.cpp
+++ b/src/dag/dag_block_manager.cpp
@@ -188,6 +188,7 @@ void DagBlockManager::processSyncedBlock(DagBlock const &blk) {
 void DagBlockManager::processSyncedTransactions(std::vector<Transaction> const &transactions) {
   DbStorage::MultiGetQuery db_query(db_, transactions.size());
   std::vector<trx_hash_t> trx_hashes;
+  trx_hashes.reserve(transactions.size());
   for (auto const &trx : transactions) trx_hashes.emplace_back(trx.getHash());
   db_query.append(DbStorage::Columns::trx_status, trx_hashes);
   auto db_trxs_statuses = db_query.execute();
@@ -201,9 +202,9 @@ void DagBlockManager::processSyncedTransactions(std::vector<Transaction> const &
       status = TransactionStatus(RLP(data));
     }
     const trx_hash_t &trx_hash = trx_hashes[idx];
-    if (status.status == TransactionStatusEnum::not_seen) {
+    if (status.state == TransactionStatusEnum::not_seen) {
       db_->addTransactionToBatch(transactions[idx], trx_batch);
-    } else if (status.status == TransactionStatusEnum::in_block || status.status == TransactionStatusEnum::executed) {
+    } else if (status.state == TransactionStatusEnum::in_block || status.state == TransactionStatusEnum::executed) {
       newly_added_txs_to_block_counter--;
       continue;
     }

--- a/src/dag/dag_block_manager.cpp
+++ b/src/dag/dag_block_manager.cpp
@@ -156,8 +156,7 @@ void DagBlockManager::pushUnverifiedBlock(DagBlock const &blk, std::vector<Trans
   cond_for_unverified_qu_.notify_one();
 }
 
-void DagBlockManager::processSyncedBlockWithTransactions(const DagBlock &blk,
-                                                         const std::vector<Transaction> &transactions) {
+void DagBlockManager::processSyncedBlock(DagBlock const &blk) {
   blk_hash_t block_hash = blk.getHash();
 
   // This dag block was already processed, skip it
@@ -176,45 +175,6 @@ void DagBlockManager::processSyncedBlockWithTransactions(const DagBlock &blk,
     blk_status_.update(block_hash, BlockStatus::invalid);
     return;
   }
-
-  DbStorage::MultiGetQuery db_query(db_, all_block_trx_hashes.size());
-  db_query.append(DbStorage::Columns::trx_status, all_block_trx_hashes);
-  auto db_trxs_statuses = db_query.execute();
-
-  std::unordered_map<trx_hash_t, Transaction> known_trx(transactions.size());
-
-  std::transform(transactions.begin(), transactions.end(), std::inserter(known_trx, known_trx.end()),
-                 [](Transaction const &t) { return std::make_pair(t.getHash(), t); });
-
-  // Filter known txs + save unseen txs to the db
-  auto trx_batch = db_->createWriteBatch();
-  size_t newly_added_txs_to_block_counter = all_block_trx_hashes.size();
-  for (size_t idx = 0; idx < db_trxs_statuses.size(); ++idx) {
-    const TransactionStatus &status = db_trxs_statuses[idx].empty()
-                                          ? TransactionStatus::not_seen
-                                          : (TransactionStatus) * (uint16_t *)&db_trxs_statuses[idx][0];
-    const trx_hash_t &trx_hash = all_block_trx_hashes[idx];
-    if (status == TransactionStatus::not_seen) {
-      if (known_trx.count(trx_hash)) {
-        db_->addTransactionToBatch(known_trx[trx_hash], trx_batch);
-      } else {
-        LOG(log_er_) << "Ignore block " << block_hash << " since it has missing transaction " << trx_hash;
-        blk_status_.update(block_hash, BlockStatus::invalid);
-        return;
-      }
-    } else if (status == TransactionStatus::in_block) {
-      newly_added_txs_to_block_counter--;
-      continue;
-    }
-    db_->addTransactionStatusToBatch(trx_batch, trx_hash, TransactionStatus::in_block);
-  }
-
-  trx_mgr_->addTrxCount(newly_added_txs_to_block_counter);
-  db_->addStatusFieldToBatch(StatusDbField::TrxCount, trx_mgr_->getTransactionCount(), trx_batch);
-  db_->commitWriteBatch(trx_batch);
-
-  trx_mgr_->getTransactionQueue().removeBlockTransactionsFromQueue(all_block_trx_hashes);
-
   {
     uLock lock(shared_mutex_for_verified_qu_);
     verified_qu_[blk.getLevel()].emplace_back(blk);
@@ -223,6 +183,38 @@ void DagBlockManager::processSyncedBlockWithTransactions(const DagBlock &blk,
 
   LOG(log_dg_) << "Synced dag block: " << block_hash;
   cond_for_verified_qu_.notify_one();
+}
+
+void DagBlockManager::processSyncedTransactions(std::vector<Transaction> const &transactions) {
+  DbStorage::MultiGetQuery db_query(db_, transactions.size());
+  std::vector<trx_hash_t> trx_hashes;
+  for (auto const &trx : transactions) trx_hashes.emplace_back(trx.getHash());
+  db_query.append(DbStorage::Columns::trx_status, trx_hashes);
+  auto db_trxs_statuses = db_query.execute();
+  // Filter known txs + save unseen txs to the db
+  auto trx_batch = db_->createWriteBatch();
+  size_t newly_added_txs_to_block_counter = trx_hashes.size();
+  for (size_t idx = 0; idx < db_trxs_statuses.size(); ++idx) {
+    TransactionStatus status;
+    if (!db_trxs_statuses[idx].empty()) {
+      auto data = asBytes(db_trxs_statuses[idx]);
+      status = TransactionStatus(RLP(data));
+    }
+    const trx_hash_t &trx_hash = trx_hashes[idx];
+    if (status.status == TransactionStatusEnum::not_seen) {
+      db_->addTransactionToBatch(transactions[idx], trx_batch);
+    } else if (status.status == TransactionStatusEnum::in_block || status.status == TransactionStatusEnum::executed) {
+      newly_added_txs_to_block_counter--;
+      continue;
+    }
+    db_->addTransactionStatusToBatch(trx_batch, trx_hash, TransactionStatus(TransactionStatusEnum::in_block));
+  }
+
+  trx_mgr_->addTrxCount(newly_added_txs_to_block_counter);
+  db_->addStatusFieldToBatch(StatusDbField::TrxCount, trx_mgr_->getTransactionCount(), trx_batch);
+  db_->commitWriteBatch(trx_batch);
+
+  trx_mgr_->getTransactionQueue().removeBlockTransactionsFromQueue(trx_hashes);
 }
 
 void DagBlockManager::insertBroadcastedBlockWithTransactions(DagBlock const &blk,

--- a/src/dag/dag_block_manager.hpp
+++ b/src/dag/dag_block_manager.hpp
@@ -27,7 +27,8 @@ class DagBlockManager {
    * @param blk
    * @param transactions
    */
-  void processSyncedBlockWithTransactions(DagBlock const &blk, std::vector<Transaction> const &transactions);
+  void processSyncedBlock(DagBlock const &dag_block);
+  void processSyncedTransactions(std::vector<Transaction> const &transactions);
   void insertBroadcastedBlockWithTransactions(DagBlock const &blk, std::vector<Transaction> const &transactions);
   void pushUnverifiedBlock(DagBlock const &block,
                            bool critical);  // add to unverified queue
@@ -81,8 +82,8 @@ class DagBlockManager {
   boost::condition_variable_any cond_for_verified_qu_;
   uint32_t queue_limit_;
 
-  std::map<uint64_t, std::deque<std::pair<DagBlock, std::vector<Transaction> > > > unverified_qu_;
-  std::map<uint64_t, std::deque<DagBlock> > verified_qu_;
+  std::map<uint64_t, std::deque<std::pair<DagBlock, std::vector<Transaction>>>> unverified_qu_;
+  std::map<uint64_t, std::deque<DagBlock>> verified_qu_;
 
   vdf_sortition::VdfConfig vdf_config_;
   optional<state_api::DPOSConfig> dpos_config_;

--- a/src/final_chain/final_chain.hpp
+++ b/src/final_chain/final_chain.hpp
@@ -30,7 +30,8 @@ class FinalChain {
   virtual ~FinalChain() = default;
 
   using finalize_precommit_ext = std::function<void(FinalizationResult const&, DB::Batch&)>;
-  virtual future<shared_ptr<FinalizationResult const>> finalize(NewBlock new_blk, finalize_precommit_ext = {}) = 0;
+  virtual future<shared_ptr<FinalizationResult const>> finalize(NewBlock new_blk, uint64_t period,
+                                                                finalize_precommit_ext = {}) = 0;
 
   virtual shared_ptr<BlockHeader const> block_header(optional<EthBlockNumber> n = {}) const = 0;
   virtual EthBlockNumber last_block_number() const = 0;

--- a/src/final_chain/final_chain.hpp
+++ b/src/final_chain/final_chain.hpp
@@ -74,8 +74,7 @@ class FinalChain {
   }
 };
 
-unique_ptr<FinalChain> NewFinalChain(shared_ptr<DB> const& db, Config const& config, Opts const& opts = {},
-                                     addr_t const& node_addr = {});
+unique_ptr<FinalChain> NewFinalChain(shared_ptr<DB> const& db, Config const& config, addr_t const& node_addr = {});
 
 }  // namespace taraxa::final_chain
 

--- a/src/network/rpc/Taraxa.cpp
+++ b/src/network/rpc/Taraxa.cpp
@@ -79,12 +79,11 @@ Json::Value Taraxa::taraxa_getScheduleBlockByPeriod(std::string const& _period) 
   try {
     auto node = tryGetNode();
     auto db = node->getDB();
-    auto blk_h = db->getPeriodPbftBlock(std::stoull(_period, 0, 16));
-    if (!blk_h) {
+    auto blk = db->getPbftBlock(std::stoull(_period, 0, 16));
+    if (!blk) {
       return Json::Value();
     }
-    auto blk = node->getPbftChain()->getPbftBlockInChain(*blk_h);
-    return PbftBlock::toJson(blk, db->getFinalizedDagBlockHashesByAnchor(blk.getPivotDagBlockHash()));
+    return PbftBlock::toJson(*blk, db->getFinalizedDagBlockHashesByAnchor(blk->getPivotDagBlockHash()));
   } catch (...) {
     BOOST_THROW_EXCEPTION(JsonRpcException(Errors::ERROR_RPC_INVALID_PARAMS));
   }

--- a/src/network/taraxa_capability.cpp
+++ b/src/network/taraxa_capability.cpp
@@ -766,15 +766,16 @@ void TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
           received_dag_blocks_str += dag_blk_h.toString() + " ";
         }
 
+        Transactions transactions;
+
         for (auto const &trx_rlp : *it) {
           auto trx = Transaction(trx_rlp);
           peer->markTransactionAsKnown(trx.getHash());
-          peer->sync_transactions_.emplace_back(trx);
+          transactions.emplace_back(trx);
         }
         LOG(log_nf_dag_sync_) << "PbftBlockPacket: Received Dag Blocks: " << received_dag_blocks_str;
 
-        dag_blk_mgr_->processSyncedTransactions(peer->sync_transactions_);
-        peer->sync_transactions_.clear();
+        dag_blk_mgr_->processSyncedTransactions(transactions);
         for (auto const &block_level : dag_blocks_per_level) {
           for (auto const &block : block_level.second) {
             auto status = checkDagBlockValidation(block);
@@ -788,7 +789,7 @@ void TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
               return;
             }
             LOG(log_nf_dag_sync_) << "Storing DAG block " << block.getHash().toString() << " with "
-                                  << peer->sync_transactions_.size() << " transactions";
+                                  << transactions.size() << " transactions";
             if (block.getLevel() > peer->dag_level_) {
               peer->dag_level_ = block.getLevel();
             }

--- a/src/network/taraxa_capability.hpp
+++ b/src/network/taraxa_capability.hpp
@@ -79,6 +79,7 @@ struct TaraxaCapability : virtual CapabilityFace {
   void syncPeerPbft(unsigned long height_to_sync);
   void restartSyncingPbft(bool force = false);
   void delayedPbftSync(int counter);
+  void pbftSyncComplete();
   std::pair<bool, std::unordered_set<blk_hash_t>> checkDagBlockValidation(DagBlock const &block);
   void requestBlocks(const NodeID &_nodeID, std::unordered_set<blk_hash_t> const &blocks,
                      GetBlocksPacketRequestType mode = MissingHashes);
@@ -190,12 +191,12 @@ struct TaraxaCapability : virtual CapabilityFace {
 
   const uint16_t MAX_CHECK_ALIVE_COUNT = 5;
 
-  // Only allow up to 2 nodes syncing from our node
-  const uint16_t MAX_SYNCING_NODES = 2;
+  // Only allow up to 10 nodes syncing from our node
+  const uint16_t MAX_SYNCING_NODES = 10;
 
   // If there are more than 10 packets in queue to be processed syncing will be delayed or node disconnected in queue
   // not cleared in defined time
-  const uint16_t MAX_NETWORK_QUEUE_TO_DROP_SYNCING = 10;
+  const uint16_t MAX_NETWORK_QUEUE_TO_DROP_SYNCING = 1000;
   const uint16_t MAX_TIME_TO_WAIT_FOR_QUEUE_TO_CLEAR_MS = 2000;
 
   static constexpr uint16_t INITIAL_STATUS_PACKET_ITEM_COUNT = 10;

--- a/src/network/taraxa_peer.hpp
+++ b/src/network/taraxa_peer.hpp
@@ -56,8 +56,6 @@ class TaraxaPeer : public boost::noncopyable {
   std::atomic<uint64_t> pbft_round_ = 1;
   std::atomic<size_t> pbft_previous_round_next_votes_size_ = 0;
 
-  std::vector<Transaction> sync_transactions_;
-
  private:
   dev::p2p::NodeID m_id;
 

--- a/src/network/taraxa_peer.hpp
+++ b/src/network/taraxa_peer.hpp
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <boost/noncopyable.hpp>
 
+#include "transaction_manager/transaction.hpp"
 #include "util/util.hpp"
 
 namespace taraxa {
@@ -54,6 +55,8 @@ class TaraxaPeer : public boost::noncopyable {
   std::atomic<uint64_t> pbft_chain_size_ = 0;
   std::atomic<uint64_t> pbft_round_ = 1;
   std::atomic<size_t> pbft_previous_round_next_votes_size_ = 0;
+
+  std::vector<Transaction> sync_transactions_;
 
  private:
   dev::p2p::NodeID m_id;

--- a/src/network/taraxa_peer.hpp
+++ b/src/network/taraxa_peer.hpp
@@ -5,7 +5,6 @@
 #include <atomic>
 #include <boost/noncopyable.hpp>
 
-#include "transaction_manager/transaction.hpp"
 #include "util/util.hpp"
 
 namespace taraxa {

--- a/src/node/full_node.cpp
+++ b/src/node/full_node.cpp
@@ -278,69 +278,26 @@ void FullNode::rebuildDb() {
   uint64_t period = 1;
 
   while (true) {
-    std::map<uint64_t, std::map<blk_hash_t, std::pair<DagBlock, std::vector<Transaction>>>> dag_blocks_per_level;
-    auto pbft_blk_hash = old_db_->getPeriodPbftBlock(period);
-    if (pbft_blk_hash == nullptr) {
+    map<uint64_t, vector<DagBlock>> dag_blocks_per_level;
+    auto data = old_db_->getPeriodDataRaw(period);
+    if (data.size() == 0) {
       break;
     }
-    auto pbft_block = old_db_->getPbftBlock(*pbft_blk_hash);
-    auto pivot_dag_hash = pbft_block->getPivotDagBlockHash();
-    std::set<blk_hash_t> pbft_dag_blocks;
-    std::vector<blk_hash_t> dag_blocks;
-    pbft_dag_blocks.emplace(pivot_dag_hash);
-    dag_blocks.push_back(pivot_dag_hash);
+    RLP rlp_data(data);
+    std::vector<Vote> cert_votes;
+    std::vector<DagBlock> dag_blocks;
+    std::vector<Transaction> transactions;
+    PbftBlock pbft_block = old_db_->parsePeriodData(rlp_data, cert_votes, dag_blocks, transactions);
 
-    // Read all the dag blocks from the pbft period
-    while (!dag_blocks.empty()) {
-      std::vector<blk_hash_t> new_dag_blocks;
-      for (auto &dag_block_hash : dag_blocks) {
-        auto dag_block = old_db_->getDagBlock(dag_block_hash);
-        auto pivot_hash = dag_block->getPivot();
-        auto tips = dag_block->getTips();
-        if (pbft_dag_blocks.count(pivot_hash) == 0 && !(dag_blk_mgr_->isBlockKnown(pivot_hash))) {
-          pbft_dag_blocks.emplace(pivot_hash);
-          new_dag_blocks.push_back(pivot_hash);
-        }
-        for (auto &tip : tips) {
-          if (pbft_dag_blocks.count(tip) == 0 && !(dag_blk_mgr_->isBlockKnown(tip))) {
-            pbft_dag_blocks.emplace(tip);
-            new_dag_blocks.push_back(tip);
-          }
-        }
-      }
-      dag_blocks = new_dag_blocks;
-    }
-
-    // Read the transactions for dag blocks
-    for (auto &dag_block_hash : pbft_dag_blocks) {
-      std::vector<Transaction> transactions;
-      auto dag_block = old_db_->getDagBlock(dag_block_hash);
-
-      DbStorage::MultiGetQuery db_query(old_db_);
-      db_query.append(DbStorage::Columns::transactions, dag_block->getTrxs());
-      auto db_response = db_query.execute();
-      for (auto &db_trx : db_response) {
-        transactions.push_back(Transaction(asBytes(db_trx)));
-      }
-      dag_blocks_per_level[dag_block->getLevel()][dag_block_hash] = std::make_pair(*dag_block, transactions);
-    }
-
-    // Add pbft blocks with certified votes in queue
-    auto cert_votes = old_db_->getCertVotes(*pbft_blk_hash);
-    if (cert_votes.empty()) {
-      LOG(log_er_) << "Cannot find any cert votes for PBFT block " << pbft_block;
-      assert(false);
-    }
-    PbftBlockCert pbft_blk_and_votes(*pbft_block, cert_votes);
-    LOG(log_nf_) << "Adding pbft block into queue " << pbft_block->getBlockHash().toString();
+    PbftBlockCert pbft_blk_and_votes(pbft_block, cert_votes);
+    LOG(log_nf_) << "Adding pbft block into queue " << pbft_block.getBlockHash().toString();
     pbft_chain_->setSyncedPbftBlockIntoQueue(pbft_blk_and_votes);
 
     // Add dag blocks and transactions from above to the queue
-    for (auto const &block_level : dag_blocks_per_level) {
-      for (auto const &block : block_level.second) {
-        LOG(log_nf_) << "Storing block " << block.second.first.getHash().toString() << " with "
-                     << block.second.second.size() << " transactions";
-        dag_blk_mgr_->processSyncedBlockWithTransactions(block.second.first, block.second.second);
+    dag_blk_mgr_->processSyncedTransactions(transactions);
+    for (auto const &level : dag_blocks_per_level) {
+      for (auto const &blk : level.second) {
+        dag_blk_mgr_->processSyncedBlock(blk);
       }
     }
 

--- a/src/node/full_node.cpp
+++ b/src/node/full_node.cpp
@@ -79,7 +79,7 @@ void FullNode::init() {
   }
   LOG(log_nf_) << "DB initialized ...";
 
-  final_chain_ = NewFinalChain(db_, conf_.chain.final_chain, conf_.opts_final_chain, node_addr);
+  final_chain_ = NewFinalChain(db_, conf_.chain.final_chain, node_addr);
   register_s_ptr(final_chain_);
   emplace(trx_mgr_, conf_, node_addr, db_, log_time_);
 

--- a/src/node/full_node.cpp
+++ b/src/node/full_node.cpp
@@ -293,6 +293,10 @@ void FullNode::rebuildDb() {
     LOG(log_nf_) << "Adding pbft block into queue " << pbft_block.getBlockHash().toString();
     pbft_chain_->setSyncedPbftBlockIntoQueue(pbft_blk_and_votes);
 
+    for (auto const &dag_block : dag_blocks) {
+      dag_blocks_per_level[dag_block.getLevel()].push_back(dag_block);
+    }
+
     // Add dag blocks and transactions from above to the queue
     dag_blk_mgr_->processSyncedTransactions(transactions);
     for (auto const &level : dag_blocks_per_level) {

--- a/src/node/full_node.cpp
+++ b/src/node/full_node.cpp
@@ -110,6 +110,7 @@ void FullNode::start() {
   if (bool b = true; !stopped_.compare_exchange_strong(b, !b)) {
     return;
   }
+
   // Inits rpc related members
   if (conf_.rpc) {
     emplace(rpc_thread_pool_, conf_.rpc->threads_num);
@@ -251,6 +252,7 @@ void FullNode::start() {
     started_ = false;
     return;
   }
+
   started_ = true;
   LOG(log_nf_) << "Node started ... ";
 }

--- a/src/storage/db_storage.cpp
+++ b/src/storage/db_storage.cpp
@@ -738,20 +738,20 @@ pair<bool, uint64_t> DbStorage::getPeriodFromPbftHash(taraxa::blk_hash_t const& 
   return {false, 0};
 }
 
-shared_ptr<pair<uint64_t, uint64_t>> DbStorage::getDagBlockPeriod(blk_hash_t const& hash) {
+shared_ptr<pair<uint32_t, uint32_t>> DbStorage::getDagBlockPeriod(blk_hash_t const& hash) {
   auto data = asBytes(lookup(toSlice(hash.asBytes()), Columns::dag_block_period));
   if (data.size() > 0) {
     RLP rlp(data);
     auto it = rlp.begin();
-    auto period = (*it++).toInt<uint64_t>();
-    auto position = (*it++).toInt<uint64_t>();
+    auto period = (*it++).toInt<uint32_t>();
+    auto position = (*it++).toInt<uint32_t>();
 
-    return make_shared<pair<uint64_t, uint64_t>>(period, position);
+    return make_shared<pair<uint32_t, uint32_t>>(period, position);
   }
   return nullptr;
 }
 
-void DbStorage::addDagBlockPeriodToBatch(blk_hash_t const& hash, uint64_t period, uint64_t position,
+void DbStorage::addDagBlockPeriodToBatch(blk_hash_t const& hash, uint32_t period, uint32_t position,
                                          Batch& write_batch) {
   RLPStream s;
   s.appendList(2);

--- a/src/storage/db_storage.cpp
+++ b/src/storage/db_storage.cpp
@@ -348,18 +348,21 @@ PbftBlock DbStorage::parsePeriodData(RLP& rlp, std::vector<Vote>& cert_votes, st
 
   auto pbft_block = PbftBlock(*it++);
   auto votes_rlp = (*it++);
+  cert_votes.reserve(votes_rlp.size());
   for (auto const& vote : votes_rlp) {
     cert_votes.emplace_back(Vote(vote));
   }
 
   auto blks_rlp = (*it++);
+  dag_blocks.reserve(blks_rlp.size());
   for (auto const& blk : blks_rlp) {
-    dag_blocks.push_back(DagBlock(blk));
+    dag_blocks.emplace_back(DagBlock(blk));
   }
 
   auto trx_rlp = (*it++);
+  transactions.reserve(trx_rlp.size());
   for (auto const& trx : trx_rlp) {
-    transactions.push_back(Transaction(trx));
+    transactions.emplace_back(Transaction(trx));
   }
 
   return pbft_block;

--- a/src/storage/db_storage.cpp
+++ b/src/storage/db_storage.cpp
@@ -406,14 +406,6 @@ std::shared_ptr<PbftBlock> DbStorage::getPbftBlock(uint64_t period) {
   return nullptr;
 }
 
-dev::bytes DbStorage::getTransactionRaw(trx_hash_t const& hash) {
-  auto trx = getTransaction(hash);
-  if (trx) {
-    return *trx->rlp(true);
-  }
-  return dev::bytes();
-}
-
 std::shared_ptr<Transaction> DbStorage::getTransaction(trx_hash_t const& hash) {
   auto status = getTransactionStatus(hash);
   switch (status.status) {

--- a/src/storage/db_storage.hpp
+++ b/src/storage/db_storage.hpp
@@ -174,10 +174,10 @@ struct DbStorage {
                             std::vector<Transaction>& transactions);
   shared_ptr<PbftBlock> getPbftBlock(uint64_t period);
 
-  static constexpr uint16_t pbft_block_pos_in_period_data = 0;
-  static constexpr uint16_t cert_votes_pos_in_period_data = 1;
-  static constexpr uint16_t dag_blocks_pos_in_period_data = 2;
-  static constexpr uint16_t transactions_pos_in_period_data = 3;
+  static constexpr uint16_t PBFT_BLOCK_POS_IN_PERIOD_DATA = 0;
+  static constexpr uint16_t CERT_VOTES_POS_IN_PERIOD_DATA = 1;
+  static constexpr uint16_t DAG_BLOCKS_POS_IN_PERIOD_DATA = 2;
+  static constexpr uint16_t TRANSACTIONS_POS_IN_PERIOD_DATA = 3;
 
   // DAG
   void saveDagBlock(DagBlock const& blk, Batch* write_batch_p = nullptr);
@@ -200,7 +200,7 @@ struct DbStorage {
   void saveTransactionStatus(trx_hash_t const& trx, TransactionStatus const& status);
   void addTransactionStatusToBatch(Batch& write_batch, trx_hash_t const& trx, TransactionStatus const& status);
   TransactionStatus getTransactionStatus(trx_hash_t const& hash);
-  std::map<trx_hash_t, TransactionStatus> getAllTransactionStatus();
+  std::unordered_map<trx_hash_t, TransactionStatus> getAllTransactionStatus();
 
   // PBFT manager
   uint64_t getPbftMgrField(PbftMgrRoundStep const& field);

--- a/src/storage/db_storage.hpp
+++ b/src/storage/db_storage.hpp
@@ -166,7 +166,7 @@ struct DbStorage {
   void loadSnapshots();
 
   // Period data
-  void savePeriodData(uint64_t period, const PbftBlock& pbft_block, const std::vector<Vote>& cert_votes,
+  void savePeriodData(const PbftBlock& pbft_block, const std::vector<Vote>& cert_votes,
                       const std::vector<DagBlock>& dag_blocks, const std::vector<Transaction>& transactions,
                       Batch& write_batch);
   dev::bytes getPeriodDataRaw(uint64_t period);
@@ -174,10 +174,10 @@ struct DbStorage {
                             std::vector<Transaction>& transactions);
   shared_ptr<PbftBlock> getPbftBlock(uint64_t period);
 
-  const int pbft_block_pos_in_period_data = 0;
-  const int cert_votes_pos_in_period_data = 1;
-  const int dag_blocks_pos_in_period_data = 2;
-  const int transactions_pos_in_period_data = 3;
+  static constexpr uint16_t pbft_block_pos_in_period_data = 0;
+  static constexpr uint16_t cert_votes_pos_in_period_data = 1;
+  static constexpr uint16_t dag_blocks_pos_in_period_data = 2;
+  static constexpr uint16_t transactions_pos_in_period_data = 3;
 
   // DAG
   void saveDagBlock(DagBlock const& blk, Batch* write_batch_p = nullptr);

--- a/src/storage/db_storage.hpp
+++ b/src/storage/db_storage.hpp
@@ -271,8 +271,8 @@ struct DbStorage {
   void addPbftBlockPeriodToBatch(uint64_t period, taraxa::blk_hash_t const& pbft_block_hash, Batch& write_batch);
   pair<bool, uint64_t> getPeriodFromPbftHash(taraxa::blk_hash_t const& pbft_block_hash);
   // dag_block_period
-  shared_ptr<std::pair<uint64_t, uint64_t>> getDagBlockPeriod(blk_hash_t const& hash);
-  void addDagBlockPeriodToBatch(blk_hash_t const& hash, uint64_t period, uint64_t position, Batch& write_batch);
+  shared_ptr<std::pair<uint32_t, uint32_t>> getDagBlockPeriod(blk_hash_t const& hash);
+  void addDagBlockPeriodToBatch(blk_hash_t const& hash, uint32_t period, uint32_t position, Batch& write_batch);
 
   uint64_t getDagBlocksCount() const { return dag_blocks_count_.load(); }
   uint64_t getDagEdgeCount() const { return dag_edge_count_.load(); }

--- a/src/storage/db_storage.hpp
+++ b/src/storage/db_storage.hpp
@@ -192,7 +192,6 @@ struct DbStorage {
 
   // Transaction
   void saveTransaction(Transaction const& trx, bool verified = false);
-  dev::bytes getTransactionRaw(trx_hash_t const& hash);
   shared_ptr<Transaction> getTransaction(trx_hash_t const& hash);
   shared_ptr<pair<Transaction, taraxa::bytes>> getTransactionExt(trx_hash_t const& hash);
   bool transactionInDb(trx_hash_t const& hash);

--- a/src/taraxad/taraxad_version.hpp
+++ b/src/taraxad/taraxad_version.hpp
@@ -1,4 +1,0 @@
-#pragma once
-
-// get version of cmake project
-#define TARAXAD_VERSION "1.9.0"

--- a/src/taraxad/taraxad_version.hpp
+++ b/src/taraxad/taraxad_version.hpp
@@ -1,0 +1,4 @@
+#pragma once
+
+// get version of cmake project
+#define TARAXAD_VERSION "1.9.0"

--- a/src/transaction_manager/transaction_manager.cpp
+++ b/src/transaction_manager/transaction_manager.cpp
@@ -85,18 +85,21 @@ std::pair<bool, std::string> TransactionManager::insertTransaction(const Transac
   auto hash = trx.getHash();
 
   TransactionStatus status = db_->getTransactionStatus(hash);
-  if (status != TransactionStatus::not_seen) {
-    switch (status) {
-      case TransactionStatus::in_queue_verified:
+  if (status.status != TransactionStatusEnum::not_seen) {
+    switch (status.status) {
+      case TransactionStatusEnum::in_queue_verified:
         LOG(log_dg_) << "Trx: " << hash << "skip, seen in verified queue. " << std::endl;
         return std::make_pair(false, "in verified queue");
-      case TransactionStatus::in_queue_unverified:
+      case TransactionStatusEnum::in_queue_unverified:
         LOG(log_dg_) << "Trx: " << hash << "skip, seen in unverified queue. " << std::endl;
         return std::make_pair(false, "in unverified queue");
-      case TransactionStatus::in_block:
+      case TransactionStatusEnum::in_block:
         LOG(log_dg_) << "Trx: " << hash << "skip, seen in block. " << std::endl;
         return std::make_pair(false, "in block");
-      case TransactionStatus::invalid:
+      case TransactionStatusEnum::executed:
+        LOG(log_dg_) << "Trx: " << hash << "skip, executed " << std::endl;
+        return std::make_pair(false, "executed");
+      case TransactionStatusEnum::invalid:
         LOG(log_dg_) << "Trx: " << hash << "skip, seen but invalid. " << std::endl;
         return std::make_pair(false, "already invalid");
       default:
@@ -104,7 +107,7 @@ std::pair<bool, std::string> TransactionManager::insertTransaction(const Transac
     }
   }
 
-  status = verify ? TransactionStatus::in_queue_verified : TransactionStatus::in_queue_unverified;
+  status = verify ? TransactionStatusEnum::in_queue_verified : TransactionStatusEnum::in_queue_unverified;
   db_->saveTransaction(trx, verify && mode_ != VerifyMode::skip_verify_sig);
   db_->saveTransactionStatus(hash, status);
   trx_qu_.insert(trx, verify);
@@ -154,27 +157,31 @@ uint32_t TransactionManager::insertBroadcastedTransactions(const std::vector<tar
     auto &trx_raw_status = db_trxs_statuses[idx];
     const trx_hash_t &trx_hash = trxs_hashes[idx];
 
-    TransactionStatus trx_status =
-        trx_raw_status.empty() ? TransactionStatus::not_seen : (TransactionStatus) * (uint16_t *)&trx_raw_status[0];
-    // TransactionStatus trx_status = trx_raw_status.empty() ? TransactionStatus::not_seen :
-    // static_cast<TransactionStatus>(*reinterpret_cast<uint16_t*>(&trx_raw_status[0]));
+    TransactionStatus trx_status;
+    if (!trx_raw_status.empty()) {
+      auto data = asBytes(trx_raw_status);
+      trx_status = TransactionStatus(RLP(data));
+    }
 
     LOG(log_dg_) << "Broadcasted transaction " << trx_hash << " received at: " << getCurrentTimeMilliSeconds();
 
     // Trx status was already saved in db -> it means we already processed this trx
     // Do not process it again
-    if (trx_status != TransactionStatus::not_seen) {
-      switch (trx_status) {
-        case TransactionStatus::in_queue_verified:
+    if (trx_status.status != TransactionStatusEnum::not_seen) {
+      switch (trx_status.status) {
+        case TransactionStatusEnum::in_queue_verified:
           LOG(log_dg_) << "Trx: " << trx_hash << " skipped, seen in verified queue.";
           break;
-        case TransactionStatus::in_queue_unverified:
+        case TransactionStatusEnum::in_queue_unverified:
           LOG(log_dg_) << "Trx: " << trx_hash << " skipped, seen in unverified queue.";
           break;
-        case TransactionStatus::in_block:
+        case TransactionStatusEnum::in_block:
           LOG(log_dg_) << "Trx: " << trx_hash << " skipped, seen in block.";
           break;
-        case TransactionStatus::invalid:
+        case TransactionStatusEnum::executed:
+          LOG(log_dg_) << "Trx: " << trx_hash << " skipped, executed.";
+          break;
+        case TransactionStatusEnum::invalid:
           LOG(log_dg_) << "Trx: " << trx_hash << " skipped, seen but invalid.";
           break;
         default:
@@ -187,7 +194,7 @@ uint32_t TransactionManager::insertBroadcastedTransactions(const std::vector<tar
     const Transaction &trx = trxs[idx];
 
     db_->addTransactionToBatch(trx, write_batch);
-    db_->addTransactionStatusToBatch(write_batch, trx_hash, TransactionStatus::in_queue_unverified);
+    db_->addTransactionStatusToBatch(write_batch, trx_hash, TransactionStatusEnum::in_queue_unverified);
 
     unseen_trxs.push_back(std::move(trx));
     if (ws_server_) ws_server_->newPendingTransaction(trx_hash);
@@ -217,7 +224,7 @@ void TransactionManager::verifyQueuedTrxs() {
     }
     // mark invalid
     if (!valid.first) {
-      db_->saveTransactionStatus(hash, TransactionStatus::invalid);
+      db_->saveTransactionStatus(hash, TransactionStatusEnum::invalid);
       trx_qu_.removeTransactionFromBuffer(hash);
 
       LOG(log_wr_) << " Trx: " << hash << "invalid: " << valid.second << std::endl;
@@ -225,8 +232,9 @@ void TransactionManager::verifyQueuedTrxs() {
     }
     {
       auto status = db_->getTransactionStatus(hash);
-      if (status == TransactionStatus::in_queue_unverified) {
-        db_->saveTransactionStatus(hash, TransactionStatus::in_queue_verified);
+      if (status.status == TransactionStatusEnum::in_queue_unverified) {
+        status.status = TransactionStatusEnum::in_queue_verified;
+        db_->saveTransactionStatus(hash, status);
         db_->saveTransaction(*item.second, mode_ != VerifyMode::skip_verify_sig);
         trx_qu_.addTransactionToVerifiedQueue(hash, item.second);
       }
@@ -324,9 +332,10 @@ void TransactionManager::packTrxs(vec_trx_t &to_be_packed_trx, uint16_t max_trx_
       trx_hash_t const &hash = i.first;
       Transaction const &trx = i.second;
       auto status = db_->getTransactionStatus(hash);
-      if (status == TransactionStatus::in_queue_verified) {
+      if (status.status == TransactionStatusEnum::in_queue_verified) {
         // Skip if transaction is already in existing block
-        db_->addTransactionStatusToBatch(trx_batch, hash, TransactionStatus::in_block);
+        status.status = TransactionStatusEnum::in_block;
+        db_->addTransactionStatusToBatch(trx_batch, hash, status);
         trx_count_.fetch_add(1);
         accepted_trx_hashes.emplace_back(hash);
         LOG(log_dg_) << "Trx: " << hash << " ready to pack" << std::endl;
@@ -379,11 +388,14 @@ bool TransactionManager::verifyBlockTransactions(DagBlock const &blk, std::vecto
   trx_hash_t missing_trx;
   auto trx_batch = db_->createWriteBatch();
   for (size_t idx = 0; idx < db_trxs_statuses.size(); ++idx) {
-    const TransactionStatus &status = db_trxs_statuses[idx].empty()
-                                          ? TransactionStatus::not_seen
-                                          : (TransactionStatus) * (uint16_t *)&db_trxs_statuses[idx][0];
+    TransactionStatus status;
+    if (!db_trxs_statuses[idx].empty()) {
+      auto data = asBytes(db_trxs_statuses[idx]);
+      status = TransactionStatus(RLP(data));
+    }
 
-    if (status == TransactionStatus::in_queue_unverified || status == TransactionStatus::not_seen) {
+    if (status.status == TransactionStatusEnum::in_queue_unverified ||
+        status.status == TransactionStatusEnum::not_seen) {
       const trx_hash_t &trx_hash = all_block_trx_hashes[idx];
       if (known_trx.count(trx_hash)) {
         if (const auto valid = verifyTransaction(known_trx[trx_hash]); !valid.first) {
@@ -393,7 +405,7 @@ bool TransactionManager::verifyBlockTransactions(DagBlock const &blk, std::vecto
         }
         db_->addTransactionToBatch(known_trx[trx_hash], trx_batch, true);
 
-      } else if (status == TransactionStatus::in_queue_unverified) {
+      } else if (status.status == TransactionStatusEnum::in_queue_unverified) {
         auto tx = db_->getTransaction(trx_hash);
         if (const auto valid = verifyTransaction(*tx); !valid.first) {
           LOG(log_er_) << "Block " << blk.getHash() << " has invalid transaction " << trx_hash.toString() << " "
@@ -419,14 +431,17 @@ bool TransactionManager::verifyBlockTransactions(DagBlock const &blk, std::vecto
     accepted_trx_hashes.reserve(all_block_trx_hashes.size());
     db_trxs_statuses = db_query.execute();
     for (size_t idx = 0; idx < db_trxs_statuses.size(); ++idx) {
-      const TransactionStatus &status = db_trxs_statuses[idx].empty()
-                                            ? TransactionStatus::not_seen
-                                            : (TransactionStatus) * (uint16_t *)&db_trxs_statuses[idx][0];
-      if (status != TransactionStatus::in_block) {
+      TransactionStatus status;
+      if (!db_trxs_statuses[idx].empty()) {
+        auto data = asBytes(db_trxs_statuses[idx]);
+        status = TransactionStatus(RLP(data));
+      }
+
+      if (status.status != TransactionStatusEnum::in_block && status.status != TransactionStatusEnum::executed) {
         const trx_hash_t &trx_hash = all_block_trx_hashes[idx];
         newly_added_txs_to_block_counter++;
         accepted_trx_hashes.push_back(trx_hash);
-        db_->addTransactionStatusToBatch(trx_batch, trx_hash, TransactionStatus::in_block);
+        db_->addTransactionStatusToBatch(trx_batch, trx_hash, TransactionStatusEnum::in_block);
       }
     }
     // Write prepared batch to db

--- a/src/transaction_manager/transaction_status.hpp
+++ b/src/transaction_manager/transaction_status.hpp
@@ -13,24 +13,21 @@ enum class TransactionStatusEnum {
 
 class TransactionStatus {
  public:
-  TransactionStatusEnum status = TransactionStatusEnum::not_seen;
+  TransactionStatusEnum state = TransactionStatusEnum::not_seen;
   uint32_t period = 0;
   uint32_t position = 0;
 
   TransactionStatus() = default;
 
-  TransactionStatus(TransactionStatusEnum transactionStatus, uint32_t tPeriod = 0, uint32_t tPosition = 0) {
-    status = transactionStatus;
-    period = tPeriod;
-    position = tPosition;
-  }
+  TransactionStatus(TransactionStatusEnum state, uint32_t period = 0, uint32_t position = 0)
+      : state(state), period(period), position(position) {}
 
   TransactionStatus(dev::RLP const &rlp) {
     if (!rlp.isList()) {
       throw std::invalid_argument("TransactionStatus RLP must be a list");
     }
     auto it = rlp.begin();
-    status = (TransactionStatusEnum)(*it++).toInt<uint16_t>();
+    state = (TransactionStatusEnum)(*it++).toInt<uint8_t>();
     period = (*it++).toInt<uint32_t>();
     position = (*it++).toInt<uint32_t>();
   }
@@ -38,7 +35,7 @@ class TransactionStatus {
   dev::bytes rlp() const {
     dev::RLPStream s;
     s.appendList(3);
-    s << (uint16_t)status << period << position;
+    s << (uint8_t)state << period << position;
     return s.invalidate();
   }
 };

--- a/src/transaction_manager/transaction_status.hpp
+++ b/src/transaction_manager/transaction_status.hpp
@@ -14,12 +14,12 @@ enum class TransactionStatusEnum {
 class TransactionStatus {
  public:
   TransactionStatusEnum status = TransactionStatusEnum::not_seen;
-  uint64_t period = 0;
-  uint64_t position = 0;
+  uint32_t period = 0;
+  uint32_t position = 0;
 
   TransactionStatus() = default;
 
-  TransactionStatus(TransactionStatusEnum transactionStatus, uint64_t tPeriod = 0, uint64_t tPosition = 0) {
+  TransactionStatus(TransactionStatusEnum transactionStatus, uint32_t tPeriod = 0, uint32_t tPosition = 0) {
     status = transactionStatus;
     period = tPeriod;
     position = tPosition;
@@ -31,8 +31,8 @@ class TransactionStatus {
     }
     auto it = rlp.begin();
     status = (TransactionStatusEnum)(*it++).toInt<uint16_t>();
-    period = (*it++).toInt<uint64_t>();
-    position = (*it++).toInt<uint64_t>();
+    period = (*it++).toInt<uint32_t>();
+    position = (*it++).toInt<uint32_t>();
   }
 
   dev::bytes rlp() const {

--- a/src/transaction_manager/transaction_status.hpp
+++ b/src/transaction_manager/transaction_status.hpp
@@ -2,12 +2,45 @@
 
 namespace taraxa {
 
-enum class TransactionStatus {
+enum class TransactionStatusEnum {
   invalid = 0,
   in_block,  // confirmed state, inside of block created by us or someone else
   in_queue_unverified,
   in_queue_verified,
+  executed,
   not_seen
 };
 
-}
+class TransactionStatus {
+ public:
+  TransactionStatusEnum status = TransactionStatusEnum::not_seen;
+  uint64_t period = 0;
+  uint64_t position = 0;
+
+  TransactionStatus() = default;
+
+  TransactionStatus(TransactionStatusEnum transactionStatus, uint64_t tPeriod = 0, uint64_t tPosition = 0) {
+    status = transactionStatus;
+    period = tPeriod;
+    position = tPosition;
+  }
+
+  TransactionStatus(dev::RLP const &rlp) {
+    if (!rlp.isList()) {
+      throw std::invalid_argument("TransactionStatus RLP must be a list");
+    }
+    auto it = rlp.begin();
+    status = (TransactionStatusEnum)(*it++).toInt<uint16_t>();
+    period = (*it++).toInt<uint64_t>();
+    position = (*it++).toInt<uint64_t>();
+  }
+
+  dev::bytes rlp() const {
+    dev::RLPStream s;
+    s.appendList(3);
+    s << (uint16_t)status << period << position;
+    return s.invalidate();
+  }
+};
+
+}  // namespace taraxa

--- a/tests/final_chain_test.cpp
+++ b/tests/final_chain_test.cpp
@@ -53,7 +53,7 @@ struct FinalChainTest : WithDataDir {
     vDagBlocks.push_back(dag_blk);
 
     auto batch = db->createWriteBatch();
-    db->savePeriodData(1, pbft_block, vVotes, vDagBlocks, trxs, batch);
+    db->savePeriodData(pbft_block, vVotes, vDagBlocks, trxs, batch);
 
     db->commitWriteBatch(batch);
     NewBlock new_blk{

--- a/tests/final_chain_test.cpp
+++ b/tests/final_chain_test.cpp
@@ -48,12 +48,12 @@ struct FinalChainTest : WithDataDir {
     DagBlock dag_blk({}, {}, {}, trx_hashes, {}, secret_t::random());
     db->saveDagBlock(dag_blk);
     PbftBlock pbft_block(blk_hash_t(), blk_hash_t(), 1, addr_t(1), KeyPair::create().secret());
-    std::vector<Vote> vVotes;
-    std::vector<DagBlock> vDagBlocks;
-    vDagBlocks.push_back(dag_blk);
+    std::vector<Vote> votes;
+    std::vector<DagBlock> dag_blocks;
+    dag_blocks.push_back(dag_blk);
 
     auto batch = db->createWriteBatch();
-    db->savePeriodData(pbft_block, vVotes, vDagBlocks, trxs, batch);
+    db->savePeriodData(pbft_block, votes, dag_blocks, trxs, batch);
 
     db->commitWriteBatch(batch);
     NewBlock new_blk{

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -228,14 +228,14 @@ TEST_F(FullNodeTest, db_test) {
   }
 
   batch = db.createWriteBatch();
-  std::vector<Vote> vVotes;
-  std::vector<DagBlock> vDagBlocks;
+  std::vector<Vote> votes;
+  std::vector<DagBlock> dag_blocks;
   std::vector<Transaction> vTrxs;
 
-  db.savePeriodData(pbft_block1, cert_votes, vDagBlocks, vTrxs, batch);
-  db.savePeriodData(pbft_block2, vVotes, vDagBlocks, vTrxs, batch);
-  db.savePeriodData(pbft_block3, vVotes, vDagBlocks, vTrxs, batch);
-  db.savePeriodData(pbft_block4, vVotes, vDagBlocks, vTrxs, batch);
+  db.savePeriodData(pbft_block1, cert_votes, dag_blocks, vTrxs, batch);
+  db.savePeriodData(pbft_block2, votes, dag_blocks, vTrxs, batch);
+  db.savePeriodData(pbft_block3, votes, dag_blocks, vTrxs, batch);
+  db.savePeriodData(pbft_block4, votes, dag_blocks, vTrxs, batch);
 
   db.commitWriteBatch(batch);
   EXPECT_TRUE(db.pbftBlockInDb(pbft_block1.getBlockHash()));

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -199,18 +199,35 @@ TEST_F(FullNodeTest, db_test) {
   EXPECT_EQ(db.getPbftCertVotedBlock(pbft_block3.getBlockHash())->rlp(false), pbft_block3.rlp(false));
   EXPECT_EQ(db.getPbftCertVotedBlock(pbft_block4.getBlockHash())->rlp(false), pbft_block4.rlp(false));
 
-  // pbft_blocks
+  // pbft_blocks and cert votes
   EXPECT_FALSE(db.pbftBlockInDb(blk_hash_t(0)));
   EXPECT_FALSE(db.pbftBlockInDb(blk_hash_t(1)));
   pbft_block1 = make_simple_pbft_block(blk_hash_t(1), 2);
   pbft_block2 = make_simple_pbft_block(blk_hash_t(2), 3);
   pbft_block3 = make_simple_pbft_block(blk_hash_t(3), 4);
   pbft_block4 = make_simple_pbft_block(blk_hash_t(4), 5);
+
+  // Certified votes
+  std::vector<Vote> cert_votes;
+  for (auto i = 0; i < 3; i++) {
+    VrfPbftMsg msg(cert_vote_type, 2, 3, 0);
+    vrf_wrapper::vrf_sk_t vrf_sk(
+        "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
+        "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
+    VrfPbftSortition vrf_sortition(vrf_sk, msg);
+    Vote vote(g_secret, vrf_sortition, blk_hash_t(10));
+    cert_votes.emplace_back(vote);
+  }
+
   batch = db.createWriteBatch();
-  db.addPbftBlockToBatch(pbft_block1, batch);
-  db.addPbftBlockToBatch(pbft_block2, batch);
-  db.addPbftBlockToBatch(pbft_block3, batch);
-  db.addPbftBlockToBatch(pbft_block4, batch);
+  std::vector<Vote> vVotes;
+  std::vector<DagBlock> vDagBlocks;
+  std::vector<Transaction> vTrxs;
+
+  db.savePeriodData(1, pbft_block1, cert_votes, vDagBlocks, vTrxs, batch);
+  db.savePeriodData(2, pbft_block2, vVotes, vDagBlocks, vTrxs, batch);
+  db.savePeriodData(3, pbft_block3, vVotes, vDagBlocks, vTrxs, batch);
+  db.savePeriodData(4, pbft_block4, vVotes, vDagBlocks, vTrxs, batch);
   db.commitWriteBatch(batch);
   EXPECT_TRUE(db.pbftBlockInDb(pbft_block1.getBlockHash()));
   EXPECT_TRUE(db.pbftBlockInDb(pbft_block2.getBlockHash()));
@@ -220,6 +237,11 @@ TEST_F(FullNodeTest, db_test) {
   EXPECT_EQ(db.getPbftBlock(pbft_block2.getBlockHash())->rlp(false), pbft_block2.rlp(false));
   EXPECT_EQ(db.getPbftBlock(pbft_block3.getBlockHash())->rlp(false), pbft_block3.rlp(false));
   EXPECT_EQ(db.getPbftBlock(pbft_block4.getBlockHash())->rlp(false), pbft_block4.rlp(false));
+
+  PbftBlockCert pbft_block_cert_votes(pbft_block1, cert_votes);
+  auto cert_votes_from_db = db.getCertVotes(pbft_block1.getPeriod());
+  PbftBlockCert pbft_block_cert_votes_from_db(pbft_block1, cert_votes_from_db);
+  EXPECT_EQ(pbft_block_cert_votes.rlp(), pbft_block_cert_votes_from_db.rlp());
 
   // pbft_blocks (head)
   PbftChain pbft_chain(blk_hash_t(0), addr_t(), db_ptr);
@@ -353,29 +375,6 @@ TEST_F(FullNodeTest, db_test) {
   soft_votes_from_db = db.getSoftVotes(round);
   EXPECT_TRUE(soft_votes_from_db.empty());
 
-  // Certified votes
-  std::vector<Vote> cert_votes;
-  voted_pbft_block_hash = blk_hash_t(10);
-  weighted_index = 0;
-  for (auto i = 0; i < 3; i++) {
-    weighted_index = i;
-    VrfPbftMsg msg(cert_vote_type, 2, 3, weighted_index);
-    vrf_wrapper::vrf_sk_t vrf_sk(
-        "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
-        "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
-    VrfPbftSortition vrf_sortition(vrf_sk, msg);
-    Vote vote(g_secret, vrf_sortition, voted_pbft_block_hash);
-    cert_votes.emplace_back(vote);
-  }
-  batch = db.createWriteBatch();
-  db.addCertVotesToBatch(voted_pbft_block_hash, cert_votes, batch);
-  db.commitWriteBatch(batch);
-  auto pbft_block = make_simple_pbft_block(voted_pbft_block_hash, 1);
-  PbftBlockCert pbft_block_cert_votes(pbft_block, cert_votes);
-  auto cert_votes_from_db = db.getCertVotes(voted_pbft_block_hash);
-  PbftBlockCert pbft_block_cert_votes_from_db(pbft_block, cert_votes_from_db);
-  EXPECT_EQ(pbft_block_cert_votes.rlp(), pbft_block_cert_votes_from_db.rlp());
-
   // Next votes
   round = 3, step = 5;
   weighted_index = 0;
@@ -423,16 +422,18 @@ TEST_F(FullNodeTest, db_test) {
   db.addPbftBlockPeriodToBatch(1, blk_hash_t(1), batch);
   db.addPbftBlockPeriodToBatch(2, blk_hash_t(2), batch);
   db.commitWriteBatch(batch);
-  EXPECT_EQ(*db.getPeriodPbftBlock(1), blk_hash_t(1));
-  EXPECT_EQ(*db.getPeriodPbftBlock(2), blk_hash_t(2));
+  EXPECT_EQ(db.getPbftBlock(1)->getBlockHash(), blk_hash_t(1));
+  EXPECT_EQ(db.getPbftBlock(2)->getBlockHash(), blk_hash_t(2));
 
   // dag_block_period
   batch = db.createWriteBatch();
-  db.addDagBlockPeriodToBatch(blk_hash_t(1), 1, batch);
-  db.addDagBlockPeriodToBatch(blk_hash_t(2), 2, batch);
+  db.addDagBlockPeriodToBatch(blk_hash_t(1), 1, 2, batch);
+  db.addDagBlockPeriodToBatch(blk_hash_t(2), 3, 4, batch);
   db.commitWriteBatch(batch);
-  EXPECT_EQ(1, *db.getDagBlockPeriod(blk_hash_t(1)));
-  EXPECT_EQ(2, *db.getDagBlockPeriod(blk_hash_t(2)));
+  EXPECT_EQ(1, db.getDagBlockPeriod(blk_hash_t(1))->first);
+  EXPECT_EQ(2, db.getDagBlockPeriod(blk_hash_t(1))->second);
+  EXPECT_EQ(3, db.getDagBlockPeriod(blk_hash_t(2))->first);
+  EXPECT_EQ(4, db.getDagBlockPeriod(blk_hash_t(2))->second);
 
   // DPOS proposal period DAG levels status
   EXPECT_EQ(0, db.getDposProposalPeriodLevelsField(DposProposalPeriodLevelsStatus::max_proposal_period));

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -403,12 +403,12 @@ TEST_F(NetworkTest, node_pbft_sync) {
   std::cout << "Generate 1 vote for first PBFT block" << std::endl;
   // Add cert votes in DB
   // Add PBFT block in DB
-  std::vector<DagBlock> vDagBlocks;
-  vDagBlocks.push_back(blk1);
-  std::vector<Transaction> vTrxs;
-  vTrxs.push_back(g_signed_trx_samples[0]);
-  vTrxs.push_back(g_signed_trx_samples[1]);
-  db1->savePeriodData(pbft_block1, votes_for_pbft_blk1, vDagBlocks, vTrxs, batch);
+  std::vector<DagBlock> dag_blocks;
+  dag_blocks.push_back(blk1);
+  std::vector<Transaction> trxs;
+  trxs.push_back(g_signed_trx_samples[0]);
+  trxs.push_back(g_signed_trx_samples[1]);
+  db1->savePeriodData(pbft_block1, votes_for_pbft_blk1, dag_blocks, trxs, batch);
   // Update period_pbft_block in DB
   // Update pbft chain
   pbft_chain1->updatePbftChain(pbft_block1.getBlockHash());
@@ -446,12 +446,12 @@ TEST_F(NetworkTest, node_pbft_sync) {
   // node1 put block2 into pbft chain and store into DB
   // Add cert votes in DB
   // Add PBFT block in DB
-  vDagBlocks.clear();
-  vTrxs.clear();
-  vDagBlocks.push_back(blk2);
-  vTrxs.push_back(g_signed_trx_samples[2]);
-  vTrxs.push_back(g_signed_trx_samples[3]);
-  db1->savePeriodData(pbft_block2, votes_for_pbft_blk2, vDagBlocks, vTrxs, batch);
+  dag_blocks.clear();
+  trxs.clear();
+  dag_blocks.push_back(blk2);
+  trxs.push_back(g_signed_trx_samples[2]);
+  trxs.push_back(g_signed_trx_samples[3]);
+  db1->savePeriodData(pbft_block2, votes_for_pbft_blk2, dag_blocks, trxs, batch);
 
   // Update pbft chain
   pbft_chain1->updatePbftChain(pbft_block2.getBlockHash());
@@ -534,12 +534,12 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   std::cout << "Generate 1 vote for first PBFT block" << std::endl;
   // Add cert votes in DB
   // Add PBFT block in DB
-  std::vector<DagBlock> vDagBlocks;
-  vDagBlocks.push_back(blk1);
-  std::vector<Transaction> vTrxs;
-  vTrxs.push_back(g_signed_trx_samples[0]);
-  vTrxs.push_back(g_signed_trx_samples[1]);
-  db1->savePeriodData(pbft_block1, votes_for_pbft_blk1, vDagBlocks, vTrxs, batch);
+  std::vector<DagBlock> dag_blocks;
+  dag_blocks.push_back(blk1);
+  std::vector<Transaction> trxs;
+  trxs.push_back(g_signed_trx_samples[0]);
+  trxs.push_back(g_signed_trx_samples[1]);
+  db1->savePeriodData(pbft_block1, votes_for_pbft_blk1, dag_blocks, trxs, batch);
   // Update pbft chain
   pbft_chain1->updatePbftChain(pbft_block1.getBlockHash());
   // Update PBFT chain head block
@@ -573,12 +573,12 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   // node1 put block2 into pbft chain and use fake votes storing into DB (malicious player)
   // Add fake votes in DB
   // Add PBFT block in DB
-  vDagBlocks.clear();
-  vTrxs.clear();
-  vDagBlocks.push_back(blk2);
-  vTrxs.push_back(g_signed_trx_samples[2]);
-  vTrxs.push_back(g_signed_trx_samples[3]);
-  db1->savePeriodData(pbft_block2, votes_for_pbft_blk1, vDagBlocks, vTrxs, batch);
+  dag_blocks.clear();
+  trxs.clear();
+  dag_blocks.push_back(blk2);
+  trxs.push_back(g_signed_trx_samples[2]);
+  trxs.push_back(g_signed_trx_samples[3]);
+  db1->savePeriodData(pbft_block2, votes_for_pbft_blk1, dag_blocks, trxs, batch);
   // Update pbft chain
   pbft_chain1->updatePbftChain(pbft_block2.getBlockHash());
   // Update PBFT chain head block

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -408,9 +408,8 @@ TEST_F(NetworkTest, node_pbft_sync) {
   std::vector<Transaction> vTrxs;
   vTrxs.push_back(g_signed_trx_samples[0]);
   vTrxs.push_back(g_signed_trx_samples[1]);
-  db1->savePeriodData(pbft_block1.getPeriod(), pbft_block1, votes_for_pbft_blk1, vDagBlocks, vTrxs, batch);
+  db1->savePeriodData(pbft_block1, votes_for_pbft_blk1, vDagBlocks, vTrxs, batch);
   // Update period_pbft_block in DB
-  db1->addPbftBlockPeriodToBatch(period, pbft_block1.getBlockHash(), batch);
   // Update pbft chain
   pbft_chain1->updatePbftChain(pbft_block1.getBlockHash());
   // Update PBFT chain head block
@@ -452,10 +451,8 @@ TEST_F(NetworkTest, node_pbft_sync) {
   vDagBlocks.push_back(blk2);
   vTrxs.push_back(g_signed_trx_samples[2]);
   vTrxs.push_back(g_signed_trx_samples[3]);
-  db1->savePeriodData(pbft_block2.getPeriod(), pbft_block2, votes_for_pbft_blk2, vDagBlocks, vTrxs, batch);
+  db1->savePeriodData(pbft_block2, votes_for_pbft_blk2, vDagBlocks, vTrxs, batch);
 
-  // Update period_pbft_block in DB
-  db1->addPbftBlockPeriodToBatch(period, pbft_block2.getBlockHash(), batch);
   // Update pbft chain
   pbft_chain1->updatePbftChain(pbft_block2.getBlockHash());
   // Update PBFT chain head block
@@ -542,9 +539,7 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   std::vector<Transaction> vTrxs;
   vTrxs.push_back(g_signed_trx_samples[0]);
   vTrxs.push_back(g_signed_trx_samples[1]);
-  db1->savePeriodData(pbft_block1.getPeriod(), pbft_block1, votes_for_pbft_blk1, vDagBlocks, vTrxs, batch);
-  // Update period_pbft_block in DB
-  db1->addPbftBlockPeriodToBatch(period, pbft_block1.getBlockHash(), batch);
+  db1->savePeriodData(pbft_block1, votes_for_pbft_blk1, vDagBlocks, vTrxs, batch);
   // Update pbft chain
   pbft_chain1->updatePbftChain(pbft_block1.getBlockHash());
   // Update PBFT chain head block
@@ -583,9 +578,7 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   vDagBlocks.push_back(blk2);
   vTrxs.push_back(g_signed_trx_samples[2]);
   vTrxs.push_back(g_signed_trx_samples[3]);
-  db1->savePeriodData(pbft_block2.getPeriod(), pbft_block2, votes_for_pbft_blk1, vDagBlocks, vTrxs, batch);
-  // Update period_pbft_block in DB
-  db1->addPbftBlockPeriodToBatch(period, pbft_block2.getBlockHash(), batch);
+  db1->savePeriodData(pbft_block2, votes_for_pbft_blk1, vDagBlocks, vTrxs, batch);
   // Update pbft chain
   pbft_chain1->updatePbftChain(pbft_block2.getBlockHash());
   // Update PBFT chain head block

--- a/tests/pbft_chain_test.cpp
+++ b/tests/pbft_chain_test.cpp
@@ -40,20 +40,31 @@ TEST_F(PbftChainTest, pbft_db_test) {
   std::string pbft_head_from_db = db->getPbftHead(pbft_chain_head_hash);
   EXPECT_FALSE(pbft_head_from_db.empty());
 
+  auto dag_genesis = node->getConfig().chain.dag_genesis_block.getHash();
+  auto sk = node->getSecretKey();
+  auto vrf_sk = node->getVrfSecretKey();
+  vdf_sortition::VdfConfig vdf_config(node_cfgs[0].chain.vdf);
+
   // generate PBFT block sample
   blk_hash_t prev_block_hash(0);
-  blk_hash_t dag_blk(123);
+  level_t level = 1;
+  vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk, getRlpBytes(level));
+  vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes());
+  DagBlock blk1(dag_genesis, 1, {}, {}, vdf1, sk);
+
   uint64_t period = 1;
   addr_t beneficiary(987);
-  PbftBlock pbft_block(prev_block_hash, dag_blk, period, beneficiary, node->getSecretKey());
+  PbftBlock pbft_block(prev_block_hash, blk1.getHash(), period, beneficiary, node->getSecretKey());
 
   // put into pbft chain and store into DB
   auto batch = db->createWriteBatch();
   // Add PBFT block in DB
   std::vector<Vote> vVotes;
   std::vector<DagBlock> vDagBlocks;
+  vDagBlocks.push_back(blk1);
   std::vector<Transaction> vTrxs;
-  db->savePeriodData(pbft_block.getPeriod(), pbft_block, vVotes, vDagBlocks, vTrxs, batch);
+  db->savePeriodData(pbft_block, vVotes, vDagBlocks, vTrxs, batch);
+
   // Update PBFT chain
   pbft_chain->updatePbftChain(pbft_block.getBlockHash());
   // Update PBFT chain head block
@@ -120,7 +131,7 @@ TEST_F(PbftChainTest, block_broadcast) {
   std::vector<Vote> vVotes;
   std::vector<DagBlock> vDagBlocks;
   std::vector<Transaction> vTrxs;
-  db1->savePeriodData(pbft_block->getPeriod(), *pbft_block, vVotes, vDagBlocks, vTrxs, batch);
+  db1->savePeriodData(*pbft_block, vVotes, vDagBlocks, vTrxs, batch);
 
   // Update pbft chain
   pbft_chain1->updatePbftChain(pbft_block->getBlockHash());
@@ -159,7 +170,7 @@ TEST_F(PbftChainTest, block_broadcast) {
   auto db2 = node2->getDB();
   batch = db2->createWriteBatch();
   // Add PBFT block in DB
-  db2->savePeriodData(pbft_block->getPeriod(), *pbft_block, vVotes, vDagBlocks, vTrxs, batch);
+  db2->savePeriodData(*pbft_block, vVotes, vDagBlocks, vTrxs, batch);
 
   // Update PBFT chain
   pbft_chain2->updatePbftChain(pbft_block->getBlockHash());
@@ -179,7 +190,7 @@ TEST_F(PbftChainTest, block_broadcast) {
   auto db3 = node3->getDB();
   batch = db3->createWriteBatch();
   // Add PBFT block in DB
-  db3->savePeriodData(pbft_block->getPeriod(), *pbft_block, vVotes, vDagBlocks, vTrxs, batch);
+  db3->savePeriodData(*pbft_block, vVotes, vDagBlocks, vTrxs, batch);
 
   // Update PBFT chain
   pbft_chain3->updatePbftChain(pbft_block->getBlockHash());

--- a/tests/pbft_chain_test.cpp
+++ b/tests/pbft_chain_test.cpp
@@ -50,7 +50,10 @@ TEST_F(PbftChainTest, pbft_db_test) {
   // put into pbft chain and store into DB
   auto batch = db->createWriteBatch();
   // Add PBFT block in DB
-  db->addPbftBlockToBatch(pbft_block, batch);
+  std::vector<Vote> vVotes;
+  std::vector<DagBlock> vDagBlocks;
+  std::vector<Transaction> vTrxs;
+  db->savePeriodData(pbft_block.getPeriod(), pbft_block, vVotes, vDagBlocks, vTrxs, batch);
   // Update PBFT chain
   pbft_chain->updatePbftChain(pbft_block.getBlockHash());
   // Update PBFT chain head block
@@ -114,7 +117,11 @@ TEST_F(PbftChainTest, block_broadcast) {
   auto db1 = node1->getDB();
   auto batch = db1->createWriteBatch();
   // Add PBFT block in DB
-  db1->addPbftBlockToBatch(*pbft_block, batch);
+  std::vector<Vote> vVotes;
+  std::vector<DagBlock> vDagBlocks;
+  std::vector<Transaction> vTrxs;
+  db1->savePeriodData(pbft_block->getPeriod(), *pbft_block, vVotes, vDagBlocks, vTrxs, batch);
+
   // Update pbft chain
   pbft_chain1->updatePbftChain(pbft_block->getBlockHash());
   // Update PBFT chain head block
@@ -152,7 +159,8 @@ TEST_F(PbftChainTest, block_broadcast) {
   auto db2 = node2->getDB();
   batch = db2->createWriteBatch();
   // Add PBFT block in DB
-  db2->addPbftBlockToBatch(*pbft_block, batch);
+  db2->savePeriodData(pbft_block->getPeriod(), *pbft_block, vVotes, vDagBlocks, vTrxs, batch);
+
   // Update PBFT chain
   pbft_chain2->updatePbftChain(pbft_block->getBlockHash());
   // Update PBFT chain head block
@@ -171,7 +179,8 @@ TEST_F(PbftChainTest, block_broadcast) {
   auto db3 = node3->getDB();
   batch = db3->createWriteBatch();
   // Add PBFT block in DB
-  db3->addPbftBlockToBatch(*pbft_block, batch);
+  db3->savePeriodData(pbft_block->getPeriod(), *pbft_block, vVotes, vDagBlocks, vTrxs, batch);
+
   // Update PBFT chain
   pbft_chain3->updatePbftChain(pbft_block->getBlockHash());
   // Update PBFT chain head block

--- a/tests/pbft_chain_test.cpp
+++ b/tests/pbft_chain_test.cpp
@@ -59,11 +59,11 @@ TEST_F(PbftChainTest, pbft_db_test) {
   // put into pbft chain and store into DB
   auto batch = db->createWriteBatch();
   // Add PBFT block in DB
-  std::vector<Vote> vVotes;
-  std::vector<DagBlock> vDagBlocks;
-  vDagBlocks.push_back(blk1);
-  std::vector<Transaction> vTrxs;
-  db->savePeriodData(pbft_block, vVotes, vDagBlocks, vTrxs, batch);
+  std::vector<Vote> votes;
+  std::vector<DagBlock> dag_blocks;
+  dag_blocks.push_back(blk1);
+  std::vector<Transaction> trxs;
+  db->savePeriodData(pbft_block, votes, dag_blocks, trxs, batch);
 
   // Update PBFT chain
   pbft_chain->updatePbftChain(pbft_block.getBlockHash());
@@ -128,10 +128,10 @@ TEST_F(PbftChainTest, block_broadcast) {
   auto db1 = node1->getDB();
   auto batch = db1->createWriteBatch();
   // Add PBFT block in DB
-  std::vector<Vote> vVotes;
-  std::vector<DagBlock> vDagBlocks;
-  std::vector<Transaction> vTrxs;
-  db1->savePeriodData(*pbft_block, vVotes, vDagBlocks, vTrxs, batch);
+  std::vector<Vote> votes;
+  std::vector<DagBlock> dag_blocks;
+  std::vector<Transaction> trxs;
+  db1->savePeriodData(*pbft_block, votes, dag_blocks, trxs, batch);
 
   // Update pbft chain
   pbft_chain1->updatePbftChain(pbft_block->getBlockHash());
@@ -170,7 +170,7 @@ TEST_F(PbftChainTest, block_broadcast) {
   auto db2 = node2->getDB();
   batch = db2->createWriteBatch();
   // Add PBFT block in DB
-  db2->savePeriodData(*pbft_block, vVotes, vDagBlocks, vTrxs, batch);
+  db2->savePeriodData(*pbft_block, votes, dag_blocks, trxs, batch);
 
   // Update PBFT chain
   pbft_chain2->updatePbftChain(pbft_block->getBlockHash());
@@ -190,7 +190,7 @@ TEST_F(PbftChainTest, block_broadcast) {
   auto db3 = node3->getDB();
   batch = db3->createWriteBatch();
   // Add PBFT block in DB
-  db3->savePeriodData(*pbft_block, vVotes, vDagBlocks, vTrxs, batch);
+  db3->savePeriodData(*pbft_block, votes, dag_blocks, trxs, batch);
 
   // Update PBFT chain
   pbft_chain3->updatePbftChain(pbft_block->getBlockHash());

--- a/tests/transaction_test.cpp
+++ b/tests/transaction_test.cpp
@@ -36,6 +36,7 @@ TEST_F(TransactionTest, double_verification) {
   EXPECT_EQ(trx_rlp.itemCount(), 10);  // check if there is sender field
 
   db.saveTransaction(g_signed_trx_samples[0]);  // save it unverified
+  db.saveTransactionStatus(g_signed_trx_samples[0].getHash(), TransactionStatus(TransactionStatusEnum::in_block));
   auto trx_data = db.getTransactionRaw(g_signed_trx_samples[0].getHash());
   trx_rlp = RLP(trx_data);
   EXPECT_EQ(trx_rlp.itemCount(), 9);

--- a/tests/transaction_test.cpp
+++ b/tests/transaction_test.cpp
@@ -28,25 +28,6 @@ auto g_blk_samples = Lazy([] { return samples::createMockDagBlkSamples(0, NUM_BL
 
 struct TransactionTest : BaseTest {};
 
-TEST_F(TransactionTest, double_verification) {
-  DbStorage db(data_dir);
-
-  auto trx_data_ptr = g_signed_trx_samples[0].rlp(false, true);
-  RLP trx_rlp = RLP(*trx_data_ptr);
-  EXPECT_EQ(trx_rlp.itemCount(), 10);  // check if there is sender field
-
-  db.saveTransaction(g_signed_trx_samples[0]);  // save it unverified
-  db.saveTransactionStatus(g_signed_trx_samples[0].getHash(), TransactionStatus(TransactionStatusEnum::in_block));
-  auto trx_data = db.getTransactionRaw(g_signed_trx_samples[0].getHash());
-  trx_rlp = RLP(trx_data);
-  EXPECT_EQ(trx_rlp.itemCount(), 9);
-
-  db.saveTransaction(g_signed_trx_samples[0], true);  // save it verified
-  trx_data = db.getTransactionRaw(g_signed_trx_samples[0].getHash());
-  trx_rlp = RLP(trx_data);
-  EXPECT_EQ(trx_rlp.itemCount(), 10);
-}
-
 TEST_F(TransactionTest, status_table_lru) {
   using TestStatus = StatusTable<int, int>;
   TestStatus status_table(100);

--- a/tests/util_test/util.hpp
+++ b/tests/util_test/util.hpp
@@ -291,13 +291,10 @@ inline vector<blk_hash_t> getOrderedDagBlocks(shared_ptr<DbStorage> const& db) {
   uint64_t period = 1;
   vector<blk_hash_t> res;
   while (true) {
-    auto pbft_block_hash = db->getPeriodPbftBlock(period);
-    if (pbft_block_hash) {
-      auto pbft_block = db->getPbftBlock(*pbft_block_hash);
-      if (pbft_block) {
-        for (auto const& dag_block_hash : db->getFinalizedDagBlockHashesByAnchor(pbft_block->getPivotDagBlockHash())) {
-          res.push_back(dag_block_hash);
-        }
+    auto pbft_block = db->getPbftBlock(period);
+    if (pbft_block) {
+      for (auto const& dag_block_hash : db->getFinalizedDagBlockHashesByAnchor(pbft_block->getPivotDagBlockHash())) {
+        res.push_back(dag_block_hash);
       }
       period++;
       continue;


### PR DESCRIPTION
For an executed pbft block, cert votes, dag blocks and transactions are now stored as a single block data which improves syncing performance.