### PR TITLE
Improve dag status

### DIFF
--- a/src/consensus/block_proposer.cpp
+++ b/src/consensus/block_proposer.cpp
@@ -115,20 +115,6 @@ void BlockProposer::stop() {
   proposer_worker_->join();
 }
 
-bool BlockProposer::getLatestPivotAndTips(blk_hash_t& pivot, vec_blk_t& tips) {
-  bool ok = dag_mgr_->getLatestPivotAndTips(pivot, tips);
-  if (ok) {
-    LOG(log_nf_) << "BlockProposer: pivot: " << pivot.toString() << ", tip size = " << tips.size() << std::endl;
-    LOG(log_tr_) << "Tips: " << tips;
-  } else {
-    LOG(log_er_) << "Pivot and tips unavailable ..." << std::endl;
-    return ok;
-  }
-
-  LOG(log_time_) << "Pivot and Tips retrieved at: " << getCurrentTimeMilliSeconds();
-  return ok;
-}
-
 bool BlockProposer::getShardedTrxs(vec_trx_t& sharded_trxs) {
   vec_trx_t to_be_packed_trx;
   trx_mgr_->packTrxs(to_be_packed_trx, bp_config_.transaction_limit);

--- a/src/consensus/block_proposer.hpp
+++ b/src/consensus/block_proposer.hpp
@@ -99,7 +99,6 @@ class BlockProposer : public std::enable_shared_from_this<BlockProposer> {
   void setNetwork(std::weak_ptr<Network> network) { network_ = move(network); }
   void proposeBlock(blk_hash_t const& pivot, level_t level, vec_blk_t tips, vec_trx_t trxs, VdfSortition const& vdf);
   bool getShardedTrxs(vec_trx_t& sharded_trx);
-  bool getLatestPivotAndTips(blk_hash_t& pivot, vec_blk_t& tips);
   level_t getProposeLevel(blk_hash_t const& pivot, vec_blk_t const& tips);
   bool validDposProposer(level_t const propose_level);
   // debug

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -113,8 +113,7 @@ void PbftManager::run() {
                    << pbft_block->getPeriod() << " in block data than in block order db: " << period;
       assert(false);
     }
-    finalize_(*pbft_block, db_->getFinalizedDagBlockHashesByAnchor(pbft_block->getPivotDagBlockHash()),
-              period == curr_period);
+    finalize_(*pbft_block, db_->getFinalizedDagBlockHashesByPeriod(period), period == curr_period);
   }
 
   // Initialize PBFT status

--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -1380,7 +1380,7 @@ std::optional<vec_blk_t> PbftManager::comparePbftBlockScheduleWithDAGblocks_(std
     dag_blocks_order.reserve(cert_sync_block_.dag_blocks.size());
     std::transform(cert_sync_block_.dag_blocks.begin(), cert_sync_block_.dag_blocks.end(),
                    std::back_inserter(dag_blocks_order), [](const DagBlock &dag_block) { return dag_block.getHash(); });
-    return std::move(dag_blocks_order);
+    return {std::move(dag_blocks_order)};
   }
   auto const &anchor_hash = pbft_block->getPivotDagBlockHash();
   auto dag_blocks_order = dag_mgr_->getDagBlockOrder(anchor_hash).second;
@@ -1435,7 +1435,7 @@ std::optional<vec_blk_t> PbftManager::comparePbftBlockScheduleWithDAGblocks_(std
     }
     cert_sync_block_.pbft_blk = std::move(pbft_block);
 
-    return std::move(dag_blocks_order);
+    return {std::move(dag_blocks_order)};
   }
   syncPbftChainFromPeers_(missing_dag_blk, anchor_hash);
   return {};
