### PR TITLE
fix: requestblocks endless loop fix

### DIFF
--- a/src/network/taraxa_capability.cpp
+++ b/src/network/taraxa_capability.cpp
@@ -503,7 +503,9 @@ void TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
         dag_blk_mgr_->insertBroadcastedBlockWithTransactions(block, newTransactions);
       }
 
-      requestBlocks(_nodeID, missing_blks);
+      if (missing_blks.size() > 0) {
+        requestBlocks(_nodeID, missing_blks);
+      }
 
       syncing_state_.set_dag_syncing(false);
       LOG(log_nf_dag_sync_) << "Received DagBlocksPacket with blocks: " << received_dag_blocks_str;


### PR DESCRIPTION
requestblocks would go into endless loop of requesting 0 blocks and retrieving 0 blocks