### PR TITLE
fix: dag order

### DIFF
--- a/src/cli/testnet_config.hpp
+++ b/src/cli/testnet_config.hpp
@@ -86,14 +86,14 @@ const char *testnet_json = R"foo({
       "level": "0x0",
       "pivot": "0x0000000000000000000000000000000000000000000000000000000000000000",
       "sig": "0xb7e22d46c1ba94d5e8347b01d137b5c428fcbbeaf0a77fb024cbbf1517656ff00d04f7f25be608c321b0d7483c402c294ff46c49b265305d046a52236c0a363701",
-      "timestamp": "0x60b0329f",
+      "timestamp": "0x60b032a0",
       "tips": [],
       "transactions": []
     },
     "final_chain": {
       "genesis_block_fields": {
         "author": "0x0000000000000000000000000000000000000000",
-        "timestamp": "0x60b0329f"
+        "timestamp": "0x60b032a0"
       },
       "state": {
         "disable_block_rewards": true,

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -1614,6 +1614,9 @@ bool PbftManager::pushPbftBlock_(SyncBlock &sync_block, vec_blk_t &dag_blocks_or
   auto const &cert_votes = sync_block.cert_votes;
   auto pbft_period = sync_block.pbft_blk->getPeriod();
 
+  auto batch = db_->createWriteBatch();
+  dag_blk_mgr_->processSyncedBlock(batch, sync_block);
+
   if (!sync) {
     std::unordered_set<trx_hash_t> trx_set;
     std::vector<trx_hash_t> transactions_to_query;
@@ -1673,9 +1676,6 @@ bool PbftManager::pushPbftBlock_(SyncBlock &sync_block, vec_blk_t &dag_blocks_or
       return false;
     }
   }
-
-  auto batch = db_->createWriteBatch();
-  dag_blk_mgr_->processSyncedBlock(batch, sync_block);
 
   LOG(log_nf_) << "Storing cert votes of pbft blk " << pbft_block_hash;
   LOG(log_dg_) << "Stored following cert votes:\n" << cert_votes;

--- a/src/consensus/pbft_manager.hpp
+++ b/src/consensus/pbft_manager.hpp
@@ -143,7 +143,8 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   bool broadcastAlreadyThisStep_() const;
 
   bool comparePbftBlockScheduleWithDAGblocks_(blk_hash_t const &pbft_block_hash);
-  std::pair<vec_blk_t, bool> comparePbftBlockScheduleWithDAGblocks_(PbftBlock const &pbft_block);
+  std::optional<vec_blk_t> comparePbftBlockScheduleWithDAGblocks_(PbftBlock const &pbft_block);
+  bool checkHashOrderAndBuildSyncBlock(std::shared_ptr<PbftBlock> pbft_block, vec_blk_t const &dag_blocks);
 
   bool pushCertVotedPbftBlockIntoChain_(blk_hash_t const &cert_voted_block_hash,
                                         std::vector<Vote> const &cert_votes_for_round);
@@ -211,6 +212,9 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   std::pair<blk_hash_t, bool> soft_voted_block_for_this_round_ = std::make_pair(NULL_BLOCK_HASH, false);
 
   std::vector<Vote> votes_;
+
+  // Full sync block for pbft block that is being currecntly cert voted for
+  SyncBlock cert_sync_block_;
 
   time_point round_clock_initial_datetime_;
   time_point now_;

--- a/src/network/sync_block.hpp
+++ b/src/network/sync_block.hpp
@@ -17,6 +17,7 @@ class DagBlock;
 
 class SyncBlock {
  public:
+  SyncBlock() = default;
   SyncBlock(PbftBlock const& pbft_blk, std::vector<Vote> const& cert_votes);
   SyncBlock(dev::RLP const& all_rlp);
   SyncBlock(bytes const& all_rlp);


### PR DESCRIPTION
When a pbft block with incorrect order hash was pushed into a chain the push would fail but at the same time dag blocks within the pbft block were removed from the non-finalized set with method setDagBlockOrder, breaking the DAG and network got stuck. The check for incorrect order hash is now moved before calling setDagBlockOrder