### PR TITLE
fix(pbft): last cert voted value doesn't alway equal to the block is going to push into chain

### DIFF
--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -394,6 +394,7 @@ bool PbftManager::resetRound_() {
     // reset next voted value since start a new round
     next_voted_null_block_hash_ = false;
     next_voted_soft_value_ = false;
+    polling_state_print_log_ = true;
 
     reset_own_value_to_null_block_hash_in_this_round_ = false;
 
@@ -582,6 +583,7 @@ void PbftManager::setFilterState_() {
   next_step_time_ms_ = 2 * LAMBDA_ms;
   last_step_clock_initial_datetime_ = current_step_clock_initial_datetime_;
   current_step_clock_initial_datetime_ = std::chrono::system_clock::now();
+  polling_state_print_log_ = true;
 }
 
 void PbftManager::setCertifyState_() {
@@ -590,6 +592,7 @@ void PbftManager::setCertifyState_() {
   next_step_time_ms_ = 2 * LAMBDA_ms;
   last_step_clock_initial_datetime_ = current_step_clock_initial_datetime_;
   current_step_clock_initial_datetime_ = std::chrono::system_clock::now();
+  polling_state_print_log_ = true;
 }
 
 void PbftManager::setFinishState_() {
@@ -599,6 +602,7 @@ void PbftManager::setFinishState_() {
   next_step_time_ms_ = 4 * LAMBDA_ms;
   last_step_clock_initial_datetime_ = current_step_clock_initial_datetime_;
   current_step_clock_initial_datetime_ = std::chrono::system_clock::now();
+  polling_state_print_log_ = true;
 }
 
 void PbftManager::setFinishPollingState_() {
@@ -610,6 +614,7 @@ void PbftManager::setFinishPollingState_() {
   db_->commitWriteBatch(batch);
   next_voted_soft_value_ = false;
   next_voted_null_block_hash_ = false;
+  polling_state_print_log_ = true;
   last_step_clock_initial_datetime_ = current_step_clock_initial_datetime_;
   current_step_clock_initial_datetime_ = std::chrono::system_clock::now();
 }
@@ -642,6 +647,7 @@ void PbftManager::loopBackFinishState_() {
   db_->commitWriteBatch(batch);
   next_voted_soft_value_ = false;
   next_voted_null_block_hash_ = false;
+  polling_state_print_log_ = true;
   assert(step_ >= startingStepInRound_);
   next_step_time_ms_ = (1 + step_ - startingStepInRound_) * LAMBDA_ms;
   last_step_clock_initial_datetime_ = current_step_clock_initial_datetime_;
@@ -1652,8 +1658,11 @@ bool PbftManager::giveUpNextVotedBlock_() {
 
   if (last_cert_voted_value_ != NULL_BLOCK_HASH) {
     // Last cert voted value should equal to voted value
-    LOG(log_nf_) << "In round " << round << " step " << step_ << ", last cert voted value is "
-                 << last_cert_voted_value_;
+    if (polling_state_print_log_) {
+      LOG(log_nf_) << "In round " << round << " step " << step_ << ", last cert voted value is "
+                   << last_cert_voted_value_;
+      polling_state_print_log_ = false;
+    }
     return false;
   }
 

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -1569,10 +1569,6 @@ bool PbftManager::pushPbftBlock_(PbftBlockCert const &pbft_block_cert_votes, vec
     }
     return false;
   }
-  if (last_cert_voted_value_ != NULL_BLOCK_HASH && last_cert_voted_value_ != pbft_block_hash) {
-    LOG(log_er_) << "Push block hash " << pbft_block_hash << ", but last cert voted value " << last_cert_voted_value_;
-    assert(false);
-  }
 
   auto pbft_block = pbft_block_cert_votes.pbft_blk;
   auto const &cert_votes = pbft_block_cert_votes.cert_votes;

--- a/src/consensus/pbft_manager.hpp
+++ b/src/consensus/pbft_manager.hpp
@@ -223,6 +223,7 @@ class PbftManager {
   bool go_finish_state_ = false;
   bool loop_back_finish_state_ = false;
   bool reset_own_value_to_null_block_hash_in_this_round_ = false;
+  bool polling_state_print_log_ = true;
 
   uint64_t max_wait_for_soft_voted_block_steps_ms_ = 30;
   uint64_t max_wait_for_next_voted_block_steps_ms_ = 30;


### PR DESCRIPTION
PBFT failed assertion
Debug on consensus node3:

Round 79176, pushed PBFT block #2f2977bf with period 73717 into chain
At the time, last_cert_voted_value_ is NULL_BLOCK_HASH

Round 79177, propose #428f3182, soft vote at #804aa5cb, cannot cert vote because DAG not synced yet
Round 79178, propose #428f3182, soft vote at #c2e7b300, synced block #804aa5cb but cannot push into chain because DAG not synced yet

Round 79179, propose #428f3182, soft vote at #428f3182, cert vote at #428f3182. DAG synced for #804aa5cb, want to push #804aa5cb into chain. But last cert voted value (#428f3182) != the block (#804aa5cb) going to push into chain. Assertion failed.

The special situation shows us that we cannot guaranty last cert voted value must equal to the block is going to push into chain. Should remove the assertion check

Conclusion: node cert voted value is not always correct, 2t+1 cert voted values should be always correct.