### PR TITLE
chore: vrf range improvement

### DIFF
--- a/libraries/cli/include/cli/default_config.hpp
+++ b/libraries/cli/include/cli/default_config.hpp
@@ -128,7 +128,7 @@ const char *default_json = R"foo({
       "computation_interval": "0x32",
       "vrf": {
         "threshold_upper": "0xeffd",
-        "threshold_lower": "0xebf7"
+        "threshold_range": "0x406"
       },
       "vdf": {
         "difficulty_max": "0x12",

--- a/libraries/cli/include/cli/devnet_config.hpp
+++ b/libraries/cli/include/cli/devnet_config.hpp
@@ -146,7 +146,7 @@ const char *devnet_json = R"foo({
       "computation_interval": "0x32",
       "vrf": {
         "threshold_upper": "0xbffd",
-        "threshold_lower": "0x6bf7"
+        "threshold_range": "0x5406"
       },
       "vdf": {
         "difficulty_max": "0x12",

--- a/libraries/cli/include/cli/testnet_config.hpp
+++ b/libraries/cli/include/cli/testnet_config.hpp
@@ -149,7 +149,7 @@ const char *testnet_json = R"foo({
       "computation_interval": "0x32",
       "vrf": {
         "threshold_upper": "0x2fff",
-        "threshold_lower": "0x17ff"
+        "threshold_range": "0x1800"
       },
       "vdf": {
         "difficulty_max": "0x15",

--- a/libraries/config/src/chain_config.cpp
+++ b/libraries/config/src/chain_config.cpp
@@ -55,7 +55,7 @@ decltype(ChainConfig::predefined_) const ChainConfig::predefined_([] {
     dpos.genesis_state[root_node_addr][root_node_addr] = dpos.eligibility_balance_threshold;
     // VDF config
     cfg.sortition.vrf.threshold_upper = 0x8000;
-    cfg.sortition.vrf.threshold_lower = 0x7200;
+    cfg.sortition.vrf.threshold_range = 0xE00;
     cfg.sortition.vdf.difficulty_min = 16;
     cfg.sortition.vdf.difficulty_max = 21;
     cfg.sortition.vdf.difficulty_stale = 22;

--- a/libraries/core_libs/consensus/src/dag/sortition_params_manager.cpp
+++ b/libraries/core_libs/consensus/src/dag/sortition_params_manager.cpp
@@ -34,7 +34,7 @@ uint16_t SortitionParamsChange::correctionPerPercent(const SortitionParamsChange
 bytes SortitionParamsChange::rlp() const {
   dev::RLPStream s;
   s.appendList(5);
-  s << vrf_params.threshold_lower;
+  s << vrf_params.threshold_range;
   s << vrf_params.threshold_upper;
   s << period;
   s << interval_efficiency;
@@ -46,7 +46,7 @@ bytes SortitionParamsChange::rlp() const {
 SortitionParamsChange SortitionParamsChange::from_rlp(const dev::RLP& rlp) {
   SortitionParamsChange p;
 
-  p.vrf_params.threshold_lower = rlp[0].toInt<uint16_t>();
+  p.vrf_params.threshold_range = rlp[0].toInt<uint16_t>();
   p.vrf_params.threshold_upper = rlp[1].toInt<uint16_t>();
   p.period = rlp[2].toInt<uint64_t>();
   p.interval_efficiency = rlp[3].toInt<uint16_t>();
@@ -157,7 +157,7 @@ int32_t SortitionParamsManager::getChange(uint64_t period, uint16_t efficiency) 
   const int32_t change = correction * per_percent / kOnePercent;
 
   LOG(log_dg_) << "Average interval efficiency: " << efficiency / 100. << "%, correction per percent: " << per_percent;
-  LOG(log_nf_) << "Changing VRF params on " << period << " period from (" << config_.vrf.threshold_lower << ", "
+  LOG(log_nf_) << "Changing VRF params on " << period << " period from (" << config_.vrf.threshold_range << ", "
                << config_.vrf.threshold_upper << ") by " << change;
 
   return change;

--- a/libraries/vdf/include/vdf/config.hpp
+++ b/libraries/vdf/include/vdf/config.hpp
@@ -9,8 +9,10 @@ namespace taraxa {
 
 struct VrfParams {
   uint16_t threshold_upper = 0;  // upper bound of normal selection
-  uint16_t threshold_lower = 0;  // lower bound of normal selection
+  uint16_t threshold_range = 0;  // range of normal selection
   VrfParams& operator+=(int32_t change);
+
+  static constexpr uint16_t kThresholdUpperMinValue = 0x50;
 };
 
 struct VdfParams {
@@ -24,9 +26,9 @@ struct SortitionParams {
   SortitionParams() = default;
   SortitionParams(SortitionParams&&) = default;
   SortitionParams(const SortitionParams& config) = default;
-  SortitionParams(uint16_t threshold_upper, uint16_t threshold_lower, uint16_t min, uint16_t max, uint16_t stale,
+  SortitionParams(uint16_t threshold_upper, uint16_t threshold_range, uint16_t min, uint16_t max, uint16_t stale,
                   uint16_t lambda_max_bound)
-      : vrf{threshold_upper, threshold_lower}, vdf{min, max, stale, lambda_max_bound} {}
+      : vrf{threshold_upper, threshold_range}, vdf{min, max, stale, lambda_max_bound} {}
   SortitionParams(const VrfParams& vrf, const VdfParams& vdf) : vrf{vrf}, vdf{vdf} {}
 
   SortitionParams& operator=(SortitionParams&&) = default;
@@ -35,7 +37,7 @@ struct SortitionParams {
   friend std::ostream& operator<<(std::ostream& strm, const SortitionParams& config) {
     strm << " [VDF config] " << std::endl;
     strm << "    vrf upper threshold: " << config.vrf.threshold_upper << std::endl;
-    strm << "    vrf lower threshold: " << config.vrf.threshold_lower << std::endl;
+    strm << "    vrf range threshold: " << config.vrf.threshold_range << std::endl;
     strm << "    difficulty minimum: " << config.vdf.difficulty_min << std::endl;
     strm << "    difficulty maximum: " << config.vdf.difficulty_max << std::endl;
     strm << "    difficulty stale: " << config.vdf.difficulty_stale << std::endl;

--- a/libraries/vdf/src/config.cpp
+++ b/libraries/vdf/src/config.cpp
@@ -14,24 +14,23 @@ int32_t fixFromOverflow(uint16_t value, int32_t change, uint16_t limit) {
 
 VrfParams& VrfParams::operator+=(int32_t change) {
   if (change < 0) {
-    change = fixFromOverflow(threshold_lower, change, std::numeric_limits<uint16_t>::min());
+    change = fixFromOverflow(threshold_upper, change, kThresholdUpperMinValue);
   } else {
     change = fixFromOverflow(threshold_upper, change, std::numeric_limits<uint16_t>::max());
   }
   threshold_upper += change;
-  threshold_lower += change;
   return *this;
 }
 
 Json::Value enc_json(VrfParams const& obj) {
   Json::Value ret(Json::objectValue);
   ret["threshold_upper"] = dev::toJS(obj.threshold_upper);
-  ret["threshold_lower"] = dev::toJS(obj.threshold_lower);
+  ret["threshold_range"] = dev::toJS(obj.threshold_range);
   return ret;
 }
 void dec_json(Json::Value const& json, VrfParams& obj) {
   obj.threshold_upper = dev::jsToInt(json["threshold_upper"].asString());
-  obj.threshold_lower = dev::jsToInt(json["threshold_lower"].asString());
+  obj.threshold_range = dev::jsToInt(json["threshold_range"].asString());
 }
 
 Json::Value enc_json(VdfParams const& obj) {

--- a/libraries/vdf/src/sortition.cpp
+++ b/libraries/vdf/src/sortition.cpp
@@ -10,7 +10,10 @@ VdfSortition::VdfSortition(SortitionParams const& config, vrf_sk_t const& sk, by
   difficulty_ = calculateDifficulty(config);
 }
 
-bool VdfSortition::isOmitVdf(SortitionParams const& config) const { return threshold <= config.vrf.threshold_lower; }
+bool VdfSortition::isOmitVdf(SortitionParams const& config) const {
+  return config.vrf.threshold_upper >= config.vrf.threshold_range &&
+         threshold <= config.vrf.threshold_upper - config.vrf.threshold_range;
+}
 
 bool VdfSortition::isStale(SortitionParams const& config) const { return threshold > config.vrf.threshold_upper; }
 
@@ -96,7 +99,7 @@ void VdfSortition::verifyVdf(SortitionParams const& config, bytes const& vrf_inp
       throw InvalidVdfSortition(
           "VDF solution verification failed. Incorrect difficulty. VDF input " + bytes2str(vdf_input) + ", lambda " +
           std::to_string(config.vdf.lambda_bound) + ", difficulty " + std::to_string(getDifficulty()) +
-          ", expected: " + std::to_string(expected) + ", vrf_params: (" + std::to_string(config.vrf.threshold_lower) +
+          ", expected: " + std::to_string(expected) + ", vrf_params: (" + std::to_string(config.vrf.threshold_range) +
           ", " + std::to_string(config.vrf.threshold_upper) + ") THRESHOLD: " + std::to_string(threshold));
     }
 

--- a/libraries/vdf/src/sortition.cpp
+++ b/libraries/vdf/src/sortition.cpp
@@ -96,11 +96,13 @@ void VdfSortition::verifyVdf(SortitionParams const& config, bytes const& vrf_inp
   if (!isOmitVdf(config)) {
     const auto expected = calculateDifficulty(config);
     if (difficulty_ != expected) {
-      throw InvalidVdfSortition(
-          "VDF solution verification failed. Incorrect difficulty. VDF input " + bytes2str(vdf_input) + ", lambda " +
-          std::to_string(config.vdf.lambda_bound) + ", difficulty " + std::to_string(getDifficulty()) +
-          ", expected: " + std::to_string(expected) + ", vrf_params: (" + std::to_string(config.vrf.threshold_range) +
-          ", " + std::to_string(config.vrf.threshold_upper) + ") THRESHOLD: " + std::to_string(threshold));
+      throw InvalidVdfSortition("VDF solution verification failed. Incorrect difficulty. VDF input " +
+                                bytes2str(vdf_input) + ", lambda " + std::to_string(config.vdf.lambda_bound) +
+                                ", difficulty " + std::to_string(getDifficulty()) +
+                                ", expected: " + std::to_string(expected) +
+                                ", vrf_params: ( range: " + std::to_string(config.vrf.threshold_range) +
+                                ", threshold_upper: " + std::to_string(config.vrf.threshold_upper) +
+                                ") THRESHOLD: " + std::to_string(threshold));
     }
 
     // Verify VDF solution

--- a/tests/crypto_test.cpp
+++ b/tests/crypto_test.cpp
@@ -109,7 +109,7 @@ TEST_F(CryptoTest, vrf_sortition) {
 }
 
 TEST_F(CryptoTest, vdf_sortition) {
-  SortitionParams sortition_params(0xffff, 0xe665, 5, 10, 10, 1500);
+  SortitionParams sortition_params(0xffff, 0xffff - 0xe665, 5, 10, 10, 1500);
   vrf_sk_t sk(
       "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
       "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
@@ -125,15 +125,15 @@ TEST_F(CryptoTest, vdf_sortition) {
   EXPECT_EQ(vdf, vdf2);
   EXPECT_EQ(vdf, vdf3);
 
-  SortitionParams sortition_params_no_omit_no_stale(0xffff, 0, 5, 10, 10, 1500);
+  SortitionParams sortition_params_no_omit_no_stale(0xffff, 0xffff, 5, 10, 10, 1500);
   EXPECT_FALSE(vdf.isStale(sortition_params_no_omit_no_stale));
   EXPECT_FALSE(vdf.isOmitVdf(sortition_params_no_omit_no_stale));
 
-  SortitionParams sortition_params_omit_no_stale(0xffff, 0xff00, 5, 10, 10, 1500);
+  SortitionParams sortition_params_omit_no_stale(0xffff, 0xffff - 0xff00, 5, 10, 10, 1500);
   EXPECT_FALSE(vdf.isStale(sortition_params_omit_no_stale));
   EXPECT_TRUE(vdf.isOmitVdf(sortition_params_omit_no_stale));
 
-  SortitionParams sortition_params_stale(0xfff, 0, 5, 10, 10, 1500);
+  SortitionParams sortition_params_stale(0xfff, 0xfff, 5, 10, 10, 1500);
   EXPECT_TRUE(vdf.isStale(sortition_params_stale));
 }
 
@@ -183,7 +183,7 @@ TEST_F(CryptoTest, DISABLED_compute_vdf_solution_cost_time) {
       "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
   level_t level = 1;
   uint16_t threshold_upper = 0;  // diffculty == diffuclty_stale
-  uint16_t threshold_lower = 0;  // Force no omit VDF
+  uint16_t threshold_range = 0;  // Force no omit VDF
   uint16_t difficulty_min = 0;
   uint16_t difficulty_max = 0;
   uint16_t lambda_bound = 100;
@@ -196,7 +196,7 @@ TEST_F(CryptoTest, DISABLED_compute_vdf_solution_cost_time) {
   // Fix lambda, vary difficulty
   for (uint16_t difficulty_stale = 0; difficulty_stale <= 20; difficulty_stale++) {
     std::cout << "Start at difficulty " << difficulty_stale << " :" << std::endl;
-    SortitionParams sortition_params(threshold_upper, threshold_lower, difficulty_min, difficulty_max, difficulty_stale,
+    SortitionParams sortition_params(threshold_upper, threshold_range, difficulty_min, difficulty_max, difficulty_stale,
                                      lambda_bound);
     VdfSortition vdf(sortition_params, sk, getRlpBytes(level));
     vdf.computeVdfSolution(sortition_params, proposal_dag_block_pivot_hash1.asBytes());
@@ -216,7 +216,7 @@ TEST_F(CryptoTest, DISABLED_compute_vdf_solution_cost_time) {
   uint16_t difficulty_stale = 15;
   for (uint16_t lambda = 100; lambda <= 5000; lambda += 200) {
     std::cout << "Start at lambda " << lambda << " :" << std::endl;
-    SortitionParams sortition_params(threshold_upper, threshold_lower, difficulty_min, difficulty_max, difficulty_stale,
+    SortitionParams sortition_params(threshold_upper, threshold_range, difficulty_min, difficulty_max, difficulty_stale,
                                      lambda);
     VdfSortition vdf(sortition_params, sk, getRlpBytes(level));
     vdf.computeVdfSolution(sortition_params, proposal_dag_block_pivot_hash1.asBytes());

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -1503,7 +1503,7 @@ TEST_F(FullNodeTest, chain_config_json) {
       "lambda_bound": "0x64"
     },
     "vrf": {
-      "threshold_lower": "0x7200",
+      "threshold_range": "0xE00",
       "threshold_upper": "0x8000"
     }
   }

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -1503,7 +1503,7 @@ TEST_F(FullNodeTest, chain_config_json) {
       "lambda_bound": "0x64"
     },
     "vrf": {
-      "threshold_range": "0xE00",
+      "threshold_range": "0xe00",
       "threshold_upper": "0x8000"
     }
   }

--- a/tests/util_test/util.hpp
+++ b/tests/util_test/util.hpp
@@ -123,7 +123,7 @@ inline auto make_node_cfgs(uint count) {
       if constexpr (tests_speed != 1) {
         // VDF config
         cfg.chain.sortition.vrf.threshold_upper = 0xffff;
-        cfg.chain.sortition.vrf.threshold_lower = 0xe665;
+        cfg.chain.sortition.vrf.threshold_range = 0x199a;
         cfg.chain.sortition.vdf.difficulty_min = 0;
         cfg.chain.sortition.vdf.difficulty_max = 5;
         cfg.chain.sortition.vdf.difficulty_stale = 5;


### PR DESCRIPTION
Improvement to enable vrf upper range to be lowered up to a minimum level even if lower bound is at zero