### PR TITLE
chore(docker): adds taraxa-bootnode binary to final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,6 +121,7 @@ WORKDIR /root/.taraxa
 
 # Copy required binaries
 COPY --from=build /opt/taraxa/$BUILD_OUTPUT_DIR/bin/taraxad /usr/local/bin/taraxad
+COPY --from=build /opt/taraxa/$BUILD_OUTPUT_DIR/bin/taraxa-bootnode /usr/local/bin/taraxa-bootnode
 COPY --from=build /opt/taraxa/$BUILD_OUTPUT_DIR/lib/*.so /usr/local/lib/
 
 # Copy scripts


### PR DESCRIPTION
## Purpose

adds taraxa-bootnode binary to final image

