### PR TITLE
fix: update transaction status correctly

### DIFF
--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -23,14 +23,15 @@ PbftManager::PbftManager(PbftConfig const &conf, blk_hash_t const &genesis, addr
                          std::shared_ptr<DbStorage> db, std::shared_ptr<PbftChain> pbft_chain,
                          std::shared_ptr<VoteManager> vote_mgr,
                          std::shared_ptr<NextVotesForPreviousRound> next_votes_mgr, std::shared_ptr<DagManager> dag_mgr,
-                         std::shared_ptr<DagBlockManager> dag_blk_mgr, std::shared_ptr<FinalChain> final_chain,
-                         secret_t node_sk, vrf_sk_t vrf_sk)
+                         std::shared_ptr<DagBlockManager> dag_blk_mgr, std::shared_ptr<TransactionManager> trx_mgr,
+                         std::shared_ptr<FinalChain> final_chain, secret_t node_sk, vrf_sk_t vrf_sk)
     : db_(db),
       previous_round_next_votes_(next_votes_mgr),
       pbft_chain_(pbft_chain),
       vote_mgr_(vote_mgr),
       dag_mgr_(dag_mgr),
       dag_blk_mgr_(dag_blk_mgr),
+      trx_mgr_(trx_mgr),
       final_chain_(final_chain),
       node_addr_(node_addr),
       node_sk_(node_sk),
@@ -1671,6 +1672,8 @@ bool PbftManager::pushPbftBlock_(SyncBlock &sync_block, vec_blk_t &dag_blocks_or
 
   // Commit DB
   db_->commitWriteBatch(batch);
+
+  trx_mgr_->updateFinalizedTransactionsStatus(sync_block);
 
   // update PBFT chain size
   pbft_chain_->updatePbftChain(pbft_block_hash);

--- a/src/consensus/pbft_manager.hpp
+++ b/src/consensus/pbft_manager.hpp
@@ -49,8 +49,8 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   PbftManager(PbftConfig const &conf, blk_hash_t const &genesis, addr_t node_addr, std::shared_ptr<DbStorage> db,
               std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<VoteManager> vote_mgr,
               std::shared_ptr<NextVotesForPreviousRound> next_votes_mgr, std::shared_ptr<DagManager> dag_mgr,
-              std::shared_ptr<DagBlockManager> dag_blk_mgr, std::shared_ptr<FinalChain> final_chain, secret_t node_sk,
-              vrf_sk_t vrf_sk);
+              std::shared_ptr<DagBlockManager> dag_blk_mgr, std::shared_ptr<TransactionManager> trx_mgr,
+              std::shared_ptr<FinalChain> final_chain, secret_t node_sk, vrf_sk_t vrf_sk);
   ~PbftManager();
 
   void setNetwork(std::weak_ptr<Network> network);
@@ -176,6 +176,7 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   std::shared_ptr<DagManager> dag_mgr_;
   std::weak_ptr<Network> network_;
   std::shared_ptr<DagBlockManager> dag_blk_mgr_;
+  std::shared_ptr<TransactionManager> trx_mgr_;
   std::shared_ptr<FinalChain> final_chain_;
 
   addr_t node_addr_;

--- a/src/node/full_node.cpp
+++ b/src/node/full_node.cpp
@@ -103,8 +103,8 @@ void FullNode::init() {
   vote_mgr_ = std::make_shared<VoteManager>(node_addr, db_, final_chain_, pbft_chain_);
   trx_order_mgr_ = std::make_shared<TransactionOrderManager>(node_addr, db_);
   pbft_mgr_ = std::make_shared<PbftManager>(conf_.chain.pbft, genesis_hash, node_addr, db_, pbft_chain_, vote_mgr_,
-                                            next_votes_mgr_, dag_mgr_, dag_blk_mgr_, final_chain_, kp_.secret(),
-                                            conf_.vrf_secret);
+                                            next_votes_mgr_, dag_mgr_, dag_blk_mgr_, trx_mgr_, final_chain_,
+                                            kp_.secret(), conf_.vrf_secret);
   blk_proposer_ = std::make_shared<BlockProposer>(conf_.test_params.block_proposer, conf_.chain.vdf, dag_mgr_, trx_mgr_,
                                                   dag_blk_mgr_, final_chain_, node_addr, getSecretKey(),
                                                   getVrfSecretKey(), log_time_);

