### PR TITLE
fix: dag order

### DIFF
--- a/libraries/cli/include/cli/testnet_config.hpp
+++ b/libraries/cli/include/cli/testnet_config.hpp
@@ -86,14 +86,14 @@ const char *testnet_json = R"foo({
       "level": "0x0",
       "pivot": "0x0000000000000000000000000000000000000000000000000000000000000000",
       "sig": "0xb7e22d46c1ba94d5e8347b01d137b5c428fcbbeaf0a77fb024cbbf1517656ff00d04f7f25be608c321b0d7483c402c294ff46c49b265305d046a52236c0a363701",
-      "timestamp": "0x60b03302",
+      "timestamp": "0x60b03303",
       "tips": [],
       "transactions": []
     },
     "final_chain": {
       "genesis_block_fields": {
         "author": "0x0000000000000000000000000000000000000000",
-        "timestamp": "0x60b03302"
+        "timestamp": "0x60b03303"
       },
       "state": {
         "disable_block_rewards": true,

--- a/libraries/core_libs/consensus/src/dag/dag.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag.cpp
@@ -369,6 +369,7 @@ void DagManager::worker() {
   while (!stopped_) {
     // will block if no verified block available
     auto verified_block = dag_blk_mgr_->popVerifiedBlock(level_limit, level);
+
     level_limit = false;
     auto const &blk = *(verified_block.first);
 
@@ -401,6 +402,10 @@ void DagManager::addDagBlock(DagBlock const &blk, bool save) {
   {
     ULock lock(mutex_);
     if (save) {
+      if (db_->dagBlockInDb(blk.getHash())) {
+        LOG(log_dg_) << "Block already in DB: " << blk.getHash();
+        return;
+      }
       db_->saveDagBlock(blk, &write_batch);
     }
     auto blk_hash = blk.getHash();

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1579,10 +1579,6 @@ bool PbftManager::pushPbftBlock_(SyncBlock &sync_block, vec_blk_t &dag_blocks_or
     db_->updateDagBlockCounters(batch, dag_blocks_to_update_counters);
   }
 
-  // Set DAG blocks period
-  auto const &anchor_hash = sync_block.pbft_blk->getPivotDagBlockHash();
-  dag_mgr_->setDagBlockOrder(anchor_hash, pbft_period, dag_blocks_order);
-
   db_->savePeriodData(sync_block, batch);
 
   // Reset last cert voted value to NULL_BLOCK_HASH
@@ -1590,6 +1586,10 @@ bool PbftManager::pushPbftBlock_(SyncBlock &sync_block, vec_blk_t &dag_blocks_or
 
   // Commit DB
   db_->commitWriteBatch(batch);
+
+  // Set DAG blocks period
+  auto const &anchor_hash = sync_block.pbft_blk->getPivotDagBlockHash();
+  dag_mgr_->setDagBlockOrder(anchor_hash, pbft_period, dag_blocks_order);
 
   trx_mgr_->updateFinalizedTransactionsStatus(sync_block);
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/common/syncing_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/common/syncing_handler.cpp
@@ -161,7 +161,7 @@ std::pair<bool, std::unordered_set<blk_hash_t>> SyncingHandler::checkDagBlockVal
   for (auto const &tip : block.getTips()) {
     auto tip_block = dag_blk_mgr_->getDagBlock(tip);
     if (!tip_block) {
-      LOG(log_er_) << "Block " << block.getHash().abridged() << " has a missing tip " << tip.abridged();
+      LOG(log_nf_) << "Block " << block.getHash().abridged() << " has a missing tip " << tip.abridged();
       missing_blks.insert(tip);
     } else {
       expected_level = std::max(tip_block->getLevel(), expected_level);
@@ -171,7 +171,7 @@ std::pair<bool, std::unordered_set<blk_hash_t>> SyncingHandler::checkDagBlockVal
   const auto pivot = block.getPivot();
   const auto pivot_block = dag_blk_mgr_->getDagBlock(pivot);
   if (!pivot_block) {
-    LOG(log_er_) << "Block " << block.getHash().abridged() << " has a missing pivot " << pivot.abridged();
+    LOG(log_nf_) << "Block " << block.getHash().abridged() << " has a missing pivot " << pivot.abridged();
     missing_blks.insert(pivot);
   }
 
@@ -180,7 +180,7 @@ std::pair<bool, std::unordered_set<blk_hash_t>> SyncingHandler::checkDagBlockVal
   expected_level = std::max(pivot_block->getLevel(), expected_level);
   expected_level++;
   if (expected_level != block.getLevel()) {
-    LOG(log_er_) << "Invalid block level " << block.getLevel() << " for block " << block.getHash().abridged()
+    LOG(log_nf_) << "Invalid block level " << block.getLevel() << " for block " << block.getHash().abridged()
                  << " . Expected level " << expected_level;
     return std::make_pair(false, missing_blks);
   }

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/dag_block_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/dag_block_packet_handler.cpp
@@ -55,7 +55,7 @@ void DagBlockPacketHandler::process(const PacketData &packet_data, const std::sh
         return;
       }
 
-      LOG(log_wr_) << "Received NewBlock " << hash.toString() << " has missing pivot or/and tips";
+      LOG(log_er_) << "Received NewBlock " << hash.toString() << " has missing pivot or/and tips " << status.second;
       status.second.insert(hash);
       syncing_handler_->requestBlocks(packet_data.from_node_id_, status.second, DagSyncRequestType::MissingHashes);
       return;


### PR DESCRIPTION
Issue was found on testnet that sometimes a dag block that has been already finalized has been mistakenly added to the memory DAG as non-finalized block. This could happen if a dag block is in queue while it is also synced within a pbft block and finalized. As a result an incorrect dag order was retrieved.

The fix ensures that a finalized block can not be added to DAG as non-finalized block.
SetDagBlockOrder is now called only after the dag block is saved to the db in savePeriodData. If the same Dag block is in the queue at the time pbft block is synced, addDagBlock will reject such a block by checking if it is already saved in the database.