### PR TITLE
fix: missing transaction

### DIFF
--- a/libraries/core_libs/network/src/tarcap/packets_handlers/dag_block_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/dag_block_packet_handler.cpp
@@ -47,6 +47,8 @@ void DagBlockPacketHandler::process(const PacketData &packet_data, const std::sh
     }
 
     if (auto status = syncing_handler_->checkDagBlockValidation(block); !status.first) {
+      trx_mgr_->insertBroadcastedTransactions(new_transactions);
+
       // Ignore new block packets when pbft syncing
       if (syncing_state_->is_pbft_syncing()) {
         LOG(log_dg_) << "Ignore new dag block " << hash.abridged() << ", pbft syncing is on";


### PR DESCRIPTION
Even if block is missing a tip or pivot, save the transactions included in the block