### PR TITLE
fix: mark invalid block

### DIFF
--- a/libraries/core_libs/consensus/src/dag/dag_block_manager.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_block_manager.cpp
@@ -220,7 +220,8 @@ void DagBlockManager::verifyBlock() {
     // Verify transactions
     if (!trx_mgr_->checkBlockTransactions(blk)) {
       LOG(log_er_) << "Ignore block " << block_hash << " since it has invalid or missing transactions";
-      markBlockInvalid(block_hash);
+      // This can be a valid block so just remove it from the seen list
+      seen_blocks_.erase(block_hash);
       continue;
     }
 
@@ -338,8 +339,7 @@ std::shared_ptr<ProposalPeriodDagLevelsMap> DagBlockManager::newProposePeriodDag
 }
 
 void DagBlockManager::markBlockInvalid(blk_hash_t const &hash) {
-  // TODO: uncomment once differentiate between invalid and incomplete blocks
-  // invalid_blocks_.insert(hash);
+  invalid_blocks_.insert(hash);
   seen_blocks_.erase(hash);
 }
 


### PR DESCRIPTION
Mark blocks which fail vdf and dpos verification as invalid. Block that have missing transactions could be valid so just clear them from seen blocks.