### PR TITLE
fix: dag order

### DIFF
--- a/src/consensus/pbft_manager.hpp
+++ b/src/consensus/pbft_manager.hpp
@@ -123,7 +123,7 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   bool broadcastAlreadyThisStep_() const;
 
   bool comparePbftBlockScheduleWithDAGblocks_(blk_hash_t const &pbft_block_hash);
-  std::pair<vec_blk_t, bool> comparePbftBlockScheduleWithDAGblocks_(PbftBlock const &pbft_block);
+  std::optional<vec_blk_t> comparePbftBlockScheduleWithDAGblocks_(std::shared_ptr<PbftBlock> pbft_block);
 
   bool pushCertVotedPbftBlockIntoChain_(blk_hash_t const &cert_voted_block_hash,
                                         std::vector<std::shared_ptr<Vote>> const &cert_votes_for_round);
@@ -189,6 +189,9 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   blk_hash_t own_starting_value_for_round_ = NULL_BLOCK_HASH;
 
   std::pair<blk_hash_t, bool> soft_voted_block_for_this_round_ = std::make_pair(NULL_BLOCK_HASH, false);
+
+  // Full sync block for pbft block that is being currently cert voted for
+  SyncBlock cert_sync_block_;
 
   time_point round_clock_initial_datetime_;
   time_point now_;

--- a/src/consensus/sync_block.cpp
+++ b/src/consensus/sync_block.cpp
@@ -52,6 +52,13 @@ bytes SyncBlock::rlp() const {
   return s.out();
 }
 
+void SyncBlock::clear() {
+  pbft_blk.reset();
+  dag_blocks.clear();
+  transactions.clear();
+  cert_votes.clear();
+}
+
 std::ostream& operator<<(std::ostream& strm, SyncBlock const& b) {
   strm << "[SyncBlock] : " << b.pbft_blk << " , num of votes " << b.cert_votes.size() << std::endl;
   return strm;

--- a/src/consensus/sync_block.hpp
+++ b/src/consensus/sync_block.hpp
@@ -17,6 +17,7 @@ class DagBlock;
 
 class SyncBlock {
  public:
+  SyncBlock() = default;
   SyncBlock(PbftBlock const& pbft_blk, std::vector<std::shared_ptr<Vote>> const& cert_votes);
   SyncBlock(dev::RLP const& all_rlp);
   SyncBlock(bytes const& all_rlp);
@@ -26,6 +27,7 @@ class SyncBlock {
   std::vector<DagBlock> dag_blocks;
   std::vector<Transaction> transactions;
   bytes rlp() const;
+  void clear();
 };
 std::ostream& operator<<(std::ostream& strm, SyncBlock const& b);
 

--- a/src/dag/dag_block_manager.cpp
+++ b/src/dag/dag_block_manager.cpp
@@ -157,12 +157,23 @@ void DagBlockManager::processSyncedBlock(DbStorage::Batch &batch, SyncBlock cons
   // TODO: check synchronization due to concurrent processing of packets,
   // TODO: shouldn't be dag blocks marked as known trhough markBlockAsSeen here ?
 
-  trx_mgr_->addTrxCount(sync_block.transactions.size());
-  db_->addStatusFieldToBatch(StatusDbField::TrxCount, trx_mgr_->getTransactionCount(), batch);
   vector<trx_hash_t> transactions;
   transactions.reserve(sync_block.transactions.size());
   std::transform(sync_block.transactions.begin(), sync_block.transactions.end(), std::back_inserter(transactions),
                  [](const Transaction &transaction) { return transaction.getHash(); });
+
+  // TODO: optimize counters
+  uint32_t new_trx_count = 0;
+  auto trx_statuses = db_->getTransactionStatus(transactions);
+  for (auto const &trx_status : trx_statuses) {
+    if (trx_status.state != TransactionStatusEnum::in_block) {
+      new_trx_count++;
+    }
+  }
+
+  trx_mgr_->addTrxCount(new_trx_count);
+  db_->addStatusFieldToBatch(StatusDbField::TrxCount, trx_mgr_->getTransactionCount(), batch);
+
   trx_mgr_->getTransactionQueue().removeBlockTransactionsFromQueue(transactions);
   for (auto const &blk : sync_block.dag_blocks) {
     blk_status_.update(blk.getHash(), BlockStatus::verified);


### PR DESCRIPTION
Fix for dag order hash verification. Similar fix is already applied to testnet branch. This is the same fix but with moving the verification inside existing comparePbftBlockScheduleWithDAGblocks_ method