### PR TITLE
fix: filter sync irrelevant packets

### DIFF
--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -338,9 +338,9 @@ inline bool TaraxaCapability::filterSyncIrrelevantPackets(SubprotocolPacketType 
     case GetPbftSyncPacket:
     case PbftSyncPacket:
     case SyncedPacket:
-      return true;
-    default:
       return false;
+    default:
+      return true;
   }
 }
 


### PR DESCRIPTION
Filtering sync irrelevant packets was not working correctly