### PR TITLE
chore(db): max_open_files setting for DB, to limit memory usage

### DIFF
--- a/libraries/config/include/config/config.hpp
+++ b/libraries/config/include/config/config.hpp
@@ -58,6 +58,7 @@ struct TestParamsConfig {
   uint32_t max_block_queue_warn = 0;
   uint32_t db_snapshot_each_n_pbft_block = 0;
   uint32_t db_max_snapshots = 0;
+  uint32_t db_max_open_files = 0;
   uint32_t db_revert_to_period = 0;
   bool rebuild_db = false;
   uint64_t rebuild_db_period = 0;

--- a/libraries/config/src/config.cpp
+++ b/libraries/config/src/config.cpp
@@ -152,6 +152,7 @@ FullNodeConfig::FullNodeConfig(Json::Value const &string_or_object, Json::Value 
         getConfigDataAsUInt(root, {"test_params", "db_snapshot_each_n_pbft_block"}, true);
 
     test_params.db_max_snapshots = getConfigDataAsUInt(root, {"test_params", "db_max_snapshots"}, true);
+    test_params.db_max_open_files = getConfigDataAsUInt(root, {"test_params", "db_max_open_files"}, true);
 
     // DAG proposal
     test_params.block_proposer.shard = getConfigDataAsUInt(root, {"test_params", "block_proposer", "shard"});

--- a/libraries/core_libs/node/src/node.cpp
+++ b/libraries/core_libs/node/src/node.cpp
@@ -56,24 +56,25 @@ void FullNode::init() {
   {
     if (conf_.test_params.rebuild_db) {
       old_db_ = std::make_shared<DbStorage>(conf_.db_path, conf_.test_params.db_snapshot_each_n_pbft_block,
-                                            conf_.test_params.db_max_snapshots, conf_.test_params.db_revert_to_period,
-                                            node_addr, true);
+                                            conf_.test_params.db_max_open_files, conf_.test_params.db_max_snapshots,
+                                            conf_.test_params.db_revert_to_period, node_addr, true);
     }
 
     db_ = std::make_shared<DbStorage>(conf_.db_path, conf_.test_params.db_snapshot_each_n_pbft_block,
-                                      conf_.test_params.db_max_snapshots, conf_.test_params.db_revert_to_period,
-                                      node_addr, false, conf_.test_params.rebuild_db_columns);
+                                      conf_.test_params.db_max_open_files, conf_.test_params.db_max_snapshots,
+                                      conf_.test_params.db_revert_to_period, node_addr, false,
+                                      conf_.test_params.rebuild_db_columns);
 
     if (db_->hasMinorVersionChanged()) {
       LOG(log_si_) << "Minor DB version has changed. Rebuilding Db";
       conf_.test_params.rebuild_db = true;
       db_ = nullptr;
       old_db_ = std::make_shared<DbStorage>(conf_.db_path, conf_.test_params.db_snapshot_each_n_pbft_block,
-                                            conf_.test_params.db_max_snapshots, conf_.test_params.db_revert_to_period,
-                                            node_addr, true);
+                                            conf_.test_params.db_max_open_files, conf_.test_params.db_max_snapshots,
+                                            conf_.test_params.db_revert_to_period, node_addr, true);
       db_ = std::make_shared<DbStorage>(conf_.db_path, conf_.test_params.db_snapshot_each_n_pbft_block,
-                                        conf_.test_params.db_max_snapshots, conf_.test_params.db_revert_to_period,
-                                        node_addr);
+                                        conf_.test_params.db_max_open_files, conf_.test_params.db_max_snapshots,
+                                        conf_.test_params.db_revert_to_period, node_addr);
     }
 
     if (db_->getNumDagBlocks() == 0) {

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -128,7 +128,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   fs::path state_db_path_;
   const std::string db_dir = "db";
   const std::string state_db_dir = "state_db";
-  rocksdb::DB* db_;
+  std::unique_ptr<rocksdb::DB> db_;
   std::vector<rocksdb::ColumnFamilyHandle*> handles_;
   rocksdb::ReadOptions read_options_;
   rocksdb::WriteOptions write_options_;
@@ -150,7 +150,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   DbStorage(DbStorage const&) = delete;
   DbStorage& operator=(DbStorage const&) = delete;
 
-  explicit DbStorage(fs::path const& base_path, uint32_t db_snapshot_each_n_pbft_block = 0,
+  explicit DbStorage(fs::path const& base_path, uint32_t db_snapshot_each_n_pbft_block = 0, uint32_t max_open_files = 0,
                      uint32_t db_max_snapshots = 0, uint32_t db_revert_to_period = 0, addr_t node_addr = addr_t(),
                      bool rebuild = false, bool rebuild_columns = false);
   ~DbStorage();


### PR DESCRIPTION
## Purpose

This new setting should limit rocksDB memory usage, I think it is caused by `ulimit -n` that is set on our nodes to extreme number `1048576`. With this setting we can limit number of open files ~= RAM consumption. I am not 100% sure, but I would like to deploy it to our testnet and let's see if this can help