### PR TITLE
fix(pbft): update DPOS state when node restart

### DIFF
--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -44,7 +44,6 @@ PbftManager::PbftManager(PbftConfig const &conf, blk_hash_t const &genesis, addr
       RUN_COUNT_VOTES(conf.run_count_votes),
       dag_genesis_(genesis) {
   LOG_OBJECTS_CREATE("PBFT_MGR");
-  updateDposState_();
 }
 
 PbftManager::~PbftManager() { stop(); }
@@ -533,6 +532,7 @@ void PbftManager::initialState_() {
   last_step_clock_initial_datetime_ = current_step_clock_initial_datetime_;
   next_step_time_ms_ = 0;
 
+  updateDposState_();
   // Initialize TWO_T_PLUS_ONE and sortition_threshold
   updateTwoTPlusOneAndThreshold_();
 }


### PR DESCRIPTION
## Purpose

Update DPOS state after execute finalized PBFT blocks when node restart.
Before the fix, final chain will return 0 on DPOS eligible total vote count. That will make 2t+1 to 1. So one next vote in current round will push node go to next round. 


## For reviewers

<!-- Describe anything you want to call out to the reviewers e.g. areas to focus on, decisions you made, specific feedback you are looking for, etc. -->

## Related Github issues

<!-- Include related github issues. -->

## Changes

<!-- Summary or changes that have been made. -->

## Tests

<!-- Describe what you did to test these changes, including unit tests that have been added or changed. -->

## Deployment Considerations

## Version Notes ##
{ major | minor | patch }

<!--

Decide whether this is a major, minor, or patch version change. Major is for backwards incompatible changes (This is only relevant once the service is live and in production and the major version is at least 1. While the major version is 0, it is ok to have backwards incompatible changes in a minor version.). Minor is for additional features. Patch is for bug fixes.

Describe the changes in this version. This is essentially the details you would include in the squash commit message.
-->

**NOTE: Include the version notes in the squash commit message**
