### PR TITLE
chore(dag): create seen cache to not request same block multiple times

### DIFF
--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/dag_block_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/dag_block_packet_handler.hpp
@@ -30,8 +30,7 @@ class DagBlockPacketHandler : public ExtSyncingPacketHandler {
   std::shared_ptr<DbStorage> db_;
   std::shared_ptr<TestState> test_state_;
   std::shared_ptr<TransactionManager> trx_mgr_{nullptr};
-
-  thread_local static std::mt19937_64 urng_;
+  ExpirationCache<blk_hash_t> seen_dags_;
 };
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/dag_block_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/dag_block_packet_handler.cpp
@@ -30,6 +30,8 @@ void DagBlockPacketHandler::process(const PacketData &packet_data, const std::sh
 
   peer->markDagBlockAsKnown(hash);
 
+  // This cache is used save block that we requested from the peer
+  // dag_blk_mgr_ cache is only for valid DagBlocks that means with all the tips/pivots
   if (!seen_dags_.insert(block.getHash())) {
     LOG(log_dg_) << "Received dag block" << block.getHash() << " (from " << packet_data.from_node_id_.abridged()
                  << ") already seen.";


### PR DESCRIPTION
## Purpose

When we received dag block with missing something from node A, we request missing blocks, but when meanwhile we receive same block from node B,C ... we to the same thing. So, we basically DDoS ourselfs. I have create small cache that should solve this behaviour  