### PR TITLE
chore: include threadID into the log format + use short version of No…

### DIFF
--- a/src/cli/default_config.hpp
+++ b/src/cli/default_config.hpp
@@ -48,14 +48,14 @@ const char *default_json = R"foo({
         "outputs": [
           {
             "type": "console",
-            "format": "%TimeStamp% %Channel% %SeverityStr% %Message%"
+            "format": "%ThreadID% %Channel% [%TimeStamp%] %SeverityStr%: %Message%"
           },
           {
             "type": "file",
             "file_name": "Taraxa_N1_%m%d%Y_%H%M%S_%5N.log",
             "rotation_size": 10000000,
             "time_based_rotation": "0,0,0",
-            "format": "%NodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%",
+            "format": "%ThreadID% %ShortNodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%",
             "max_size": 1000000000
           }
         ]

--- a/src/cli/devnet_config.hpp
+++ b/src/cli/devnet_config.hpp
@@ -66,14 +66,14 @@ const char *devnet_json = R"foo({
         "outputs": [
           {
             "type": "console",
-            "format": "%TimeStamp% %Channel% %SeverityStr% %Message%"
+            "format": "%ThreadID% %Channel% [%TimeStamp%] %SeverityStr%: %Message%"
           },
           {
             "type": "file",
             "file_name": "Taraxa_N1_%m%d%Y_%H%M%S_%5N.log",
             "rotation_size": 10000000,
             "time_based_rotation": "0,0,0",
-            "format": "%NodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%",
+            "format": "%ThreadID% %ShortNodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%",
             "max_size": 1000000000
           }
         ]

--- a/src/cli/testnet_config.hpp
+++ b/src/cli/testnet_config.hpp
@@ -66,14 +66,14 @@ const char *testnet_json = R"foo({
         "outputs": [
           {
             "type": "console",
-            "format": "%TimeStamp% %Channel% %SeverityStr% %Message%"
+            "format": "%ThreadID% %Channel% [%TimeStamp%] %SeverityStr%: %Message%"
           },
           {
             "type": "file",
             "file_name": "Taraxa_N1_%m%d%Y_%H%M%S_%5N.log",
             "rotation_size": 10000000,
             "time_based_rotation": "0,0,0",
-            "format": "%NodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%",
+            "format": "%ThreadID% %ShortNodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%",
             "max_size": 1000000000
           }
         ]

--- a/src/logger/log.cpp
+++ b/src/logger/log.cpp
@@ -31,7 +31,7 @@ Logger createLogger(Verbosity verboseLevel, const std::string& channel, const ad
   Logger logger(boost::log::keywords::severity = verboseLevel, boost::log::keywords::channel = channel);
   std::string severity_str = verbosityToString(verboseLevel);
   logger.add_attribute("SeverityStr", boost::log::attributes::constant<std::string>(severity_str));
-  logger.add_attribute("ShortNodeId", boost::log::attributes::constant<uint32_t>(*(uint32_t*)node_id.data()));
+  logger.add_attribute("ShortNodeId", boost::log::attributes::constant<std::string>(node_id.abridged()));
   logger.add_attribute("NodeId", boost::log::attributes::constant<std::string>(node_id.toString()));
   return logger;
 }

--- a/src/logger/log.hpp
+++ b/src/logger/log.hpp
@@ -21,7 +21,7 @@ using Logger = boost::log::sources::severity_channel_logger_mt<>;
  *       logging_config.verbosity = logger::Verbosity::Error;
  *       logging_config.channels["SAMPLE_CHANNEL"] = logger::Verbosity::Error;
  *
- *       // Initializes logging according to the provied config
+ *       // Initializes logging according to the provided config
  *       InitLogging(logging_config);
  *
  *       addr_t node_addr;

