### PR TITLE
chore(vote_mngr): do not save all votes to DB

### DIFF
--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -505,9 +505,15 @@ void PbftManager::initialState_() {
 
   auto soft_voted_block_hash = db_->getPbftMgrVotedValue(PbftMgrVotedValue::SoftVotedBlockHashInRound);
   auto soft_voted_block = db_->getPbftMgrStatus(PbftMgrStatus::SoftVotedBlockInRound);
+
   if (soft_voted_block_hash) {
     // From DB
     soft_voted_block_for_this_round_ = std::make_pair(*soft_voted_block_hash, soft_voted_block);
+    for (const auto &vote : db_->getSoftVotes(round)) {
+      if (vote->getBlockHash() == *soft_voted_block_hash) {
+        vote_mgr_->addVerifiedVote(vote);
+      }
+    }
   } else {
     // Default value
     soft_voted_block_for_this_round_ = std::make_pair(NULL_BLOCK_HASH, soft_voted_block);

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -101,7 +101,6 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
     COLUMN(pbft_mgr_voted_value);
     COLUMN(pbft_cert_voted_block);
     COLUMN(pbft_head);
-    COLUMN(unverified_votes);
     COLUMN(verified_votes);
     COLUMN(soft_votes);  // only for current PBFT round
     COLUMN(next_votes);  // only for previous PBFT round
@@ -140,7 +139,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   bool snapshot_enable_ = true;
   uint32_t db_max_snapshots_ = 0;
   std::set<uint64_t> snapshots_;
-  addr_t node_addr_;
+
   bool minor_version_changed_ = false;
 
   auto handle(Column const& col) const { return handles_[col.ordinal_]; }
@@ -240,14 +239,6 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   uint64_t getStatusField(StatusDbField const& field);
   void saveStatusField(StatusDbField const& field, uint64_t value);
   void addStatusFieldToBatch(StatusDbField const& field, uint64_t value, Batch& write_batch);
-
-  // Unverified votes
-  std::vector<std::shared_ptr<Vote>> getUnverifiedVotes();
-  std::shared_ptr<Vote> getUnverifiedVote(vote_hash_t const& vote_hash);
-  bool unverifiedVoteExist(vote_hash_t const& vote_hash);
-  void saveUnverifiedVote(std::shared_ptr<Vote> const& vote);
-  void addUnverifiedVoteToBatch(std::shared_ptr<Vote> const& vote, Batch& write_batch);
-  void removeUnverifiedVoteToBatch(vote_hash_t const& vote_hash, Batch& write_batch);
 
   // Verified votes
   std::vector<std::shared_ptr<Vote>> getVerifiedVotes();

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -312,46 +312,11 @@ TEST_F(FullNodeTest, db_test) {
   EXPECT_EQ(db.getStatusField(StatusDbField::ExecutedBlkCount), 10);
   EXPECT_EQ(db.getStatusField(StatusDbField::ExecutedTrxCount), 20);
 
-  // Unverified votes
-  auto unverified_votes = db.getUnverifiedVotes();
-  EXPECT_TRUE(unverified_votes.empty());
-  EXPECT_FALSE(db.unverifiedVoteExist(blk_hash_t(0)));
-  blk_hash_t voted_pbft_block_hash(1);
-  auto weighted_index = 0;
-  for (auto i = 0; i < 3; i++) {
-    auto round = i;
-    auto step = i;
-    VrfPbftMsg msg(soft_vote_type, round, step, weighted_index);
-    vrf_wrapper::vrf_sk_t vrf_sk(
-        "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
-        "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
-    VrfPbftSortition vrf_sortition(vrf_sk, msg);
-    Vote vote(g_secret, vrf_sortition, voted_pbft_block_hash);
-    unverified_votes.emplace_back(std::make_shared<Vote>(vote));
-  }
-  db.saveUnverifiedVote(unverified_votes[0]);
-  EXPECT_TRUE(db.unverifiedVoteExist(unverified_votes[0]->getHash()));
-  EXPECT_EQ(db.getUnverifiedVote(unverified_votes[0]->getHash())->rlp(true), unverified_votes[0]->rlp(true));
-  batch = db.createWriteBatch();
-  db.addUnverifiedVoteToBatch(unverified_votes[1], batch);
-  db.addUnverifiedVoteToBatch(unverified_votes[2], batch);
-  db.commitWriteBatch(batch);
-  EXPECT_TRUE(db.unverifiedVoteExist(unverified_votes[1]->getHash()));
-  EXPECT_TRUE(db.unverifiedVoteExist(unverified_votes[2]->getHash()));
-  EXPECT_EQ(db.getUnverifiedVotes().size(), unverified_votes.size());
-  batch = db.createWriteBatch();
-  db.removeUnverifiedVoteToBatch(unverified_votes[0]->getHash(), batch);
-  db.removeUnverifiedVoteToBatch(unverified_votes[1]->getHash(), batch);
-  db.commitWriteBatch(batch);
-  EXPECT_FALSE(db.unverifiedVoteExist(unverified_votes[0]->getHash()));
-  EXPECT_FALSE(db.unverifiedVoteExist(unverified_votes[1]->getHash()));
-  EXPECT_EQ(db.getUnverifiedVotes().size(), unverified_votes.size() - 2);
-
   // Verified votes
   auto verified_votes = db.getVerifiedVotes();
   EXPECT_TRUE(verified_votes.empty());
-  voted_pbft_block_hash = blk_hash_t(2);
-  weighted_index = 0;
+  auto voted_pbft_block_hash = blk_hash_t(2);
+  auto weighted_index = 0;
   for (auto i = 0; i < 3; i++) {
     auto round = i;
     auto step = i;

--- a/tests/vote_test.cpp
+++ b/tests/vote_test.cpp
@@ -26,13 +26,9 @@ void clearAllVotes(std::shared_ptr<FullNode> &node) {
   // Clear unverified votes and verified votes table
   auto db = node->getDB();
   auto vote_mgr = node->getVoteManager();
-  auto unverified_votes = db->getUnverifiedVotes();
   auto verified_votes = db->getVerifiedVotes();
 
   auto batch = db->createWriteBatch();
-  for (auto const &v : unverified_votes) {
-    db->removeUnverifiedVoteToBatch(v->getHash(), batch);
-  }
   for (auto const &v : verified_votes) {
     db->removeVerifiedVoteToBatch(v->getHash(), batch);
   }
@@ -152,7 +148,6 @@ TEST_F(VoteTest, remove_verified_votes) {
   EXPECT_EQ(vote_mgr->getVerifiedVotes().size(), 0);
   EXPECT_TRUE(db->getVerifiedVotes().empty());
   EXPECT_EQ(vote_mgr->getUnverifiedVotesSize(), votes.size());
-  EXPECT_EQ(db->getUnverifiedVotes().size(), votes.size());
 }
 
 // Add votes round 1, 2 and 3 into unverified vote table


### PR DESCRIPTION
## Purpose

This PR should optimize what votes are we saving to DB, so now on it is only our votes and the rest we will receive after the node restarts 

