### PR TITLE
fix: get dag order with correct period

### DIFF
--- a/libraries/core_libs/consensus/include/dag/dag.hpp
+++ b/libraries/core_libs/consensus/include/dag/dag.hpp
@@ -134,7 +134,7 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
 
   // return {period, block order}, for pbft-pivot-blk proposing (does not
   // finalize)
-  std::pair<uint64_t, vec_blk_t> getDagBlockOrder(blk_hash_t const &anchor);
+  std::pair<uint64_t, vec_blk_t> getDagBlockOrder(blk_hash_t const &anchor, uint64_t period);
   // receive pbft-povit-blk, update periods and finalized, return size of
   // ordered blocks
   uint setDagBlockOrder(blk_hash_t const &anchor, uint64_t period, vec_blk_t const &dag_order);

--- a/libraries/core_libs/consensus/include/dag/dag.hpp
+++ b/libraries/core_libs/consensus/include/dag/dag.hpp
@@ -132,9 +132,8 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
   void addDagBlock(DagBlock const &blk,
                    bool save = true);  // insert to buffer if fail
 
-  // return {period, block order}, for pbft-pivot-blk proposing (does not
-  // finalize)
-  std::pair<uint64_t, vec_blk_t> getDagBlockOrder(blk_hash_t const &anchor, uint64_t period);
+  // return block order
+  vec_blk_t getDagBlockOrder(blk_hash_t const &anchor, uint64_t period);
   // receive pbft-povit-blk, update periods and finalized, return size of
   // ordered blocks
   uint setDagBlockOrder(blk_hash_t const &anchor, uint64_t period, vec_blk_t const &dag_order);

--- a/libraries/core_libs/consensus/src/dag/dag.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag.cpp
@@ -475,19 +475,19 @@ void DagManager::getGhostPath(std::vector<blk_hash_t> &ghost) const {
 }
 
 // return {period, block order}, for pbft-pivot-blk proposing
