### PR TITLE
Fix for syncing state

### DIFF
--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -911,7 +911,7 @@ void PbftManager::certifyBlock_() {
 
       if (executed_soft_voted_block_for_this_round || unverified_soft_vote_block_for_this_round_is_valid) {
         // generate cert vote
-        
+
         // comparePbftBlockScheduleWithDAGblocks_ has checked the cert voted block exist
 
         last_cert_voted_value_ = soft_voted_block_for_this_round_.first;
@@ -923,7 +923,7 @@ void PbftManager::certifyBlock_() {
         db_->commitWriteBatch(batch);
 
         should_have_cert_voted_in_this_round_ = true;
-        
+
         auto place_votes = placeVote_(soft_voted_block_for_this_round_.first, cert_vote_type, round, step_);
         if (place_votes) {
           LOG(log_nf_) << "Cert votes " << place_votes << " voting " << soft_voted_block_for_this_round_.first
@@ -971,9 +971,9 @@ void PbftManager::firstFinish_() {
                      << step_;
       }
     } else {
-      
-      if (own_starting_value_for_round_ != previous_round_next_voted_value_ && previous_round_next_voted_value_ != NULL_BLOCK_HASH && !pbft_chain_->findPbftBlockInChain(previous_round_next_voted_value_)) {
-
+      if (own_starting_value_for_round_ != previous_round_next_voted_value_ &&
+          previous_round_next_voted_value_ != NULL_BLOCK_HASH &&
+          !pbft_chain_->findPbftBlockInChain(previous_round_next_voted_value_)) {
         if (own_starting_value_for_round_ == NULL_BLOCK_HASH) {
           db_->savePbftMgrVotedValue(PbftMgrVotedValue::own_starting_value_in_round, previous_round_next_voted_value_);
           own_starting_value_for_round_ = previous_round_next_voted_value_;
@@ -983,10 +983,9 @@ void PbftManager::firstFinish_() {
           // Check if we have received the previous round next voted value and its a viable value...
           // IF it is viable then reset own starting value to it...
           db_->savePbftMgrVotedValue(PbftMgrVotedValue::own_starting_value_in_round, previous_round_next_voted_value_);
-          LOG(log_dg_) << "Updating own starting value of " << own_starting_value_for_round_ << " to previous round next voted value of "
-                       << previous_round_next_voted_value_;
+          LOG(log_dg_) << "Updating own starting value of " << own_starting_value_for_round_
+                       << " to previous round next voted value of " << previous_round_next_voted_value_;
           own_starting_value_for_round_ = previous_round_next_voted_value_;
-          
         }
       }
 
@@ -1440,7 +1439,7 @@ bool PbftManager::comparePbftBlockScheduleWithDAGblocks_(blk_hash_t const &pbft_
     // Read from DB pushing into unverified queue
     pbft_chain_->pushUnverifiedPbftBlock(pbft_block);
   }
-  
+
   return comparePbftBlockScheduleWithDAGblocks_(*pbft_block).second;
 }
 

--- a/src/dag/dag_block_manager.cpp
+++ b/src/dag/dag_block_manager.cpp
@@ -234,7 +234,7 @@ std::pair<size_t, size_t> DagBlockManager::getDagBlockQueueSize() const {
   return res;
 }
 
-DagBlock DagBlockManager::popVerifiedBlock(bool level_limit, uint64_t level) {
+std::pair<std::shared_ptr<DagBlock>, bool> DagBlockManager::popVerifiedBlock(bool level_limit, uint64_t level) {
   uLock lock(shared_mutex_for_verified_qu_);
   if (level_limit) {
     while ((verified_qu_.empty() || verified_qu_.begin()->first >= level) && !stopped_) {
@@ -245,12 +245,14 @@ DagBlock DagBlockManager::popVerifiedBlock(bool level_limit, uint64_t level) {
       cond_for_verified_qu_.wait(lock);
     }
   }
-  if (stopped_) return DagBlock();
+  if (stopped_) return {std::make_shared<DagBlock>(), false};
 
-  auto blk = verified_qu_.begin()->second.front();
+  auto blk = std::make_shared<DagBlock>(verified_qu_.begin()->second.front());
   verified_qu_.begin()->second.pop_front();
   if (verified_qu_.begin()->second.empty()) verified_qu_.erase(verified_qu_.begin());
-  return blk;
+  auto status = blk_status_.get(blk->getHash());
+
+  return {blk, status.second && status.first == BlockStatus::proposed};
 }
 
 void DagBlockManager::pushVerifiedBlock(DagBlock const &blk) {

--- a/src/dag/dag_block_manager.hpp
+++ b/src/dag/dag_block_manager.hpp
@@ -33,8 +33,9 @@ class DagBlockManager {
   void pushUnverifiedBlock(DagBlock const &block,
                            bool critical);  // add to unverified queue
   void pushUnverifiedBlock(DagBlock const &block, std::vector<Transaction> const &transactions,
-                           bool critical);                                  // add to unverified queue
-  DagBlock popVerifiedBlock(bool level_limit = false, uint64_t level = 0);  // get one verified block and pop
+                           bool critical);  // add to unverified queue
+  std::pair<std::shared_ptr<DagBlock>, bool> popVerifiedBlock(bool level_limit = false,
+                                                              uint64_t level = 0);  // get one verified block and pop
   void pushVerifiedBlock(DagBlock const &blk);
   std::pair<size_t, size_t> getDagBlockQueueSize() const;
   level_t getMaxDagLevelInQueue() const;

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -115,9 +115,9 @@ Json::Value Network::getStatus() { return taraxa_capability_->getStatus(); }
 
 std::vector<NodeID> Network::getAllPeersIDs() const { return taraxa_capability_->getAllPeersIDs(); }
 
-void Network::onNewBlockVerified(shared_ptr<DagBlock> const &blk) {
-  tp_.post([this, blk] {
-    taraxa_capability_->onNewBlockVerified(*blk);
+void Network::onNewBlockVerified(shared_ptr<DagBlock> const &blk, bool proposed) {
+  tp_.post([this, blk, proposed] {
+    taraxa_capability_->onNewBlockVerified(*blk, proposed);
     LOG(log_dg_) << "On new block verified:" << blk->getHash().toString();
   });
 }

--- a/src/network/network.hpp
+++ b/src/network/network.hpp
@@ -46,7 +46,7 @@ class Network {
   unsigned getNodeCount();
   Json::Value getStatus();
   std::vector<NodeID> getAllPeersIDs() const;
-  void onNewBlockVerified(shared_ptr<DagBlock> const &blk);
+  void onNewBlockVerified(shared_ptr<DagBlock> const &blk, bool proposed);
   void onNewTransactions(std::vector<taraxa::bytes> transactions);
   void restartSyncingPbft(bool force = false);
   void onNewPbftBlock(std::shared_ptr<PbftBlock> const &pbft_block);

--- a/src/network/taraxa_capability.hpp
+++ b/src/network/taraxa_capability.hpp
@@ -87,7 +87,7 @@ struct TaraxaCapability : virtual CapabilityFace {
   void sendTestMessage(NodeID const &_id, int _x, std::vector<char> const &data);
   bool sendStatus(NodeID const &_id, bool _initial);
   void onNewBlockReceived(DagBlock block, std::vector<Transaction> transactions);
-  void onNewBlockVerified(DagBlock const &block);
+  void onNewBlockVerified(DagBlock const &block, bool proposed);
   void onNewTransactions(std::vector<taraxa::bytes> const &transactions, bool fromNetwork);
   Json::Value getStatus() const;
   std::pair<int, int> retrieveTestData(NodeID const &_id);

--- a/src/node/full_node.cpp
+++ b/src/node/full_node.cpp
@@ -213,9 +213,9 @@ void FullNode::start() {
     uint64_t level = 0;
     while (!stopped_) {
       // will block if no verified block available
-      auto blk_ptr = std::make_shared<DagBlock>(dag_blk_mgr_->popVerifiedBlock(level_limit, level));
+      auto verified_block = dag_blk_mgr_->popVerifiedBlock(level_limit, level);
       level_limit = false;
-      auto const &blk = *blk_ptr;
+      auto const &blk = *(verified_block.first);
 
       if (!stopped_) {
         received_blocks_++;
@@ -226,7 +226,7 @@ void FullNode::start() {
         if (jsonrpc_ws_) {
           jsonrpc_ws_->newDagBlock(blk);
         }
-        network_->onNewBlockVerified(blk_ptr);
+        network_->onNewBlockVerified(verified_block.first, verified_block.second);
         LOG(log_time_) << "Broadcast block " << blk.getHash() << " at: " << getCurrentTimeMilliSeconds();
       } else {
         // Networking makes sure that dag block that reaches queue already had

--- a/tests/dag_block_test.cpp
+++ b/tests/dag_block_test.cpp
@@ -186,8 +186,8 @@ TEST_F(DagBlockTest, push_and_pop) {
   blk_qu.pushUnverifiedBlock(blk1, true);
   blk_qu.pushUnverifiedBlock(blk2, true);
 
-  auto blk3 = blk_qu.popVerifiedBlock();
-  auto blk4 = blk_qu.popVerifiedBlock();
+  auto blk3 = *blk_qu.popVerifiedBlock().first;
+  auto blk4 = *blk_qu.popVerifiedBlock().first;
   // The order is non-deterministic
   bool res = (blk1 == blk3) ? blk2 == blk4 : blk2 == blk3;
   EXPECT_TRUE(res);


### PR DESCRIPTION
Fixed a bug that dag_syncing state would be left incorrectly to true if an empty BlocksPacket was not sent back
Enable gossip of any proposed block even if in syncing state. 
Enable gossip any block if not in pbft syncing state
Prevent gossip of pbft blocks that are missing dag anchor