### PR TITLE
fix: sync block validation and malicious issues

### DIFF
--- a/src/consensus/pbft_manager.cpp
+++ b/src/consensus/pbft_manager.cpp
@@ -1772,6 +1772,11 @@ std::optional<SyncBlock> PbftManager::processSyncBlock() {
   auto pbft_block_hash = sync_block.first.pbft_blk->getBlockHash();
   LOG(log_nf_) << "Pop pbft block " << pbft_block_hash << " from synced queue";
 
+  if (pbft_chain_->findPbftBlockInChain(pbft_block_hash)) {
+    LOG(log_dg_) << "PBFT block " << pbft_block_hash << " already present in chain.";
+    return nullopt;
+  }
+
   auto net = network_.lock();
   assert(net);  // Should never happen
 
@@ -1815,11 +1820,6 @@ std::optional<SyncBlock> PbftManager::processSyncBlock() {
                  << "; Trx order: " << trx_order << "; from " << sync_block.second.abridged() << ", stop syncing.";
     sync_queue_.clear();
     net->handleMaliciousSyncPeer(sync_block.second);
-    return nullopt;
-  }
-
-  if (pbft_chain_->findPbftBlockInChain(pbft_block_hash)) {
-    LOG(log_dg_) << "PBFT block " << pbft_block_hash << " already present in chain.";
     return nullopt;
   }
 

--- a/src/dag/dag_block_manager.cpp
+++ b/src/dag/dag_block_manager.cpp
@@ -380,7 +380,8 @@ std::shared_ptr<ProposalPeriodDagLevelsMap> DagBlockManager::newProposePeriodDag
 }
 
 void DagBlockManager::markBlockInvalid(blk_hash_t const &hash) {
-  blk_status_.update(hash, BlockStatus::invalid);
+  // TODO: uncomment once differentiate between invalid and incomplete blocks
+  // blk_status_.update(hash, BlockStatus::invalid);
   seen_blocks_.erase(hash);
   db_->removeNonfinalizedDagBlock(hash);
 }

--- a/src/network/tarcap/taraxa_capability.cpp
+++ b/src/network/tarcap/taraxa_capability.cpp
@@ -343,7 +343,8 @@ void TaraxaCapability::restartSyncingPbft(bool force) { syncing_handler_->restar
 bool TaraxaCapability::pbft_syncing() const { return syncing_state_->is_pbft_syncing(); }
 
 void TaraxaCapability::handleMaliciousSyncPeer(dev::p2p::NodeID const &id) {
-  syncing_state_->set_peer_malicious(id);
+  // TODO: enable once malicious issues are resolved
+  // syncing_state_->set_peer_malicious(id);
 
   if (auto host = peers_state_->host_.lock(); host) {
     host->disconnect(id, p2p::UserReason);


### PR DESCRIPTION
Fix for incorrectly marking node malicious
Temporary disabling marking dag blocks as invalid to investigate issues with it
Temporary disabling marking nodes malicious to investigate issues with it