--- a/src/storage/db_storage.cpp
+++ b/src/storage/db_storage.cpp
@@ -338,14 +338,6 @@ void DbStorage::savePeriodData(const SyncBlock& sync_block, Batch& write_batch) 
     // Remove dag blocks
     remove(write_batch, Columns::dag_blocks, toSlice(block.getHash()));
   }
-  uint64_t position = 0;
-  for (auto const& trx : sync_block.transactions) {
-    // Remove transactions
-    remove(write_batch, Columns::transactions, toSlice(trx.getHash()));
-    addTransactionStatusToBatch(write_batch, trx.getHash(),
-                                TransactionStatus(TransactionStatusEnum::finalized, period, position));
-    position++;
-  }
 
   insert(write_batch, Columns::period_data, toSlice(period), toSlice(sync_block.rlp()));
 }
@@ -449,6 +441,10 @@ std::shared_ptr<std::pair<Transaction, taraxa::bytes>> DbStorage::getTransaction
 void DbStorage::addTransactionToBatch(Transaction const& trx, Batch& write_batch, bool verified) {
   insert(write_batch, DbStorage::Columns::transactions, toSlice(trx.getHash().asBytes()),
          toSlice(*trx.rlp(false, verified)));
+}
+
+void DbStorage::removeTransactionToBatch(trx_hash_t const& trx, Batch& write_batch) {
+  remove(write_batch, Columns::transactions, toSlice(trx));
 }
 
 bool DbStorage::transactionInDb(trx_hash_t const& hash) {

--- a/src/storage/db_storage.hpp
+++ b/src/storage/db_storage.hpp
@@ -195,6 +195,7 @@ struct DbStorage : std::enable_shared_from_this<DbStorage> {
   shared_ptr<pair<Transaction, taraxa::bytes>> getTransactionExt(trx_hash_t const& hash);
   bool transactionInDb(trx_hash_t const& hash);
   void addTransactionToBatch(Transaction const& trx, Batch& write_batch, bool verified = false);
+  void removeTransactionToBatch(trx_hash_t const& trx, Batch& write_batch);
 
   void saveTransactionStatus(trx_hash_t const& trx, TransactionStatus const& status);
   void addTransactionStatusToBatch(Batch& write_batch, trx_hash_t const& trx, TransactionStatus const& status);

--- a/src/transaction_manager/transaction_manager.hpp
+++ b/src/transaction_manager/transaction_manager.hpp
@@ -90,6 +90,9 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
   // Verify transactions in broadcasted blocks
   bool verifyBlockTransactions(DagBlock const &blk, std::vector<Transaction> const &trxs);
 
+  // Update the status of transactions to finalized and remove from transactions column
+  void updateFinalizedTransactionsStatus(SyncBlock const &sync_block);
+
   std::shared_ptr<std::pair<Transaction, taraxa::bytes>> getTransaction(trx_hash_t const &hash) const;
   unsigned long getTransactionCount() const;
   void addTrxCount(unsigned long num);
@@ -121,6 +124,8 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
   addr_t node_addr_;
   std::shared_ptr<DagManager> dag_mgr_;
   logger::Logger log_time_;
+  // Guards updating transaction status based on retrieved status
+  std::shared_mutex transaction_status_mutex_;
 
   LOG_OBJECTS_DEFINE
 };


### PR DESCRIPTION
Any time transaction status is updated based on the current transaction status, get and update operation are now protected with a mutex inside of transaction manager to prevent a race condition where transactions status ends up in an incorrect state:
Example:
At the same time transaction arrives with gossip and with syncing in executed block:
1. Syncing thread asks for a transaction status and gets unknown
2. Gossip handling thread asks for a transaction status and gets unknown
3. Syncing thread updates the status to finalized
4. Gossip thread updates the status to in_queue

With the added mutex this scenario is not possible 