### PR TITLE
chore(vote): add know votes to vote packet handler

### DIFF
--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/vote_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/vote_packet_handler.hpp
@@ -22,6 +22,7 @@ class VotePacketHandler : public ExtVotesPacketHandler {
 
   std::shared_ptr<PbftManager> pbft_mgr_;
   std::shared_ptr<VoteManager> vote_mgr_;
+  ExpirationCache<vote_hash_t> known_votes_;
 };
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
@@ -17,7 +17,7 @@ class TaraxaPeer : public boost::noncopyable {
         known_pbft_blocks_(10000, 1000),
         known_votes_(10000, 1000) {}
   explicit TaraxaPeer(dev::p2p::NodeID id)
-      : m_id(id),
+      : m_id(std::move(id)),
         known_dag_blocks_(10000, 1000),
         known_transactions_(100000, 10000),
         known_pbft_blocks_(10000, 1000),

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
@@ -10,7 +10,8 @@ VotePacketHandler::VotePacketHandler(std::shared_ptr<PeersState> peers_state,
                                      std::shared_ptr<VoteManager> vote_mgr, const addr_t &node_addr)
     : ExtVotesPacketHandler(std::move(peers_state), std::move(packets_stats), node_addr, "PBFT_VOTE_PH"),
       pbft_mgr_(std::move(pbft_mgr)),
-      vote_mgr_(std::move(vote_mgr)) {}
+      vote_mgr_(std::move(vote_mgr)),
+      known_votes_(1000000, 1000) {}
 
 void VotePacketHandler::process(const PacketData &packet_data, const std::shared_ptr<TaraxaPeer> &peer) {
   auto vote = std::make_shared<Vote>(packet_data.rlp_[0].toBytes());
@@ -25,13 +26,14 @@ void VotePacketHandler::process(const PacketData &packet_data, const std::shared
     return;
   }
 
-  peer->markVoteAsKnown(vote_hash);
-
-  if (vote_mgr_->voteInUnverifiedMap(vote_round, vote_hash) || vote_mgr_->voteInVerifiedMap(vote)) {
+  if (!known_votes_.insert(vote_hash)) {
     LOG(log_dg_) << "Received PBFT vote " << vote_hash << " (from " << packet_data.from_node_id_.abridged()
-                 << ") already saved in queue.";
+                 << ") already processed.";
     return;
   }
+
+  // Do not mark it before, as peers have small caches of known votes.
+  peer->markVoteAsKnown(vote_hash);
 
   // Synchronization point in case multiple threads are processing the same vote at the same time
   // Adds unverified vote into local structure + database


### PR DESCRIPTION
## Purpose

As marking votes as know for peers is not sufficient (cache sizes 100k) and checking in verified/unverified queues also (invalid votes is not in either of them). I have introduced additional cache that show performance improvements. 
Checking in verified/unverified queues seems to be also quite slow.

TLDR: 
- processing function speed up 973 [us] -> 500 [us] = 48% !!!!
- amplifying level of IN:OUT packets 4.29 -> 1.45 = 66% !!!!



BEFORE: 
IN: 
```
[VotePacket -> total_count: 27371, total_size: 6351761 [B], avg_size: 232 [B], processing_duration: 26654686 [us], avg processing_duration: 973 [us], tp_wait_duration: 2537067446395 [us], avg tp_wait_duration: 92691806 [us]]
```
OUT

```
[VotePacket -> total_count: 117504, total_size: 27265706 [B], avg_size: 232 [B], processing_duration: 0 [us], avg processing_duration: 0 [us], tp_wait_duration: 0 [us], avg tp_wait_duration: 0 [us]]
```

AFTER: 
IN: 
```
[VotePacket -> total_count: 51853, total_size: 12031326 [B], avg_size: 232 [B], processing_duration: 25934699 [us], avg processing_duration: 500 [us], tp_wait_duration: 11712612747492 [us], avg tp_wait_duration: 225881101 [us]]
```

OUT
```
[VotePacket -> total_count: 75288, total_size: 17469704 [B], avg_size: 232 [B], processing_duration: 0 [us], avg processing_duration: 0 [us], tp_wait_duration: 0 [us], avg tp_wait_duration: 0 [us]]
```  