@@ -1580,7 +1580,7 @@ bool PbftManager::pushPbftBlock_(SyncBlock &sync_block, vec_blk_t &dag_blocks_or
 
   // Set DAG blocks period
   auto const &anchor_hash = sync_block.pbft_blk->getPivotDagBlockHash();
-  dag_mgr_->setDagBlockOrder(anchor_hash, pbft_period, dag_blocks_order, batch);
+  dag_mgr_->setDagBlockOrder(anchor_hash, pbft_period, dag_blocks_order);
 
   db_->savePeriodData(sync_block, batch);
 

--- a/src/dag/dag.cpp
+++ b/src/dag/dag.cpp
@@ -510,7 +510,6 @@ uint DagManager::setDagBlockOrder(blk_hash_t const &new_anchor, uint64_t period,
                                   DbStorage::Batch &write_batch) {
   uLock lock(mutex_);
   LOG(log_dg_) << "setDagBlockOrder called with anchor " << new_anchor << " and period " << period;
-  db_->putFinalizedDagBlockHashesByAnchor(write_batch, new_anchor, dag_order);
   if (period != period_ + 1) {
     LOG(log_er_) << " Inserting period (" << period << ") anchor " << new_anchor
                  << " does not match ..., previous internal period (" << period_ << ") " << anchor_;

--- a/src/dag/dag.hpp
+++ b/src/dag/dag.hpp
@@ -128,7 +128,7 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
   blk_hash_t const &get_genesis() { return genesis_; }
 
   bool pivotAndTipsAvailable(DagBlock const &blk);
-  void addDagBlock(DagBlock const &blk, bool finalized = false,
+  void addDagBlock(DagBlock const &blk,
                    bool save = true);  // insert to buffer if fail
 
   // return {period, block order}, for pbft-pivot-blk proposing (does not
@@ -136,8 +136,7 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
   std::pair<uint64_t, vec_blk_t> getDagBlockOrder(blk_hash_t const &anchor);
   // receive pbft-povit-blk, update periods and finalized, return size of
   // ordered blocks
-  uint setDagBlockOrder(blk_hash_t const &anchor, uint64_t period, vec_blk_t const &dag_order,
-                        DbStorage::Batch &write_batch);
+  uint setDagBlockOrder(blk_hash_t const &anchor, uint64_t period, vec_blk_t const &dag_order);
 
   bool getLatestPivotAndTips(blk_hash_t &pivot, std::vector<blk_hash_t> &tips) const;
 
@@ -179,7 +178,7 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
  private:
   void recoverDag();
   void addToDag(blk_hash_t const &hash, blk_hash_t const &pivot, std::vector<blk_hash_t> const &tips, uint64_t level,
-                DbStorage::Batch &write_batch, bool finalized = false);
+                bool finalized = false);
   void worker();
   std::pair<blk_hash_t, std::vector<blk_hash_t>> getFrontier() const;  // return pivot and tips
   std::atomic<level_t> max_level_ = 0;

--- a/src/dag/dag.hpp
+++ b/src/dag/dag.hpp
@@ -113,8 +113,8 @@ class FullNode;
 
 class DagManager : public std::enable_shared_from_this<DagManager> {
  public:
-  using uLock = boost::unique_lock<boost::shared_mutex>;
-  using sharedLock = boost::shared_lock<boost::shared_mutex>;
+  using ULock = boost::unique_lock<boost::shared_mutex>;
+  using SharedLock = boost::shared_lock<boost::shared_mutex>;
 
   explicit DagManager(blk_hash_t const &genesis, addr_t node_addr, std::shared_ptr<TransactionManager> trx_mgr,
                       std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<DagBlockManager> dag_blk_mgr,
@@ -138,7 +138,7 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
   // ordered blocks
   uint setDagBlockOrder(blk_hash_t const &anchor, uint64_t period, vec_blk_t const &dag_order);
 
-  bool getLatestPivotAndTips(blk_hash_t &pivot, std::vector<blk_hash_t> &tips) const;
+  std::optional<std::pair<blk_hash_t, std::vector<blk_hash_t>>> getLatestPivotAndTips() const;
 
   void getGhostPath(blk_hash_t const &source, std::vector<blk_hash_t> &ghost) const;
   void getGhostPath(std::vector<blk_hash_t> &ghost) const;  // get ghost path from last anchor
@@ -156,11 +156,11 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
 
   // DAG anchors
   uint64_t getLatestPeriod() const {
-    sharedLock lock(mutex_);
+    SharedLock lock(mutex_);
     return period_;
   }
   std::pair<blk_hash_t, blk_hash_t> getAnchors() const {
-    sharedLock lock(mutex_);
+    SharedLock lock(mutex_);
     return std::make_pair(old_anchor_, anchor_);
   }
 

--- a/src/dag/dag_block_manager.cpp
+++ b/src/dag/dag_block_manager.cpp
@@ -175,9 +175,6 @@ void DagBlockManager::processSyncedBlock(DbStorage::Batch &batch, SyncBlock cons
   db_->addStatusFieldToBatch(StatusDbField::TrxCount, trx_mgr_->getTransactionCount(), batch);
 
   trx_mgr_->getTransactionQueue().removeBlockTransactionsFromQueue(transactions);
-  for (auto const &blk : sync_block.dag_blocks) {
-    blk_status_.update(blk.getHash(), BlockStatus::verified);
-  }
 }
 
 void DagBlockManager::insertBroadcastedBlockWithTransactions(DagBlock const &blk,
@@ -326,9 +323,6 @@ void DagBlockManager::verifyBlock() {
         verified_qu_[blk.first.getLevel()].emplace_back(blk.first);
       }
     }
-
-    blk_status_.update(block_hash, BlockStatus::verified);
-
     cond_for_verified_qu_.notify_one();
     LOG(log_dg_) << "Verified block: " << block_hash << std::endl;
   }

--- a/src/dag/dag_block_manager.hpp
+++ b/src/dag/dag_block_manager.hpp
@@ -66,6 +66,7 @@ class DagBlockManager {
   using sharedLock = boost::shared_lock<boost::shared_mutex>;
 
   void verifyBlock();
+  void markBlockInvalid(blk_hash_t const &hash);
 
   std::atomic<bool> stopped_ = true;
   size_t num_verifiers_ = 4;

--- a/src/dag/dag_block_manager.hpp
+++ b/src/dag/dag_block_manager.hpp
@@ -8,7 +8,7 @@
 
 namespace taraxa {
 
-enum class BlockStatus { invalid, proposed, broadcasted, verified, unseen };
+enum class BlockStatus { invalid, proposed, broadcasted };
 
 using BlockStatusTable = ExpirationCacheMap<blk_hash_t, BlockStatus>;
 

--- a/src/network/rpc/Taraxa.cpp
+++ b/src/network/rpc/Taraxa.cpp
@@ -83,7 +83,7 @@ Json::Value Taraxa::taraxa_getScheduleBlockByPeriod(std::string const& _period) 
     if (!blk.has_value()) {
       return Json::Value();
     }
-    return PbftBlock::toJson(*blk, db->getFinalizedDagBlockHashesByAnchor(blk->getPivotDagBlockHash()));
+    return PbftBlock::toJson(*blk, db->getFinalizedDagBlockHashesByPeriod(std::stoull(_period, 0, 16)));
   } catch (...) {
     BOOST_THROW_EXCEPTION(JsonRpcException(Errors::ERROR_RPC_INVALID_PARAMS));
   }

--- a/src/storage/db_storage.hpp
+++ b/src/storage/db_storage.hpp
@@ -96,8 +96,6 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
     COLUMN(period_data);
     COLUMN(dag_blocks);
     COLUMN(dag_blocks_index);
-    COLUMN(dag_blocks_state);  // remove
-    // anchor_hash->[...dag_block_hashes_since_previous_anchor, anchor_hash]
     COLUMN(transactions);
     COLUMN(trx_status);
     COLUMN(status);
@@ -191,11 +189,8 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   std::set<blk_hash_t> getBlocksByLevel(level_t level);
   std::vector<std::shared_ptr<DagBlock>> getDagBlocksAtLevel(level_t level, int number_of_levels);
   void updateDagBlockCounters(Batch& write_batch, std::vector<DagBlock> blks);
-
-  // DAG state
-  void addDagBlockStateToBatch(Batch& write_batch, blk_hash_t const& blk_hash, bool finalized);
-  void removeDagBlockStateToBatch(Batch& write_batch, blk_hash_t const& blk_hash);
-  std::map<blk_hash_t, bool> getAllDagBlockState();
+  std::vector<DagBlock> getNonfinalizedDagBlocks();
+  void removeNonfinalizedDagBlock(blk_hash_t const& hash);
 
   // Transaction
   void saveTransaction(Transaction const& trx, bool verified = false);

--- a/src/storage/db_storage.hpp
+++ b/src/storage/db_storage.hpp
@@ -41,6 +41,7 @@ enum PbftMgrPreviousRoundStatus : uint8_t {
 };
 
 enum PbftMgrRoundStep : uint8_t { PbftRound = 0, PbftStep };
+
 enum PbftMgrStatus : uint8_t {
   SoftVotedBlockInRound = 0,
   ExecutedBlock,
@@ -91,14 +92,12 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
 
 #define COLUMN(__name__) static inline auto const __name__ = all_.emplace_back(#__name__, all_.size())
 
-    COLUMN(default_column);
     // Contains full data for an executed PBFT block including PBFT block, cert votes, dag blocks and transactions
     COLUMN(period_data);
     COLUMN(dag_blocks);
     COLUMN(dag_blocks_index);
-    COLUMN(dag_blocks_state);
+    COLUMN(dag_blocks_state);  // remove
     // anchor_hash->[...dag_block_hashes_since_previous_anchor, anchor_hash]
-    COLUMN(dag_finalized_blocks);
     COLUMN(transactions);
     COLUMN(trx_status);
     COLUMN(status);
@@ -298,8 +297,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   auto getNumBlockExecuted() { return getStatusField(StatusDbField::ExecutedBlkCount); }
   uint64_t getNumDagBlocks() { return getDagBlocksCount(); }
 
-  vector<blk_hash_t> getFinalizedDagBlockHashesByAnchor(blk_hash_t const& anchor);
-  void putFinalizedDagBlockHashesByAnchor(WriteBatch& b, blk_hash_t const& anchor, vector<blk_hash_t> const& hs);
+  vector<blk_hash_t> getFinalizedDagBlockHashesByPeriod(uint32_t period);
 
   // DPOS proposal period levels status
   uint64_t getDposProposalPeriodLevelsField(DposProposalPeriodLevelsStatus field);

--- a/tests/dag_test.cpp
+++ b/tests/dag_test.cpp
@@ -234,13 +234,10 @@ TEST_F(DagTest, receive_block_in_order) {
   mgr->addDagBlock(blk3);
   taraxa::thisThreadSleepForMilliSeconds(500);
 
-  blk_hash_t pivot;
-  std::vector<blk_hash_t> tips;
-  std::vector<Dag::vertex_t> criticals;
-  mgr->getLatestPivotAndTips(pivot, tips);
+  auto ret = mgr->getLatestPivotAndTips();
 
-  EXPECT_EQ(pivot, blk_hash_t("0000000000000000000000000000000000000000000000000000000000000002"));
-  EXPECT_EQ(tips.size(), 1);
+  EXPECT_EQ(ret->first, blk_hash_t("0000000000000000000000000000000000000000000000000000000000000002"));
+  EXPECT_EQ(ret->second.size(), 1);
   EXPECT_EQ(mgr->getNumVerticesInDag().first, 4);
   // total edges
   EXPECT_EQ(mgr->getNumEdgesInDag().first, 5);
@@ -350,14 +347,11 @@ TEST_F(DagTest, get_latest_pivot_tips) {
   mgr->addDagBlock(blk6);
   taraxa::thisThreadSleepForMilliSeconds(100);
 
-  blk_hash_t pivot;
-  std::vector<blk_hash_t> tips;
-  std::vector<Dag::vertex_t> criticals;
-  mgr->getLatestPivotAndTips(pivot, tips);
+  auto ret = mgr->getLatestPivotAndTips();
 
-  EXPECT_EQ(pivot, blk_hash_t("0000000000000000000000000000000000000000000000000000000000000003"));
-  EXPECT_EQ(tips.size(), 1);
-  EXPECT_EQ(tips[0], blk_hash_t("0000000000000000000000000000000000000000000000000000000000000006"));
+  EXPECT_EQ(ret->first, blk_hash_t("0000000000000000000000000000000000000000000000000000000000000003"));
+  EXPECT_EQ(ret->second.size(), 1);
+  EXPECT_EQ(ret->second[0], blk_hash_t("0000000000000000000000000000000000000000000000000000000000000006"));
 }
 
 }  // namespace taraxa::core_tests

--- a/tests/dag_test.cpp
+++ b/tests/dag_test.cpp
@@ -177,9 +177,7 @@ TEST_F(DagTest, compute_epoch) {
   EXPECT_EQ(orders.size(), 1);
   EXPECT_EQ(period, 1);
 
-  auto write_batch = db_ptr->createWriteBatch();
-  mgr->setDagBlockOrder(blkA.getHash(), period, orders, write_batch);
-  db_ptr->commitWriteBatch(write_batch);
+  mgr->setDagBlockOrder(blkA.getHash(), period, orders);
 
   std::tie(period, orders) = mgr->getDagBlockOrder(blkC.getHash());
   EXPECT_EQ(orders.size(), 2);
@@ -189,23 +187,17 @@ TEST_F(DagTest, compute_epoch) {
   EXPECT_EQ(orders.size(), 2);
   EXPECT_EQ(period, 2);
 
-  write_batch = db_ptr->createWriteBatch();
-  mgr->setDagBlockOrder(blkC.getHash(), period, orders, write_batch);
-  db_ptr->commitWriteBatch(write_batch);
+  mgr->setDagBlockOrder(blkC.getHash(), period, orders);
 
   std::tie(period, orders) = mgr->getDagBlockOrder(blkE.getHash());
   EXPECT_EQ(orders.size(), 3);
   EXPECT_EQ(period, 3);
-  write_batch = db_ptr->createWriteBatch();
-  mgr->setDagBlockOrder(blkE.getHash(), period, orders, write_batch);
-  db_ptr->commitWriteBatch(write_batch);
+  mgr->setDagBlockOrder(blkE.getHash(), period, orders);
 
   std::tie(period, orders) = mgr->getDagBlockOrder(blkH.getHash());
   EXPECT_EQ(orders.size(), 4);
   EXPECT_EQ(period, 4);
-  write_batch = db_ptr->createWriteBatch();
-  mgr->setDagBlockOrder(blkH.getHash(), period, orders, write_batch);
-  db_ptr->commitWriteBatch(write_batch);
+  mgr->setDagBlockOrder(blkH.getHash(), period, orders);
 
   if (orders.size() == 4) {
     EXPECT_EQ(orders[0], blk_hash_t(11));
@@ -216,9 +208,7 @@ TEST_F(DagTest, compute_epoch) {
   std::tie(period, orders) = mgr->getDagBlockOrder(blkK.getHash());
   EXPECT_EQ(orders.size(), 1);
   EXPECT_EQ(period, 5);
-  write_batch = db_ptr->createWriteBatch();
-  mgr->setDagBlockOrder(blkK.getHash(), period, orders, write_batch);
-  db_ptr->commitWriteBatch(write_batch);
+  mgr->setDagBlockOrder(blkK.getHash(), period, orders);
 }
 
 TEST_F(DagTest, receive_block_in_order) {
@@ -302,9 +292,7 @@ TEST_F(DagTest, compute_epoch_2) {
   EXPECT_EQ(orders.size(), 1);
   EXPECT_EQ(period, 1);
 
-  auto write_batch = db_ptr->createWriteBatch();
-  mgr->setDagBlockOrder(blkA.getHash(), period, orders, write_batch);
-  db_ptr->commitWriteBatch(write_batch);
+  mgr->setDagBlockOrder(blkA.getHash(), period, orders);
 
   std::tie(period, orders) = mgr->getDagBlockOrder(blkC.getHash());
   EXPECT_EQ(orders.size(), 2);
@@ -314,23 +302,17 @@ TEST_F(DagTest, compute_epoch_2) {
   EXPECT_EQ(orders.size(), 2);
   EXPECT_EQ(period, 2);
 
-  write_batch = db_ptr->createWriteBatch();
-  mgr->setDagBlockOrder(blkC.getHash(), period, orders, write_batch);
-  db_ptr->commitWriteBatch(write_batch);
+  mgr->setDagBlockOrder(blkC.getHash(), period, orders);
 
   std::tie(period, orders) = mgr->getDagBlockOrder(blkE.getHash());
   EXPECT_EQ(orders.size(), 3);
   EXPECT_EQ(period, 3);
-  write_batch = db_ptr->createWriteBatch();
-  mgr->setDagBlockOrder(blkE.getHash(), period, orders, write_batch);
-  db_ptr->commitWriteBatch(write_batch);
+  mgr->setDagBlockOrder(blkE.getHash(), period, orders);
 
   std::tie(period, orders) = mgr->getDagBlockOrder(blkH.getHash());
   EXPECT_EQ(orders.size(), 4);
   EXPECT_EQ(period, 4);
-  write_batch = db_ptr->createWriteBatch();
-  mgr->setDagBlockOrder(blkH.getHash(), period, orders, write_batch);
-  db_ptr->commitWriteBatch(write_batch);
+  mgr->setDagBlockOrder(blkH.getHash(), period, orders);
 
   if (orders.size() == 4) {
     EXPECT_EQ(orders[0], blk_hash_t(11));
@@ -341,9 +323,7 @@ TEST_F(DagTest, compute_epoch_2) {
   std::tie(period, orders) = mgr->getDagBlockOrder(blkK.getHash());
   EXPECT_EQ(orders.size(), 1);
   EXPECT_EQ(period, 5);
-  write_batch = db_ptr->createWriteBatch();
-  mgr->setDagBlockOrder(blkK.getHash(), period, orders, write_batch);
-  db_ptr->commitWriteBatch(write_batch);
+  mgr->setDagBlockOrder(blkK.getHash(), period, orders);
 }
 
 TEST_F(DagTest, get_latest_pivot_tips) {

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -836,15 +836,12 @@ TEST_F(FullNodeTest, insert_anchor_and_compute_order) {
     node->getDagBlockManager()->insertBlock(g_mock_dag0[i]);
   }
   taraxa::thisThreadSleepForMilliSeconds(200);
-  blk_hash_t pivot;
-  std::vector<blk_hash_t> tips;
-
   // -------- first period ----------
 
-  node->getDagManager()->getLatestPivotAndTips(pivot, tips);
+  auto ret = node->getDagManager()->getLatestPivotAndTips();
   uint64_t period;
   vec_blk_t order;
-  std::tie(period, order) = node->getDagManager()->getDagBlockOrder(pivot);
+  std::tie(period, order) = node->getDagManager()->getDagBlockOrder(ret->first);
   EXPECT_EQ(period, 1);
   EXPECT_EQ(order.size(), 6);
 
@@ -856,7 +853,7 @@ TEST_F(FullNodeTest, insert_anchor_and_compute_order) {
     EXPECT_EQ(order[4], blk_hash_t(5));
     EXPECT_EQ(order[5], blk_hash_t(7));
   }
-  auto num_blks_set = node->getDagManager()->setDagBlockOrder(pivot, period, order);
+  auto num_blks_set = node->getDagManager()->setDagBlockOrder(ret->first, period, order);
   EXPECT_EQ(num_blks_set, 6);
   // -------- second period ----------
 
@@ -865,8 +862,8 @@ TEST_F(FullNodeTest, insert_anchor_and_compute_order) {
   }
   taraxa::thisThreadSleepForMilliSeconds(200);
 
-  node->getDagManager()->getLatestPivotAndTips(pivot, tips);
-  std::tie(period, order) = node->getDagManager()->getDagBlockOrder(pivot);
+  ret = node->getDagManager()->getLatestPivotAndTips();
+  std::tie(period, order) = node->getDagManager()->getDagBlockOrder(ret->first);
   EXPECT_EQ(period, 2);
   if (order.size() == 7) {
     EXPECT_EQ(order[0], blk_hash_t(11));
@@ -877,7 +874,7 @@ TEST_F(FullNodeTest, insert_anchor_and_compute_order) {
     EXPECT_EQ(order[5], blk_hash_t(14));
     EXPECT_EQ(order[6], blk_hash_t(15));
   }
-  num_blks_set = node->getDagManager()->setDagBlockOrder(pivot, period, order);
+  num_blks_set = node->getDagManager()->setDagBlockOrder(ret->first, period, order);
   EXPECT_EQ(num_blks_set, 7);
 
   // -------- third period ----------
@@ -887,8 +884,8 @@ TEST_F(FullNodeTest, insert_anchor_and_compute_order) {
   }
   taraxa::thisThreadSleepForMilliSeconds(200);
 
-  node->getDagManager()->getLatestPivotAndTips(pivot, tips);
-  std::tie(period, order) = node->getDagManager()->getDagBlockOrder(pivot);
+  ret = node->getDagManager()->getLatestPivotAndTips();
+  std::tie(period, order) = node->getDagManager()->getDagBlockOrder(ret->first);
   EXPECT_EQ(period, 3);
   if (order.size() == 5) {
     EXPECT_EQ(order[0], blk_hash_t(17));
@@ -897,7 +894,7 @@ TEST_F(FullNodeTest, insert_anchor_and_compute_order) {
     EXPECT_EQ(order[3], blk_hash_t(18));
     EXPECT_EQ(order[4], blk_hash_t(19));
   }
-  num_blks_set = node->getDagManager()->setDagBlockOrder(pivot, period, order);
+  num_blks_set = node->getDagManager()->setDagBlockOrder(ret->first, period, order);
   EXPECT_EQ(num_blks_set, 5);
 }
 

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -856,9 +856,7 @@ TEST_F(FullNodeTest, insert_anchor_and_compute_order) {
     EXPECT_EQ(order[4], blk_hash_t(5));
     EXPECT_EQ(order[5], blk_hash_t(7));
   }
-  auto write_batch = node->getDB()->createWriteBatch();
-  auto num_blks_set = node->getDagManager()->setDagBlockOrder(pivot, period, order, write_batch);
-  node->getDB()->commitWriteBatch(write_batch);
+  auto num_blks_set = node->getDagManager()->setDagBlockOrder(pivot, period, order);
   EXPECT_EQ(num_blks_set, 6);
   // -------- second period ----------
 
@@ -879,9 +877,7 @@ TEST_F(FullNodeTest, insert_anchor_and_compute_order) {
     EXPECT_EQ(order[5], blk_hash_t(14));
     EXPECT_EQ(order[6], blk_hash_t(15));
   }
-  write_batch = node->getDB()->createWriteBatch();
-  num_blks_set = node->getDagManager()->setDagBlockOrder(pivot, period, order, write_batch);
-  node->getDB()->commitWriteBatch(write_batch);
+  num_blks_set = node->getDagManager()->setDagBlockOrder(pivot, period, order);
   EXPECT_EQ(num_blks_set, 7);
 
   // -------- third period ----------
@@ -901,9 +897,7 @@ TEST_F(FullNodeTest, insert_anchor_and_compute_order) {
     EXPECT_EQ(order[3], blk_hash_t(18));
     EXPECT_EQ(order[4], blk_hash_t(19));
   }
-  write_batch = node->getDB()->createWriteBatch();
-  num_blks_set = node->getDagManager()->setDagBlockOrder(pivot, period, order, write_batch);
-  node->getDB()->commitWriteBatch(write_batch);
+  num_blks_set = node->getDagManager()->setDagBlockOrder(pivot, period, order);
   EXPECT_EQ(num_blks_set, 5);
 }
 

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -167,7 +167,7 @@ TEST_F(NetworkTest, sync_large_pbft_block) {
   // Verify that a block over MAX_PACKET_SIZE is created
   auto pbft_blocks = nodes[0]->getDB()->getPbftBlock(1);
   size_t total_size = pbft_blocks->rlp(true).size();
-  auto blocks = nodes[0]->getDB()->getFinalizedDagBlockHashesByAnchor(pbft_blocks->getPivotDagBlockHash());
+  auto blocks = nodes[0]->getDB()->getFinalizedDagBlockHashesByPeriod(1);
   for (auto b : blocks) {
     auto block = nodes[0]->getDB()->getDagBlock(b);
     EXPECT_NE(block, nullptr);
@@ -395,8 +395,6 @@ TEST_F(NetworkTest, node_pbft_sync) {
 
   PbftBlock pbft_block1(prev_block_hash, blk1.getHash(), dev::sha3(order_stream.out()), period, beneficiary,
                         node1->getSecretKey());
-  db1->putFinalizedDagBlockHashesByAnchor(batch, pbft_block1.getPivotDagBlockHash(),
-                                          {pbft_block1.getPivotDagBlockHash()});
   std::vector<std::shared_ptr<Vote>> votes_for_pbft_blk1;
   votes_for_pbft_blk1.emplace_back(
       node1->getPbftManager()->generateVote(pbft_block1.getBlockHash(), cert_vote_type, 1, 3, 0));
@@ -443,9 +441,6 @@ TEST_F(NetworkTest, node_pbft_sync) {
   order_stream2 << g_signed_trx_samples[2].getHash() << g_signed_trx_samples[3].getHash();
   PbftBlock pbft_block2(prev_block_hash, blk2.getHash(), dev::sha3(order_stream2.out()), 2, beneficiary,
                         node1->getSecretKey());
-  db1->putFinalizedDagBlockHashesByAnchor(batch, pbft_block2.getPivotDagBlockHash(),
-                                          {pbft_block2.getPivotDagBlockHash()});
-
   std::vector<std::shared_ptr<Vote>> votes_for_pbft_blk2;
   votes_for_pbft_blk2.emplace_back(
       node1->getPbftManager()->generateVote(pbft_block2.getBlockHash(), cert_vote_type, 2, 3, 0));
@@ -541,8 +536,6 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
 
   PbftBlock pbft_block1(prev_block_hash, blk1.getHash(), dev::sha3(order_stream.out()), period, beneficiary,
                         node1->getSecretKey());
-  db1->putFinalizedDagBlockHashesByAnchor(batch, pbft_block1.getPivotDagBlockHash(),
-                                          {pbft_block1.getPivotDagBlockHash()});
   std::vector<std::shared_ptr<Vote>> votes_for_pbft_blk1;
   votes_for_pbft_blk1.emplace_back(
       node1->getPbftManager()->generateVote(pbft_block1.getBlockHash(), cert_vote_type, 1, 3, 0));
@@ -590,8 +583,6 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
 
   PbftBlock pbft_block2(prev_block_hash, blk2.getHash(), dev::sha3(order_stream2.out()), period, beneficiary,
                         node1->getSecretKey());
-  db1->putFinalizedDagBlockHashesByAnchor(batch, pbft_block2.getPivotDagBlockHash(),
-                                          {pbft_block2.getPivotDagBlockHash()});
   std::cout << "Use fake votes for the second PBFT block" << std::endl;
   // node1 put block2 into pbft chain and use fake votes storing into DB (malicious player)
   // Add fake votes in DB

--- a/tests/pbft_manager_test.cpp
+++ b/tests/pbft_manager_test.cpp
@@ -624,7 +624,7 @@ TEST_F(PbftManagerTest, pbft_manager_run_multi_nodes) {
   PbftBlock pbft_second_block = nodes[0]->getPbftChain()->getPbftBlockInChain(pbft_second_block_hash);
   for (auto &node : nodes) {
     auto db = node->getDB();
-    auto dag_blocks_hash_in_schedule = db->getFinalizedDagBlockHashesByAnchor(pbft_second_block.getPivotDagBlockHash());
+    auto dag_blocks_hash_in_schedule = db->getFinalizedDagBlockHashesByPeriod(pbft_second_block.getPeriod());
     // due to change of trx packing change, a trx can be packed in multiple
     // blocks
     std::unordered_set<blk_hash_t> unique_dag_block_hash_set;
@@ -637,7 +637,7 @@ TEST_F(PbftManagerTest, pbft_manager_run_multi_nodes) {
     blk_hash_t pbft_first_block_hash = pbft_second_block.getPrevBlockHash();
     // PBFT first block
     PbftBlock pbft_first_block = nodes[0]->getPbftChain()->getPbftBlockInChain(pbft_first_block_hash);
-    dag_blocks_hash_in_schedule = db->getFinalizedDagBlockHashesByAnchor(pbft_first_block.getPivotDagBlockHash());
+    dag_blocks_hash_in_schedule = db->getFinalizedDagBlockHashesByPeriod(pbft_first_block.getPeriod());
     // due to change of trx packing change, a trx can be packed in multiple
     // blocks
     EXPECT_GE(dag_blocks_hash_in_schedule.size(), 1);

--- a/tests/util_test/util.hpp
+++ b/tests/util_test/util.hpp
@@ -327,8 +327,8 @@ inline vector<blk_hash_t> getOrderedDagBlocks(shared_ptr<DbStorage> const& db) {
   while (true) {
     auto pbft_block = db->getPbftBlock(period);
     if (pbft_block.has_value()) {
-      for (auto const& dag_block_hash : db->getFinalizedDagBlockHashesByAnchor(pbft_block->getPivotDagBlockHash())) {
-        res.push_back(dag_block_hash);
+      for (auto const& dag_block_hash : db->getFinalizedDagBlockHashesByPeriod(period)) {
+        res.push_back(std::move(dag_block_hash));
       }
       period++;
       continue;

--- a/tests/util_test/util.hpp
+++ b/tests/util_test/util.hpp
@@ -327,7 +327,7 @@ inline vector<blk_hash_t> getOrderedDagBlocks(shared_ptr<DbStorage> const& db) {
   while (true) {
     auto pbft_block = db->getPbftBlock(period);
     if (pbft_block.has_value()) {
-      for (auto const& dag_block_hash : db->getFinalizedDagBlockHashesByPeriod(period)) {
+      for (auto& dag_block_hash : db->getFinalizedDagBlockHashesByPeriod(period)) {
         res.push_back(std::move(dag_block_hash));
       }
       period++;


### PR DESCRIPTION
## Purpose

This PR improves DAG block status handling and completely removes redundant DB data. It is based on this PR https://github.com/Taraxa-project/taraxa-node/pull/1118 this should be merged before!!!

"dag_block_period": 38520098,
    "dag_blocks": 2880577,
    "dag_blocks_index": 31480472,
  REMOVED  ----> "dag_blocks_state": 2028541,   <---- REMOVED
  REMOVED  ----> "dag_finalized_blocks": 27889837,   <---- REMOVED
    "default": 0,
    "dpos_proposal_period_levels_status": 3301,
    "final_chain_blk_by_number": 7247123,
    "final_chain_blk_hash_by_number": 745559,
    "final_chain_blk_number_by_hash": 744199,
    "final_chain_log_blooms_index": 4164726,
    "final_chain_meta": 3253,
    "final_chain_receipt_by_trx_hash": 229678726,
    "final_chain_replay_protection": 0,
    "final_chain_transaction_count_by_blk_number": 391413,
    "final_chain_transaction_hashes_by_blk_number": 140407817,
    "final_chain_transaction_location_by_hash": 206590064,
    "next_votes": 104382,
    "pbft_block_period": 744178,
    "pbft_cert_voted_block": 2955383,
    "pbft_head": 4585,
    "pbft_mgr_round_step": 3321,
    "pbft_mgr_status": 3405,
    "pbft_mgr_voted_value": 3705,
    "pbft_round_2t_plus_1": 418042,
    "period_data": 1503914655,
    "proposal_period_levels_map": 439397,
    "soft_votes": 80270,
    "status": 3555,
    "transactions": 3325643,
    "trx_status": 211065444,
    "unverified_votes": 15561489,
    "verified_votes": 8568994
