### PR TITLE
fix(pbft): fix last period

### DIFF
--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -1763,7 +1763,7 @@ bool PbftManager::is_syncing_() {
 }
 
 std::optional<SyncBlock> PbftManager::processSyncBlock() {
-  std::unique_lock lock(sync_queue_access_);
+  std::shared_lock lock(sync_queue_access_);
   auto sync_block = sync_queue_.front();
   lock.unlock();
   auto pbft_block_hash = sync_block.first.pbft_blk->getBlockHash();

--- a/src/consensus/pbft_manager.hpp
+++ b/src/consensus/pbft_manager.hpp
@@ -65,6 +65,7 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   size_t getDposWeightedVotesCount() const;
 
   uint64_t pbftSyncingPeriod() const;
+  void syncBlockQueuePop();
   void clearSyncBlockQueue();
   size_t syncBlockQueueSize() const;
   void syncBlockQueuePush(SyncBlock &&block, dev::p2p::NodeID const &node_id);
@@ -239,7 +240,6 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   std::mutex stop_mtx_;
 
   std::deque<std::pair<SyncBlock, dev::p2p::NodeID>> sync_queue_;
-  std::atomic<uint64_t> sync_period_{0};
   mutable std::shared_mutex sync_queue_access_;
 
   // TODO: will remove later, TEST CODE


### PR DESCRIPTION
Matus add a new variable sync_period_. But sync_period_ only update when push syncing PBFT blocks. When get enough cert votes to push proposed gossiping PBFT blocks, the sync_period_ doesn't update. 
For example: node syncing period 1 to 10 and catched up. Then push proposed gossiping PBFT blocks period from 11 - 15 by getting enough cert votes. Then, if want to push syncing PBFT block period 16, that will fail because sync_period_ is still 10. 
I remove the sync_period_. Since I think that's better using the last block in synced queue/PBFT chain to instruct the last period