### PR TITLE
chore: difficulty adjustment testnet fork

### DIFF
--- a/libraries/core_libs/consensus/include/dag/sortition_params_manager.hpp
+++ b/libraries/core_libs/consensus/include/dag/sortition_params_manager.hpp
@@ -77,6 +77,8 @@ class SortitionParamsManager {
   int32_t getChange(uint64_t period, uint16_t efficiency) const;
   void cleanup(uint64_t current_period);
 
+  const uint64_t k_threshold_testnet_hard_fork_period = 50000;
+
   LOG_OBJECTS_DEFINE
 };
 

--- a/libraries/core_libs/consensus/include/dag/sortition_params_manager.hpp
+++ b/libraries/core_libs/consensus/include/dag/sortition_params_manager.hpp
@@ -77,7 +77,7 @@ class SortitionParamsManager {
   int32_t getChange(uint64_t period, uint16_t efficiency) const;
   void cleanup(uint64_t current_period);
 
-  const uint64_t k_threshold_testnet_hard_fork_period = 50000;
+  const uint64_t k_threshold_testnet_hard_fork_period = 110000;
 
   LOG_OBJECTS_DEFINE
 };

--- a/libraries/core_libs/consensus/src/dag/sortition_params_manager.cpp
+++ b/libraries/core_libs/consensus/src/dag/sortition_params_manager.cpp
@@ -180,7 +180,7 @@ std::optional<SortitionParamsChange> SortitionParamsManager::calculateChange(uin
 
   const int32_t change = getChange(period, average_dag_efficiency);
   config_.vrf.addChange(change, period >= k_threshold_testnet_hard_fork_period);
-  
+
   if (params_changes_.empty()) {
     return SortitionParamsChange{period, average_dag_efficiency, config_.vrf};
   }

--- a/libraries/core_libs/consensus/src/dag/sortition_params_manager.cpp
+++ b/libraries/core_libs/consensus/src/dag/sortition_params_manager.cpp
@@ -52,6 +52,12 @@ SortitionParamsChange SortitionParamsChange::from_rlp(const dev::RLP& rlp) {
   p.interval_efficiency = rlp[3].toInt<uint16_t>();
   p.actual_correction_per_percent = rlp[4].toInt<uint16_t>();
 
+  if (p.vrf_params.threshold_lower == 0) {
+    assert(p.vrf_params.threshold_upper <= p.vrf_params.k_threshold_range);
+  } else {
+    assert(p.vrf_params.threshold_upper - p.vrf_params.threshold_lower == p.vrf_params.k_threshold_range);
+  }
+
   return p;
 }
 
@@ -173,8 +179,8 @@ std::optional<SortitionParamsChange> SortitionParamsManager::calculateChange(uin
   }
 
   const int32_t change = getChange(period, average_dag_efficiency);
-  config_.vrf += change;
-
+  config_.vrf.addChange(change, period >= k_threshold_testnet_hard_fork_period);
+  
   if (params_changes_.empty()) {
     return SortitionParamsChange{period, average_dag_efficiency, config_.vrf};
   }

--- a/libraries/vdf/include/vdf/config.hpp
+++ b/libraries/vdf/include/vdf/config.hpp
@@ -10,7 +10,10 @@ namespace taraxa {
 struct VrfParams {
   uint16_t threshold_upper = 0;  // upper bound of normal selection
   uint16_t threshold_lower = 0;  // lower bound of normal selection
-  VrfParams& operator+=(int32_t change);
+  void addChange(int32_t change, bool fork_threshold);
+
+  static constexpr uint16_t k_threshold_range = 0x1800;
+  static constexpr uint16_t k_threshold_upper_min_value = 0x50;
 };
 
 struct VdfParams {


### PR DESCRIPTION
This PR is made only for the testnet to enable difficulty adjustment changes in a hard fork without changing the db format. A different change is needed for develop branch.

k_threshold_testnet_hard_fork_period defines the period on which the vrf upper bound will be reduced even though lower bound reached 0. To implement this without modifying the current testnet db format, there is a range constant k_threshold_range which defines a constant difference between lover and upper bound to be able to recover once the lower bound reaches 0 and upper bound is reduced below this range.

Upper bound can now be reduced up to k_threshold_upper_min_value = 0x50