--- a/src/logger/logger_config.cpp
+++ b/src/logger/logger_config.cpp
@@ -11,7 +11,7 @@
 namespace taraxa::logger {
 
 BOOST_LOG_ATTRIBUTE_KEYWORD(channel, "Channel", std::string)
-BOOST_LOG_ATTRIBUTE_KEYWORD(short_node_id, "ShortNodeId", uint32_t)
+BOOST_LOG_ATTRIBUTE_KEYWORD(short_node_id, "ShortNodeId", std::string)
 BOOST_LOG_ATTRIBUTE_KEYWORD(severity, "Severity", int)
 
 Verbosity stringToVerbosity(std::string _verbosity) {
@@ -91,7 +91,7 @@ void Config::InitLogging(addr_t const &node) {
     outputs.push_back(Config::OutputConfig());
   }
 
-  auto filter = [this, short_node_id_conf = *(uint32_t *)node.data()](boost::log::attribute_value_set const &_set) {
+  auto filter = [this, short_node_id_conf = node.abridged()](boost::log::attribute_value_set const &_set) {
     if (channels.count(*_set[channel])) {
       if (short_node_id_conf == _set[short_node_id] || _set[short_node_id].empty()) {
         auto channel_name = _set[channel].get();

--- a/src/logger/logger_config.hpp
+++ b/src/logger/logger_config.hpp
@@ -43,7 +43,7 @@ class Config {
     std::string file_name;
     uint64_t rotation_size = 0;
     std::string time_based_rotation;
-    std::string format = "%NodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%";
+    std::string format = "%ThreadID% %ShortNodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%";
     uint64_t max_size = 0;
   };
 

--- a/tests/util_test/conf/conf_taraxa1.json
+++ b/tests/util_test/conf/conf_taraxa1.json
@@ -48,43 +48,14 @@
         "outputs": [
           {
             "type": "console",
-            "format": "%NodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%"
+            "format": "%ThreadID% %ShortNodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%"
           },
           {
             "type": "file",
             "file_name": "Taraxa_N1_%m%d%Y_%H%M%S_%5N.log",
             "rotation_size": 10000000,
             "time_based_rotation": "0,0,0",
-            "format": "%NodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%",
-            "max_size": 1000000000
-          }
-        ]
-      },
-      {
-        "name": "pbft",
-        "on": false,
-        "verbosity": "TRACE",
-        "channels": [
-          {
-            "name": "PBFT_CHAIN",
-            "verbosity": "TRACE"
-          },
-          {
-            "name": "PBFT_MGR",
-            "verbosity": "TRACE"
-          }
-        ],
-        "outputs": [
-          {
-            "type": "console",
-            "format": "%NodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%"
-          },
-          {
-            "type": "file",
-            "file_name": "Pbft_N1_%m%d%Y_%H%M%S_%5N.log",
-            "rotation_size": 10000000,
-            "time_based_rotation": "0,0,0",
-            "format": "%NodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%",
+            "format": "%ThreadID% %ShortNodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%",
             "max_size": 1000000000
           }
         ]

--- a/tests/util_test/conf/conf_taraxa2.json
+++ b/tests/util_test/conf/conf_taraxa2.json
@@ -47,14 +47,14 @@
         "outputs": [
           {
             "type": "console",
-            "format": "%NodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%"
+            "format": "%ThreadID% %ShortNodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%"
           },
           {
             "type": "file",
             "file_name": "Taraxa_N2_%m%d%Y_%H%M%S_%5N.log",
             "rotation_size": 10000000,
             "time_based_rotation": "0,0,0",
-            "format": "%NodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%",
+            "format": "%ThreadID% %ShortNodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%",
             "max_size": 1000000000
           }
         ]

--- a/tests/util_test/conf/conf_taraxa3.json
+++ b/tests/util_test/conf/conf_taraxa3.json
@@ -47,14 +47,14 @@
         "outputs": [
           {
             "type": "console",
-            "format": "%NodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%"
+            "format": "%ThreadID% %ShortNodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%"
           },
           {
             "type": "file",
             "file_name": "Taraxa_N3_%m%d%Y_%H%M%S_%5N.log",
             "rotation_size": 10000000,
             "time_based_rotation": "0,0,0",
-            "format": "%NodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%",
+            "format": "%ThreadID% %ShortNodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%",
             "max_size": 1000000000
           }
         ]

--- a/tests/util_test/conf/conf_taraxa4.json
+++ b/tests/util_test/conf/conf_taraxa4.json
@@ -47,14 +47,14 @@
         "outputs": [
           {
             "type": "console",
-            "format": "%NodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%"
+            "format": "%ThreadID% %ShortNodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%"
           },
           {
             "type": "file",
             "file_name": "Taraxa_N4_%m%d%Y_%H%M%S_%5N.log",
             "rotation_size": 10000000,
             "time_based_rotation": "0,0,0",
-            "format": "%NodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%",
+            "format": "%ThreadID% %ShortNodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%",
             "max_size": 1000000000
           }
         ]

--- a/tests/util_test/conf/conf_taraxa5.json
+++ b/tests/util_test/conf/conf_taraxa5.json
@@ -47,14 +47,14 @@
         "outputs": [
           {
             "type": "console",
-            "format": "%NodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%"
+            "format": "%ThreadID% %ShortNodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%"
           },
           {
             "type": "file",
             "file_name": "Taraxa_N5_%m%d%Y_%H%M%S_%5N.log",
             "rotation_size": 10000000,
             "time_based_rotation": "0,0,0",
-            "format": "%NodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%",
+            "format": "%ThreadID% %ShortNodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%",
             "max_size": 1000000000
           }
         ]


### PR DESCRIPTION
## Purpose

- Add threadID into the log format as due to new tarcap design, it can happen for example that multiple packets of the same type are processed at the same time and logs would mix up, which would make debugging very difficult. ThreadID should enable filtering if needed

- use short node id instead of full version

New format:

```
"%ThreadID% %ShortNodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%"
0x00007f4652ffd700 de2b1203… TARCAP_TP [2021-09-28 16:10:46.099704] DEBUG: Worker (0) started
```
