### PR TITLE
chore(db): new option to remove old columns from DB

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -452,7 +452,7 @@ jobs:
       - run:
          name: Build docker builder image
          command: |
-                docker build --no-cache -t ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} --target builder .
+                docker build -t ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} --target builder .
 
       - run:
          name: Checkout Submodules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -452,7 +452,7 @@ jobs:
       - run:
          name: Build docker builder image
          command: |
-                docker build -t ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} --target builder .
+                docker build --no-cache -t ${IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM} --target builder .
 
       - run:
          name: Checkout Submodules

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ ENV CXX="clang++-${LLVM_VERSION}"
 ENV CC="clang-${LLVM_VERSION}"
 
 # Install conan
-RUN pip3 install conan
+RUN pip3 install --upgrade conan
 
 # Install go
 RUN curl -SL https://dl.google.com/go/go$GO_VERSION.linux-amd64.tar.gz \

--- a/libraries/cli/include/cli/config.hpp
+++ b/libraries/cli/include/cli/config.hpp
@@ -36,6 +36,7 @@ class Config {
   static constexpr const char* REBUILD_DB = "rebuild-db";
   static constexpr const char* REBUILD_DB_PERIOD = "rebuild-db-period";
   static constexpr const char* REVERT_TO_PERIOD = "revert-to-period";
+  static constexpr const char* REBUILD_DB_COLUMNS = "rebuild-db-columns";
   static constexpr const char* HELP = "help";
   static constexpr const char* VERSION = "version";
   static constexpr const char* WALLET = "wallet";

--- a/libraries/cli/src/config.cpp
+++ b/libraries/cli/src/config.cpp
@@ -29,9 +29,10 @@ Config::Config(int argc, const char* argv[]) {
   bool overwrite_config;
 
   bool boot_node = false;
-  bool destroy_db = 0;
-  bool rebuild_network = 0;
-  bool rebuild_db = 0;
+  bool destroy_db = false;
+  bool rebuild_network = false;
+  bool rebuild_db = false;
+  bool rebuild_db_columns = false;
   bool version = false;
   uint64_t rebuild_db_period = 0;
   uint64_t revert_to_period = 0;
@@ -66,6 +67,8 @@ Config::Config(int argc, const char* argv[]) {
                                      "rebuilding all the other "
                                      "database tables - this could take a long "
                                      "time");
+  node_command_options.add_options()(REBUILD_DB_COLUMNS, bpo::bool_switch(&rebuild_db_columns),
+                                     "Removes old DB columns ");
   node_command_options.add_options()(REBUILD_DB_PERIOD, bpo::value<uint64_t>(&rebuild_db_period),
                                      "Use with rebuild-db - Rebuild db up "
                                      "to a specified period");
@@ -184,6 +187,7 @@ Config::Config(int argc, const char* argv[]) {
     }
     node_config_.test_params.db_revert_to_period = revert_to_period;
     node_config_.test_params.rebuild_db = rebuild_db;
+    node_config_.test_params.rebuild_db_columns = rebuild_db_columns;
     node_config_.test_params.rebuild_db_period = rebuild_db_period;
     if (command[0] == NODE_COMMAND) node_configured_ = true;
   } else if (command.size() > 0 && command[0] == ACCOUNT_COMMAND) {

--- a/libraries/config/include/config/config.hpp
+++ b/libraries/config/include/config/config.hpp
@@ -59,8 +59,9 @@ struct TestParamsConfig {
   uint32_t db_snapshot_each_n_pbft_block = 0;
   uint32_t db_max_snapshots = 0;
   uint32_t db_revert_to_period = 0;
-  bool rebuild_db = 0;
+  bool rebuild_db = false;
   uint64_t rebuild_db_period = 0;
+  bool rebuild_db_columns = false;
 };
 
 struct FullNodeConfig {

--- a/libraries/core_libs/node/src/node.cpp
+++ b/libraries/core_libs/node/src/node.cpp
@@ -62,7 +62,7 @@ void FullNode::init() {
 
     db_ = std::make_shared<DbStorage>(conf_.db_path, conf_.test_params.db_snapshot_each_n_pbft_block,
                                       conf_.test_params.db_max_snapshots, conf_.test_params.db_revert_to_period,
-                                      node_addr);
+                                      node_addr, false, conf_.test_params.rebuild_db_columns);
 
     if (db_->hasMinorVersionChanged()) {
       LOG(log_si_) << "Minor DB version has changed. Rebuilding Db";

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -85,6 +85,8 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
 
 #define COLUMN(__name__) static inline auto const __name__ = all_.emplace_back(#__name__, all_.size())
 
+    // do not change/move
+    COLUMN(default_column);
     // Contains full data for an executed PBFT block including PBFT block, cert votes, dag blocks and transactions
     COLUMN(period_data);
     COLUMN(dag_blocks);
@@ -151,7 +153,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
 
   explicit DbStorage(fs::path const& base_path, uint32_t db_snapshot_each_n_pbft_block = 0,
                      uint32_t db_max_snapshots = 0, uint32_t db_revert_to_period = 0, addr_t node_addr = addr_t(),
-                     bool rebuild = 0);
+                     bool rebuild = false, bool rebuild_columns = false);
   ~DbStorage();
 
   auto const& path() const { return path_; }
@@ -161,6 +163,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   void commitWriteBatch(Batch& write_batch, rocksdb::WriteOptions const& opts);
   void commitWriteBatch(Batch& write_batch) { commitWriteBatch(write_batch, write_options_); }
 
+  void rebuildColumns(const rocksdb::Options& options);
   bool createSnapshot(uint64_t period);
   void deleteSnapshot(uint64_t period);
   void recoverToPeriod(uint64_t period);


### PR DESCRIPTION
## Purpose

Added new options `--rebuild-db-columns`, that will remove old columns from DB and node can continue working even if DB scheme changes.

IMPORTANT:  `COLUMN(default_column);` is introduced again (it was removed, maybe even by me) but it needs to be there. This is default column for rocks DB, that can not be change. Right now we have there all period data and that's not good. So this is probably BREAKING CHANGE

