### PR TITLE
Nonfinalized trx fix

### DIFF
--- a/libraries/core_libs/consensus/include/transaction_manager/transaction_manager.hpp
+++ b/libraries/core_libs/consensus/include/transaction_manager/transaction_manager.hpp
@@ -31,9 +31,9 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
   SharedTransactions packTrxs(uint16_t max_trx_to_pack = 0);
 
   /**
-   * Removes transactions from memory pool. Invoked when transactions are included in proposed or received dag block
+   * Saves transactions from dag block which was added to the DAG. Removes transactions from memory pool
    */
-  void removeTransactionsFromPool(SharedTransactions const &trxs);
+  void saveTransactionsFromDagBlock(SharedTransactions const &trxs);
 
   /**
    * @brief Inserts new transaction to transaction pool

--- a/libraries/core_libs/consensus/src/dag/dag.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag.cpp
@@ -607,8 +607,8 @@ void DagManager::recoverDag() {
     for (auto &blk : lvl.second) {
       addDagBlock(std::move(blk), {}, false, false);
     }
-    trx_mgr_->recoverNonfinalizedTransactions();
   }
+  trx_mgr_->recoverNonfinalizedTransactions();
 }
 
 const std::map<uint64_t, std::vector<blk_hash_t>> DagManager::getNonFinalizedBlocks() const {

--- a/libraries/core_libs/storage/src/storage.cpp
+++ b/libraries/core_libs/storage/src/storage.cpp
@@ -542,6 +542,10 @@ std::optional<PbftBlock> DbStorage::getPbftBlock(uint64_t period) {
 }
 
 std::shared_ptr<Transaction> DbStorage::getTransaction(trx_hash_t const& hash) {
+  auto data = asBytes(lookup(toSlice(hash.asBytes()), Columns::transactions));
+  if (data.size() > 0) {
+    return std::make_shared<Transaction>(data);
+  }
   auto res = getTransactionPeriod(hash);
   if (res) {
     auto period_data = getPeriodDataRaw(res->first);
@@ -550,10 +554,6 @@ std::shared_ptr<Transaction> DbStorage::getTransaction(trx_hash_t const& hash) {
     auto period_data_rlp = dev::RLP(period_data);
     auto transaction_data = period_data_rlp[TRANSACTIONS_POS_IN_PERIOD_DATA];
     return std::make_shared<Transaction>(transaction_data[res->second]);
-  }
-  auto data = asBytes(lookup(toSlice(hash.asBytes()), Columns::transactions));
-  if (data.size() > 0) {
-    return std::make_shared<Transaction>(data);
   }
   return nullptr;
 }

--- a/libraries/core_libs/storage/src/storage.cpp
+++ b/libraries/core_libs/storage/src/storage.cpp
@@ -579,19 +579,20 @@ std::vector<bool> DbStorage::transactionsInDb(std::vector<trx_hash_t> const& trx
   result.reserve(trx_hashes.size());
 
   DbStorage::MultiGetQuery db_query(shared_from_this(), trx_hashes.size());
-  db_query.append(DbStorage::Columns::trx_period, trx_hashes);
+  db_query.append(DbStorage::Columns::transactions, trx_hashes);
   auto db_trxs_statuses = db_query.execute();
   for (size_t idx = 0; idx < db_trxs_statuses.size(); idx++) {
     auto& trx_raw_status = db_trxs_statuses[idx];
     result[idx] = !trx_raw_status.empty();
   }
 
-  db_query.append(DbStorage::Columns::transactions, trx_hashes);
+  db_query.append(DbStorage::Columns::trx_period, trx_hashes);
   db_trxs_statuses = db_query.execute();
   for (size_t idx = 0; idx < db_trxs_statuses.size(); idx++) {
     auto& trx_raw_status = db_trxs_statuses[idx];
     result[idx] = result[idx] || (!trx_raw_status.empty());
   }
+
   return result;
 }
 

--- a/tests/transaction_test.cpp
+++ b/tests/transaction_test.cpp
@@ -179,7 +179,7 @@ TEST_F(TransactionTest, prepare_signed_trx_for_propose) {
   do {
     packed_trxs = trx_mgr.packTrxs();
     total_packed_trxs.insert(total_packed_trxs.end(), packed_trxs.begin(), packed_trxs.end());
-    trx_mgr.removeTransactionsFromPool(packed_trxs);
+    trx_mgr.saveTransactionsFromDagBlock(packed_trxs);
     thisThreadSleepForMicroSeconds(100);
   } while (!packed_trxs.empty());
   wakeup.join();
@@ -204,8 +204,7 @@ TEST_F(TransactionTest, transaction_concurrency) {
 
   // 2/3 of transactions removed from pool and saved to db
   for (size_t i = 0; i < g_signed_trx_samples->size() * 2 / 3; i++) {
-    db->saveTransaction(*g_signed_trx_samples[i]);
-    trx_mgr.removeTransactionsFromPool({g_signed_trx_samples[i]});
+    trx_mgr.saveTransactionsFromDagBlock({g_signed_trx_samples[i]});
   }
 
   // 1/3 transactions finalized


### PR DESCRIPTION
Transactions that were already finalized in a pbft block were incorrectly included in the nonfinalized_transactions_in_dag_ structure and in db when transactions were included in another dag block creating a memory leak. Fix is checking if the transactions is already in the db before saving it.

The fix includes removing all incorrectly saved transactions in recoverNonfinalizedTransactions from DB on restart so that existing node data is properly processed on startup. This part can later be removed 