### PR TITLE
Check Synced Cert Votes

### DIFF
--- a/libraries/storage/include/storage/storage.hpp
+++ b/libraries/storage/include/storage/storage.hpp
@@ -178,7 +178,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   std::set<blk_hash_t> getBlocksByLevel(level_t level);
   std::vector<std::shared_ptr<DagBlock>> getDagBlocksAtLevel(level_t level, int number_of_levels);
   void updateDagBlockCounters(Batch& write_batch, std::vector<DagBlock> blks);
-  std::map<int, std::vector<DagBlock>> getNonfinalizedDagBlocks();
+  std::map<level_t, std::vector<DagBlock>> getNonfinalizedDagBlocks();
   void removeNonfinalizedDagBlock(blk_hash_t const& hash);
 
   // Transaction

--- a/libraries/storage/src/storage.cpp
+++ b/libraries/storage/src/storage.cpp
@@ -250,8 +250,8 @@ std::vector<std::shared_ptr<DagBlock>> DbStorage::getDagBlocksAtLevel(level_t le
   return res;
 }
 
-std::map<int, std::vector<DagBlock>> DbStorage::getNonfinalizedDagBlocks() {
-  std::map<int, std::vector<DagBlock>> res;
+std::map<level_t, std::vector<DagBlock>> DbStorage::getNonfinalizedDagBlocks() {
+  std::map<level_t, std::vector<DagBlock>> res;
   auto i = std::unique_ptr<rocksdb::Iterator>(db_->NewIterator(read_options_, handle(Columns::dag_blocks)));
   i->SeekToFirst();
   if (!i->Valid()) return res;


### PR DESCRIPTION
Since node only save 2t+1 cert votes for each finalized PBFT block. When node receive a synced PBFT block from peers, if the number of cert votes are not 2t+1, or any cert votes failed checking conditions, the whole cert votes bundle should be invalid and failed immediately.