### PR TITLE
Fix issue with khan/pull-request-comment-trigger@master

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -1,4 +1,4 @@
-name: prnet-actions
+name: prnet-actions 
 on:
   pull_request:
     types: [opened,reopened]
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     steps:
       - uses: khan/pull-request-comment-trigger@master
         id: check

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -32,7 +32,7 @@ jobs:
           pull_request: '${{ steps.request.outputs.data }}'
         if: steps.check.outputs.triggered == 'true'
   redeploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     steps:
       - uses: khan/pull-request-comment-trigger@master
         id: check
@@ -57,7 +57,7 @@ jobs:
           pull_request: '${{ steps.request.outputs.data }}'
         if: steps.check.outputs.triggered == 'true'
   cleanup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     steps:
       - uses: khan/pull-request-comment-trigger@master
         id: check


### PR DESCRIPTION
## Purpose

This fixes an issue with the khan/pull-request-comment-trigger@master, which stopped working.
## For reviewers
The problem seems to be related to the node version installed on each ubuntu revision ubuntu-latest changes and so this may cause problems, found that ubuntu-16.04 works and fixing to this version.

## Related Github issues

<!-- Include related github issues. -->

## Changes

<!-- Summary or changes that have been made. -->

## Tests

<!-- Describe what you did to test these changes, including unit tests that have been added or changed. -->

## Deployment Considerations

## Version Notes ##
{ major | minor | patch }

<!--

Decide whether this is a major, minor, or patch version change. Major is for backwards incompatible changes (This is only relevant once the service is live and in production and the major version is at least 1. While the major version is 0, it is ok to have backwards incompatible changes in a minor version.). Minor is for additional features. Patch is for bug fixes.

Describe the changes in this version. This is essentially the details you would include in the squash commit message.
-->

**NOTE: Include the version notes in the squash commit message**
