### PR TITLE
Trx rlp cache

### DIFF
--- a/src/consensus/pbft_chain.cpp
+++ b/src/consensus/pbft_chain.cpp
@@ -165,11 +165,11 @@ bool PbftChain::findUnverifiedPbftBlock(taraxa::blk_hash_t const& pbft_block_has
 
 PbftBlock PbftChain::getPbftBlockInChain(const taraxa::blk_hash_t& pbft_block_hash) {
   auto pbft_block = db_->getPbftBlock(pbft_block_hash);
-  if (pbft_block == nullptr) {
+  if (!pbft_block.has_value()) {
     LOG(log_er_) << "Cannot find PBFT block hash " << pbft_block_hash << " in DB";
     assert(false);
   }
-  return *pbft_block;
+  return pbft_block.value();
 }
 
 std::shared_ptr<PbftBlock> PbftChain::getUnverifiedPbftBlock(const taraxa::blk_hash_t& pbft_block_hash) {
@@ -187,7 +187,7 @@ std::vector<std::string> PbftChain::getPbftBlocksStr(size_t period, size_t count
   std::vector<std::string> result;
   for (auto i = period; i < period + count; i++) {
     auto pbft_block = db_->getPbftBlock(i);
-    if (pbft_block == nullptr) {
+    if (!pbft_block.has_value()) {
       LOG(log_er_) << "PBFT block period " << i << " does not exist in blocks order DB.";
       break;
     }

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -1845,7 +1845,10 @@ std::optional<SyncBlock> PbftManager::processSyncBlock() {
 
 void PbftManager::syncBlockQueuePush(SyncBlock &&block, dev::p2p::NodeID const &node_id) {
   const auto period = block.pbft_blk->getPeriod();
-  if (period <= sync_period_) return;
+  if ((period != sync_period_ + 1) && sync_period_ != 0) {
+    LOG(log_er_) << "Trying to push block with " << period << " period, but current period is " << sync_period_;
+    return;
+  }
   sync_period_ = period;
   std::unique_lock lock(sync_queue_access_);
   sync_queue_.emplace_back(std::move(block), node_id);

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -104,7 +104,7 @@ void PbftManager::run() {
        period <= curr_period;  //
        ++period) {
     auto pbft_block = db_->getPbftBlock(period);
-    if (!pbft_block) {
+    if (!pbft_block.has_value()) {
       LOG(log_er_) << "DB corrupted - Cannot find PBFT block in period " << period << " in PBFT chain DB pbft_blocks.";
       assert(false);
     }
@@ -660,12 +660,12 @@ bool PbftManager::stateOperations_() {
     if (voted_block_hash_with_cert_votes.enough) {
       LOG(log_dg_) << "PBFT block " << voted_block_hash_with_cert_votes.voted_block_hash << " has enough certed votes";
       // put pbft block into chain
+      const auto vote_size = voted_block_hash_with_cert_votes.votes.size();
       if (pushCertVotedPbftBlockIntoChain_(voted_block_hash_with_cert_votes.voted_block_hash,
-                                           voted_block_hash_with_cert_votes.votes)) {
+                                           std::move(voted_block_hash_with_cert_votes.votes))) {
         db_->savePbftMgrStatus(PbftMgrStatus::ExecutedInRound, true);
         have_executed_this_round_ = true;
-        LOG(log_nf_) << "Write " << voted_block_hash_with_cert_votes.votes.size() << " cert votes ... in round "
-                     << round;
+        LOG(log_nf_) << "Write " << vote_size << " cert votes ... in round " << round;
 
         duration_ = std::chrono::system_clock::now() - now_;
         auto execute_trxs_in_ms = std::chrono::duration_cast<std::chrono::milliseconds>(duration_).count();
@@ -1443,7 +1443,7 @@ std::optional<vec_blk_t> PbftManager::comparePbftBlockScheduleWithDAGblocks_(std
 }
 
 bool PbftManager::pushCertVotedPbftBlockIntoChain_(taraxa::blk_hash_t const &cert_voted_block_hash,
-                                                   std::vector<std::shared_ptr<Vote>> const &cert_votes_for_round) {
+                                                   std::vector<std::shared_ptr<Vote>> &&cert_votes_for_round) {
   auto pbft_block = getUnfinalizedBlock_(cert_voted_block_hash);
   if (!pbft_block) {
     LOG(log_nf_) << "Can not find the cert voted block hash " << cert_voted_block_hash << " in both pbft queue and DB";
@@ -1460,7 +1460,7 @@ bool PbftManager::pushCertVotedPbftBlockIntoChain_(taraxa::blk_hash_t const &cer
     LOG(log_nf_) << "DAG has not build up for PBFT block " << cert_voted_block_hash;
     return false;
   }
-  cert_sync_block_.cert_votes = cert_votes_for_round;
+  cert_sync_block_.cert_votes = std::move(cert_votes_for_round);
   if (!pushPbftBlock_(cert_sync_block_, *dag_blocks_order)) {
     LOG(log_er_) << "Failed push PBFT block " << pbft_block->getBlockHash() << " into chain";
     return false;
@@ -1487,8 +1487,6 @@ void PbftManager::pushSyncedPbftBlocksIntoChain_() {
         LOG(log_er_) << "Failed push PBFT block " << pbft_block_hash << " into chain";
         break;
       }
-
-      syncBlockQueuePop();
 
       if (executed_pbft_block_) {
         vote_mgr_->removeVerifiedVotes();
@@ -1767,22 +1765,13 @@ bool PbftManager::is_syncing_() {
 }
 
 uint64_t PbftManager::pbftSyncingPeriod() const {
-  std::shared_lock lock(sync_queue_access_);
-  if (sync_queue_.size()) {
-    return sync_queue_.back().first.pbft_blk->getPeriod();
-  } else {
-    return pbft_chain_->getPbftChainSize();
-  }
-}
-
-void PbftManager::syncBlockQueuePop() {
-  std::unique_lock lock(sync_queue_access_);
-  sync_queue_.pop();
+  return std::max(sync_period_.load(), pbft_chain_->getPbftChainSize());
 }
 
 std::optional<SyncBlock> PbftManager::processSyncBlock() {
-  std::shared_lock lock(sync_queue_access_);
-  auto sync_block = sync_queue_.front();
+  std::unique_lock lock(sync_queue_access_);
+  auto sync_block = std::move(sync_queue_.front());
+  sync_queue_.pop_front();
   lock.unlock();
   auto pbft_block_hash = sync_block.first.pbft_blk->getBlockHash();
   LOG(log_nf_) << "Pop pbft block " << pbft_block_hash << " from synced queue";
@@ -1798,7 +1787,7 @@ std::optional<SyncBlock> PbftManager::processSyncBlock() {
                  << sync_block.second.abridged() << " received, stop syncing.";
     clearSyncBlockQueue();
     // Handle malicious peer on network level
-    net->handleMaliciousSyncPeer(sync_queue_.front().second);
+    net->handleMaliciousSyncPeer(sync_block.second);
     return nullopt;
   }
 
@@ -1808,7 +1797,7 @@ std::optional<SyncBlock> PbftManager::processSyncBlock() {
       LOG(log_er_) << "Invalid cert votes block hash " << vote->getBlockHash() << " instead of " << pbft_block_hash
                    << " from peer " << sync_block.second.abridged() << " received, stop syncing.";
       clearSyncBlockQueue();
-      net->handleMaliciousSyncPeer(sync_queue_.front().second);
+      net->handleMaliciousSyncPeer(sync_block.second);
       return nullopt;
     }
   }
@@ -1835,7 +1824,6 @@ std::optional<SyncBlock> PbftManager::processSyncBlock() {
 
   if (pbft_chain_->findPbftBlockInChain(pbft_block_hash)) {
     LOG(log_dg_) << "PBFT block " << pbft_block_hash << " already present in chain.";
-    syncBlockQueuePop();
     return nullopt;
   }
 
@@ -1855,15 +1843,18 @@ std::optional<SyncBlock> PbftManager::processSyncBlock() {
   return std::optional<SyncBlock>(std::move(sync_block.first));
 }
 
-void PbftManager::syncBlockQueuePush(SyncBlock const &block, dev::p2p::NodeID const &node_id) {
+void PbftManager::syncBlockQueuePush(SyncBlock &&block, dev::p2p::NodeID const &node_id) {
+  const auto period = block.pbft_blk->getPeriod();
+  if (period <= sync_period_) return;
+  sync_period_ = period;
   std::unique_lock lock(sync_queue_access_);
-  sync_queue_.push({block, node_id});
+  sync_queue_.emplace_back(std::move(block), node_id);
 }
 
 void PbftManager::clearSyncBlockQueue() {
+  sync_period_ = 0;
   std::unique_lock lock(sync_queue_access_);
-  std::queue<std::pair<SyncBlock, dev::p2p::NodeID>> empty;
-  std::swap(sync_queue_, empty);
+  sync_queue_.clear();
 }
 
 size_t PbftManager::syncBlockQueueSize() const {

--- a/src/consensus/sync_block.cpp
+++ b/src/consensus/sync_block.cpp
@@ -11,10 +11,10 @@ namespace taraxa {
 
 using namespace std;
 
-SyncBlock::SyncBlock(PbftBlock const& pbft_blk, std::vector<std::shared_ptr<Vote>> const& cert_votes)
-    : pbft_blk(new PbftBlock(pbft_blk)), cert_votes(cert_votes) {}
+SyncBlock::SyncBlock(std::shared_ptr<PbftBlock> pbft_blk, std::vector<std::shared_ptr<Vote>> cert_votes)
+    : pbft_blk(std::move(pbft_blk)), cert_votes(std::move(cert_votes)) {}
 
-SyncBlock::SyncBlock(dev::RLP const& rlp) {
+SyncBlock::SyncBlock(dev::RLP&& rlp) {
   auto it = rlp.begin();
   pbft_blk = std::make_shared<PbftBlock>(*it++);
   for (auto const vote_rlp : *it++) {
@@ -22,13 +22,11 @@ SyncBlock::SyncBlock(dev::RLP const& rlp) {
   }
 
   for (auto const dag_block_rlp : *it++) {
-    DagBlock block(dag_block_rlp);
-    dag_blocks.emplace_back(block);
+    dag_blocks.emplace_back(dag_block_rlp);
   }
 
   for (auto const trx_rlp : *it) {
-    auto trx = Transaction(trx_rlp);
-    transactions.emplace_back(trx);
+    transactions.emplace_back(trx_rlp);
   }
 }
 
@@ -47,7 +45,7 @@ bytes SyncBlock::rlp() const {
   }
   s.appendList(transactions.size());
   for (auto const& t : transactions) {
-    s.appendRaw(*t.rlp(true));
+    s.appendRaw(*t.rlp());
   }
   return s.out();
 }

--- a/src/consensus/sync_block.cpp
+++ b/src/consensus/sync_block.cpp
@@ -11,8 +11,8 @@ namespace taraxa {
 
 using namespace std;
 
-SyncBlock::SyncBlock(std::shared_ptr<PbftBlock> pbft_blk, std::vector<std::shared_ptr<Vote>> cert_votes)
-    : pbft_blk(std::move(pbft_blk)), cert_votes(std::move(cert_votes)) {}
+SyncBlock::SyncBlock(std::shared_ptr<PbftBlock> pbft_blk, std::vector<std::shared_ptr<Vote>> const& cert_votes)
+    : pbft_blk(std::move(pbft_blk)), cert_votes(cert_votes) {}
 
 SyncBlock::SyncBlock(dev::RLP&& rlp) {
   auto it = rlp.begin();

--- a/src/consensus/sync_block.hpp
+++ b/src/consensus/sync_block.hpp
@@ -18,7 +18,7 @@ class DagBlock;
 class SyncBlock {
  public:
   SyncBlock() = default;
-  SyncBlock(std::shared_ptr<PbftBlock> pbft_blk, std::vector<std::shared_ptr<Vote>> cert_votes);
+  SyncBlock(std::shared_ptr<PbftBlock> pbft_blk, std::vector<std::shared_ptr<Vote>> const& cert_votes);
   SyncBlock(dev::RLP&& all_rlp);
   SyncBlock(bytes const& all_rlp);
 

--- a/src/consensus/sync_block.hpp
+++ b/src/consensus/sync_block.hpp
@@ -18,8 +18,8 @@ class DagBlock;
 class SyncBlock {
  public:
   SyncBlock() = default;
-  SyncBlock(PbftBlock const& pbft_blk, std::vector<std::shared_ptr<Vote>> const& cert_votes);
-  SyncBlock(dev::RLP const& all_rlp);
+  SyncBlock(std::shared_ptr<PbftBlock> pbft_blk, std::vector<std::shared_ptr<Vote>> cert_votes);
+  SyncBlock(dev::RLP&& all_rlp);
   SyncBlock(bytes const& all_rlp);
 
   std::shared_ptr<PbftBlock> pbft_blk;

--- a/src/final_chain/final_chain.cpp
+++ b/src/final_chain/final_chain.cpp
@@ -94,21 +94,21 @@ class FinalChainImpl final : public FinalChain {
       // stuff as soon as possible
       auto period_raw = db_->getPeriodDataRaw(period);
       SyncBlock sync_block(period_raw);
-      std::vector<Transaction>& period_transactions = sync_block.transactions;
-      DB::MultiGetQuery db_query(db_, period_transactions.size());
-      for (auto const& trx : period_transactions) {
+      DB::MultiGetQuery db_query(db_, sync_block.transactions.size());
+      for (auto const& trx : sync_block.transactions) {
         db_query.append(DB::Columns::final_chain_transaction_location_by_hash, trx.getHash());
       }
       auto trx_db_results = db_query.execute(false);
-      to_execute.reserve(period_transactions.size());
-      for (uint i = 0; i < period_transactions.size(); ++i) {
+      to_execute.reserve(sync_block.transactions.size());
+      for (size_t i = 0; i < sync_block.transactions.size(); ++i) {
         if (auto has_been_executed = !trx_db_results[i].empty(); has_been_executed) {
           continue;
         }
         // Non-executed trxs
-        auto const& trx = to_execute.emplace_back(period_transactions[i]);
-        if (replay_protection_service_ && replay_protection_service_->is_nonce_stale(trx.getSender(), trx.getNonce())) {
-          to_execute.pop_back();
+        auto const& trx = sync_block.transactions[i];
+        if (!(replay_protection_service_ &&
+              replay_protection_service_->is_nonce_stale(trx.getSender(), trx.getNonce()))) [[likely]] {
+          to_execute.push_back(std::move(trx));
         }
       }
     }

--- a/src/network/rpc/Taraxa.cpp
+++ b/src/network/rpc/Taraxa.cpp
@@ -80,7 +80,7 @@ Json::Value Taraxa::taraxa_getScheduleBlockByPeriod(std::string const& _period) 
     auto node = tryGetNode();
     auto db = node->getDB();
     auto blk = db->getPbftBlock(std::stoull(_period, 0, 16));
-    if (!blk) {
+    if (!blk.has_value()) {
       return Json::Value();
     }
     return PbftBlock::toJson(*blk, db->getFinalizedDagBlockHashesByAnchor(blk->getPivotDagBlockHash()));

--- a/src/network/rpc/eth/Eth.cpp
+++ b/src/network/rpc/eth/Eth.cpp
@@ -86,7 +86,7 @@ class EthImpl : public Eth, EthParams {
     Transaction trx(t.nonce.value_or(0), t.value, t.gas_price.value_or(0), t.gas.value_or(0), t.data, secret,
                     t.to ? optional(t.to) : nullopt, chain_id);
     send_trx(trx);
-    trx.rlp(true);
+    trx.rlp();
     return toJS(trx.getHash());
   }
 

--- a/src/network/tarcap/packets_handlers/pbft_blocks_sync_packet_handler.cpp
+++ b/src/network/tarcap/packets_handlers/pbft_blocks_sync_packet_handler.cpp
@@ -80,12 +80,12 @@ void PbftSyncPacketHandler::process(const PacketData &packet_data, const std::sh
     peer->pbft_chain_size_ = sync_block.pbft_blk->getPeriod();
   }
 
-  pbft_mgr_->syncBlockQueuePush(sync_block, packet_data.from_node_id_);
-
-  auto pbft_sync_period = pbft_mgr_->pbftSyncingPeriod();
   LOG(log_nf_) << "Synced PBFT block hash " << pbft_blk_hash << " with " << sync_block.cert_votes.size()
                << " cert votes";
   LOG(log_dg_) << "Synced PBFT block " << sync_block;
+  pbft_mgr_->syncBlockQueuePush(std::move(sync_block), packet_data.from_node_id_);
+
+  auto pbft_sync_period = pbft_mgr_->pbftSyncingPeriod();
 
   // Reset last sync packet received time
   syncing_state_->set_last_sync_packet_time();

--- a/src/node/full_node.cpp
+++ b/src/node/full_node.cpp
@@ -265,7 +265,7 @@ void FullNode::rebuildDb() {
     SyncBlock sync_block(data);
 
     LOG(log_nf_) << "Adding sync block into queue " << sync_block.pbft_blk->getBlockHash().toString();
-    pbft_mgr_->syncBlockQueuePush(sync_block, dev::p2p::NodeID());
+    pbft_mgr_->syncBlockQueuePush(std::move(sync_block), dev::p2p::NodeID());
 
     // Wait if more than 10 pbft blocks in queue to be processed
     while (pbft_mgr_->syncBlockQueueSize() > 10) {

--- a/src/storage/db_storage.hpp
+++ b/src/storage/db_storage.hpp
@@ -178,7 +178,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   // Period data
   void savePeriodData(const SyncBlock& sync_block, Batch& write_batch);
   dev::bytes getPeriodDataRaw(uint64_t period);
-  shared_ptr<PbftBlock> getPbftBlock(uint64_t period);
+  std::optional<PbftBlock> getPbftBlock(uint64_t period);
 
   static constexpr uint16_t PBFT_BLOCK_POS_IN_PERIOD_DATA = 0;
   static constexpr uint16_t CERT_VOTES_POS_IN_PERIOD_DATA = 1;
@@ -238,7 +238,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   void addPbftCertVotedBlockToBatch(PbftBlock const& pbft_block, Batch& write_batch);
 
   // pbft_blocks
-  shared_ptr<PbftBlock> getPbftBlock(blk_hash_t const& hash);
+  std::optional<PbftBlock> getPbftBlock(blk_hash_t const& hash);
   bool pbftBlockInDb(blk_hash_t const& hash);
   // pbft_blocks (head)
   // TODO: I would recommend storing this differently and not in the same db as

--- a/src/transaction_manager/transaction.hpp
+++ b/src/transaction_manager/transaction.hpp
@@ -48,13 +48,6 @@ struct Transaction {
                        bool rlp_w_sender = false);
   explicit Transaction(bytes const &_rlp, bool verify_strict = false, h256 const &hash = {})
       : Transaction(dev::RLP(_rlp), verify_strict, hash) {}
-  explicit Transaction(bytes &&_rlp, bool verify_strict = false, h256 const &hash = {}, bool cache_rlp = false,
-                       bool rlp_w_sender = false)
-      : Transaction(dev::RLP(_rlp), verify_strict, hash, rlp_w_sender) {
-    if (cache_rlp) {
-      cached_rlp_ = std::make_shared<bytes>(std::move(_rlp));
-    }
-  }
 
   auto isZero() const { return is_zero_; }
   trx_hash_t const &getHash() const;
@@ -70,7 +63,7 @@ struct Transaction {
 
   bool operator==(Transaction const &other) const { return getHash() == other.getHash(); }
 
-  std::shared_ptr<bytes> rlp(bool cache = false, bool w_sender = false) const;
+  std::shared_ptr<bytes> rlp(bool w_sender = false) const;
 
   Json::Value toJSON() const;
 };

--- a/tests/final_chain_test.cpp
+++ b/tests/final_chain_test.cpp
@@ -49,7 +49,7 @@ struct FinalChainTest : WithDataDir {
     db->saveDagBlock(dag_blk);
     PbftBlock pbft_block(blk_hash_t(), blk_hash_t(), blk_hash_t(), 1, addr_t(1), KeyPair::create().secret());
     std::vector<std::shared_ptr<Vote>> votes;
-    SyncBlock sync_block(std::make_shared<PbftBlock>(std::move(pbft_block)), std::move(votes));
+    SyncBlock sync_block(std::make_shared<PbftBlock>(std::move(pbft_block)), votes);
     sync_block.dag_blocks.push_back(dag_blk);
     sync_block.transactions = trxs;
 

--- a/tests/final_chain_test.cpp
+++ b/tests/final_chain_test.cpp
@@ -49,7 +49,7 @@ struct FinalChainTest : WithDataDir {
     db->saveDagBlock(dag_blk);
     PbftBlock pbft_block(blk_hash_t(), blk_hash_t(), blk_hash_t(), 1, addr_t(1), KeyPair::create().secret());
     std::vector<std::shared_ptr<Vote>> votes;
-    SyncBlock sync_block(pbft_block, votes);
+    SyncBlock sync_block(std::make_shared<PbftBlock>(std::move(pbft_block)), std::move(votes));
     sync_block.dag_blocks.push_back(dag_blk);
     sync_block.transactions = trxs;
 

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -270,10 +270,10 @@ TEST_F(FullNodeTest, db_test) {
   batch = db.createWriteBatch();
   std::vector<std::shared_ptr<Vote>> votes;
 
-  SyncBlock sync_block1(pbft_block1, cert_votes);
-  SyncBlock sync_block2(pbft_block2, votes);
-  SyncBlock sync_block3(pbft_block3, votes);
-  SyncBlock sync_block4(pbft_block4, votes);
+  SyncBlock sync_block1(std::make_shared<PbftBlock>(pbft_block1), cert_votes);
+  SyncBlock sync_block2(std::make_shared<PbftBlock>(pbft_block2), votes);
+  SyncBlock sync_block3(std::make_shared<PbftBlock>(pbft_block3), votes);
+  SyncBlock sync_block4(std::make_shared<PbftBlock>(pbft_block4), std::move(votes));
 
   db.savePeriodData(sync_block1, batch);
   db.savePeriodData(sync_block2, batch);
@@ -290,9 +290,9 @@ TEST_F(FullNodeTest, db_test) {
   EXPECT_EQ(db.getPbftBlock(pbft_block3.getBlockHash())->rlp(false), pbft_block3.rlp(false));
   EXPECT_EQ(db.getPbftBlock(pbft_block4.getBlockHash())->rlp(false), pbft_block4.rlp(false));
 
-  SyncBlock pbft_block_cert_votes(pbft_block1, cert_votes);
+  SyncBlock pbft_block_cert_votes(std::make_shared<PbftBlock>(pbft_block1), std::move(cert_votes));
   auto cert_votes_from_db = db.getCertVotes(pbft_block1.getPeriod());
-  SyncBlock pbft_block_cert_votes_from_db(pbft_block1, cert_votes_from_db);
+  SyncBlock pbft_block_cert_votes_from_db(std::make_shared<PbftBlock>(pbft_block1), std::move(cert_votes_from_db));
   EXPECT_EQ(pbft_block_cert_votes.rlp(), pbft_block_cert_votes_from_db.rlp());
 
   // pbft_blocks (head)

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -273,7 +273,7 @@ TEST_F(FullNodeTest, db_test) {
   SyncBlock sync_block1(std::make_shared<PbftBlock>(pbft_block1), cert_votes);
   SyncBlock sync_block2(std::make_shared<PbftBlock>(pbft_block2), votes);
   SyncBlock sync_block3(std::make_shared<PbftBlock>(pbft_block3), votes);
-  SyncBlock sync_block4(std::make_shared<PbftBlock>(pbft_block4), std::move(votes));
+  SyncBlock sync_block4(std::make_shared<PbftBlock>(pbft_block4), votes);
 
   db.savePeriodData(sync_block1, batch);
   db.savePeriodData(sync_block2, batch);
@@ -290,9 +290,9 @@ TEST_F(FullNodeTest, db_test) {
   EXPECT_EQ(db.getPbftBlock(pbft_block3.getBlockHash())->rlp(false), pbft_block3.rlp(false));
   EXPECT_EQ(db.getPbftBlock(pbft_block4.getBlockHash())->rlp(false), pbft_block4.rlp(false));
 
-  SyncBlock pbft_block_cert_votes(std::make_shared<PbftBlock>(pbft_block1), std::move(cert_votes));
+  SyncBlock pbft_block_cert_votes(std::make_shared<PbftBlock>(pbft_block1), cert_votes);
   auto cert_votes_from_db = db.getCertVotes(pbft_block1.getPeriod());
-  SyncBlock pbft_block_cert_votes_from_db(std::make_shared<PbftBlock>(pbft_block1), std::move(cert_votes_from_db));
+  SyncBlock pbft_block_cert_votes_from_db(std::make_shared<PbftBlock>(pbft_block1), cert_votes_from_db);
   EXPECT_EQ(pbft_block_cert_votes.rlp(), pbft_block_cert_votes_from_db.rlp());
 
   // pbft_blocks (head)

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -404,7 +404,7 @@ TEST_F(NetworkTest, node_pbft_sync) {
   // Add cert votes in DB
   // Add PBFT block in DB
 
-  SyncBlock sync_block1(std::make_shared<PbftBlock>(pbft_block1), std::move(votes_for_pbft_blk1));
+  SyncBlock sync_block1(std::make_shared<PbftBlock>(pbft_block1), votes_for_pbft_blk1);
   sync_block1.dag_blocks.push_back(blk1);
   sync_block1.transactions.push_back(g_signed_trx_samples[0]);
   sync_block1.transactions.push_back(g_signed_trx_samples[1]);
@@ -454,7 +454,7 @@ TEST_F(NetworkTest, node_pbft_sync) {
   // Add cert votes in DB
   // Add PBFT block in DB
 
-  SyncBlock sync_block2(std::make_shared<PbftBlock>(pbft_block2), std::move(votes_for_pbft_blk2));
+  SyncBlock sync_block2(std::make_shared<PbftBlock>(pbft_block2), votes_for_pbft_blk2);
   sync_block2.dag_blocks.push_back(blk2);
   sync_block2.transactions.push_back(g_signed_trx_samples[2]);
   sync_block2.transactions.push_back(g_signed_trx_samples[3]);
@@ -597,7 +597,7 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   // Add fake votes in DB
   // Add PBFT block in DB
 
-  SyncBlock sync_block2(std::make_shared<PbftBlock>(pbft_block2), std::move(votes_for_pbft_blk1));
+  SyncBlock sync_block2(std::make_shared<PbftBlock>(pbft_block2), votes_for_pbft_blk1);
   sync_block2.dag_blocks.push_back(blk1);
   sync_block2.transactions.push_back(g_signed_trx_samples[2]);
   sync_block2.transactions.push_back(g_signed_trx_samples[3]);

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -175,7 +175,7 @@ TEST_F(NetworkTest, sync_large_pbft_block) {
     for (auto t : block->getTrxs()) {
       auto trx = nodes[0]->getDB()->getTransaction(t);
       EXPECT_NE(trx, nullptr);
-      total_size += trx->rlp(true)->size();
+      total_size += trx->rlp()->size();
     }
   }
   EXPECT_GT(total_size, MAX_PACKET_SIZE);
@@ -404,7 +404,7 @@ TEST_F(NetworkTest, node_pbft_sync) {
   // Add cert votes in DB
   // Add PBFT block in DB
 
-  SyncBlock sync_block1(pbft_block1, votes_for_pbft_blk1);
+  SyncBlock sync_block1(std::make_shared<PbftBlock>(pbft_block1), std::move(votes_for_pbft_blk1));
   sync_block1.dag_blocks.push_back(blk1);
   sync_block1.transactions.push_back(g_signed_trx_samples[0]);
   sync_block1.transactions.push_back(g_signed_trx_samples[1]);
@@ -454,7 +454,7 @@ TEST_F(NetworkTest, node_pbft_sync) {
   // Add cert votes in DB
   // Add PBFT block in DB
 
-  SyncBlock sync_block2(pbft_block2, votes_for_pbft_blk2);
+  SyncBlock sync_block2(std::make_shared<PbftBlock>(pbft_block2), std::move(votes_for_pbft_blk2));
   sync_block2.dag_blocks.push_back(blk2);
   sync_block2.transactions.push_back(g_signed_trx_samples[2]);
   sync_block2.transactions.push_back(g_signed_trx_samples[3]);
@@ -550,7 +550,7 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   // Add cert votes in DB
   // Add PBFT block in DB
 
-  SyncBlock sync_block1(pbft_block1, votes_for_pbft_blk1);
+  SyncBlock sync_block1(std::make_shared<PbftBlock>(pbft_block1), votes_for_pbft_blk1);
   sync_block1.dag_blocks.push_back(blk1);
   sync_block1.transactions.push_back(g_signed_trx_samples[0]);
   sync_block1.transactions.push_back(g_signed_trx_samples[1]);
@@ -597,7 +597,7 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   // Add fake votes in DB
   // Add PBFT block in DB
 
-  SyncBlock sync_block2(pbft_block2, votes_for_pbft_blk1);
+  SyncBlock sync_block2(std::make_shared<PbftBlock>(pbft_block2), std::move(votes_for_pbft_blk1));
   sync_block2.dag_blocks.push_back(blk1);
   sync_block2.transactions.push_back(g_signed_trx_samples[2]);
   sync_block2.transactions.push_back(g_signed_trx_samples[3]);

--- a/tests/pbft_chain_test.cpp
+++ b/tests/pbft_chain_test.cpp
@@ -70,7 +70,7 @@ TEST_F(PbftChainTest, pbft_db_test) {
   // Add PBFT block in DB
   std::vector<std::shared_ptr<Vote>> votes;
 
-  SyncBlock sync_block(std::make_shared<PbftBlock>(pbft_block), std::move(votes));
+  SyncBlock sync_block(std::make_shared<PbftBlock>(pbft_block), votes);
   sync_block.dag_blocks.push_back(blk1);
   db->savePeriodData(sync_block, batch);
 
@@ -155,7 +155,7 @@ TEST_F(PbftChainTest, block_broadcast) {
   auto batch = db1->createWriteBatch();
   // Add PBFT block in DB
   std::vector<std::shared_ptr<Vote>> votes;
-  SyncBlock sync_block(pbft_block, std::move(votes));
+  SyncBlock sync_block(pbft_block, votes);
   sync_block.dag_blocks.push_back(blk1);
   db1->savePeriodData(sync_block, batch);
 

--- a/tests/pbft_chain_test.cpp
+++ b/tests/pbft_chain_test.cpp
@@ -70,7 +70,7 @@ TEST_F(PbftChainTest, pbft_db_test) {
   // Add PBFT block in DB
   std::vector<std::shared_ptr<Vote>> votes;
 
-  SyncBlock sync_block(pbft_block, votes);
+  SyncBlock sync_block(std::make_shared<PbftBlock>(pbft_block), std::move(votes));
   sync_block.dag_blocks.push_back(blk1);
   db->savePeriodData(sync_block, batch);
 
@@ -155,7 +155,7 @@ TEST_F(PbftChainTest, block_broadcast) {
   auto batch = db1->createWriteBatch();
   // Add PBFT block in DB
   std::vector<std::shared_ptr<Vote>> votes;
-  SyncBlock sync_block(*pbft_block, votes);
+  SyncBlock sync_block(pbft_block, std::move(votes));
   sync_block.dag_blocks.push_back(blk1);
   db1->savePeriodData(sync_block, batch);
 

--- a/tests/util_test/util.hpp
+++ b/tests/util_test/util.hpp
@@ -326,7 +326,7 @@ inline vector<blk_hash_t> getOrderedDagBlocks(shared_ptr<DbStorage> const& db) {
   vector<blk_hash_t> res;
   while (true) {
     auto pbft_block = db->getPbftBlock(period);
-    if (pbft_block) {
+    if (pbft_block.has_value()) {
       for (auto const& dag_block_hash : db->getFinalizedDagBlockHashesByAnchor(pbft_block->getPivotDagBlockHash())) {
         res.push_back(dag_block_hash);
       }


### PR DESCRIPTION
This PR enabled RLP cache for transactions. Transaction RLP serialization during syncing accounted for 28% of cpu usage and after this change just to 16%.
Before:
![Screenshot_20210920_164554](https://user-images.githubusercontent.com/6115866/134022789-6c9aacfc-4ac3-4360-aebc-91595e3d2968.png)

After:
![Screenshot_20210920_164702](https://user-images.githubusercontent.com/6115866/134022799-96cb567c-0692-4347-b0ed-9c38a3b5a087.png)
