### PR TITLE
fix: not remove old VrfParamsChanges to validate old dag block correctly

### DIFF
--- a/libraries/core_libs/consensus/src/dag/sortition_params_manager.cpp
+++ b/libraries/core_libs/consensus/src/dag/sortition_params_manager.cpp
@@ -117,7 +117,6 @@ void SortitionParamsManager::cleanup(uint64_t current_period) {
   }
   auto batch = db_->createWriteBatch();
   db_->cleanupDagEfficiencies(current_period);
-  db_->cleanupParamsChanges(batch, config_.changes_count_for_average);
   db_->commitWriteBatch(batch);
 }
 

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -201,7 +201,6 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   // Sortition params
   void saveSortitionParamsChange(uint64_t period, SortitionParamsChange params, DbStorage::Batch& batch);
   std::deque<SortitionParamsChange> getLastSortitionParams(size_t count);
-  void cleanupParamsChanges(DbStorage::Batch& batch, uint16_t changes_to_leave);
 
   // Transaction
   void saveTransaction(Transaction const& trx, bool verified = false);

--- a/libraries/core_libs/storage/src/storage.cpp
+++ b/libraries/core_libs/storage/src/storage.cpp
@@ -423,17 +423,6 @@ std::deque<SortitionParamsChange> DbStorage::getLastSortitionParams(size_t count
   return changes;
 }
 
-void DbStorage::cleanupParamsChanges(DbStorage::Batch& batch, uint16_t changes_to_leave) {
-  auto it =
-      std::unique_ptr<rocksdb::Iterator>(db_->NewIterator(read_options_, handle(Columns::sortition_params_change)));
-  it->SeekToLast();
-  for (uint16_t i = 0; it->Valid(); it->Prev(), ++i) {
-    if (i >= changes_to_leave) {
-      remove(batch, Columns::sortition_params_change, it->key());
-    }
-  }
-}
-
 void DbStorage::savePeriodData(const SyncBlock& sync_block, Batch& write_batch) {
   uint64_t period = sync_block.pbft_blk->getPeriod();
   addPbftBlockPeriodToBatch(period, sync_block.pbft_blk->getBlockHash(), write_batch);


### PR DESCRIPTION
## Purpose

Keep old VrfParamsChanges to validate old dag block correctly