### PR TITLE
chore(syncing): hotfix for syncing without response

### DIFF
--- a/libraries/core_libs/network/include/network/tarcap/shared_states/syncing_state.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/shared_states/syncing_state.hpp
@@ -50,9 +50,9 @@ class SyncingState {
    */
   bool is_actively_syncing() const;
 
-  bool is_syncing() const;
+  bool is_syncing();
   bool is_deep_pbft_syncing() const;
-  bool is_pbft_syncing() const;
+  bool is_pbft_syncing();
   bool is_dag_syncing() const;
 
   const dev::p2p::NodeID syncing_peer() const;

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/status_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/status_packet_handler.cpp
@@ -119,7 +119,7 @@ void StatusPacketHandler::process(const PacketData& packet_data, const std::shar
   }
 
   // If we are still syncing - do not trigger new syncing
-  if (syncing_state_->is_pbft_syncing() && syncing_state_->is_actively_syncing()) {
+  if (syncing_state_->is_pbft_syncing()) {
     LOG(log_dg_) << "There is ongoing syncing, do not trigger new one.";
     return;
   }

--- a/libraries/core_libs/network/src/tarcap/shared_states/syncing_state.cpp
+++ b/libraries/core_libs/network/src/tarcap/shared_states/syncing_state.cpp
@@ -82,11 +82,16 @@ void SyncingState::set_peer_malicious(const std::optional<dev::p2p::NodeID> &pee
 
 bool SyncingState::is_peer_malicious(const dev::p2p::NodeID &peer_id) const { return malicious_peers_.count(peer_id); }
 
-bool SyncingState::is_syncing() const { return is_pbft_syncing() || is_dag_syncing(); }
+bool SyncingState::is_syncing() { return is_pbft_syncing() || is_dag_syncing(); }
 
 bool SyncingState::is_deep_pbft_syncing() const { return deep_pbft_syncing_; }
 
-bool SyncingState::is_pbft_syncing() const { return pbft_syncing_; }
+bool SyncingState::is_pbft_syncing() {
+  if (!is_actively_syncing()) {
+    set_pbft_syncing(false);
+  }
+  return pbft_syncing_;
+}
 
 bool SyncingState::is_dag_syncing() const { return dag_syncing_; }
 


### PR DESCRIPTION
I do know how is this happening, but we somehow end up without any syncing repose from peer (maybe this TP is overloaded?), because we still received other packets from that peer. 
This should fix it.