### PR TITLE
chore: remove dag block hash packets

### DIFF
--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -101,8 +101,6 @@ FullNodeConfig::FullNodeConfig(Json::Value const &string_or_object, Json::Value 
   network.network_performance_log_interval =
       getConfigDataAsUInt(root, {"network_performance_log_interval"}, true, 30000 /*ms*/);
   network.network_transaction_interval = getConfigDataAsUInt(root, {"network_transaction_interval"});
-  network.network_min_dag_block_broadcast = getConfigDataAsUInt(root, {"network_min_dag_block_broadcast"}, true, 5);
-  network.network_max_dag_block_broadcast = getConfigDataAsUInt(root, {"network_max_dag_block_broadcast"}, true, 20);
   network.network_bandwidth = getConfigDataAsUInt(root, {"network_bandwidth"});
   network.network_ideal_peer_count = getConfigDataAsUInt(root, {"network_ideal_peer_count"});
   network.network_max_peer_count = getConfigDataAsUInt(root, {"network_max_peer_count"});

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -37,8 +37,6 @@ struct NetworkConfig {
   uint16_t network_ideal_peer_count = 0;
   uint16_t network_max_peer_count = 0;
   uint16_t network_transaction_interval = 0;
-  uint16_t network_min_dag_block_broadcast = 0;
-  uint16_t network_max_dag_block_broadcast = 0;
   uint16_t network_sync_level_size = 0;
   uint64_t network_id;
   uint16_t network_performance_log_interval = 0;

--- a/src/network/tarcap/packet_types.hpp
+++ b/src/network/tarcap/packet_types.hpp
@@ -12,8 +12,6 @@ namespace taraxa::network::tarcap {
 enum SubprotocolPacketType : uint32_t {
   StatusPacket = 0,
   NewBlockPacket,
-  NewBlockHashPacket,
-  GetNewBlockPacket,
   GetBlocksPacket,
   BlocksPacket,
   TransactionPacket,
@@ -43,19 +41,17 @@ enum PriorityQueuePacketType : uint32_t {
   kPqMidPriorityPackets = 1 << 3,
   kPqNewPbftBlockPacket = 1 << 4,
   kPqNewBlockPacket = 1 << 5,
-  kPqNewBlockHashPacket = 1 << 6,
-  kPqGetNewBlockPacket = 1 << 7,
-  kPqTransactionPacket = 1 << 8,
+  kPqTransactionPacket = 1 << 6,
 
   // Non critical packets with low processing priority
-  kPqLowPriorityPackets = 1 << 9,
-  kPqTestPacket = 1 << 10,
-  kPqStatusPacket = 1 << 11,
-  kPqGetBlocksPacket = 1 << 12,
-  kPqBlocksPacket = 1 << 13,
-  kPqGetPbftBlockPacket = 1 << 14,
-  kPqPbftBlockPacket = 1 << 15,
-  kPqSyncedPacket = 1 << 16,
+  kPqLowPriorityPackets = 1 << 7,
+  kPqTestPacket = 1 << 8,
+  kPqStatusPacket = 1 << 9,
+  kPqGetBlocksPacket = 1 << 10,
+  kPqBlocksPacket = 1 << 11,
+  kPqGetPbftBlockPacket = 1 << 12,
+  kPqPbftBlockPacket = 1 << 13,
+  kPqSyncedPacket = 1 << 14,
 };
 
 /**
@@ -68,10 +64,6 @@ inline PriorityQueuePacketType mapSubProtocolToPriorityPacketType(SubprotocolPac
       return PriorityQueuePacketType::kPqStatusPacket;
     case SubprotocolPacketType::NewBlockPacket:
       return PriorityQueuePacketType::kPqNewBlockPacket;
-    case SubprotocolPacketType::NewBlockHashPacket:
-      return PriorityQueuePacketType::kPqNewBlockHashPacket;
-    case SubprotocolPacketType::GetNewBlockPacket:
-      return PriorityQueuePacketType::kPqGetNewBlockPacket;
     case SubprotocolPacketType::GetBlocksPacket:
       return PriorityQueuePacketType::kPqGetBlocksPacket;
     case SubprotocolPacketType::BlocksPacket:
@@ -112,10 +104,6 @@ inline std::string convertPacketTypeToString(SubprotocolPacketType packet_type) 
       return "StatusPacket";
     case NewBlockPacket:
       return "NewBlockPacket";
-    case NewBlockHashPacket:
-      return "NewBlockHashPacket";
-    case GetNewBlockPacket:
-      return "GetNewBlockPacket";
     case GetBlocksPacket:
       return "GetBlocksPacket";
     case BlocksPacket:

--- a/src/network/tarcap/packets_handlers/dag_packets_handler.cpp
+++ b/src/network/tarcap/packets_handlers/dag_packets_handler.cpp
@@ -29,15 +29,6 @@ thread_local mt19937_64 DagPacketsHandler::urng_{std::mt19937_64(std::random_dev
 void DagPacketsHandler::process(const dev::RLP &packet_rlp, const PacketData &packet_data,
 
                                 const std::shared_ptr<TaraxaPeer> &peer) {
-  if (packet_data.type_ == PriorityQueuePacketType::kPqNewBlockPacket) {
-    processNewBlockPacket(packet_rlp, packet_data, peer);
-  } else {
-    assert(false);
-  }
-}
-
-inline void DagPacketsHandler::processNewBlockPacket(const dev::RLP &packet_rlp, const PacketData &packet_data,
-                                                     const std::shared_ptr<TaraxaPeer> &peer) {
   DagBlock block(packet_rlp[0].data().toBytes());
   blk_hash_t const hash = block.getHash();
   peer->markBlockAsKnown(hash);
@@ -121,12 +112,6 @@ void DagPacketsHandler::onNewBlockReceived(DagBlock block, std::vector<Transacti
     LOG(log_dg_) << "Received NewBlock " << block.getHash().toString() << "that is already known";
     return;
   }
-}
-
-bool DagPacketsHandler::insertBlockRequest(const blk_hash_t &block_hash) {
-  std::unique_lock lock(block_requestes_mutex_);
-
-  return block_requestes_set_.insert(block_hash).second;
 }
 
 void DagPacketsHandler::onNewBlockVerified(DagBlock const &block, bool proposed) {

--- a/src/network/tarcap/packets_handlers/dag_packets_handler.cpp
+++ b/src/network/tarcap/packets_handlers/dag_packets_handler.cpp
@@ -15,17 +15,14 @@ DagPacketsHandler::DagPacketsHandler(std::shared_ptr<PeersState> peers_state,
                                      std::shared_ptr<SyncingHandler> syncing_handler,
                                      std::shared_ptr<TransactionManager> trx_mgr,
                                      std::shared_ptr<DagBlockManager> dag_blk_mgr, std::shared_ptr<DbStorage> db,
-                                     std::shared_ptr<TestState> test_state, uint16_t network_min_dag_block_broadcast,
-                                     uint16_t network_max_dag_block_broadcast, const addr_t &node_addr)
+                                     std::shared_ptr<TestState> test_state, const addr_t &node_addr)
     : PacketHandler(std::move(peers_state), std::move(packets_stats), node_addr, "DAG_BLOCKS_PH"),
       syncing_state_(std::move(syncing_state)),
       syncing_handler_(std::move(syncing_handler)),
       trx_mgr_(std::move(trx_mgr)),
       dag_blk_mgr_(std::move(dag_blk_mgr)),
       db_(std::move(db)),
-      test_state_(std::move(test_state)),
-      network_min_dag_block_broadcast_(network_min_dag_block_broadcast),
-      network_max_dag_block_broadcast_(network_max_dag_block_broadcast) {}
+      test_state_(std::move(test_state)) {}
 
 thread_local mt19937_64 DagPacketsHandler::urng_{std::mt19937_64(std::random_device()())};
 
@@ -34,10 +31,6 @@ void DagPacketsHandler::process(const dev::RLP &packet_rlp, const PacketData &pa
                                 const std::shared_ptr<TaraxaPeer> &peer) {
   if (packet_data.type_ == PriorityQueuePacketType::kPqNewBlockPacket) {
     processNewBlockPacket(packet_rlp, packet_data, peer);
-  } else if (packet_data.type_ == PriorityQueuePacketType::kPqNewBlockHashPacket) {
-    processNewBlockHashPacket(packet_rlp, packet_data, peer);
-  } else if (packet_data.type_ == PriorityQueuePacketType::kPqGetNewBlockPacket) {
-    processGetNewBlockPacket(packet_rlp, packet_data, peer);
   } else {
     assert(false);
   }
@@ -77,50 +70,6 @@ inline void DagPacketsHandler::processNewBlockPacket(const dev::RLP &packet_rlp,
   }
 
   onNewBlockReceived(block, new_transactions);
-}
-
-inline void DagPacketsHandler::processNewBlockHashPacket(const dev::RLP &packet_rlp, const PacketData &packet_data,
-                                                         const std::shared_ptr<TaraxaPeer> &peer) {
-  blk_hash_t const hash(packet_rlp[0]);
-  peer->markBlockAsKnown(hash);
-
-  LOG(log_dg_) << "Received NewBlockHashPacket " << hash.toString();
-
-  if (dag_blk_mgr_) {
-    if (!dag_blk_mgr_->isBlockKnown(hash) && insertBlockRequest(hash)) {
-      requestBlock(packet_data.from_node_id_, hash);
-    }
-
-    return;
-  }
-
-  // Functionality needed only in tests...
-  // TODO: refactor tests so this is not used anymore
-  if (!test_state_->hasBlock(hash) && insertBlockRequest(hash)) {
-    requestBlock(packet_data.from_node_id_, hash);
-  }
-}
-
-inline void DagPacketsHandler::processGetNewBlockPacket(const dev::RLP &packet_rlp, const PacketData &packet_data,
-                                                        const std::shared_ptr<TaraxaPeer> &peer) {
-  blk_hash_t const hash(packet_rlp[0]);
-  LOG(log_dg_) << "Received GetNewBlockPacket" << hash.toString();
-
-  if (dag_blk_mgr_) {
-    auto block = dag_blk_mgr_->getDagBlock(hash);
-    if (block) {
-      sendBlock(packet_data.from_node_id_, *block);
-    } else
-      LOG(log_nf_) << "Requested block: " << hash.toString() << " not in DB";
-  } else if (test_state_->hasBlock(hash)) {
-    sendBlock(packet_data.from_node_id_, test_state_->getBlock(hash));
-  }
-  peer->markBlockAsKnown(hash);
-}
-
-void DagPacketsHandler::requestBlock(dev::p2p::NodeID const &peer_id, blk_hash_t hash) {
-  LOG(log_dg_) << "requestBlock " << hash.toString();
-  sealAndSend(peer_id, GetNewBlockPacket, std::move(dev::RLPStream(1) << hash));
 }
 
 void DagPacketsHandler::sendBlock(dev::p2p::NodeID const &peer_id, taraxa::DagBlock block) {
@@ -190,15 +139,12 @@ void DagPacketsHandler::onNewBlockVerified(DagBlock const &block, bool proposed)
   const auto &block_hash = block.getHash();
   LOG(log_dg_) << "Verified NewBlock " << block_hash.toString();
 
-  auto const peers_without_block = selectPeers(block_hash);
-
-  auto const peers_to_send_number = std::min<std::size_t>(
-      std::max<std::size_t>(network_min_dag_block_broadcast_, std::sqrt(peers_state_->getPeersCount())),
-      network_max_dag_block_broadcast_);
-
   std::vector<dev::p2p::NodeID> peers_to_send;
-  std::vector<dev::p2p::NodeID> peers_to_announce;
-  std::tie(peers_to_send, peers_to_announce) = randomPartitionPeers(peers_without_block, peers_to_send_number);
+  for (auto const &peer : peers_state_->getAllPeers()) {
+    if (!peer.second->isBlockKnown(block_hash) && !peer.second->syncing_) {
+      peers_to_send.push_back(peer.first);
+    }
+  }
 
   for (dev::p2p::NodeID const &peer_id : peers_to_send) {
     RLPStream ts;
@@ -209,50 +155,5 @@ void DagPacketsHandler::onNewBlockVerified(DagBlock const &block, bool proposed)
     }
   }
   if (!peers_to_send.empty()) LOG(log_dg_) << "Sent block to " << peers_to_send.size() << " peers";
-
-  for (dev::p2p::NodeID const &peer_id : peers_to_announce) {
-    RLPStream ts;
-    auto peer = peers_state_->getPeer(peer_id);
-    if (peer && !peer->syncing_) {
-      sendBlockHash(peer_id, block);
-      peer->markBlockAsKnown(block_hash);
-    }
-  }
-  if (!peers_to_announce.empty()) LOG(log_dg_) << "Anounced block to " << peers_to_announce.size() << " peers";
 }
-
-void DagPacketsHandler::sendBlockHash(dev::p2p::NodeID const &peer_id, taraxa::DagBlock block) {
-  LOG(log_dg_) << "sendBlockHash " << block.getHash().toString();
-  sealAndSend(peer_id, NewBlockHashPacket, std::move(RLPStream(1) << block.getHash()));
-}
-
-std::pair<std::vector<dev::p2p::NodeID>, std::vector<dev::p2p::NodeID>> DagPacketsHandler::randomPartitionPeers(
-    std::vector<dev::p2p::NodeID> const &_peers, std::size_t _number) {
-  vector<dev::p2p::NodeID> part1(_peers);
-  vector<dev::p2p::NodeID> part2;
-
-  if (_number >= _peers.size()) return std::make_pair(part1, part2);
-
-  std::shuffle(part1.begin(), part1.end(), urng_);
-
-  // Remove elements from the end of the shuffled part1 vector and move
-  // them to part2.
-  std::move(part1.begin() + _number, part1.end(), std::back_inserter(part2));
-  part1.erase(part1.begin() + _number, part1.end());
-  return std::make_pair(move(part1), move(part2));
-}
-
-std::vector<dev::p2p::NodeID> DagPacketsHandler::selectPeers(const blk_hash_t &block_hash) {
-  std::vector<dev::p2p::NodeID> allowed;
-  for (auto const &peer : peers_state_->getAllPeers()) {
-    if (peer.second->isBlockKnown(block_hash)) {
-      continue;
-    }
-
-    allowed.push_back(peer.first);
-  }
-
-  return allowed;
-}
-
 }  // namespace taraxa::network::tarcap

--- a/src/network/tarcap/packets_handlers/dag_packets_handler.hpp
+++ b/src/network/tarcap/packets_handlers/dag_packets_handler.hpp
@@ -34,23 +34,12 @@ class DagPacketsHandler : public PacketHandler {
   inline void processNewBlockPacket(const dev::RLP &packet_rlp, const PacketData &packet_data,
                                     const std::shared_ptr<TaraxaPeer> &peer);
 
-  /**
-   * @brief Inserts block request
-   *
-   * @param block_hash
-   * @return true in case actual insertion took place, otherwise false
-   */
-  bool insertBlockRequest(const blk_hash_t &block_hash);
-
   std::shared_ptr<SyncingState> syncing_state_;
   std::shared_ptr<SyncingHandler> syncing_handler_;
   std::shared_ptr<TransactionManager> trx_mgr_;
   std::shared_ptr<DagBlockManager> dag_blk_mgr_;
   std::shared_ptr<DbStorage> db_;
   std::shared_ptr<TestState> test_state_;
-
-  mutable std::shared_mutex block_requestes_mutex_;
-  std::unordered_set<blk_hash_t> block_requestes_set_;
 
   thread_local static std::mt19937_64 urng_;
 };

--- a/src/network/tarcap/packets_handlers/dag_packets_handler.hpp
+++ b/src/network/tarcap/packets_handlers/dag_packets_handler.hpp
@@ -19,15 +19,11 @@ class DagPacketsHandler : public PacketHandler {
   DagPacketsHandler(std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
                     std::shared_ptr<SyncingState> syncing_state, std::shared_ptr<SyncingHandler> syncing_handler,
                     std::shared_ptr<TransactionManager> trx_mgr, std::shared_ptr<DagBlockManager> dag_blk_mgr,
-                    std::shared_ptr<DbStorage> db, std::shared_ptr<TestState> test_state,
-                    uint16_t network_min_dag_block_broadcast, uint16_t network_max_dag_block_broadcast,
-                    const addr_t &node_addr = {});
+                    std::shared_ptr<DbStorage> db, std::shared_ptr<TestState> test_state, const addr_t &node_addr = {});
 
   virtual ~DagPacketsHandler() = default;
 
-  void requestBlock(dev::p2p::NodeID const &peer_id, blk_hash_t hash);
   void sendBlock(dev::p2p::NodeID const &peer_id, DagBlock block);
-  void sendBlockHash(dev::p2p::NodeID const &peer_id, taraxa::DagBlock block);
   void onNewBlockReceived(DagBlock block, std::vector<Transaction> transactions);
   void onNewBlockVerified(DagBlock const &block, bool proposed);
 
@@ -37,10 +33,6 @@ class DagPacketsHandler : public PacketHandler {
 
   inline void processNewBlockPacket(const dev::RLP &packet_rlp, const PacketData &packet_data,
                                     const std::shared_ptr<TaraxaPeer> &peer);
-  inline void processNewBlockHashPacket(const dev::RLP &packet_rlp, const PacketData &packet_data,
-                                        const std::shared_ptr<TaraxaPeer> &peer);
-  inline void processGetNewBlockPacket(const dev::RLP &packet_rlp, const PacketData &packet_data,
-                                       const std::shared_ptr<TaraxaPeer> &peer);
 
   /**
    * @brief Inserts block request
@@ -50,20 +42,12 @@ class DagPacketsHandler : public PacketHandler {
    */
   bool insertBlockRequest(const blk_hash_t &block_hash);
 
-  std::pair<std::vector<dev::p2p::NodeID>, std::vector<dev::p2p::NodeID>> randomPartitionPeers(
-      std::vector<dev::p2p::NodeID> const &_peers, std::size_t _number);
-
-  std::vector<dev::p2p::NodeID> selectPeers(const blk_hash_t &block_hash);
-
   std::shared_ptr<SyncingState> syncing_state_;
   std::shared_ptr<SyncingHandler> syncing_handler_;
   std::shared_ptr<TransactionManager> trx_mgr_;
   std::shared_ptr<DagBlockManager> dag_blk_mgr_;
   std::shared_ptr<DbStorage> db_;
   std::shared_ptr<TestState> test_state_;
-
-  const uint16_t network_min_dag_block_broadcast_;
-  const uint16_t network_max_dag_block_broadcast_;
 
   mutable std::shared_mutex block_requestes_mutex_;
   std::unordered_set<blk_hash_t> block_requestes_set_;

--- a/src/network/tarcap/taraxa_capability.cpp
+++ b/src/network/tarcap/taraxa_capability.cpp
@@ -191,11 +191,8 @@ void TaraxaCapability::registerPacketHandlers(
       std::make_shared<NewPbftBlockPacketHandler>(peers_state_, packets_stats, pbft_chain, pbft_mgr, node_addr));
 
   const auto dag_handler = std::make_shared<DagPacketsHandler>(
-      peers_state_, packets_stats, syncing_state_, syncing_handler_, trx_mgr, dag_blk_mgr, db, test_state_,
-      conf.network_min_dag_block_broadcast, conf.network_max_dag_block_broadcast, node_addr);
+      peers_state_, packets_stats, syncing_state_, syncing_handler_, trx_mgr, dag_blk_mgr, db, test_state_, node_addr);
   packets_handlers_->registerHandler(PriorityQueuePacketType::kPqNewBlockPacket, dag_handler);
-  packets_handlers_->registerHandler(PriorityQueuePacketType::kPqNewBlockHashPacket, dag_handler);
-  packets_handlers_->registerHandler(PriorityQueuePacketType::kPqGetNewBlockPacket, dag_handler);
 
   packets_handlers_->registerHandler(
       PriorityQueuePacketType::kPqTransactionPacket,

--- a/src/network/tarcap/threadpool/priority_queue.cpp
+++ b/src/network/tarcap/threadpool/priority_queue.cpp
@@ -125,7 +125,6 @@ void PriorityQueue::updateDependenciesStart(const PacketData& packet) {
   // block before sending txs it contains...
   if (packet.type_ == PriorityQueuePacketType::kPqTransactionPacket) {
     blocked_packets_mask_.markPacketAsPeerTimeBlocked(packet, PriorityQueuePacketType::kPqNewBlockPacket);
-    blocked_packets_mask_.markPacketAsPeerTimeBlocked(packet, PriorityQueuePacketType::kPqNewBlockHashPacket);
   }
 }
 
@@ -145,7 +144,6 @@ void PriorityQueue::updateDependenciesFinish(const PacketData& packet, std::mute
     std::unique_lock<std::mutex> lock(queue_mutex);
 
     blocked_packets_mask_.markPacketAsPeerTimeUnblocked(packet, PriorityQueuePacketType::kPqNewBlockPacket);
-    blocked_packets_mask_.markPacketAsPeerTimeUnblocked(packet, PriorityQueuePacketType::kPqNewBlockHashPacket);
   }
 
   act_total_workers_count_--;


### PR DESCRIPTION
Removing functionality of sending only dag block hashes as part of gossiping as it makes it very difficult to synchronize dag blocks order. This functionality does not make sense in an environment where a lot of dag blocks are proposed in parallel in short amount of time.