### PR TITLE
chore: prevent dag blocks production oscillation

### DIFF
--- a/libraries/core_libs/consensus/include/dag/sortition_params_manager.hpp
+++ b/libraries/core_libs/consensus/include/dag/sortition_params_manager.hpp
@@ -68,6 +68,12 @@ class SortitionParamsManager {
    */
   uint16_t averageDagEfficiency();
 
+  /**
+   * Calculate average DAG efficiency from extended dag_efficiencies_. Used at the end of interval.
+   * @returns average DAG efficiency in current interval
+   */
+  uint16_t averageDagEfficiencyExtended();
+
  private:
   SortitionConfig config_;
   std::shared_ptr<DbStorage> db_;
@@ -78,6 +84,7 @@ class SortitionParamsManager {
   void cleanup(uint64_t current_period);
 
   const uint64_t k_threshold_testnet_hard_fork_period = 110000;
+  const uint64_t k_threshold_testnet_oscillation_hard_fork_period = 200000;
 
   LOG_OBJECTS_DEFINE
 };

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -124,7 +124,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
     COLUMN(final_chain_blk_number_by_hash);
     COLUMN(final_chain_receipt_by_trx_hash);
     COLUMN(final_chain_log_blooms_index);
-    COLUMN(pbft_block_dag_efficiency);
+    COLUMN_W_COMP(pbft_block_dag_efficiency, getIntComparator<uint64_t>());
     COLUMN_W_COMP(sortition_params_change, getIntComparator<uint64_t>());
 
 #undef COLUMN


### PR DESCRIPTION
Preventing oscillation by extending the efficiency calculation interval and reducing the change