### PR TITLE
fix: votes memory leak on syncing

### DIFF
--- a/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
@@ -137,6 +137,9 @@ class TaraxaCapability : public dev::p2p::CapabilityFace {
   // Fake threadpool (1 thread) for periodic events like printing summary logs, packets stats, etc...
   util::ThreadPool periodic_events_tp_;
 
+  // Pbft Chain
+  std::shared_ptr<PbftChain> pbft_chain_;
+
   LOG_OBJECTS_DEFINE
 };
 }  // namespace taraxa::network::tarcap


### PR DESCRIPTION
This issue is already fixed on develop with a deep syncing feature. This is only a hotfix for the testnet for votes memory leaks.