### PR TITLE
fix(transaction): fix invalid lock guard in getHash()

### DIFF
--- a/src/transaction_manager/transaction.cpp
+++ b/src/transaction_manager/transaction.cpp
@@ -78,8 +78,8 @@ trx_hash_t const &Transaction::getHash() const {
       l.lock();
       return hash_;
     }
-    hash_initialized_ = true;
     hash_ = dev::sha3(*rlp());
+    hash_initialized_ = true;
   }
   return hash_;
 }


### PR DESCRIPTION
## Purpose

We had bug (race condition) in getHash() function:  tx hash is cached during first call to the getHash() and after that  this cached value is returned. To see if we already cached it or not, flag is used but we set this flag before we actually assigned cached value itself.  

## For reviewers

<!-- Describe anything you want to call out to the reviewers e.g. areas to focus on, decisions you made, specific feedback you are looking for, etc. -->

## Related Github issues

<!-- Include related github issues. -->

## Changes

<!-- Summary or changes that have been made. -->

## Tests

<!-- Describe what you did to test these changes, including unit tests that have been added or changed. -->

## Deployment Considerations

## Version Notes ##
{ major | minor | patch }

<!--

Decide whether this is a major, minor, or patch version change. Major is for backwards incompatible changes (This is only relevant once the service is live and in production and the major version is at least 1. While the major version is 0, it is ok to have backwards incompatible changes in a minor version.). Minor is for additional features. Patch is for bug fixes.

Describe the changes in this version. This is essentially the details you would include in the squash commit message.
-->

**NOTE: Include the version notes in the squash commit message**
