### PR TITLE
Vote fix

### DIFF
--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1091,11 +1091,8 @@ size_t PbftManager::placeVote_(taraxa::blk_hash_t const &blockhash, PbftVoteType
     if (auto net = network_.lock()) {
       net->onNewPbftVotes({std::move(vote)});
     }
-
-    return weight;
   }
-
-  return 0;
+  return weight;
 }
 
 blk_hash_t PbftManager::calculateOrderHash(std::vector<blk_hash_t> const &dag_block_hashes,

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1073,18 +1073,28 @@ std::shared_ptr<Vote> PbftManager::generateVote(blk_hash_t const &blockhash, Pbf
 size_t PbftManager::placeVote_(taraxa::blk_hash_t const &blockhash, PbftVoteTypes vote_type, uint64_t round,
                                size_t step) {
   if (!weighted_votes_count_) {
+    // No delegation
     return 0;
   }
+
+  auto dpos_weighted_votes_count = weighted_votes_count_.load();
+  if (step == 1) {
+    // For proposal vote, only use 1 weight for VRF sortition
+    dpos_weighted_votes_count = 1;
+  }
+
   auto vote = generateVote(blockhash, vote_type, round, step);
-  if (const auto weight = vote->calculateWeight(weighted_votes_count_, getDposTotalVotesCount(), sortition_threshold_);
-      weight) {
+  const auto weight = vote->calculateWeight(dpos_weighted_votes_count, getDposTotalVotesCount(), sortition_threshold_);
+  if (weight) {
     db_->saveVerifiedVote(vote);
     vote_mgr_->addVerifiedVote(vote);
     if (auto net = network_.lock()) {
       net->onNewPbftVotes({std::move(vote)});
     }
+
     return weight;
   }
+
   return 0;
 }
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/status_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/status_packet_handler.cpp
@@ -140,11 +140,11 @@ void StatusPacketHandler::process(const PacketData& packet_data, const std::shar
   if (pbft_current_round < selected_peer->pbft_round_) {
     syncPbftNextVotes(pbft_current_round, pbft_previous_round_next_votes_size);
   } else if (pbft_current_round == selected_peer->pbft_round_) {
-    // because of weighted votes some peers could have more votes than we have
-    // if we have 2 * 2T+1 votes, we will not request more votes
-    //
-    if (pbft_previous_round_next_votes_size < (pbft_mgr_->getTwoTPlusOne() * 2) &&
-        pbft_previous_round_next_votes_size < selected_peer->pbft_previous_round_next_votes_size_) {
+    auto two_times_2t_plus_1 = pbft_mgr_->getTwoTPlusOne() * 2;
+    // Node at lease have one next vote value for previoud PBFT round. There may have 2 next vote values for previous
+    // PBFT round. If node own have one next vote value and peer have two, need sync here.
+    if (pbft_previous_round_next_votes_size < two_times_2t_plus_1 &&
+        selected_peer->pbft_previous_round_next_votes_size_ >= two_times_2t_plus_1) {
       syncPbftNextVotes(pbft_current_round, pbft_previous_round_next_votes_size);
     }
   }

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/status_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/status_packet_handler.cpp
@@ -140,7 +140,7 @@ void StatusPacketHandler::process(const PacketData& packet_data, const std::shar
   if (pbft_current_round < selected_peer->pbft_round_) {
     syncPbftNextVotes(pbft_current_round, pbft_previous_round_next_votes_size);
   } else if (pbft_current_round == selected_peer->pbft_round_) {
-    auto two_times_2t_plus_1 = pbft_mgr_->getTwoTPlusOne() * 2;
+    const auto two_times_2t_plus_1 = pbft_mgr_->getTwoTPlusOne() * 2;
     // Node at lease have one next vote value for previoud PBFT round. There may have 2 next vote values for previous
     // PBFT round. If node own have one next vote value and peer have two, need sync here.
     if (pbft_previous_round_next_votes_size < two_times_2t_plus_1 &&


### PR DESCRIPTION
When I review the PR introduce binominal distribution for votes, I find 2 issues:
1. When generate proposal vote use normal ”weighted_votes_count_”, but when generate proposal PBFT block and verify proposal vote only use stake “1”. 
2. Node at lease have one next vote value for previoud PBFT round. There may have 2 next vote values for previous PBFT round. Only if node own have one next vote value and peer have two, need sync there.