-std::pair<uint64_t, std::vector<blk_hash_t>> DagManager::getDagBlockOrder(blk_hash_t const &anchor, uint64_t period) {
+std::vector<blk_hash_t> DagManager::getDagBlockOrder(blk_hash_t const &anchor, uint64_t period) {
   SharedLock lock(mutex_);
   std::vector<blk_hash_t> blk_orders;
 
   if (period != period_ + 1) {
     LOG(log_er_) << "getDagBlockOrder called with period " << period << ". Expected period " << period_ + 1
                  << std::endl;
-    return {0, {}};
+    return {};
   }
 
   if (anchor_ == anchor) {
     LOG(log_wr_) << "Query period from " << anchor_ << " to " << anchor << " not ok " << std::endl;
-    return {0, {}};
+    return {};
   }
 
   auto new_period = period_ + 1;
@@ -495,13 +495,13 @@ std::pair<uint64_t, std::vector<blk_hash_t>> DagManager::getDagBlockOrder(blk_ha
   auto ok = total_dag_->computeOrder(anchor, blk_orders, non_finalized_blks_);
   if (!ok) {
     LOG(log_er_) << " Create period " << new_period << " anchor: " << anchor << " failed " << std::endl;
-    return {0, {}};
+    return {};
   }
 
   LOG(log_dg_) << "Get period " << new_period << " from " << anchor_ << " to " << anchor << " with "
                << blk_orders.size() << " blks" << std::endl;
 
-  return {new_period, std::move(blk_orders)};
+  return blk_orders;
 }
 
 uint DagManager::setDagBlockOrder(blk_hash_t const &new_anchor, uint64_t period, vec_blk_t const &dag_order) {

--- a/libraries/core_libs/consensus/src/dag/dag.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag.cpp
@@ -475,11 +475,15 @@ void DagManager::getGhostPath(std::vector<blk_hash_t> &ghost) const {
 }
 
 // return {period, block order}, for pbft-pivot-blk proposing
-std::pair<uint64_t, std::vector<blk_hash_t>> DagManager::getDagBlockOrder(blk_hash_t const &anchor) {
+std::pair<uint64_t, std::vector<blk_hash_t>> DagManager::getDagBlockOrder(blk_hash_t const &anchor, uint64_t period) {
   SharedLock lock(mutex_);
-  // TODO: need to check if the anchor already processed
-  // if the period already processed
   std::vector<blk_hash_t> blk_orders;
+
+  if (period != period_ + 1) {
+    LOG(log_er_) << "getDagBlockOrder called with period " << period << ". Expected period " << period_ + 1
+                 << std::endl;
+    return {0, {}};
+  }
 
   if (anchor_ == anchor) {
     LOG(log_wr_) << "Query period from " << anchor_ << " to " << anchor << " not ok " << std::endl;

--- a/libraries/core_libs/consensus/src/dag/dag.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag.cpp
@@ -474,14 +474,13 @@ void DagManager::getGhostPath(std::vector<blk_hash_t> &ghost) const {
   pivot_tree_->getGhostPath(last_pivot, ghost);
 }
 
-// return {period, block order}, for pbft-pivot-blk proposing
+// return {block order}, for pbft-pivot-blk proposing
 std::vector<blk_hash_t> DagManager::getDagBlockOrder(blk_hash_t const &anchor, uint64_t period) {
   SharedLock lock(mutex_);
   std::vector<blk_hash_t> blk_orders;
 
   if (period != period_ + 1) {
-    LOG(log_er_) << "getDagBlockOrder called with period " << period << ". Expected period " << period_ + 1
-                 << std::endl;
+    LOG(log_wr_) << "getDagBlockOrder called with period " << period << ". Expected period " << period_ + 1;
     return {};
   }
 

--- a/libraries/core_libs/consensus/src/pbft/pbft_chain.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_chain.cpp
@@ -102,6 +102,11 @@ void PbftChain::updatePbftChain(blk_hash_t const& pbft_block_hash) {
 }
 
 bool PbftChain::checkPbftBlockValidation(taraxa::PbftBlock const& pbft_block) const {
+  if (getPbftChainSize() + 1 != pbft_block.getPeriod()) {
+    LOG(log_wr_) << "Pbft validation failed. PBFT chain size " << getPbftChainSize()
+                 << ". Pbft block period: " << pbft_block.getPeriod() << " for block " << pbft_block.getBlockHash();
+    return false;
+  }
   auto last_pbft_block_hash = getLastPbftBlockHash();
   if (pbft_block.getPrevBlockHash() != last_pbft_block_hash) {
     LOG(log_er_) << "PBFT chain last block hash " << last_pbft_block_hash << " Invalid PBFT prev block hash "

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1169,7 +1169,7 @@ std::pair<blk_hash_t, bool> PbftManager::proposeMyPbftBlock_() {
   addr_t beneficiary = node_addr_;
 
   // get DAG block and transaction order
-  auto dag_block_order = dag_mgr_->getDagBlockOrder(dag_block_hash);
+  auto dag_block_order = dag_mgr_->getDagBlockOrder(dag_block_hash, propose_pbft_period);
   if (dag_block_order.second.empty()) {
     LOG(log_er_) << "DAG anchor block hash " << dag_block_hash << " getDagBlockOrder failed in propose";
     assert(false);
@@ -1384,7 +1384,7 @@ std::optional<vec_blk_t> PbftManager::comparePbftBlockScheduleWithDAGblocks_(std
     return {std::move(dag_blocks_order)};
   }
   auto const &anchor_hash = pbft_block->getPivotDagBlockHash();
-  auto dag_blocks_order = dag_mgr_->getDagBlockOrder(anchor_hash).second;
+  auto dag_blocks_order = dag_mgr_->getDagBlockOrder(anchor_hash, pbft_block->getPeriod()).second;
   if (!dag_blocks_order.empty()) {
     std::unordered_set<trx_hash_t> trx_set;
     std::vector<trx_hash_t> transactions_to_query;

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1170,14 +1170,14 @@ std::pair<blk_hash_t, bool> PbftManager::proposeMyPbftBlock_() {
 
   // get DAG block and transaction order
   auto dag_block_order = dag_mgr_->getDagBlockOrder(dag_block_hash, propose_pbft_period);
-  if (dag_block_order.second.empty()) {
+  if (dag_block_order.empty()) {
     LOG(log_er_) << "DAG anchor block hash " << dag_block_hash << " getDagBlockOrder failed in propose";
     assert(false);
   }
   std::vector<trx_hash_t> non_executed_transactions;
   std::unordered_set<trx_hash_t> trx_hashes_set;
   std::vector<trx_hash_t> trx_hashes;
-  for (auto const &blk_hash : dag_block_order.second) {
+  for (auto const &blk_hash : dag_block_order) {
     auto dag_blk = dag_blk_mgr_->getDagBlock(blk_hash);
     if (!dag_blk) {
       LOG(log_er_) << "DAG anchor block hash " << dag_block_hash << " getDagBlock failed in propose for block "
@@ -1201,14 +1201,14 @@ std::pair<blk_hash_t, bool> PbftManager::proposeMyPbftBlock_() {
     }
   }
 
-  auto order_hash = calculateOrderHash(dag_block_order.second, non_executed_transactions);
+  auto order_hash = calculateOrderHash(dag_block_order, non_executed_transactions);
 
   // generate generate pbft block
   auto pbft_block = std::make_shared<PbftBlock>(last_pbft_block_hash, dag_block_hash, order_hash, propose_pbft_period,
                                                 beneficiary, node_sk_);
 
   LOG(log_nf_) << "Proposed Pbft block: " << pbft_block->getBlockHash() << ". Order hash:" << order_hash
-               << ". DAG order for proposed block" << dag_block_order.second << ". Transaction order for proposed block"
+               << ". DAG order for proposed block" << dag_block_order << ". Transaction order for proposed block"
                << non_executed_transactions;
 
   // push pbft block
@@ -1384,7 +1384,7 @@ std::optional<vec_blk_t> PbftManager::comparePbftBlockScheduleWithDAGblocks_(std
     return {std::move(dag_blocks_order)};
   }
   auto const &anchor_hash = pbft_block->getPivotDagBlockHash();
-  auto dag_blocks_order = dag_mgr_->getDagBlockOrder(anchor_hash, pbft_block->getPeriod()).second;
+  auto dag_blocks_order = dag_mgr_->getDagBlockOrder(anchor_hash, pbft_block->getPeriod());
   if (!dag_blocks_order.empty()) {
     std::unordered_set<trx_hash_t> trx_set;
     std::vector<trx_hash_t> transactions_to_query;

--- a/tests/dag_test.cpp
+++ b/tests/dag_test.cpp
@@ -169,32 +169,32 @@ TEST_F(DagTest, compute_epoch) {
 
   vec_blk_t orders;
   uint64_t period;
-  std::tie(period, orders) = mgr->getDagBlockOrder(blkA.getHash());
+  std::tie(period, orders) = mgr->getDagBlockOrder(blkA.getHash(), 1);
   EXPECT_EQ(orders.size(), 1);
   EXPECT_EQ(period, 1);
   // repeat, should not change
-  std::tie(period, orders) = mgr->getDagBlockOrder(blkA.getHash());
+  std::tie(period, orders) = mgr->getDagBlockOrder(blkA.getHash(), 1);
   EXPECT_EQ(orders.size(), 1);
   EXPECT_EQ(period, 1);
 
   mgr->setDagBlockOrder(blkA.getHash(), period, orders);
 
-  std::tie(period, orders) = mgr->getDagBlockOrder(blkC.getHash());
+  std::tie(period, orders) = mgr->getDagBlockOrder(blkC.getHash(), 2);
   EXPECT_EQ(orders.size(), 2);
   EXPECT_EQ(period, 2);
   // repeat, should not change
-  std::tie(period, orders) = mgr->getDagBlockOrder(blkC.getHash());
+  std::tie(period, orders) = mgr->getDagBlockOrder(blkC.getHash(), 2);
   EXPECT_EQ(orders.size(), 2);
   EXPECT_EQ(period, 2);
 
   mgr->setDagBlockOrder(blkC.getHash(), period, orders);
 
-  std::tie(period, orders) = mgr->getDagBlockOrder(blkE.getHash());
+  std::tie(period, orders) = mgr->getDagBlockOrder(blkE.getHash(), 3);
   EXPECT_EQ(orders.size(), 3);
   EXPECT_EQ(period, 3);
   mgr->setDagBlockOrder(blkE.getHash(), period, orders);
 
-  std::tie(period, orders) = mgr->getDagBlockOrder(blkH.getHash());
+  std::tie(period, orders) = mgr->getDagBlockOrder(blkH.getHash(), 4);
   EXPECT_EQ(orders.size(), 4);
   EXPECT_EQ(period, 4);
   mgr->setDagBlockOrder(blkH.getHash(), period, orders);
@@ -205,7 +205,7 @@ TEST_F(DagTest, compute_epoch) {
     EXPECT_EQ(orders[2], blk_hash_t(8));
     EXPECT_EQ(orders[3], blk_hash_t(9));
   }
-  std::tie(period, orders) = mgr->getDagBlockOrder(blkK.getHash());
+  std::tie(period, orders) = mgr->getDagBlockOrder(blkK.getHash(), 5);
   EXPECT_EQ(orders.size(), 1);
   EXPECT_EQ(period, 5);
   mgr->setDagBlockOrder(blkK.getHash(), period, orders);
@@ -281,32 +281,32 @@ TEST_F(DagTest, compute_epoch_2) {
 
   vec_blk_t orders;
   uint64_t period;
-  std::tie(period, orders) = mgr->getDagBlockOrder(blkA.getHash());
+  std::tie(period, orders) = mgr->getDagBlockOrder(blkA.getHash(), 1);
   EXPECT_EQ(orders.size(), 1);
   EXPECT_EQ(period, 1);
   // repeat, should not change
-  std::tie(period, orders) = mgr->getDagBlockOrder(blkA.getHash());
+  std::tie(period, orders) = mgr->getDagBlockOrder(blkA.getHash(), 1);
   EXPECT_EQ(orders.size(), 1);
   EXPECT_EQ(period, 1);
 
   mgr->setDagBlockOrder(blkA.getHash(), period, orders);
 
-  std::tie(period, orders) = mgr->getDagBlockOrder(blkC.getHash());
+  std::tie(period, orders) = mgr->getDagBlockOrder(blkC.getHash(), 2);
   EXPECT_EQ(orders.size(), 2);
   EXPECT_EQ(period, 2);
   // repeat, should not change
-  std::tie(period, orders) = mgr->getDagBlockOrder(blkC.getHash());
+  std::tie(period, orders) = mgr->getDagBlockOrder(blkC.getHash(), 2);
   EXPECT_EQ(orders.size(), 2);
   EXPECT_EQ(period, 2);
 
   mgr->setDagBlockOrder(blkC.getHash(), period, orders);
 
-  std::tie(period, orders) = mgr->getDagBlockOrder(blkE.getHash());
+  std::tie(period, orders) = mgr->getDagBlockOrder(blkE.getHash(), 3);
   EXPECT_EQ(orders.size(), 3);
   EXPECT_EQ(period, 3);
   mgr->setDagBlockOrder(blkE.getHash(), period, orders);
 
-  std::tie(period, orders) = mgr->getDagBlockOrder(blkH.getHash());
+  std::tie(period, orders) = mgr->getDagBlockOrder(blkH.getHash(), 4);
   EXPECT_EQ(orders.size(), 4);
   EXPECT_EQ(period, 4);
   mgr->setDagBlockOrder(blkH.getHash(), period, orders);
@@ -317,7 +317,7 @@ TEST_F(DagTest, compute_epoch_2) {
     EXPECT_EQ(orders[2], blk_hash_t(8));
     EXPECT_EQ(orders[3], blk_hash_t(9));
   }
-  std::tie(period, orders) = mgr->getDagBlockOrder(blkK.getHash());
+  std::tie(period, orders) = mgr->getDagBlockOrder(blkK.getHash(), 5);
   EXPECT_EQ(orders.size(), 1);
   EXPECT_EQ(period, 5);
   mgr->setDagBlockOrder(blkK.getHash(), period, orders);

--- a/tests/dag_test.cpp
+++ b/tests/dag_test.cpp
@@ -169,34 +169,40 @@ TEST_F(DagTest, compute_epoch) {
 
   vec_blk_t orders;
   uint64_t period;
-  std::tie(period, orders) = mgr->getDagBlockOrder(blkA.getHash(), 1);
+
+  // Test that with incorrect period, order is not returned
+  orders = mgr->getDagBlockOrder(blkA.getHash(), 2);
+  EXPECT_EQ(orders.size(), 0);
+
+  orders = mgr->getDagBlockOrder(blkA.getHash(), 0);
+  EXPECT_EQ(orders.size(), 0);
+
+  period = 1;
+  orders = mgr->getDagBlockOrder(blkA.getHash(), period);
   EXPECT_EQ(orders.size(), 1);
-  EXPECT_EQ(period, 1);
   // repeat, should not change
-  std::tie(period, orders) = mgr->getDagBlockOrder(blkA.getHash(), 1);
+  orders = mgr->getDagBlockOrder(blkA.getHash(), period);
   EXPECT_EQ(orders.size(), 1);
-  EXPECT_EQ(period, 1);
 
   mgr->setDagBlockOrder(blkA.getHash(), period, orders);
 
-  std::tie(period, orders) = mgr->getDagBlockOrder(blkC.getHash(), 2);
+  period = 2;
+  orders = mgr->getDagBlockOrder(blkC.getHash(), period);
   EXPECT_EQ(orders.size(), 2);
-  EXPECT_EQ(period, 2);
   // repeat, should not change
-  std::tie(period, orders) = mgr->getDagBlockOrder(blkC.getHash(), 2);
+  orders = mgr->getDagBlockOrder(blkC.getHash(), period);
   EXPECT_EQ(orders.size(), 2);
-  EXPECT_EQ(period, 2);
 
   mgr->setDagBlockOrder(blkC.getHash(), period, orders);
 
-  std::tie(period, orders) = mgr->getDagBlockOrder(blkE.getHash(), 3);
-  EXPECT_EQ(orders.size(), 3);
-  EXPECT_EQ(period, 3);
+  period = 3;
+  orders = mgr->getDagBlockOrder(blkE.getHash(), period);
+  EXPECT_EQ(orders.size(), period);
   mgr->setDagBlockOrder(blkE.getHash(), period, orders);
 
-  std::tie(period, orders) = mgr->getDagBlockOrder(blkH.getHash(), 4);
-  EXPECT_EQ(orders.size(), 4);
-  EXPECT_EQ(period, 4);
+  period = 4;
+  orders = mgr->getDagBlockOrder(blkH.getHash(), period);
+  EXPECT_EQ(orders.size(), period);
   mgr->setDagBlockOrder(blkH.getHash(), period, orders);
 
   if (orders.size() == 4) {
@@ -205,9 +211,10 @@ TEST_F(DagTest, compute_epoch) {
     EXPECT_EQ(orders[2], blk_hash_t(8));
     EXPECT_EQ(orders[3], blk_hash_t(9));
   }
-  std::tie(period, orders) = mgr->getDagBlockOrder(blkK.getHash(), 5);
+
+  period = 5;
+  orders = mgr->getDagBlockOrder(blkK.getHash(), period);
   EXPECT_EQ(orders.size(), 1);
-  EXPECT_EQ(period, 5);
   mgr->setDagBlockOrder(blkK.getHash(), period, orders);
 }
 
@@ -280,35 +287,32 @@ TEST_F(DagTest, compute_epoch_2) {
   taraxa::thisThreadSleepForMilliSeconds(100);
 
   vec_blk_t orders;
-  uint64_t period;
-  std::tie(period, orders) = mgr->getDagBlockOrder(blkA.getHash(), 1);
+  uint64_t period = 1;
+  orders = mgr->getDagBlockOrder(blkA.getHash(), period);
   EXPECT_EQ(orders.size(), 1);
-  EXPECT_EQ(period, 1);
   // repeat, should not change
-  std::tie(period, orders) = mgr->getDagBlockOrder(blkA.getHash(), 1);
+  orders = mgr->getDagBlockOrder(blkA.getHash(), period);
   EXPECT_EQ(orders.size(), 1);
-  EXPECT_EQ(period, 1);
 
   mgr->setDagBlockOrder(blkA.getHash(), period, orders);
 
-  std::tie(period, orders) = mgr->getDagBlockOrder(blkC.getHash(), 2);
+  period = 2;
+  orders = mgr->getDagBlockOrder(blkC.getHash(), period);
   EXPECT_EQ(orders.size(), 2);
-  EXPECT_EQ(period, 2);
   // repeat, should not change
-  std::tie(period, orders) = mgr->getDagBlockOrder(blkC.getHash(), 2);
+  orders = mgr->getDagBlockOrder(blkC.getHash(), period);
   EXPECT_EQ(orders.size(), 2);
-  EXPECT_EQ(period, 2);
 
   mgr->setDagBlockOrder(blkC.getHash(), period, orders);
 
-  std::tie(period, orders) = mgr->getDagBlockOrder(blkE.getHash(), 3);
-  EXPECT_EQ(orders.size(), 3);
-  EXPECT_EQ(period, 3);
+  period = 3;
+  orders = mgr->getDagBlockOrder(blkE.getHash(), period);
+  EXPECT_EQ(orders.size(), period);
   mgr->setDagBlockOrder(blkE.getHash(), period, orders);
 
-  std::tie(period, orders) = mgr->getDagBlockOrder(blkH.getHash(), 4);
+  period = 4;
+  orders = mgr->getDagBlockOrder(blkH.getHash(), period);
   EXPECT_EQ(orders.size(), 4);
-  EXPECT_EQ(period, 4);
   mgr->setDagBlockOrder(blkH.getHash(), period, orders);
 
   if (orders.size() == 4) {
@@ -317,9 +321,10 @@ TEST_F(DagTest, compute_epoch_2) {
     EXPECT_EQ(orders[2], blk_hash_t(8));
     EXPECT_EQ(orders[3], blk_hash_t(9));
   }
-  std::tie(period, orders) = mgr->getDagBlockOrder(blkK.getHash(), 5);
+
+  period = 5;
+  orders = mgr->getDagBlockOrder(blkK.getHash(), period);
   EXPECT_EQ(orders.size(), 1);
-  EXPECT_EQ(period, 5);
   mgr->setDagBlockOrder(blkK.getHash(), period, orders);
 }
 

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -838,10 +838,9 @@ TEST_F(FullNodeTest, insert_anchor_and_compute_order) {
   // -------- first period ----------
 
   auto ret = node->getDagManager()->getLatestPivotAndTips();
-  uint64_t period;
+  uint64_t period = 1;
   vec_blk_t order;
-  std::tie(period, order) = node->getDagManager()->getDagBlockOrder(ret->first, 1);
-  EXPECT_EQ(period, 1);
+  order = node->getDagManager()->getDagBlockOrder(ret->first, period);
   EXPECT_EQ(order.size(), 6);
 
   if (order.size() == 6) {
@@ -862,8 +861,8 @@ TEST_F(FullNodeTest, insert_anchor_and_compute_order) {
   taraxa::thisThreadSleepForMilliSeconds(200);
 
   ret = node->getDagManager()->getLatestPivotAndTips();
-  std::tie(period, order) = node->getDagManager()->getDagBlockOrder(ret->first, 2);
-  EXPECT_EQ(period, 2);
+  period = 2;
+  order = node->getDagManager()->getDagBlockOrder(ret->first, period);
   if (order.size() == 7) {
     EXPECT_EQ(order[0], blk_hash_t(11));
     EXPECT_EQ(order[1], blk_hash_t(10));
@@ -884,8 +883,8 @@ TEST_F(FullNodeTest, insert_anchor_and_compute_order) {
   taraxa::thisThreadSleepForMilliSeconds(200);
 
   ret = node->getDagManager()->getLatestPivotAndTips();
-  std::tie(period, order) = node->getDagManager()->getDagBlockOrder(ret->first, 3);
-  EXPECT_EQ(period, 3);
+  period = 3;
+  order = node->getDagManager()->getDagBlockOrder(ret->first, period);
   if (order.size() == 5) {
     EXPECT_EQ(order[0], blk_hash_t(17));
     EXPECT_EQ(order[1], blk_hash_t(16));

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -840,7 +840,7 @@ TEST_F(FullNodeTest, insert_anchor_and_compute_order) {
   auto ret = node->getDagManager()->getLatestPivotAndTips();
   uint64_t period;
   vec_blk_t order;
-  std::tie(period, order) = node->getDagManager()->getDagBlockOrder(ret->first);
+  std::tie(period, order) = node->getDagManager()->getDagBlockOrder(ret->first, 1);
   EXPECT_EQ(period, 1);
   EXPECT_EQ(order.size(), 6);
 
@@ -862,7 +862,7 @@ TEST_F(FullNodeTest, insert_anchor_and_compute_order) {
   taraxa::thisThreadSleepForMilliSeconds(200);
 
   ret = node->getDagManager()->getLatestPivotAndTips();
-  std::tie(period, order) = node->getDagManager()->getDagBlockOrder(ret->first);
+  std::tie(period, order) = node->getDagManager()->getDagBlockOrder(ret->first, 2);
   EXPECT_EQ(period, 2);
   if (order.size() == 7) {
     EXPECT_EQ(order[0], blk_hash_t(11));
@@ -884,7 +884,7 @@ TEST_F(FullNodeTest, insert_anchor_and_compute_order) {
   taraxa::thisThreadSleepForMilliSeconds(200);
 
   ret = node->getDagManager()->getLatestPivotAndTips();
-  std::tie(period, order) = node->getDagManager()->getDagBlockOrder(ret->first);
+  std::tie(period, order) = node->getDagManager()->getDagBlockOrder(ret->first, 3);
   EXPECT_EQ(period, 3);
   if (order.size() == 5) {
     EXPECT_EQ(order[0], blk_hash_t(17));


### PR DESCRIPTION
getDagBlockOrder only works correctly if it is called for the current period. New parameter was added to specify for which pbft period we request the order. If the period is not the expected one, error is logged and empty response is returned.

In general we should not be calling getDagBlockOrder with incorrect period. Additional changes in pbft_manager should be done to ensure this