### PR TITLE
refactor(pbft_manager): move queue with sync blocks into the pbft_mgr…

### DIFF
--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -1423,9 +1423,9 @@ void PbftManager::syncPbftChainFromPeers_(PbftSyncRequestReason reason, taraxa::
     return;
   }
   if (auto net = network_.lock()) {
-    if (net->syncBlockQueueSize()) {
+    if (syncBlockQueueSize()) {
       LOG(log_tr_) << "PBFT synced queue is still processing so skip syncing. Synced queue size "
-                   << net->syncBlockQueueSize();
+                   << syncBlockQueueSize();
 
       return;
     }
@@ -1532,8 +1532,8 @@ bool PbftManager::pushCertVotedPbftBlockIntoChain_(taraxa::blk_hash_t const &cer
 void PbftManager::pushSyncedPbftBlocksIntoChain_() {
   if (auto net = network_.lock()) {
     auto round = getPbftRound();
-    while (net->syncBlockQueueSize() > 0) {
-      auto sync_block_opt = net->processSyncBlock();
+    while (syncBlockQueueSize() > 0) {
+      auto sync_block_opt = processSyncBlock();
       if (!sync_block_opt) continue;
       auto &sync_block = *sync_block_opt;
       auto pbft_block_hash = sync_block.pbft_blk->getBlockHash();
@@ -1838,6 +1838,97 @@ bool PbftManager::is_syncing_() {
     return net->pbft_syncing();
   }
   return false;
+}
+
+uint64_t PbftManager::pbftSyncingPeriod() const {
+  std::shared_lock lock(sync_queue_access_);
+  if (sync_queue_.size()) {
+    return sync_queue_.back().first.pbft_blk->getPeriod();
+  } else {
+    return pbft_chain_->getPbftChainSize();
+  }
+}
+
+void PbftManager::syncBlockQueuePop() {
+  std::unique_lock lock(sync_queue_access_);
+  sync_queue_.pop();
+}
+
+std::optional<SyncBlock> PbftManager::processSyncBlock() {
+  std::shared_lock lock(sync_queue_access_);
+  auto sync_block = sync_queue_.front();
+  lock.unlock();
+  auto pbft_block_hash = sync_block.first.pbft_blk->getBlockHash();
+  LOG(log_nf_) << "Pop pbft block " << pbft_block_hash << " from synced queue";
+
+  auto net = network_.lock();
+  assert(net);  // Should never happen
+
+  // Check previous hash matches
+  if (sync_block.first.pbft_blk->getPrevBlockHash() != pbft_chain_->getLastPbftBlockHash()) {
+    // TODO: should be clear it is related to syncing, was log_er_pbft_sync_
+    LOG(log_er_) << "Invalid PBFT block " << pbft_block_hash
+                 << "; prevHash: " << sync_block.first.pbft_blk->getPrevBlockHash() << " from peer "
+                 << sync_block.second.abridged() << " received, stop syncing.";
+    // Handle malicious peer on network level
+    net->handleMaliciousSyncPeer(sync_queue_.front().second);
+    return nullopt;
+  }
+
+  // Check cert vote matches
+  for (auto const &vote : sync_block.first.cert_votes) {
+    if (vote.getBlockHash() != pbft_block_hash) {
+      LOG(log_er_) << "Invalid cert votes block hash " << vote.getBlockHash() << " instead of " << pbft_block_hash
+                   << " from peer " << sync_block.second.abridged() << " received, stop syncing.";
+      net->handleMaliciousSyncPeer(sync_queue_.front().second);
+      return nullopt;
+    }
+  }
+
+  auto order_hash = calculateOrderHash(sync_block.first.dag_blocks, sync_block.first.transactions);
+  if (order_hash != sync_block.first.pbft_blk->getOrderHash()) {
+    LOG(log_er_) << "Order hash incorrect in sync block " << pbft_block_hash << " expected: " << order_hash
+                 << " received " << sync_block.first.pbft_blk->getOrderHash() << " from "
+                 << sync_block.second.abridged() << ", stop syncing.";
+    net->handleMaliciousSyncPeer(sync_block.second);
+    return nullopt;
+  }
+
+  if (pbft_chain_->findPbftBlockInChain(pbft_block_hash)) {
+    LOG(log_dg_) << "PBFT block " << pbft_block_hash << " already present in chain.";
+    syncBlockQueuePop();
+    return nullopt;
+  }
+
+  // Check cert votes validation
+  if (!vote_mgr_->pbftBlockHasEnoughValidCertVotes(sync_block.first, getDposTotalVotesCount(), getSortitionThreshold(),
+                                                   getTwoTPlusOne())) {
+    // Failed cert votes validation, flush synced PBFT queue and set since
+    // next block validation depends on the current one
+    LOG(log_er_) << "Synced PBFT block " << pbft_block_hash
+                 << " doesn't have enough valid cert votes. Clear synced PBFT blocks! DPOS total votes count: "
+                 << getDposTotalVotesCount();
+    net->handleMaliciousSyncPeer(sync_block.second);
+    return nullopt;
+  }
+  syncBlockQueuePop();
+  return std::optional<SyncBlock>(std::move(sync_block.first));
+}
+
+void PbftManager::syncBlockQueuePush(SyncBlock const &block, NodeID const &node_id) {
+  std::unique_lock lock(sync_queue_access_);
+  sync_queue_.push({block, node_id});
+}
+
+void PbftManager::clearSyncBlockQueue() {
+  std::unique_lock lock(sync_queue_access_);
+  std::queue<std::pair<SyncBlock, NodeID>> empty;
+  std::swap(sync_queue_, empty);
+}
+
+size_t PbftManager::syncBlockQueueSize() const {
+  std::shared_lock lock(sync_queue_access_);
+  return sync_queue_.size();
 }
 
 }  // namespace taraxa

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -144,6 +144,8 @@ bool Network::pbft_syncing() { return taraxa_capability_->pbft_syncing(); }
 
 uint64_t Network::syncTimeSeconds() const { return taraxa_capability_->syncTimeSeconds(); }
 
+void Network::handleMaliciousSyncPeer(NodeID const &id) { taraxa_capability_->handleMaliciousSyncPeer({id}); }
+
 void Network::onNewPbftVotes(std::vector<Vote> votes) {
   tp_.post([this, votes = std::move(votes)] {
     for (auto const &vote : votes) {
@@ -224,13 +226,5 @@ std::pair<bool, bi::tcp::endpoint> Network::resolveHost(string const &addr, uint
   }
   return std::make_pair(true, ep);
 }
-
-uint64_t Network::pbftSyncingPeriod() const { return taraxa_capability_->pbftSyncingPeriod(); }
-
-std::optional<SyncBlock> Network::processSyncBlock() { return taraxa_capability_->processSyncBlock(); }
-
-void Network::syncBlockQueuePush(SyncBlock const &block) { taraxa_capability_->syncBlockQueuePush(block, NodeID()); }
-
-size_t Network::syncBlockQueueSize() const { return taraxa_capability_->syncBlockQueueSize(); }
 
 }  // namespace taraxa

--- a/src/network/network.hpp
+++ b/src/network/network.hpp
@@ -53,10 +53,7 @@ class Network {
   bool pbft_syncing();
   uint64_t syncTimeSeconds() const;
 
-  uint64_t pbftSyncingPeriod() const;
-  std::optional<SyncBlock> processSyncBlock();
-  void syncBlockQueuePush(SyncBlock const &block);
-  size_t syncBlockQueueSize() const;
+  void handleMaliciousSyncPeer(NodeID const &id);
 
   void onNewPbftVotes(std::vector<Vote> votes);
   void broadcastPreviousRoundNextVotesBundle();

--- a/src/network/rpc/Test.cpp
+++ b/src/network/rpc/Test.cpp
@@ -192,12 +192,12 @@ Json::Value Test::get_node_status() {
       res["trx_count"] = Json::UInt64(node->getTransactionManager()->getTransactionCount());
       res["dag_level"] = Json::UInt64(node->getDagManager()->getMaxLevel());
       res["pbft_size"] = Json::UInt64(node->getPbftChain()->getPbftChainSize());
-      res["pbft_sync_period"] = Json::UInt64(node->getNetwork()->pbftSyncingPeriod());
+      res["pbft_sync_period"] = Json::UInt64(node->getPbftManager()->pbftSyncingPeriod());
       res["pbft_round"] = Json::UInt64(node->getPbftManager()->getPbftRound());
       res["dpos_total_votes"] = Json::UInt64(node->getPbftManager()->getDposTotalVotesCount());
       res["dpos_node_votes"] = Json::UInt64(node->getPbftManager()->getDposWeightedVotesCount());
       res["dpos_quorum"] = Json::UInt64(node->getPbftManager()->getTwoTPlusOne());
-      res["pbft_sync_queue_size"] = Json::UInt64(node->getNetwork()->syncBlockQueueSize());
+      res["pbft_sync_queue_size"] = Json::UInt64(node->getPbftManager()->syncBlockQueueSize());
       res["trx_queue_unverified_size"] = Json::UInt64(node->getTransactionManager()->getTransactionQueueSize().first);
       res["trx_queue_verified_size"] = Json::UInt64(node->getTransactionManager()->getTransactionQueueSize().second);
       res["blk_queue_unverified_size"] = Json::UInt64(node->getDagBlockManager()->getDagBlockQueueSize().first);

--- a/src/network/syncing_state.cpp
+++ b/src/network/syncing_state.cpp
@@ -48,12 +48,15 @@ bool SyncingState::is_actively_syncing() const {
          SYNCING_INACTIVITY_THRESHOLD;
 }
 
-void SyncingState::set_peer_malicious() {
+void SyncingState::set_peer_malicious(const std::optional<dev::p2p::NodeID>& peer_id) {
+  if (peer_id.has_value()) {
+    malicious_peers_.insert(peer_id.value());
+  }
+
   // this lock is for peer_id_ not the malicious_peers_
   std::shared_lock lock(peer_mutex_);
-  set_peer_malicious(peer_id_);
+  malicious_peers_.insert(peer_id_);
 }
-void SyncingState::set_peer_malicious(const dev::p2p::NodeID& peer_id) { malicious_peers_.insert(peer_id); }
 
 bool SyncingState::is_peer_malicious(const dev::p2p::NodeID& peer_id) const { return malicious_peers_.count(peer_id); }
 

--- a/src/network/syncing_state.hpp
+++ b/src/network/syncing_state.hpp
@@ -47,8 +47,11 @@ class SyncingState {
 
   dev::p2p::NodeID syncing_peer() const;
 
-  void set_peer_malicious();
-  void set_peer_malicious(const dev::p2p::NodeID& peer_id);
+  /**
+   * @brief Marks peer as malicious, in case none is provided, peer_id_ (node that we currently syncing with) is marked
+   * @param peer_id
+   */
+  void set_peer_malicious(const std::optional<dev::p2p::NodeID>& peer_id = {});
   bool is_peer_malicious(const dev::p2p::NodeID& peer_id) const;
 
  private:

--- a/src/network/taraxa_capability.cpp
+++ b/src/network/taraxa_capability.cpp
@@ -327,7 +327,7 @@ void TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
       // and by syncing here we open node up to attack of sending bogus
       // status.  We also have nothing to punish a node failing to send
       // sync info.
-      auto pbft_synced_period = pbftSyncingPeriod();
+      auto pbft_synced_period = pbft_mgr_->pbftSyncingPeriod();
       if (pbft_synced_period + 1 < peer->pbft_chain_size_) {
         LOG(log_nf_) << "Restart PBFT chain syncing. Own synced PBFT at period " << pbft_synced_period
                      << ", peer PBFT chain size " << peer->pbft_chain_size_;
@@ -720,7 +720,7 @@ void TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
         peer->pbft_chain_size_ = peer_pbft_chain_size;
       }
 
-      auto pbft_synced_period = pbftSyncingPeriod();
+      auto pbft_synced_period = pbft_mgr_->pbftSyncingPeriod();
       if (pbft_synced_period >= pbft_block->getPeriod()) {
         LOG(log_dg_pbft_prp_) << "Drop it! Synced PBFT block at period " << pbft_block->getPeriod()
                               << ", own PBFT chain has synced at period " << pbft_synced_period;
@@ -764,10 +764,10 @@ void TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
         peer->markPbftBlockAsKnown(pbft_blk_hash);
         LOG(log_dg_pbft_sync_) << "Processing pbft block: " << pbft_blk_hash;
 
-        if (sync_block.pbft_blk->getPeriod() != pbftSyncingPeriod() + 1) {
+        if (sync_block.pbft_blk->getPeriod() != pbft_mgr_->pbftSyncingPeriod() + 1) {
           LOG(log_dg_pbft_sync_) << "Block " << pbft_blk_hash
                                  << " period unexpected: " << sync_block.pbft_blk->getPeriod()
-                                 << ". Expected period: " << pbftSyncingPeriod() + 1;
+                                 << ". Expected period: " << pbft_mgr_->pbftSyncingPeriod() + 1;
           return;
         }
         // Update peer's pbft period if outdated
@@ -775,9 +775,9 @@ void TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
           peer->pbft_chain_size_ = sync_block.pbft_blk->getPeriod();
         }
 
-        syncBlockQueuePush(sync_block, _nodeID);
+        pbft_mgr_->syncBlockQueuePush(sync_block, _nodeID);
 
-        auto pbft_sync_period = pbftSyncingPeriod();
+        auto pbft_sync_period = pbft_mgr_->pbftSyncingPeriod();
         LOG(log_nf_pbft_sync_) << "Synced PBFT block hash " << pbft_blk_hash << " with " << sync_block.cert_votes.size()
                                << " cert votes";
         LOG(log_dg_pbft_sync_) << "Synced PBFT block " << sync_block;
@@ -812,9 +812,9 @@ void TaraxaCapability::interpretCapabilityPacketImpl(NodeID const &_nodeID, unsi
 }
 
 void TaraxaCapability::pbftSyncComplete() {
-  if (syncBlockQueueSize()) {
+  if (pbft_mgr_->syncBlockQueueSize()) {
     LOG(log_dg_pbft_sync_) << "Syncing pbft blocks faster than processing. Remaining sync size "
-                           << syncBlockQueueSize();
+                           << pbft_mgr_->syncBlockQueueSize();
     tp_.post(1000, [this] { pbftSyncComplete(); });
   } else {
     LOG(log_dg_pbft_sync_) << "Syncing PBFT is completed";
@@ -847,7 +847,7 @@ void TaraxaCapability::handle_read_exception(weak_ptr<Session> session, unsigned
 }
 
 void TaraxaCapability::delayedPbftSync(int counter) {
-  auto pbft_sync_period = pbftSyncingPeriod();
+  auto pbft_sync_period = pbft_mgr_->pbftSyncingPeriod();
   if (counter > 60) {
     LOG(log_er_pbft_sync_) << "Pbft blocks stuck in queue, no new block processed in 60 seconds " << pbft_sync_period
                            << " " << pbft_chain_->getPbftChainSize();
@@ -892,7 +892,7 @@ void TaraxaCapability::restartSyncingPbft(bool force) {
     }
   }
 
-  auto pbft_sync_period = pbftSyncingPeriod();
+  auto pbft_sync_period = pbft_mgr_->pbftSyncingPeriod();
   if (max_pbft_chain_size > pbft_sync_period) {
     LOG(log_si_pbft_sync_) << "Restarting syncing PBFT from peer " << max_pbft_chain_nodeID << ", peer PBFT chain size "
                            << max_pbft_chain_size << ", own PBFT chain synced at period " << pbft_sync_period;
@@ -1280,7 +1280,7 @@ void TaraxaCapability::logNodeStats() {
   auto local_twotplusone = pbft_mgr_->getTwoTPlusOne();
 
   // Syncing period...
-  auto local_pbft_sync_period = pbftSyncingPeriod();
+  auto local_pbft_sync_period = pbft_mgr_->pbftSyncingPeriod();
 
   // Decide if making progress...
   auto pbft_consensus_rounds_advanced = local_pbft_round - local_pbft_round_prev_interval_;
@@ -1593,99 +1593,12 @@ void TaraxaCapability::broadcastPreviousRoundNextVotesBundle() {
   }
 }
 
-uint64_t TaraxaCapability::pbftSyncingPeriod() const {
-  shared_lock lock(sync_queue_access_);
-  if (sync_queue_.size()) {
-    return sync_queue_.back().first.pbft_blk->getPeriod();
-  } else {
-    return pbft_chain_->getPbftChainSize();
-  }
-}
-
-void TaraxaCapability::syncBlockQueuePop() {
-  unique_lock lock(sync_queue_access_);
-  sync_queue_.pop();
-}
-
-void TaraxaCapability::handleMaliciousSyncBlock(NodeID const &id) {
+void TaraxaCapability::handleMaliciousSyncPeer(NodeID const &id) {
   syncing_state_.set_peer_malicious(id);
   auto host = host_.lock();
   if (host) host->disconnect(id, p2p::UserReason);
-  clearSyncBlockQueue();
+  pbft_mgr_->clearSyncBlockQueue();
   restartSyncingPbft(true);
-}
-
-std::optional<SyncBlock> TaraxaCapability::processSyncBlock() {
-  shared_lock lock(sync_queue_access_);
-  auto sync_block = sync_queue_.front();
-  lock.unlock();
-  auto pbft_block_hash = sync_block.first.pbft_blk->getBlockHash();
-  LOG(log_nf_) << "Pop pbft block " << pbft_block_hash << " from synced queue";
-
-  // Check previous hash matches
-  if (sync_block.first.pbft_blk->getPrevBlockHash() != pbft_chain_->getLastPbftBlockHash()) {
-    LOG(log_er_pbft_sync_) << "Invalid PBFT block " << pbft_block_hash
-                           << "; prevHash: " << sync_block.first.pbft_blk->getPrevBlockHash() << " from peer "
-                           << sync_block.second.abridged() << " received, stop syncing.";
-    handleMaliciousSyncBlock(sync_queue_.front().second);
-    return nullopt;
-  }
-
-  // Check cert vote matches
-  for (auto const &vote : sync_block.first.cert_votes) {
-    if (vote.getBlockHash() != pbft_block_hash) {
-      LOG(log_er_pbft_sync_) << "Invalid cert votes block hash " << vote.getBlockHash() << " instead of "
-                             << pbft_block_hash << " from peer " << sync_block.second.abridged()
-                             << " received, stop syncing.";
-      handleMaliciousSyncBlock(sync_queue_.front().second);
-      return nullopt;
-    }
-  }
-
-  auto order_hash = pbft_mgr_->calculateOrderHash(sync_block.first.dag_blocks, sync_block.first.transactions);
-  if (order_hash != sync_block.first.pbft_blk->getOrderHash()) {
-    LOG(log_er_pbft_sync_) << "Order hash incorrect in sync block " << pbft_block_hash << " expected: " << order_hash
-                           << " received " << sync_block.first.pbft_blk->getOrderHash() << " from "
-                           << sync_block.second.abridged() << ", stop syncing.";
-    handleMaliciousSyncBlock(sync_block.second);
-    return nullopt;
-  }
-
-  if (pbft_chain_->findPbftBlockInChain(pbft_block_hash)) {
-    LOG(log_dg_) << "PBFT block " << pbft_block_hash << " already present in chain.";
-    syncBlockQueuePop();
-    return nullopt;
-  }
-
-  // Check cert votes validation
-  if (!vote_mgr_->pbftBlockHasEnoughValidCertVotes(sync_block.first, pbft_mgr_->getDposTotalVotesCount(),
-                                                   pbft_mgr_->getSortitionThreshold(), pbft_mgr_->getTwoTPlusOne())) {
-    // Failed cert votes validation, flush synced PBFT queue and set since
-    // next block validation depends on the current one
-    LOG(log_er_) << "Synced PBFT block " << pbft_block_hash
-                 << " doesn't have enough valid cert votes. Clear synced PBFT blocks! DPOS total votes count: "
-                 << pbft_mgr_->getDposTotalVotesCount();
-    handleMaliciousSyncBlock(sync_block.second);
-    return nullopt;
-  }
-  syncBlockQueuePop();
-  return std::optional<SyncBlock>(std::move(sync_block.first));
-}
-
-void TaraxaCapability::syncBlockQueuePush(SyncBlock const &block, NodeID const &node_id) {
-  unique_lock lock(sync_queue_access_);
-  sync_queue_.push({block, node_id});
-}
-
-void TaraxaCapability::clearSyncBlockQueue() {
-  unique_lock lock(sync_queue_access_);
-  std::queue<std::pair<SyncBlock, NodeID>> empty;
-  std::swap(sync_queue_, empty);
-}
-
-size_t TaraxaCapability::syncBlockQueueSize() const {
-  shared_lock lock(sync_queue_access_);
-  return sync_queue_.size();
 }
 
 Json::Value TaraxaCapability::getStatus() const {

--- a/src/network/taraxa_capability.hpp
+++ b/src/network/taraxa_capability.hpp
@@ -112,13 +112,7 @@ struct TaraxaCapability : virtual CapabilityFace {
   void sendTransactions();
   std::string packetTypeToString(unsigned int _packetType) const override;
 
-  uint64_t pbftSyncingPeriod() const;
-  void syncBlockQueuePop();
-  std::optional<SyncBlock> processSyncBlock();
-  void syncBlockQueuePush(SyncBlock const &block, NodeID const &node_id);
-  void clearSyncBlockQueue();
-  size_t syncBlockQueueSize() const;
-  void handleMaliciousSyncBlock(NodeID const &id);
+  void handleMaliciousSyncPeer(NodeID const &id);
 
   // PBFT
   void onNewPbftVote(taraxa::Vote const &vote);


### PR DESCRIPTION
## Purpose

So the only change here is that I moved(copy paste) sync_queue + methods related to processing data from this queue into the pbft_manager. Logic behind is this:

- the only thing that tarcap does is that it push data into this queue + check it's size. Similar to other queues, e.g. queues for tx_manager, dag_manager, etc...
- pbft_manager is working with data from this queue so I moved processing methods inside pbft_manager. In original PR they were inside tarcap and pbft_manager would simply call those functions from it's internal processing function.
- As a result 4 methods from intermediate network  "interface" could be deleted:
  ```
  uint64_t pbftSyncingPeriod() const;
  std::optional<SyncBlock> processSyncBlock();
  void syncBlockQueuePush(SyncBlock const &block);
  size_t syncBlockQueueSize() const;
  ```
I am totally for moving all syncing logic from pbft_manager somewhere else (even to tarcap), but I am for solution where processing of syncing data would not be triggered from pbft_manager so until we figure out how to get rid of the dependency of syncing data on pbft_manager, I think this is cleaner solution + similar to approach used in other managers and theirs queues...

To have a bigger picture about design, original PR must be checked. Check where is `processSyncBlock()` called