### PR TITLE
chore(syncing): race condtion in syncing

### DIFF
--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_syncing_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_syncing_packet_handler.hpp
@@ -38,7 +38,7 @@ class ExtSyncingPacketHandler : public PacketHandler {
    */
   void restartSyncingPbft(bool force = false);
 
-  void syncPeerPbft(unsigned long height_to_sync);
+  bool syncPeerPbft(unsigned long height_to_sync);
   void requestDagBlocks(const dev::p2p::NodeID &_nodeID, const std::unordered_set<blk_hash_t> &blocks,
                         DagSyncRequestType mode = MissingHashes);
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
@@ -97,7 +97,10 @@ void PbftSyncPacketHandler::process(const PacketData &packet_data, const std::sh
                      << ", PBFT chain size " << pbft_chain_->getPbftChainSize();
         delayed_sync_events_tp_.post(1000, [this] { delayedPbftSync(1); });
       } else {
-        syncPeerPbft(pbft_sync_period + 1);
+        if (!syncPeerPbft(pbft_sync_period + 1)) {
+          syncing_state_->set_pbft_syncing(false);
+          return restartSyncingPbft();
+        }
       }
     }
   }
@@ -141,7 +144,10 @@ void PbftSyncPacketHandler::delayedPbftSync(int counter) {
                    << pbft_chain_->getPbftChainSize();
       delayed_sync_events_tp_.post(1000, [this, counter] { delayedPbftSync(counter + 1); });
     } else {
-      syncPeerPbft(pbft_sync_period + 1);
+      if (!syncPeerPbft(pbft_sync_period + 1)) {
+        syncing_state_->set_pbft_syncing(false);
+        return restartSyncingPbft();
+      }
     }
   }
 }


### PR DESCRIPTION
## Purpose

Race condition flow:

1. we choose a peer https://github.com/Taraxa-project/taraxa-node/blob/develop/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_syncing_packet_handler.cpp#L36
2. peer is disconnected https://github.com/Taraxa-project/taraxa-node/blob/develop/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp#L273
3. we send a request (witch fails) https://github.com/Taraxa-project/taraxa-node/blob/develop/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_syncing_packet_handler.cpp#L59
4. We never restart as pbft_sync is always true https://github.com/Taraxa-project/taraxa-node/blob/develop/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_syncing_packet_handler.cpp#L27
