### PR TITLE
fix: recover dag order

### DIFF
--- a/src/cli/testnet_config.hpp
+++ b/src/cli/testnet_config.hpp
@@ -86,14 +86,14 @@ const char *testnet_json = R"foo({
       "level": "0x0",
       "pivot": "0x0000000000000000000000000000000000000000000000000000000000000000",
       "sig": "0xb7e22d46c1ba94d5e8347b01d137b5c428fcbbeaf0a77fb024cbbf1517656ff00d04f7f25be608c321b0d7483c402c294ff46c49b265305d046a52236c0a363701",
-      "timestamp": "0x60b03300",
+      "timestamp": "0x60b03301",
       "tips": [],
       "transactions": []
     },
     "final_chain": {
       "genesis_block_fields": {
         "author": "0x0000000000000000000000000000000000000000",
-        "timestamp": "0x60b03300"
+        "timestamp": "0x60b03301"
       },
       "state": {
         "disable_block_rewards": true,

--- a/src/dag/dag.cpp
+++ b/src/dag/dag.cpp
@@ -555,8 +555,10 @@ void DagManager::recoverDag() {
     }
   }
 
-  for (auto &blk : db_->getNonfinalizedDagBlocks()) {
-    addDagBlock(std::move(blk), false);
+  for (auto const &lvl : db_->getNonfinalizedDagBlocks()) {
+    for (auto const &blk : lvl.second) {
+      addDagBlock(std::move(blk), false);
+    }
   }
 }
 

--- a/src/storage/db_storage.cpp
+++ b/src/storage/db_storage.cpp
@@ -246,14 +246,15 @@ std::vector<std::shared_ptr<DagBlock>> DbStorage::getDagBlocksAtLevel(level_t le
   return res;
 }
 
-std::vector<DagBlock> DbStorage::getNonfinalizedDagBlocks() {
-  std::vector<DagBlock> res;
+std::map<int, std::vector<DagBlock>> DbStorage::getNonfinalizedDagBlocks() {
+  std::map<int, std::vector<DagBlock>> res;
   auto i = std::unique_ptr<rocksdb::Iterator>(db_->NewIterator(read_options_, handle(Columns::dag_blocks)));
   i->SeekToFirst();
   if (!i->Valid()) return res;
   i->Next();  // Skip genesis
   for (; i->Valid(); i->Next()) {
-    res.emplace_back(asBytes(i->value().ToString()));
+    DagBlock block(asBytes(i->value().ToString()));
+    res[block.getLevel()].emplace_back(std::move(block));
   }
   return res;
 }

--- a/src/storage/db_storage.hpp
+++ b/src/storage/db_storage.hpp
@@ -189,7 +189,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   std::set<blk_hash_t> getBlocksByLevel(level_t level);
   std::vector<std::shared_ptr<DagBlock>> getDagBlocksAtLevel(level_t level, int number_of_levels);
   void updateDagBlockCounters(Batch& write_batch, std::vector<DagBlock> blks);
-  std::vector<DagBlock> getNonfinalizedDagBlocks();
+  std::map<int, std::vector<DagBlock>> getNonfinalizedDagBlocks();
   void removeNonfinalizedDagBlock(blk_hash_t const& hash);
 
   // Transaction


### PR DESCRIPTION
In recoverDag method dag blocks need to be added to memory DAG in correct order. Pivot and tips need to be added before the block it self. This is done by adding non finalized blocks sorted by level.