### PR TITLE
fix(thread_pool): fix crash when trying to join ourselfs

### DIFF
--- a/src/util/thread_pool.cpp
+++ b/src/util/thread_pool.cpp
@@ -24,8 +24,12 @@ bool ThreadPool::is_running() const { return !threads_.empty(); }
 
 void ThreadPool::stop() {
   ioc_.stop();
+  auto id = std::this_thread::get_id();
   for (auto &th : threads_) {
-    th.join();
+    // check if we are not trying to join ourselfs
+    if (th.joinable() && id != threads_[0].get_id()) {
+      th.join();
+    }
   }
   threads_.clear();
   ioc_.restart();  // for potential restart


### PR DESCRIPTION
## Purpose
What was happening is that, FinalChainImpl has TP with just one thread and it also sends sheard_ptr of itself to TP. In some cases while running tests exception happened, because  FinalChainImpl destructor tied to destroy TP while it was inside, so it was basically calling join on itself

this resolves https://github.com/Taraxa-project/taraxa-node/issues/1152