### PR TITLE
chore(p2p_discover): improve p2p discovery test

### DIFF
--- a/tests/util_test/util.hpp
+++ b/tests/util_test/util.hpp
@@ -110,6 +110,14 @@ inline bool wait(wait_opts const& opts, function<void(wait_ctx&)> const& poller)
     EXPECT_NE(o1, o2);                      \
   }
 
+#define WAIT_EXPECT_LT(ctx, o1, o2)         \
+  if (o1 < o2) {                            \
+    if (ctx.fail(); !ctx.is_last_attempt) { \
+      return;                               \
+    }                                       \
+    EXPECT_LT(o1, o2);                      \
+  }
+
 inline auto const node_cfgs_original = Lazy([] {
   vector<FullNodeConfig> ret;
   for (int i = 1;; ++i) {


### PR DESCRIPTION
## Purpose

I have used this test to test `is_boot_node`flag and I would keep it for now, as it improves performance of discovery