### PR TITLE
Syncing improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,12 @@ cmake_minimum_required(VERSION 3.16)
 
 # Set current version of the project
 set(TARAXA_MAJOR_VERSION 1)
-set(TARAXA_MINOR_VERSION 14)
+set(TARAXA_MINOR_VERSION 19)
 set(TARAXA_PATCH_VERSION 0)
 set(TARAXA_VERSION ${TARAXA_MAJOR_VERSION}.${TARAXA_MINOR_VERSION}.${TARAXA_PATCH_VERSION})
 
 # Any time a change in the network protocol is introduced this version should be increased
-set(TARAXA_NET_VERSION 19)
+set(TARAXA_NET_VERSION 20)
 # Major version is modified when DAG blocks, pbft blocks and any basic building blocks of our blockchan is modified
 # in the db
 set(TARAXA_DB_MAJOR_VERSION 2)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(TARAXA_PATCH_VERSION 0)
 set(TARAXA_VERSION ${TARAXA_MAJOR_VERSION}.${TARAXA_MINOR_VERSION}.${TARAXA_PATCH_VERSION})
 
 # Any time a change in the network protocol is introduced this version should be increased
-set(TARAXA_NET_VERSION 18)
+set(TARAXA_NET_VERSION 19)
 # Major version is modified when DAG blocks, pbft blocks and any basic building blocks of our blockchan is modified
 # in the db
 set(TARAXA_DB_MAJOR_VERSION 2)

--- a/libraries/cli/include/cli/devnet_config.hpp
+++ b/libraries/cli/include/cli/devnet_config.hpp
@@ -145,13 +145,13 @@ const char *devnet_json = R"foo({
       "dag_efficiency_targets": ["0x12C0", "0x1450"],
       "computation_interval": "0x32",
       "vrf": {
-        "threshold_upper": "0xbffd",
-        "threshold_range": "0x5406"
+        "threshold_upper": "0x2fff",
+        "threshold_range": "0x1800"
       },
       "vdf": {
-        "difficulty_max": "0x12",
+        "difficulty_max": "0x15",
         "difficulty_min": "0x10",
-        "difficulty_stale": "0x13",
+        "difficulty_stale": "0x17",
         "lambda_bound": "0x64"
       }
     }

--- a/libraries/cli/include/cli/devnet_config.hpp
+++ b/libraries/cli/include/cli/devnet_config.hpp
@@ -143,7 +143,7 @@ const char *devnet_json = R"foo({
       "changes_count_for_average": "0x5",
       "max_interval_correction": "0x3E8",
       "dag_efficiency_targets": ["0x12C0", "0x1450"],
-      "computation_interval": "0x32",
+      "computation_interval": "0xC8",
       "vrf": {
         "threshold_upper": "0x2fff",
         "threshold_range": "0x1800"

--- a/libraries/core_libs/consensus/include/dag/dag.hpp
+++ b/libraries/core_libs/consensus/include/dag/dag.hpp
@@ -163,7 +163,7 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
     return std::make_pair(old_anchor_, anchor_);
   }
 
-  const std::map<uint64_t, std::vector<blk_hash_t>> getNonFinalizedBlocks() const;
+  const std::pair<uint64_t, std::map<uint64_t, std::vector<blk_hash_t>>> getNonFinalizedBlocks() const;
 
   DagFrontier getDagFrontier();
 

--- a/libraries/core_libs/consensus/include/pbft/block_proposer.hpp
+++ b/libraries/core_libs/consensus/include/pbft/block_proposer.hpp
@@ -52,8 +52,8 @@ class SortitionPropose : public ProposeModelFace {
 
  private:
   int num_tries_ = 0;
-  const int max_num_tries_ = 20;  // Wait 2000(ms)
-  level_t last_propose_level_ = 0;
+  int max_num_tries_ = 0;
+  DagFrontier last_frontier_;
   std::shared_ptr<DagManager> dag_mgr_;
   std::shared_ptr<DagBlockManager> dag_blk_mgr_;
   std::shared_ptr<TransactionManager> trx_mgr_;

--- a/libraries/core_libs/consensus/include/transaction_manager/transaction_manager.hpp
+++ b/libraries/core_libs/consensus/include/transaction_manager/transaction_manager.hpp
@@ -67,7 +67,18 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
   // Update the status of transactions to finalized and remove from transactions column
   void updateFinalizedTransactionsStatus(SyncBlock const &sync_block);
 
+  /**
+   * @brief Gets transactions from transactions pool
+   *
+   * @param trx_to_query
+   *
+   * @return Returns transactions found and list of missing transactions hashes
+   */
+  std::pair<std::vector<std::shared_ptr<Transaction>>, std::vector<trx_hash_t>> getPoolTransactions(
+      const std::vector<trx_hash_t> &trx_to_query) const;
+
   std::shared_ptr<Transaction> getTransaction(trx_hash_t const &hash) const;
+  std::shared_ptr<Transaction> getNonFinalizedTransaction(trx_hash_t const &hash) const;
   unsigned long getTransactionCount() const;
   void recoverNonfinalizedTransactions();
 

--- a/libraries/core_libs/consensus/src/dag/dag.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag.cpp
@@ -611,9 +611,9 @@ void DagManager::recoverDag() {
   trx_mgr_->recoverNonfinalizedTransactions();
 }
 
-const std::map<uint64_t, std::vector<blk_hash_t>> DagManager::getNonFinalizedBlocks() const {
+const std::pair<uint64_t, std::map<uint64_t, std::vector<blk_hash_t>>> DagManager::getNonFinalizedBlocks() const {
   SharedLock lock(mutex_);
-  return non_finalized_blks_;
+  return {period_, non_finalized_blks_};
 }
 
 std::pair<size_t, size_t> DagManager::getNonFinalizedBlocksSize() const {

--- a/libraries/core_libs/consensus/src/dag/dag_block_manager.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_block_manager.cpp
@@ -80,14 +80,29 @@ bool DagBlockManager::pivotAndTipsValid(DagBlock const &blk) {
   // Check pivot validation
   if (invalid_blocks_.count(blk.getPivot())) {
     invalid_blocks_.insert(blk.getHash());
+    seen_blocks_.erase(blk.getHash());
+    LOG(log_wr_) << "DAG Block " << blk.getHash() << " pivot " << blk.getPivot() << " is invalid";
+    return false;
+  }
+
+  if (seen_blocks_.count(blk.getPivot()) == 0) {
+    seen_blocks_.erase(blk.getHash());
     LOG(log_wr_) << "DAG Block " << blk.getHash() << " pivot " << blk.getPivot() << " is unavailable";
     return false;
   }
 
-  // check tips validation
   for (auto const &tip : blk.getTips()) {
     if (invalid_blocks_.count(tip)) {
       invalid_blocks_.insert(blk.getHash());
+      seen_blocks_.erase(blk.getHash());
+      LOG(log_wr_) << "DAG Block " << blk.getHash() << " tip " << tip << " is invalid";
+      return false;
+    }
+  }
+
+  for (auto const &tip : blk.getTips()) {
+    if (seen_blocks_.count(tip) == 0) {
+      seen_blocks_.erase(blk.getHash());
       LOG(log_wr_) << "DAG Block " << blk.getHash() << " tip " << tip << " is unavailable";
       return false;
     }

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1025,6 +1025,13 @@ void PbftManager::firstFinish_() {
       if (place_votes) {
         LOG(log_nf_) << "Next votes " << place_votes << " voting nodes own starting value "
                      << own_starting_value_for_round_ << " for round " << round << ", at step " << step_;
+        // Re-broadcast pbft block in case some nodes do not have it
+        if (step_ % 20 == 0) {
+          auto pbft_block = getUnfinalizedBlock_(own_starting_value_for_round_);
+          if (auto net = network_.lock(); net && pbft_block) {
+            net->onNewPbftBlock(pbft_block);
+          }
+        }
       }
     }
   }

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1382,7 +1382,10 @@ void PbftManager::syncPbftChainFromPeers_(PbftSyncRequestReason reason, taraxa::
           LOG(log_nf_) << "Restarting sync in round " << round << ", step " << step_;
       }
 
-      net->restartSyncingPbft();
+      // TODO: Is there any need to sync here???
+      // If we detect some stalled situation, a better step would be to disconnect/reconnect to nodes to try to get
+      // network unstuck since reconnecting both shuffles the nodes and invokes pbft/dag syncing if needed
+      // net->restartSyncingPbft();
 
       pbft_round_last_requested_sync_ = round;
       pbft_step_last_requested_sync_ = step_;

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1318,20 +1318,7 @@ std::pair<blk_hash_t, bool> PbftManager::identifyLeaderBlock_() {
 
       if (round == 1 ||
           (proposed_block_hash != NULL_BLOCK_HASH && !pbft_chain_->findPbftBlockInChain(proposed_block_hash))) {
-        // Exclude any pbft block that our node has not received or has a missing anchor
-        auto proposed_block = pbft_chain_->getUnverifiedPbftBlock(proposed_block_hash);
-        if (proposed_block) {
-          if (dag_blk_mgr_->isDagBlockKnown(proposed_block->getPivotDagBlockHash())) {
-            leader_candidates.emplace_back(std::make_pair(v->getCredential(), proposed_block_hash));
-          } else {
-            LOG(log_wr_) << "identifyLeaderBlock vote " << v->getHash()
-                         << " votes for a pbft block: " << proposed_block_hash
-                         << " with missing anchor block: " << proposed_block->getPivotDagBlockHash();
-          }
-        } else {
-          LOG(log_wr_) << "identifyLeaderBlock vote " << v->getHash()
-                       << " votes for a missing pbft block: " << proposed_block_hash;
-        }
+        leader_candidates.emplace_back(std::make_pair(v->getCredential(), proposed_block_hash));
       }
     }
   }

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1354,14 +1354,10 @@ void PbftManager::syncPbftChainFromPeers_(PbftSyncRequestReason reason, taraxa::
     if (!is_syncing_() && !syncRequestedAlreadyThisStep_()) {
       auto round = getPbftRound();
 
-      bool force = false;
-
       switch (reason) {
         case missing_dag_blk:
           LOG(log_nf_) << "DAG blocks have not synced yet, anchor block " << relevant_blk_hash
                        << " not present in DAG.";
-          // We want to force syncing the DAG...
-          force = true;
 
           break;
         case invalid_cert_voted_block:
@@ -1378,20 +1374,15 @@ void PbftManager::syncPbftChainFromPeers_(PbftSyncRequestReason reason, taraxa::
           LOG(log_nf_) << "Suspect consensus is partitioned, reached step " << step_ << " in round " << round
                        << " without advancing.";
           // We want to force sycning the DAG...
-          force = true;
           break;
         default:
           LOG(log_er_) << "Unknown PBFT sync request reason " << reason;
           assert(false);
 
-          if (force) {
-            LOG(log_nf_) << "Restarting sync in round " << round << ", step " << step_ << ", and forcing DAG sync";
-          } else {
-            LOG(log_nf_) << "Restarting sync in round " << round << ", step " << step_;
-          }
+          LOG(log_nf_) << "Restarting sync in round " << round << ", step " << step_;
       }
 
-      net->restartSyncingPbft(force);
+      net->restartSyncingPbft();
 
       pbft_round_last_requested_sync_ = round;
       pbft_step_last_requested_sync_ = step_;

--- a/libraries/core_libs/network/include/network/network.hpp
+++ b/libraries/core_libs/network/include/network/network.hpp
@@ -64,7 +64,8 @@ class Network {
 
   // METHODS USED IN TESTS ONLY
   void sendBlock(dev::p2p::NodeID const &id, DagBlock const &blk);
-  void sendBlocks(dev::p2p::NodeID const &id, std::vector<std::shared_ptr<DagBlock>> blocks);
+  void sendBlocks(dev::p2p::NodeID const &id, std::vector<std::shared_ptr<DagBlock>> blocks, uint64_t request_period,
+                  uint64_t period);
   void sendTransactions(dev::p2p::NodeID const &_id, std::vector<taraxa::bytes> const &transactions);
   void setPendingPeersToReady();
   dev::p2p::NodeID getNodeId() const;

--- a/libraries/core_libs/network/include/network/network.hpp
+++ b/libraries/core_libs/network/include/network/network.hpp
@@ -49,7 +49,7 @@ class Network {
   Json::Value getStatus();
   Json::Value getPacketsStats();
   std::vector<dev::p2p::NodeID> getAllPeersIDs() const;
-  void onNewBlockVerified(DagBlock const &blk, bool proposed);
+  void onNewBlockVerified(DagBlock const &blk, bool proposed, SharedTransactions &&trxs);
   void onNewTransactions(SharedTransactions &&transactions);
   void restartSyncingPbft(bool force = false);
   void onNewPbftBlock(std::shared_ptr<PbftBlock> const &pbft_block);
@@ -63,8 +63,8 @@ class Network {
   void broadcastPreviousRoundNextVotesBundle();
 
   // METHODS USED IN TESTS ONLY
-  void sendBlock(dev::p2p::NodeID const &id, DagBlock const &blk);
-  void sendBlocks(dev::p2p::NodeID const &id, std::vector<std::shared_ptr<DagBlock>> blocks, uint64_t request_period,
+  void sendBlock(dev::p2p::NodeID const &id, DagBlock const &blk, const SharedTransactions &trxs);
+  void sendBlocks(const dev::p2p::NodeID &id, std::vector<std::shared_ptr<DagBlock>> &&blocks, uint64_t request_period,
                   uint64_t period);
   void sendTransactions(dev::p2p::NodeID const &_id, std::vector<taraxa::bytes> const &transactions);
   void setPendingPeersToReady();

--- a/libraries/core_libs/network/include/network/tarcap/packet_types.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packet_types.hpp
@@ -31,7 +31,6 @@ enum SubprotocolPacketType : uint32_t {
   GetPbftSyncPacket,
   PbftSyncPacket,
   GetDagSyncPacket,
-  SyncedPacket,
 
   PacketCount
 };
@@ -66,8 +65,6 @@ inline std::string convertPacketTypeToString(SubprotocolPacketType packet_type) 
       return "GetPbftSyncPacket";
     case PbftSyncPacket:
       return "PbftSyncPacket";
-    case SyncedPacket:
-      return "SyncedPacket";
     default:
       break;
   }

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_syncing_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_syncing_packet_handler.hpp
@@ -39,7 +39,7 @@ class ExtSyncingPacketHandler : public PacketHandler {
 
   bool syncPeerPbft(unsigned long height_to_sync);
   void requestDagBlocks(const dev::p2p::NodeID &_nodeID, const std::unordered_set<blk_hash_t> &blocks, uint64_t period);
-  void requestPendingDagBlocks();
+  void requestPendingDagBlocks(std::shared_ptr<TaraxaPeer> peer = nullptr);
 
   std::pair<bool, std::unordered_set<blk_hash_t>> checkDagBlockValidation(const DagBlock &block) const;
   std::shared_ptr<TaraxaPeer> getMaxChainPeer();

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_syncing_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_syncing_packet_handler.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "dag/dag_block.hpp"
-#include "get_blocks_request_type.hpp"
 #include "packet_handler.hpp"
 
 namespace taraxa {
@@ -39,13 +38,10 @@ class ExtSyncingPacketHandler : public PacketHandler {
   void restartSyncingPbft(bool force = false);
 
   bool syncPeerPbft(unsigned long height_to_sync);
-  void requestDagBlocks(const dev::p2p::NodeID &_nodeID, const std::unordered_set<blk_hash_t> &blocks,
-                        DagSyncRequestType mode = MissingHashes);
+  void requestDagBlocks(const dev::p2p::NodeID &_nodeID, const std::unordered_set<blk_hash_t> &blocks, uint64_t period);
+  void requestPendingDagBlocks();
 
   std::pair<bool, std::unordered_set<blk_hash_t>> checkDagBlockValidation(const DagBlock &block) const;
-
- private:
-  void requestPendingDagBlocks();
 
  protected:
   std::shared_ptr<SyncingState> syncing_state_{nullptr};

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_syncing_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_syncing_packet_handler.hpp
@@ -42,6 +42,7 @@ class ExtSyncingPacketHandler : public PacketHandler {
   void requestPendingDagBlocks();
 
   std::pair<bool, std::unordered_set<blk_hash_t>> checkDagBlockValidation(const DagBlock &block) const;
+  std::shared_ptr<TaraxaPeer> getMaxChainPeer();
 
  protected:
   std::shared_ptr<SyncingState> syncing_state_{nullptr};

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/get_blocks_request_type.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/get_blocks_request_type.hpp
@@ -1,7 +1,0 @@
-#pragma once
-
-namespace taraxa::network::tarcap {
-
-enum DagSyncRequestType : ::byte { MissingHashes = 0x0, KnownHashes };
-
-}  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/dag_block_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/dag_block_packet_handler.hpp
@@ -20,9 +20,9 @@ class DagBlockPacketHandler : public ExtSyncingPacketHandler {
 
   virtual ~DagBlockPacketHandler() = default;
 
-  void sendBlock(dev::p2p::NodeID const &peer_id, DagBlock block);
+  void sendBlock(dev::p2p::NodeID const &peer_id, DagBlock block, const SharedTransactions &trxs);
   void onNewBlockReceived(DagBlock &&block);
-  void onNewBlockVerified(DagBlock const &block, bool proposed);
+  void onNewBlockVerified(DagBlock const &block, bool proposed, SharedTransactions &&trxs);
 
  private:
   void process(const PacketData &packet_data, const std::shared_ptr<TaraxaPeer> &peer) override;

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_dag_sync_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_dag_sync_packet_handler.hpp
@@ -20,7 +20,7 @@ class GetDagSyncPacketHandler : public PacketHandler {
 
   virtual ~GetDagSyncPacketHandler() = default;
 
-  void sendBlocks(dev::p2p::NodeID const& peer_id, std::vector<std::shared_ptr<DagBlock>> blocks,
+  void sendBlocks(const dev::p2p::NodeID& peer_id, std::vector<std::shared_ptr<DagBlock>>&& blocks,
                   uint64_t request_period, uint64_t period);
 
  private:

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_dag_sync_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_dag_sync_packet_handler.hpp
@@ -20,7 +20,8 @@ class GetDagSyncPacketHandler : public PacketHandler {
 
   virtual ~GetDagSyncPacketHandler() = default;
 
-  void sendBlocks(dev::p2p::NodeID const& peer_id, std::vector<std::shared_ptr<DagBlock>> blocks);
+  void sendBlocks(dev::p2p::NodeID const& peer_id, std::vector<std::shared_ptr<DagBlock>> blocks,
+                  uint64_t request_period, uint64_t period);
 
  private:
   void process(const PacketData& packet_data, const std::shared_ptr<TaraxaPeer>& peer) override;

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/pbft_block_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/pbft_block_packet_handler.hpp
@@ -6,14 +6,18 @@ namespace taraxa {
 class PbftBlock;
 class PbftChain;
 class PbftManager;
+class DagBlockManager;
 }  // namespace taraxa
 
 namespace taraxa::network::tarcap {
 
+class SyncingState;
+
 class PbftBlockPacketHandler : public PacketHandler {
  public:
   PbftBlockPacketHandler(std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
-                         std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<PbftManager> pbft_mgr,
+                         std::shared_ptr<SyncingState> syncing_state, std::shared_ptr<PbftChain> pbft_chain,
+                         std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<DagBlockManager> dag_blk_mgr,
                          const addr_t& node_addr);
 
   virtual ~PbftBlockPacketHandler() = default;
@@ -24,8 +28,10 @@ class PbftBlockPacketHandler : public PacketHandler {
  private:
   void process(const PacketData& packet_data, const std::shared_ptr<TaraxaPeer>& peer) override;
 
+  std::shared_ptr<SyncingState> syncing_state_;
   std::shared_ptr<PbftChain> pbft_chain_;
   std::shared_ptr<PbftManager> pbft_mgr_;
+  std::shared_ptr<DagBlockManager> dag_blk_mgr_;
 };
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/pbft_block_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/pbft_block_packet_handler.hpp
@@ -11,8 +11,6 @@ class DagBlockManager;
 
 namespace taraxa::network::tarcap {
 
-class SyncingState;
-
 class PbftBlockPacketHandler : public PacketHandler {
  public:
   PbftBlockPacketHandler(std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/pbft_block_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/pbft_block_packet_handler.hpp
@@ -16,8 +16,7 @@ class SyncingState;
 class PbftBlockPacketHandler : public PacketHandler {
  public:
   PbftBlockPacketHandler(std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
-                         std::shared_ptr<SyncingState> syncing_state, std::shared_ptr<PbftChain> pbft_chain,
-                         std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<DagBlockManager> dag_blk_mgr,
+                         std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<PbftManager> pbft_mgr,
                          const addr_t& node_addr);
 
   virtual ~PbftBlockPacketHandler() = default;
@@ -28,10 +27,8 @@ class PbftBlockPacketHandler : public PacketHandler {
  private:
   void process(const PacketData& packet_data, const std::shared_ptr<TaraxaPeer>& peer) override;
 
-  std::shared_ptr<SyncingState> syncing_state_;
   std::shared_ptr<PbftChain> pbft_chain_;
   std::shared_ptr<PbftManager> pbft_mgr_;
-  std::shared_ptr<DagBlockManager> dag_blk_mgr_;
 };
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/pbft_sync_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/pbft_sync_packet_handler.hpp
@@ -15,8 +15,6 @@ class PbftSyncPacketHandler : public ExtSyncingPacketHandler {
 
   virtual ~PbftSyncPacketHandler() = default;
 
-  void sendSyncedMessage();
-
  private:
   void process(const PacketData& packet_data, const std::shared_ptr<TaraxaPeer>& peer) override;
 

--- a/libraries/core_libs/network/include/network/tarcap/shared_states/syncing_state.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/shared_states/syncing_state.hpp
@@ -26,14 +26,6 @@ class SyncingState {
   void set_pbft_syncing(bool syncing, uint64_t current_period = 0, std::shared_ptr<TaraxaPeer> peer = nullptr);
 
   /**
-   * @brief Set dag syncing
-   *
-   * @param syncing
-   * @param peer used in case syncing flag == true to set which peer is the node syncing with
-   */
-  void set_dag_syncing(bool syncing, std::shared_ptr<TaraxaPeer> peer = nullptr);
-
-  /**
    * @brief Set current time as last received sync packet  time
    */
   void set_last_sync_packet_time();
@@ -53,7 +45,6 @@ class SyncingState {
   bool is_syncing();
   bool is_deep_pbft_syncing() const;
   bool is_pbft_syncing();
-  bool is_dag_syncing() const;
 
   const dev::p2p::NodeID syncing_peer() const;
 
@@ -70,7 +61,6 @@ class SyncingState {
  private:
   std::atomic<bool> deep_pbft_syncing_{false};
   std::atomic<bool> pbft_syncing_{false};
-  std::atomic<bool> dag_syncing_{false};
 
   ExpirationCache<dev::p2p::NodeID> malicious_peers_;
 

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
@@ -72,7 +72,7 @@ class TaraxaCapability : public dev::p2p::CapabilityFace {
 
   void restartSyncingPbft(bool force = false);
   bool pbft_syncing() const;
-  void onNewBlockVerified(DagBlock const &blk, bool proposed);
+  void onNewBlockVerified(DagBlock const &blk, bool proposed, SharedTransactions &&trxs);
   void onNewTransactions(SharedTransactions &&transactions);
   void onNewPbftBlock(std::shared_ptr<PbftBlock> const &pbft_block);
   void onNewPbftVote(const std::shared_ptr<Vote> &vote);
@@ -82,8 +82,8 @@ class TaraxaCapability : public dev::p2p::CapabilityFace {
   void setSyncStatePeriod(uint64_t period);
 
   // METHODS USED IN TESTS ONLY
-  void sendBlock(dev::p2p::NodeID const &id, DagBlock const &blk);
-  void sendBlocks(dev::p2p::NodeID const &id, std::vector<std::shared_ptr<DagBlock>> blocks, uint64_t request_period,
+  void sendBlock(dev::p2p::NodeID const &id, DagBlock const &blk, const SharedTransactions &trxs);
+  void sendBlocks(const dev::p2p::NodeID &id, std::vector<std::shared_ptr<DagBlock>> &&blocks, uint64_t request_period,
                   uint64_t period);
   size_t getReceivedBlocksCount() const;
   size_t getReceivedTransactionsCount() const;

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
@@ -83,7 +83,8 @@ class TaraxaCapability : public dev::p2p::CapabilityFace {
 
   // METHODS USED IN TESTS ONLY
   void sendBlock(dev::p2p::NodeID const &id, DagBlock const &blk);
-  void sendBlocks(dev::p2p::NodeID const &id, std::vector<std::shared_ptr<DagBlock>> blocks);
+  void sendBlocks(dev::p2p::NodeID const &id, std::vector<std::shared_ptr<DagBlock>> blocks, uint64_t request_period,
+                  uint64_t period);
   size_t getReceivedBlocksCount() const;
   size_t getReceivedTransactionsCount() const;
 

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
@@ -70,6 +70,9 @@ class TaraxaPeer : public boost::noncopyable {
   std::atomic<uint64_t> pbft_chain_size_ = 0;
   std::atomic<uint64_t> pbft_round_ = 1;
   std::atomic<size_t> pbft_previous_round_next_votes_size_ = 0;
+  std::atomic<uint64_t> last_status_pbft_chain_size_ = 0;
+  std::atomic_bool peer_dag_synced = false;
+  std::atomic_bool peer_dag_syncing = false;
 
  private:
   dev::p2p::NodeID id_;

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
@@ -74,6 +74,9 @@ class TaraxaPeer : public boost::noncopyable {
   std::atomic_bool peer_dag_synced = false;
   std::atomic_bool peer_dag_syncing = false;
 
+  // Mutex used to prevent race condition between dag syncing and gossiping
+  mutable boost::shared_mutex mutex_for_sending_dag_blocks_;
+
  private:
   dev::p2p::NodeID id_;
 

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
@@ -71,8 +71,8 @@ class TaraxaPeer : public boost::noncopyable {
   std::atomic<uint64_t> pbft_round_ = 1;
   std::atomic<size_t> pbft_previous_round_next_votes_size_ = 0;
   std::atomic<uint64_t> last_status_pbft_chain_size_ = 0;
-  std::atomic_bool peer_dag_synced = false;
-  std::atomic_bool peer_dag_syncing = false;
+  std::atomic_bool peer_dag_synced_ = false;
+  std::atomic_bool peer_dag_syncing_ = false;
 
   // Mutex used to prevent race condition between dag syncing and gossiping
   mutable boost::shared_mutex mutex_for_sending_dag_blocks_;

--- a/libraries/core_libs/network/include/network/tarcap/threadpool/packets_blocking_mask.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/threadpool/packets_blocking_mask.hpp
@@ -6,6 +6,8 @@
 #include <map>
 #include <shared_mutex>
 
+#include "config/config.hpp"
+#include "logger/logger.hpp"
 #include "network/tarcap/packet_types.hpp"
 #include "network/tarcap/threadpool/packet_data.hpp"
 
@@ -13,6 +15,7 @@ namespace taraxa::network::tarcap {
 
 class PacketsBlockingMask {
  public:
+  PacketsBlockingMask();
   void markPacketAsHardBlocked(const PacketData& blocking_packet, SubprotocolPacketType packet_type_to_block);
   void markPacketAsHardUnblocked(const PacketData& blocking_packet, SubprotocolPacketType packet_type_to_unblock);
 
@@ -58,6 +61,8 @@ class PacketsBlockingMask {
   //    concurrently
   // Order of levels must be preserved, therefore using std::map
   std::map<taraxa::level_t, std::unordered_set<PacketData::PacketId>> processing_dag_levels_;
+
+  LOG_OBJECTS_DEFINE
 };
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/include/network/tarcap/threadpool/packets_blocking_mask.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/threadpool/packets_blocking_mask.hpp
@@ -6,8 +6,6 @@
 #include <map>
 #include <shared_mutex>
 
-#include "config/config.hpp"
-#include "logger/logger.hpp"
 #include "network/tarcap/packet_types.hpp"
 #include "network/tarcap/threadpool/packet_data.hpp"
 

--- a/libraries/core_libs/network/include/network/tarcap/threadpool/packets_blocking_mask.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/threadpool/packets_blocking_mask.hpp
@@ -15,7 +15,6 @@ namespace taraxa::network::tarcap {
 
 class PacketsBlockingMask {
  public:
-  PacketsBlockingMask();
   void markPacketAsHardBlocked(const PacketData& blocking_packet, SubprotocolPacketType packet_type_to_block);
   void markPacketAsHardUnblocked(const PacketData& blocking_packet, SubprotocolPacketType packet_type_to_unblock);
 
@@ -61,8 +60,6 @@ class PacketsBlockingMask {
   //    concurrently
   // Order of levels must be preserved, therefore using std::map
   std::map<taraxa::level_t, std::unordered_set<PacketData::PacketId>> processing_dag_levels_;
-
-  LOG_OBJECTS_DEFINE
 };
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/rpc/Test.cpp
+++ b/libraries/core_libs/network/rpc/Test.cpp
@@ -60,6 +60,49 @@ Json::Value Test::get_dag_block(const Json::Value &param1) {
   return res;
 }
 
+Json::Value Test::get_sortition_change(const Json::Value &param1) {
+  Json::Value res;
+  try {
+    if (auto node = full_node_.lock()) {
+      uint64_t period = param1["period"].asUInt64();
+      auto params_change = node->getDB()->getParamsChangeForPeriod(period);
+      res["actual_correction_per_percent"] = params_change->actual_correction_per_percent;
+      res["interval_efficiency"] = params_change->interval_efficiency;
+      res["period"] = params_change->period;
+      res["threshold_range"] = params_change->vrf_params.threshold_range;
+      res["threshold_upper"] = params_change->vrf_params.threshold_upper;
+      res["kThresholdUpperMinValue"] = params_change->vrf_params.kThresholdUpperMinValue;
+    }
+  } catch (std::exception &e) {
+    res["status"] = e.what();
+  }
+  return res;
+}
+
+Json::Value Test::get_nf_blocks(const Json::Value &) {
+  Json::Value res;
+  try {
+    if (auto node = full_node_.lock()) {
+      auto nf = node->getDagManager()->getNonFinalizedBlocks();
+      res["value"] = Json::Value(Json::arrayValue);
+      for (auto const &n : nf.second) {
+        Json::Value level_json;
+        level_json["level"] = n.first;
+        level_json["blocks"] = Json::Value(Json::arrayValue);
+        for (auto const &b : n.second) {
+          Json::Value block_json;
+          block_json["hash"] = b.abridged();
+          level_json["value"].append(block_json);
+        }
+        res["value"].append(level_json);
+      }
+    }
+  } catch (std::exception &e) {
+    res["status"] = e.what();
+  }
+  return res;
+}
+
 Json::Value Test::send_coin_transaction(const Json::Value &param1) {
   Json::Value res;
   try {

--- a/libraries/core_libs/network/rpc/Test.h
+++ b/libraries/core_libs/network/rpc/Test.h
@@ -21,6 +21,8 @@ class Test : public TestFace {
 
   virtual Json::Value insert_dag_block(const Json::Value& param1) override;
   virtual Json::Value get_dag_block(const Json::Value& param1) override;
+  virtual Json::Value get_sortition_change(const Json::Value& param1) override;
+  virtual Json::Value get_nf_blocks(const Json::Value& param1) override;
   virtual Json::Value send_coin_transaction(const Json::Value& param1) override;
   virtual Json::Value create_test_coin_transactions(const Json::Value& param1) override;
   virtual Json::Value get_num_proposed_blocks() override;

--- a/libraries/core_libs/network/rpc/Test.jsonrpc.json
+++ b/libraries/core_libs/network/rpc/Test.jsonrpc.json
@@ -14,6 +14,20 @@
     "returns": {}
   },
   {
+    "name": "get_nf_blocks",
+    "params": [
+      {}
+    ],
+    "returns": {}
+  },
+  {
+    "name": "get_sortition_change",
+    "params": [
+      {}
+    ],
+    "returns": {}
+  },
+  {
     "name": "send_coin_transaction",
     "params": [
       {}

--- a/libraries/core_libs/network/rpc/TestClient.h
+++ b/libraries/core_libs/network/rpc/TestClient.h
@@ -32,6 +32,24 @@ class TestClient : public jsonrpc::Client {
     else
       throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
   }
+  Json::Value get_sortition_change(const Json::Value& param1) throw(jsonrpc::JsonRpcException) {
+    Json::Value p;
+    p.append(param1);
+    Json::Value result = this->CallMethod("get_sortition_change", p);
+    if (result.isObject())
+      return result;
+    else
+      throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
+  }
+  Json::Value get_nf_blocks(const Json::Value& param1) throw(jsonrpc::JsonRpcException) {
+    Json::Value p;
+    p.append(param1);
+    Json::Value result = this->CallMethod("get_nf_blocks", p);
+    if (result.isObject())
+      return result;
+    else
+      throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
+  }
   Json::Value send_coin_transaction(const Json::Value& param1) throw(jsonrpc::JsonRpcException) {
     Json::Value p;
     p.append(param1);

--- a/libraries/core_libs/network/rpc/TestFace.h
+++ b/libraries/core_libs/network/rpc/TestFace.h
@@ -18,6 +18,12 @@ class TestFace : public ServerInterface<TestFace> {
     this->bindAndAddMethod(jsonrpc::Procedure("get_dag_block", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT,
                                               "param1", jsonrpc::JSON_OBJECT, NULL),
                            &taraxa::net::TestFace::get_dag_blockI);
+    this->bindAndAddMethod(jsonrpc::Procedure("get_sortition_change", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT,
+                                              "param1", jsonrpc::JSON_OBJECT, NULL),
+                           &taraxa::net::TestFace::get_sortition_changeI);
+    this->bindAndAddMethod(jsonrpc::Procedure("get_nf_blocks", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT,
+                                              "param1", jsonrpc::JSON_OBJECT, NULL),
+                           &taraxa::net::TestFace::get_nf_blocksI);
     this->bindAndAddMethod(jsonrpc::Procedure("send_coin_transaction", jsonrpc::PARAMS_BY_POSITION,
                                               jsonrpc::JSON_OBJECT, "param1", jsonrpc::JSON_OBJECT, NULL),
                            &taraxa::net::TestFace::send_coin_transactionI);
@@ -94,6 +100,12 @@ class TestFace : public ServerInterface<TestFace> {
   }
   inline virtual void get_dag_blockI(const Json::Value &request, Json::Value &response) {
     response = this->get_dag_block(request[0u]);
+  }
+  inline virtual void get_sortition_changeI(const Json::Value &request, Json::Value &response) {
+    response = this->get_sortition_change(request[0u]);
+  }
+  inline virtual void get_nf_blocksI(const Json::Value &request, Json::Value &response) {
+    response = this->get_nf_blocks(request[0u]);
   }
   inline virtual void send_coin_transactionI(const Json::Value &request, Json::Value &response) {
     response = this->send_coin_transaction(request[0u]);
@@ -180,6 +192,8 @@ class TestFace : public ServerInterface<TestFace> {
   }
   virtual Json::Value insert_dag_block(const Json::Value &param1) = 0;
   virtual Json::Value get_dag_block(const Json::Value &param1) = 0;
+  virtual Json::Value get_sortition_change(const Json::Value &param1) = 0;
+  virtual Json::Value get_nf_blocks(const Json::Value &param1) = 0;
   virtual Json::Value send_coin_transaction(const Json::Value &param1) = 0;
   virtual Json::Value create_test_coin_transactions(const Json::Value &param1) = 0;
   virtual Json::Value get_num_proposed_blocks() = 0;

--- a/libraries/core_libs/network/src/network.cpp
+++ b/libraries/core_libs/network/src/network.cpp
@@ -128,9 +128,10 @@ void Network::sendBlock(dev::p2p::NodeID const &id, DagBlock const &blk) {
   LOG(log_dg_) << "Sent Block:" << blk.getHash().toString();
 }
 
-void Network::sendBlocks(dev::p2p::NodeID const &id, std::vector<std::shared_ptr<DagBlock>> blocks) {
+void Network::sendBlocks(dev::p2p::NodeID const &id, std::vector<std::shared_ptr<DagBlock>> blocks,
+                         uint64_t request_period, uint64_t period) {
   LOG(log_dg_) << "Sending Blocks:" << blocks.size();
-  taraxa_capability_->sendBlocks(id, std::move(blocks));
+  taraxa_capability_->sendBlocks(id, std::move(blocks), request_period, period);
 }
 
 void Network::sendTransactions(dev::p2p::NodeID const &_id, std::vector<taraxa::bytes> const &transactions) {

--- a/libraries/core_libs/network/src/network.cpp
+++ b/libraries/core_libs/network/src/network.cpp
@@ -83,8 +83,8 @@ std::vector<dev::p2p::NodeID> Network::getAllPeersIDs() const {
   return taraxa_capability_->getPeersState()->getAllPeersIDs();
 }
 
-void Network::onNewBlockVerified(DagBlock const &blk, bool proposed) {
-  taraxa_capability_->onNewBlockVerified(blk, proposed);
+void Network::onNewBlockVerified(DagBlock const &blk, bool proposed, SharedTransactions &&trxs) {
+  taraxa_capability_->onNewBlockVerified(blk, proposed, std::move(trxs));
   LOG(log_dg_) << "On new block verified:" << blk.getHash().toString();
 }
 
@@ -123,12 +123,12 @@ void Network::broadcastPreviousRoundNextVotesBundle() {
 }
 
 // METHODS USED IN TESTS ONLY
-void Network::sendBlock(dev::p2p::NodeID const &id, DagBlock const &blk) {
-  taraxa_capability_->sendBlock(id, blk);
+void Network::sendBlock(dev::p2p::NodeID const &id, DagBlock const &blk, const SharedTransactions &trxs) {
+  taraxa_capability_->sendBlock(id, blk, trxs);
   LOG(log_dg_) << "Sent Block:" << blk.getHash().toString();
 }
 
-void Network::sendBlocks(dev::p2p::NodeID const &id, std::vector<std::shared_ptr<DagBlock>> blocks,
+void Network::sendBlocks(const dev::p2p::NodeID &id, std::vector<std::shared_ptr<DagBlock>> &&blocks,
                          uint64_t request_period, uint64_t period) {
   LOG(log_dg_) << "Sending Blocks:" << blocks.size();
   taraxa_capability_->sendBlocks(id, std::move(blocks), request_period, period);

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_syncing_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_syncing_packet_handler.cpp
@@ -96,8 +96,7 @@ void ExtSyncingPacketHandler::requestPendingDagBlocks(std::shared_ptr<TaraxaPeer
     return;
   }
 
-  // This prevents ddos requesting dag blocks. We can only request one time from one peer. Only exception is post pbft
-  // syncing this is reset
+  // This prevents ddos requesting dag blocks. We can only request this one time from one peer.
   if (peer->peer_dag_synced) {
     LOG(log_nf_) << "requestPendingDagBlocks not possible since already requested for peer";
     return;

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_syncing_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_syncing_packet_handler.cpp
@@ -97,7 +97,7 @@ void ExtSyncingPacketHandler::requestPendingDagBlocks(std::shared_ptr<TaraxaPeer
   }
 
   // This prevents ddos requesting dag blocks. We can only request this one time from one peer.
-  if (peer->peer_dag_synced) {
+  if (peer->peer_dag_synced_) {
     LOG(log_nf_) << "requestPendingDagBlocks not possible since already requested for peer";
     return;
   }
@@ -106,7 +106,7 @@ void ExtSyncingPacketHandler::requestPendingDagBlocks(std::shared_ptr<TaraxaPeer
   auto pbft_sync_period = pbft_mgr_->pbftSyncingPeriod();
   if (pbft_sync_period == peer->pbft_chain_size_) {
     // This prevents parallel requests
-    if (bool b = false; !peer->peer_dag_syncing.compare_exchange_strong(b, !b)) {
+    if (bool b = false; !peer->peer_dag_syncing_.compare_exchange_strong(b, !b)) {
       LOG(log_nf_) << "requestPendingDagBlocks not possible since already requesting for peer";
       return;
     }

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/common/packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/common/packet_handler.cpp
@@ -18,7 +18,7 @@ void PacketHandler::processPacket(const PacketData& packet_data) {
 
     auto tmp_peer = peers_state_->getPeer(packet_data.from_node_id_);
     if (!tmp_peer && packet_data.type_ != SubprotocolPacketType::StatusPacket) {
-      LOG(log_wr_) << "Peer " << packet_data.from_node_id_.abridged()
+      LOG(log_er_) << "Peer " << packet_data.from_node_id_.abridged()
                    << " not in peers map. He probably did not send initial status message - will be disconnected.";
       disconnect(packet_data.from_node_id_, dev::p2p::UserReason);
       return;
@@ -69,7 +69,7 @@ bool PacketHandler::sealAndSend(const dev::p2p::NodeID& nodeID, SubprotocolPacke
     }
 
     if (packet_type != SubprotocolPacketType::StatusPacket) {
-      LOG(log_wr_) << "sealAndSend failed initial status check, peer " << nodeID.abridged() << " will be disconnected";
+      LOG(log_er_) << "sealAndSend failed initial status check, peer " << nodeID.abridged() << " will be disconnected";
       host->disconnect(nodeID, dev::p2p::UserReason);
       return false;
     }

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/dag_block_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/dag_block_packet_handler.cpp
@@ -73,6 +73,9 @@ void DagBlockPacketHandler::sendBlock(dev::p2p::NodeID const &peer_id, taraxa::D
     return;
   }
 
+  // This lock prevents race condition between syncing and gossiping dag blocks
+  std::unique_lock lock(peer->mutex_for_sending_dag_blocks_);
+
   vec_trx_t transactions_to_send;
   for (const auto &trx_hash : block.getTrxs()) {
     if (peer->isTransactionKnown(trx_hash)) {

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/dag_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/dag_sync_packet_handler.cpp
@@ -34,8 +34,8 @@ void DagSyncPacketHandler::process(const PacketData& packet_data, const std::sha
     if (peer->pbft_chain_size_ < response_period) {
       peer->pbft_chain_size_ = response_period;
     }
-    // We are behind, restart pbft sync
-    restartSyncingPbft(true);
+    // We might be behind, restart pbft sync
+    restartSyncingPbft();
     return;
   }
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/dag_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/dag_sync_packet_handler.cpp
@@ -22,9 +22,22 @@ DagSyncPacketHandler::DagSyncPacketHandler(std::shared_ptr<PeersState> peers_sta
 
 void DagSyncPacketHandler::process(const PacketData& packet_data, const std::shared_ptr<TaraxaPeer>& peer) {
   std::string received_dag_blocks_str;
-  std::unordered_set<blk_hash_t> missing_blks;
 
   auto it = packet_data.rlp_.begin();
+
+  const auto request_period = (*it++).toInt<uint64_t>();
+  const auto response_period = (*it++).toInt<uint64_t>();
+
+  // If the periods did not match restart syncing
+  if (response_period != request_period) {
+    LOG(log_nf_) << "Received DagSyncPacket with mismatching periods: " << response_period << " " << request_period;
+    if (peer->pbft_chain_size_ < response_period) {
+      peer->pbft_chain_size_ = response_period;
+    }
+    // We are behind, restart pbft sync
+    restartSyncingPbft(true);
+    return;
+  }
 
   for (; it != packet_data.rlp_.end();) {
     DagBlock block(*it++);
@@ -41,10 +54,12 @@ void DagSyncPacketHandler::process(const PacketData& packet_data, const std::sha
 
     auto status = checkDagBlockValidation(block);
     if (!status.first) {
-      LOG(log_er_) << "DagBlock" << block.getHash() << " Validation failed " << status.second;
-      status.second.insert(block.getHash());
-      missing_blks.merge(status.second);
-      continue;
+      // This should only happen with a malicious node or a fork
+      LOG(log_er_) << "DagBlock" << block.getHash() << " Validation failed " << status.second << " . Peer "
+                   << packet_data.from_node_id_.abridged() << " will be disconnected.";
+      disconnect(peer->getId(), dev::p2p::UserReason);
+      // TODO: malicious peer handling
+      return;
     }
 
     LOG(log_dg_) << "Storing block " << block.getHash().abridged() << " with " << new_transactions.size()
@@ -55,12 +70,7 @@ void DagSyncPacketHandler::process(const PacketData& packet_data, const std::sha
     dag_blk_mgr_->insertBroadcastedBlock(std::move(block));
   }
 
-  if (missing_blks.size() > 0) {
-    requestDagBlocks(packet_data.from_node_id_, missing_blks, DagSyncRequestType::MissingHashes);
-  }
-  syncing_state_->set_dag_syncing(false);
-
-  LOG(log_nf_) << "Received DagDagSyncPacket with blocks: " << received_dag_blocks_str;
+  LOG(log_nf_) << "Received DagSyncPacket with blocks: " << received_dag_blocks_str;
 }
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/get_dag_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/get_dag_sync_packet_handler.cpp
@@ -20,6 +20,9 @@ GetDagSyncPacketHandler::GetDagSyncPacketHandler(std::shared_ptr<PeersState> pee
 
 void GetDagSyncPacketHandler::process(const PacketData &packet_data,
                                       [[maybe_unused]] const std::shared_ptr<TaraxaPeer> &peer) {
+  // This lock prevents race condition between syncing and gossiping dag blocks
+  std::unique_lock lock(peer->mutex_for_sending_dag_blocks_);
+
   std::unordered_set<blk_hash_t> blocks_hashes;
   std::vector<std::shared_ptr<DagBlock>> dag_blocks;
   auto it = packet_data.rlp_.begin();

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/get_dag_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/get_dag_sync_packet_handler.cpp
@@ -33,7 +33,8 @@ void GetDagSyncPacketHandler::process(const PacketData &packet_data,
 
   const auto [period, blocks] = dag_mgr_->getNonFinalizedBlocks();
   // There is no point in sending blocks if periods do not match
-  if (peer_period != period) {
+  if (peer_period == period) {
+    peer->syncing_ = false;
     for (auto &level_blocks : blocks) {
       for (auto &block : level_blocks.second) {
         const auto hash = block;
@@ -49,7 +50,6 @@ void GetDagSyncPacketHandler::process(const PacketData &packet_data,
     }
   }
   sendBlocks(packet_data.from_node_id_, dag_blocks, peer_period, period);
-  peer->syncing_ = false;
 }
 
 void GetDagSyncPacketHandler::sendBlocks(dev::p2p::NodeID const &peer_id, std::vector<std::shared_ptr<DagBlock>> blocks,

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_block_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_block_packet_handler.cpp
@@ -10,15 +10,11 @@ namespace taraxa::network::tarcap {
 
 PbftBlockPacketHandler::PbftBlockPacketHandler(std::shared_ptr<PeersState> peers_state,
                                                std::shared_ptr<PacketsStats> packets_stats,
-                                               std::shared_ptr<SyncingState> syncing_state,
                                                std::shared_ptr<PbftChain> pbft_chain,
-                                               std::shared_ptr<PbftManager> pbft_mgr,
-                                               std::shared_ptr<DagBlockManager> dag_blk_mgr, const addr_t &node_addr)
+                                               std::shared_ptr<PbftManager> pbft_mgr, const addr_t &node_addr)
     : PacketHandler(std::move(peers_state), std::move(packets_stats), node_addr, "PBFT_BLOCK_PH"),
-      syncing_state_(std::move(syncing_state)),
       pbft_chain_(std::move(pbft_chain)),
-      pbft_mgr_(std::move(pbft_mgr)),
-      dag_blk_mgr_(std::move(dag_blk_mgr)) {}
+      pbft_mgr_(std::move(pbft_mgr)) {}
 
 void PbftBlockPacketHandler::process(const PacketData &packet_data, const std::shared_ptr<TaraxaPeer> &peer) {
   LOG(log_dg_) << "In PbftBlockPacket";
@@ -31,19 +27,6 @@ void PbftBlockPacketHandler::process(const PacketData &packet_data, const std::s
   peer->markPbftBlockAsKnown(pbft_block->getBlockHash());
   if (peer_pbft_chain_size > peer->pbft_chain_size_) {
     peer->pbft_chain_size_ = peer_pbft_chain_size;
-  }
-
-  // Ignore any pbft block that is missing dag anchor
-  if (!dag_blk_mgr_->isDagBlockKnown(pbft_block->getPivotDagBlockHash())) {
-    // If we are not syncing and missing anchor block, disconnect the node
-    if (!syncing_state_->is_pbft_syncing()) {
-      LOG(log_wr_) << "Pbft block" << pbft_block->getBlockHash() << " missing dag anchor "
-                   << pbft_block->getPivotDagBlockHash() << " . Peer " << packet_data.from_node_id_.abridged()
-                   << " will be disconnected.";
-      disconnect(packet_data.from_node_id_, dev::p2p::UserReason);
-    }
-    return;
-    // TODO: malicious peer handling
   }
 
   const auto pbft_synced_period = pbft_mgr_->pbftSyncingPeriod();
@@ -65,33 +48,15 @@ void PbftBlockPacketHandler::process(const PacketData &packet_data, const std::s
 
 void PbftBlockPacketHandler::onNewPbftBlock(PbftBlock const &pbft_block) {
   std::vector<std::shared_ptr<TaraxaPeer>> peers_to_send;
-  std::vector<std::shared_ptr<TaraxaPeer>> peers_missing_anchor;
   const auto my_chain_size = pbft_chain_->getPbftChainSize();
 
   for (auto const &peer : peers_state_->getAllPeers()) {
     if (!peer.second->isPbftBlockKnown(pbft_block.getBlockHash()) && !peer.second->syncing_) {
-      if (peer.second->isDagBlockKnown(pbft_block.getPivotDagBlockHash())) {
-        peers_to_send.emplace_back(peer.second);
-      } else {
-        peers_missing_anchor.emplace_back(peer.second);
+      if (!peer.second->isDagBlockKnown(pbft_block.getPivotDagBlockHash())) {
+        LOG(log_dg_) << "sending PbftBlock " << pbft_block.getBlockHash() << " with missing dag anchor"
+                     << pbft_block.getPivotDagBlockHash() << " to " << peer.first;
       }
-    }
-  }
-
-  for (auto const &peer : peers_to_send) {
-    sendPbftBlock(peer->getId(), pbft_block, my_chain_size);
-    peer->markPbftBlockAsKnown(pbft_block.getBlockHash());
-  }
-
-  peers_to_send.clear();
-
-  // Check again for peers missing anchor
-  for (auto const &peer : peers_missing_anchor) {
-    if (peer->isDagBlockKnown(pbft_block.getPivotDagBlockHash())) {
-      peers_to_send.emplace_back(peer);
-    } else {
-      LOG(log_wr_) << "PbftBlock " << pbft_block.getBlockHash() << " dag anchor is not broadcast to peer yet "
-                   << pbft_block.getPivotDagBlockHash() << " to " << peer->getId();
+      peers_to_send.emplace_back(peer.second);
     }
   }
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
@@ -29,7 +29,7 @@ void PbftSyncPacketHandler::process(const PacketData &packet_data, const std::sh
   // disabled on priority_queue blocking dependencies level
 
   if (syncing_state_->syncing_peer() != packet_data.from_node_id_) {
-    LOG(log_wr_) << "PbftSyncPacket received from unexpected peer " << packet_data.from_node_id_.abridged()
+    LOG(log_er_) << "PbftSyncPacket received from unexpected peer " << packet_data.from_node_id_.abridged()
                  << " current syncing peer " << syncing_state_->syncing_peer().abridged();
     return;
   }
@@ -63,8 +63,9 @@ void PbftSyncPacketHandler::process(const PacketData &packet_data, const std::sh
   LOG(log_dg_) << "Processing pbft block: " << pbft_blk_hash;
 
   if (sync_block.pbft_blk->getPeriod() != pbft_mgr_->pbftSyncingPeriod() + 1) {
-    LOG(log_dg_) << "Block " << pbft_blk_hash << " period unexpected: " << sync_block.pbft_blk->getPeriod()
+    LOG(log_wr_) << "Block " << pbft_blk_hash << " period unexpected: " << sync_block.pbft_blk->getPeriod()
                  << ". Expected period: " << pbft_mgr_->pbftSyncingPeriod() + 1;
+    restartSyncingPbft(true);
     return;
   }
   // Update peer's pbft period if outdated

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
@@ -90,8 +90,7 @@ void PbftSyncPacketHandler::process(const PacketData &packet_data, const std::sh
         delayed_sync_events_tp_.post(1000, [this] { delayedPbftSync(1); });
       } else {
         if (!syncPeerPbft(pbft_sync_period + 1)) {
-          syncing_state_->set_pbft_syncing(false);
-          return restartSyncingPbft();
+          return restartSyncingPbft(true);
         }
       }
     }
@@ -110,6 +109,9 @@ void PbftSyncPacketHandler::pbftSyncComplete() {
     // greater pbft chain size and we should continue syncing with
     // them, Or sync pending DAG blocks
     restartSyncingPbft(true);
+    if (!syncing_state_->is_pbft_syncing()) {
+      requestPendingDagBlocks();
+    }
   }
 }
 
@@ -130,8 +132,7 @@ void PbftSyncPacketHandler::delayedPbftSync(int counter) {
       delayed_sync_events_tp_.post(1000, [this, counter] { delayedPbftSync(counter + 1); });
     } else {
       if (!syncPeerPbft(pbft_sync_period + 1)) {
-        syncing_state_->set_pbft_syncing(false);
-        return restartSyncingPbft();
+        return restartSyncingPbft(true);
       }
     }
   }

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
@@ -29,7 +29,7 @@ void PbftSyncPacketHandler::process(const PacketData &packet_data, const std::sh
   // disabled on priority_queue blocking dependencies level
 
   if (syncing_state_->syncing_peer() != packet_data.from_node_id_) {
-    LOG(log_er_) << "PbftSyncPacket received from unexpected peer " << packet_data.from_node_id_.abridged()
+    LOG(log_dg_) << "PbftSyncPacket received from unexpected peer " << packet_data.from_node_id_.abridged()
                  << " current syncing peer " << syncing_state_->syncing_peer().abridged();
     return;
   }

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/status_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/status_packet_handler.cpp
@@ -126,7 +126,7 @@ void StatusPacketHandler::process(const PacketData& packet_data, const std::shar
             restartSyncingPbft();
           }
         }
-      } else if (pbft_synced_period == selected_peer->pbft_chain_size_ && !selected_peer->peer_dag_synced) {
+      } else if (pbft_synced_period == selected_peer->pbft_chain_size_ && !selected_peer->peer_dag_synced_) {
         // if not syncing and the peer period is matching our period request any pending dag blocks
         requestPendingDagBlocks(selected_peer);
       }

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/status_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/status_packet_handler.cpp
@@ -117,7 +117,7 @@ void StatusPacketHandler::process(const PacketData& packet_data, const std::shar
       if (pbft_synced_period < selected_peer->pbft_chain_size_) {
         LOG(log_nf_) << "Restart PBFT chain syncing. Own synced PBFT at period " << pbft_synced_period
                      << ", peer PBFT chain size " << selected_peer->pbft_chain_size_;
-        if (pbft_synced_period < selected_peer->pbft_chain_size_ + 1) {
+        if (pbft_synced_period + 1 < selected_peer->pbft_chain_size_) {
           restartSyncingPbft();
         } else {
           // If we are behind by only one block wait for two status messages before syncing because nodes are not always

--- a/libraries/core_libs/network/src/tarcap/shared_states/syncing_state.cpp
+++ b/libraries/core_libs/network/src/tarcap/shared_states/syncing_state.cpp
@@ -11,7 +11,7 @@ SyncingState::SyncingState(uint16_t deep_syncing_threshold)
 void SyncingState::set_peer(std::shared_ptr<TaraxaPeer> &&peer) {
   std::unique_lock lock(peer_mutex_);
   // we set peer to null if dag and pbft syncing are not enabled
-  if (peer == nullptr && (pbft_syncing_ || dag_syncing_)) {
+  if (peer == nullptr && pbft_syncing_) {
     return;
   }
   peer_ = std::move(peer);
@@ -50,12 +50,6 @@ void SyncingState::set_pbft_syncing(bool syncing, uint64_t current_period,
   }
 }
 
-void SyncingState::set_dag_syncing(bool syncing, std::shared_ptr<TaraxaPeer> peer /*=nullptr*/) {
-  assert((syncing && peer) || !syncing);
-  dag_syncing_ = syncing;
-  set_peer(std::move(peer));
-}
-
 void SyncingState::set_last_sync_packet_time() {
   std::unique_lock lock(time_mutex_);
   last_received_sync_packet_time_ = std::chrono::steady_clock::now();
@@ -82,7 +76,7 @@ void SyncingState::set_peer_malicious(const std::optional<dev::p2p::NodeID> &pee
 
 bool SyncingState::is_peer_malicious(const dev::p2p::NodeID &peer_id) const { return malicious_peers_.count(peer_id); }
 
-bool SyncingState::is_syncing() { return is_pbft_syncing() || is_dag_syncing(); }
+bool SyncingState::is_syncing() { return is_pbft_syncing(); }
 
 bool SyncingState::is_deep_pbft_syncing() const { return deep_pbft_syncing_; }
 
@@ -92,7 +86,5 @@ bool SyncingState::is_pbft_syncing() {
   }
   return pbft_syncing_;
 }
-
-bool SyncingState::is_dag_syncing() const { return dag_syncing_; }
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -375,10 +375,10 @@ void TaraxaCapability::handleMaliciousSyncPeer(dev::p2p::NodeID const &id) {
   restartSyncingPbft(true);
 }
 
-void TaraxaCapability::onNewBlockVerified(DagBlock const &blk, bool proposed) {
+void TaraxaCapability::onNewBlockVerified(DagBlock const &blk, bool proposed, SharedTransactions &&trxs) {
   std::static_pointer_cast<DagBlockPacketHandler>(
       packets_handlers_->getSpecificHandler(SubprotocolPacketType::DagBlockPacket))
-      ->onNewBlockVerified(blk, proposed);
+      ->onNewBlockVerified(blk, proposed, std::move(trxs));
 }
 
 void TaraxaCapability::onNewTransactions(SharedTransactions &&transactions) {
@@ -419,13 +419,13 @@ void TaraxaCapability::sendTransactions(dev::p2p::NodeID const &id, std::vector<
 void TaraxaCapability::setSyncStatePeriod(uint64_t period) { syncing_state_->setSyncStatePeriod(period); }
 
 // METHODS USED IN TESTS ONLY
-void TaraxaCapability::sendBlock(dev::p2p::NodeID const &id, DagBlock const &blk) {
+void TaraxaCapability::sendBlock(dev::p2p::NodeID const &id, DagBlock const &blk, const SharedTransactions &trxs) {
   std::static_pointer_cast<DagBlockPacketHandler>(
       packets_handlers_->getSpecificHandler(SubprotocolPacketType::DagBlockPacket))
-      ->sendBlock(id, blk);
+      ->sendBlock(id, blk, trxs);
 }
 
-void TaraxaCapability::sendBlocks(dev::p2p::NodeID const &id, std::vector<std::shared_ptr<DagBlock>> blocks,
+void TaraxaCapability::sendBlocks(const dev::p2p::NodeID &id, std::vector<std::shared_ptr<DagBlock>> &&blocks,
                                   uint64_t request_period, uint64_t period) {
   std::static_pointer_cast<GetDagSyncPacketHandler>(
       packets_handlers_->getSpecificHandler(SubprotocolPacketType::GetDagSyncPacket))

--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -193,8 +193,7 @@ void TaraxaCapability::registerPacketHandlers(
   // Standard packets with mid processing priority
   packets_handlers_->registerHandler(
       SubprotocolPacketType::PbftBlockPacket,
-      std::make_shared<PbftBlockPacketHandler>(peers_state_, packets_stats, syncing_state_, pbft_chain, pbft_mgr,
-                                               dag_blk_mgr, node_addr));
+      std::make_shared<PbftBlockPacketHandler>(peers_state_, packets_stats, pbft_chain, pbft_mgr, node_addr));
 
   const auto dag_handler =
       std::make_shared<DagBlockPacketHandler>(peers_state_, packets_stats, syncing_state_, pbft_chain, pbft_mgr,

--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -193,7 +193,8 @@ void TaraxaCapability::registerPacketHandlers(
   // Standard packets with mid processing priority
   packets_handlers_->registerHandler(
       SubprotocolPacketType::PbftBlockPacket,
-      std::make_shared<PbftBlockPacketHandler>(peers_state_, packets_stats, pbft_chain, pbft_mgr, node_addr));
+      std::make_shared<PbftBlockPacketHandler>(peers_state_, packets_stats, syncing_state_, pbft_chain, pbft_mgr,
+                                               dag_blk_mgr, node_addr));
 
   const auto dag_handler =
       std::make_shared<DagBlockPacketHandler>(peers_state_, packets_stats, syncing_state_, pbft_chain, pbft_mgr,
@@ -231,7 +232,6 @@ void TaraxaCapability::registerPacketHandlers(
       std::make_shared<PbftSyncPacketHandler>(peers_state_, packets_stats, syncing_state_, pbft_chain, pbft_mgr,
                                               dag_mgr, dag_blk_mgr, db, conf.network_sync_level_size, node_addr);
   packets_handlers_->registerHandler(SubprotocolPacketType::PbftSyncPacket, pbft_handler);
-  packets_handlers_->registerHandler(SubprotocolPacketType::SyncedPacket, pbft_handler);
 
   thread_pool_->setPacketsHandlers(packets_handlers_);
 }
@@ -277,7 +277,6 @@ void TaraxaCapability::onDisconnect(dev::p2p::NodeID const &_nodeID) {
     } else {
       LOG(log_dg_) << "Stop PBFT/DAG syncing due to syncing peer disconnect and no other peers available.";
       syncing_state_->set_pbft_syncing(false);
-      syncing_state_->set_dag_syncing(false);
     }
   }
 }
@@ -337,7 +336,6 @@ inline bool TaraxaCapability::filterSyncIrrelevantPackets(SubprotocolPacketType 
     case StatusPacket:
     case GetPbftSyncPacket:
     case PbftSyncPacket:
-    case SyncedPacket:
       return false;
     default:
       return true;
@@ -428,10 +426,11 @@ void TaraxaCapability::sendBlock(dev::p2p::NodeID const &id, DagBlock const &blk
       ->sendBlock(id, blk);
 }
 
-void TaraxaCapability::sendBlocks(dev::p2p::NodeID const &id, std::vector<std::shared_ptr<DagBlock>> blocks) {
+void TaraxaCapability::sendBlocks(dev::p2p::NodeID const &id, std::vector<std::shared_ptr<DagBlock>> blocks,
+                                  uint64_t request_period, uint64_t period) {
   std::static_pointer_cast<GetDagSyncPacketHandler>(
       packets_handlers_->getSpecificHandler(SubprotocolPacketType::GetDagSyncPacket))
-      ->sendBlocks(id, std::move(blocks));
+      ->sendBlocks(id, std::move(blocks), request_period, period);
 }
 
 size_t TaraxaCapability::getReceivedBlocksCount() const { return test_state_->getBlocksSize(); }

--- a/libraries/core_libs/network/src/tarcap/threadpool/packets_blocking_mask.cpp
+++ b/libraries/core_libs/network/src/tarcap/threadpool/packets_blocking_mask.cpp
@@ -4,6 +4,11 @@
 
 namespace taraxa::network::tarcap {
 
+PacketsBlockingMask::PacketsBlockingMask() {
+  addr_t node_addr;
+  LOG_OBJECTS_CREATE("PRIORITY_QUEUEx");
+}
+
 void PacketsBlockingMask::markPacketAsHardBlocked(const PacketData& blocking_packet,
                                                   SubprotocolPacketType packet_type_to_block) {
   auto& packet_hard_block = hard_blocked_packet_types_[packet_type_to_block];

--- a/libraries/core_libs/network/src/tarcap/threadpool/packets_blocking_mask.cpp
+++ b/libraries/core_libs/network/src/tarcap/threadpool/packets_blocking_mask.cpp
@@ -4,11 +4,6 @@
 
 namespace taraxa::network::tarcap {
 
-PacketsBlockingMask::PacketsBlockingMask() {
-  addr_t node_addr;
-  LOG_OBJECTS_CREATE("PRIORITY_QUEUEx");
-}
-
 void PacketsBlockingMask::markPacketAsHardBlocked(const PacketData& blocking_packet,
                                                   SubprotocolPacketType packet_type_to_block) {
   auto& packet_hard_block = hard_blocked_packet_types_[packet_type_to_block];

--- a/libraries/core_libs/network/src/tarcap/threadpool/priority_queue.cpp
+++ b/libraries/core_libs/network/src/tarcap/threadpool/priority_queue.cpp
@@ -150,7 +150,6 @@ void PriorityQueue::updateDependenciesStart(const PacketData& packet) {
     case SubprotocolPacketType::DagSyncPacket:
       blocked_packets_mask_.markPacketAsHardBlocked(packet, packet.type_);
       blocked_packets_mask_.markPacketAsPeerOrderBlocked(packet, SubprotocolPacketType::DagBlockPacket);
-      blocked_packets_mask_.markPacketAsPeerOrderBlocked(packet, SubprotocolPacketType::PbftBlockPacket);
       break;
 
     // When processing TransactionPacket, processing of all dag block packets that were received after that (from the
@@ -160,11 +159,8 @@ void PriorityQueue::updateDependenciesStart(const PacketData& packet) {
       blocked_packets_mask_.markPacketAsPeerOrderBlocked(packet, SubprotocolPacketType::DagBlockPacket);
       break;
 
-    // When processing DagBlockPacket, processing of all pbft block packets that were received after that (from the
-    // same peer).
     case SubprotocolPacketType::DagBlockPacket:
       blocked_packets_mask_.setDagBlockLevelBeingProcessed(packet);
-      blocked_packets_mask_.markPacketAsPeerOrderBlocked(packet, SubprotocolPacketType::PbftBlockPacket);
       break;
 
     default:
@@ -193,7 +189,6 @@ void PriorityQueue::updateDependenciesFinish(const PacketData& packet, std::mute
       std::unique_lock<std::mutex> lock(queue_mutex);
       blocked_packets_mask_.markPacketAsHardUnblocked(packet, packet.type_);
       blocked_packets_mask_.markPacketAsPeerOrderUnblocked(packet, SubprotocolPacketType::DagBlockPacket);
-      blocked_packets_mask_.markPacketAsPeerOrderUnblocked(packet, SubprotocolPacketType::PbftBlockPacket);
       cond_var.notify_all();
       break;
     }
@@ -208,7 +203,6 @@ void PriorityQueue::updateDependenciesFinish(const PacketData& packet, std::mute
     case SubprotocolPacketType::DagBlockPacket: {
       std::unique_lock<std::mutex> lock(queue_mutex);
       blocked_packets_mask_.unsetDagBlockLevelBeingProcessed(packet);
-      blocked_packets_mask_.markPacketAsPeerOrderUnblocked(packet, SubprotocolPacketType::PbftBlockPacket);
       cond_var.notify_all();
       break;
     }

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -124,7 +124,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
     COLUMN(final_chain_blk_number_by_hash);
     COLUMN(final_chain_receipt_by_trx_hash);
     COLUMN(final_chain_log_blooms_index);
-    COLUMN(pbft_block_dag_efficiency);
+    COLUMN_W_COMP(pbft_block_dag_efficiency, getIntComparator<uint64_t>());
     COLUMN_W_COMP(sortition_params_change, getIntComparator<uint64_t>());
 
 #undef COLUMN
@@ -192,7 +192,8 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   std::vector<std::shared_ptr<DagBlock>> getDagBlocksAtLevel(level_t level, int number_of_levels);
   void updateDagBlockCounters(std::vector<DagBlock> blks);
   std::map<level_t, std::vector<DagBlock>> getNonfinalizedDagBlocks();
-  void removeDagBlock(Batch& write_batch, blk_hash_t const& hash);
+  void removeDagBlockBatch(Batch& write_batch, blk_hash_t const& hash);
+  void removeDagBlock(blk_hash_t const& hash);
   // DAG Efficiency
   void savePbftBlockDagEfficiency(uint64_t period, uint16_t efficiency, DbStorage::Batch& batch);
   std::vector<uint16_t> getLastIntervalEfficiencies(uint16_t computation_interval);
@@ -205,7 +206,8 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   // Transaction
   void saveTransaction(Transaction const& trx, bool verified = false);
   std::shared_ptr<Transaction> getTransaction(trx_hash_t const& hash);
-  SharedTransactions getNonfinalizedTransactions();
+  SharedTransactions getAllNonfinalizedTransactions();
+  SharedTransactions getNonfinalizedTransactions(std::vector<trx_hash_t> const& trx_hashes);
   bool transactionInDb(trx_hash_t const& hash);
   bool transactionFinalized(trx_hash_t const& hash);
   std::vector<bool> transactionsInDb(std::vector<trx_hash_t> const& trx_hashes);

--- a/libraries/core_libs/storage/src/storage.cpp
+++ b/libraries/core_libs/storage/src/storage.cpp
@@ -588,8 +588,7 @@ bool DbStorage::transactionFinalized(trx_hash_t const& hash) {
 }
 
 std::vector<bool> DbStorage::transactionsInDb(std::vector<trx_hash_t> const& trx_hashes) {
-  std::vector<bool> result;
-  result.reserve(trx_hashes.size());
+  std::vector<bool> result(trx_hashes.size(), false);
 
   DbStorage::MultiGetQuery db_query(shared_from_this(), trx_hashes.size());
   db_query.append(DbStorage::Columns::transactions, trx_hashes);

--- a/libraries/core_libs/storage/src/storage.cpp
+++ b/libraries/core_libs/storage/src/storage.cpp
@@ -312,7 +312,7 @@ std::map<level_t, std::vector<DagBlock>> DbStorage::getNonfinalizedDagBlocks() {
   return res;
 }
 
-SharedTransactions DbStorage::getNonfinalizedTransactions() {
+SharedTransactions DbStorage::getAllNonfinalizedTransactions() {
   SharedTransactions res;
   auto i = std::unique_ptr<rocksdb::Iterator>(db_->NewIterator(read_options_, handle(Columns::transactions)));
   for (i->SeekToFirst(); i->Valid(); i->Next()) {
@@ -322,9 +322,22 @@ SharedTransactions DbStorage::getNonfinalizedTransactions() {
   return res;
 }
 
-void DbStorage::removeDagBlock(Batch& write_batch, blk_hash_t const& hash) {
+SharedTransactions DbStorage::getNonfinalizedTransactions(std::vector<trx_hash_t> const& trx_hashes) {
+  SharedTransactions res;
+  for (const auto& hash : trx_hashes) {
+    auto data = asBytes(lookup(toSlice(hash.asBytes()), Columns::transactions));
+    if (data.size() > 0) {
+      res.emplace_back(std::make_shared<Transaction>(data));
+    }
+  }
+  return res;
+}
+
+void DbStorage::removeDagBlockBatch(Batch& write_batch, blk_hash_t const& hash) {
   remove(write_batch, Columns::dag_blocks, toSlice(hash));
 }
+
+void DbStorage::removeDagBlock(blk_hash_t const& hash) { remove(Columns::dag_blocks, toSlice(hash)); }
 
 void DbStorage::updateDagBlockCounters(std::vector<DagBlock> blks) {
   // Lock is needed since we are editing some fields
@@ -450,7 +463,7 @@ void DbStorage::savePeriodData(const SyncBlock& sync_block, Batch& write_batch) 
   // Remove dag blocks from non finalized column in db and add dag_block_period in DB
   uint64_t block_pos = 0;
   for (auto const& block : sync_block.dag_blocks) {
-    removeDagBlock(write_batch, block.getHash());
+    removeDagBlockBatch(write_batch, block.getHash());
     addDagBlockPeriodToBatch(block.getHash(), period, block_pos, write_batch);
     block_pos++;
   }

--- a/libraries/types/dag_block/include/dag/dag_block.hpp
+++ b/libraries/types/dag_block/include/dag/dag_block.hpp
@@ -95,6 +95,15 @@ struct DagFrontier {
     pivot.clear();
     tips.clear();
   }
+
+  bool isEqual(const DagFrontier &frontier) {
+    if (pivot != frontier.pivot) {
+      return false;
+    }
+
+    return std::equal(tips.begin(), tips.end(), frontier.tips.begin(), frontier.tips.end());
+  }
+
   blk_hash_t pivot;
   vec_blk_t tips;
 };

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -63,7 +63,7 @@ TEST_F(NetworkTest, transfer_block) {
     WAIT_EXPECT_EQ(ctx, nw2->getPeerCount(), 1)
   });
 
-  nw2->sendBlock(nw1->getNodeId(), blk);
+  nw2->sendBlock(nw1->getNodeId(), blk, {});
 
   std::cout << "Waiting packages for 10 seconds ..." << std::endl;
 
@@ -113,6 +113,7 @@ TEST_F(NetworkTest, transfer_lot_of_blocks) {
   }
 
   nodes[0]->getNetwork()->onNewTransactions(std::move(trxs));
+  for (auto block : dag_blocks) nodes[0]->getDagBlockManager()->insertBroadcastedBlock(*block);
   taraxa::thisThreadSleepForSeconds(1);
   nodes[0]->getNetwork()->sendBlocks(nodes[1]->getNetwork()->getNodeId(), std::move(dag_blocks), 1, 1);
 

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -425,6 +425,10 @@ TEST_F(NetworkTest, node_pbft_sync) {
   db1->addPbftHeadToBatch(pbft_chain_head_hash, pbft_chain_head_str, batch);
   db1->commitWriteBatch(batch);
 
+  vec_blk_t order1;
+  order1.push_back(blk1.getHash());
+  node1->getDagManager()->setDagBlockOrder(blk1.getHash(), level, order1);
+
   uint64_t expect_pbft_chain_size = 1;
   EXPECT_EQ(node1->getPbftChain()->getPbftChainSize(), expect_pbft_chain_size);
 
@@ -475,6 +479,11 @@ TEST_F(NetworkTest, node_pbft_sync) {
   pbft_chain_head_str = pbft_chain1->getJsonStr();
   db1->addPbftHeadToBatch(pbft_chain_head_hash, pbft_chain_head_str, batch);
   db1->commitWriteBatch(batch);
+
+  vec_blk_t order2;
+  order2.push_back(blk2.getHash());
+  node1->getDagManager()->setDagBlockOrder(blk2.getHash(), level, order2);
+
   expect_pbft_chain_size = 2;
   EXPECT_EQ(node1->getPbftChain()->getPbftChainSize(), expect_pbft_chain_size);
 

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -114,7 +114,7 @@ TEST_F(NetworkTest, transfer_lot_of_blocks) {
 
   nodes[0]->getNetwork()->onNewTransactions(std::move(trxs));
   taraxa::thisThreadSleepForSeconds(1);
-  nodes[0]->getNetwork()->sendBlocks(nodes[1]->getNetwork()->getNodeId(), std::move(dag_blocks));
+  nodes[0]->getNetwork()->sendBlocks(nodes[1]->getNetwork()->getNodeId(), std::move(dag_blocks), 1, 1);
 
   std::cout << "Waiting Sync ..." << std::endl;
   wait({30s, 200ms},

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -94,14 +94,7 @@ TEST_F(NetworkTest, transfer_lot_of_blocks) {
     trx_hashes.push_back(trx->getHash());
   }
 
-  // creating lot of non valid blocks just for size
-  for (int i = 0; i < 100; ++i) {
-    DagBlock blk(blk_hash_t(1111 + i), 0, {blk_hash_t(222 + i), blk_hash_t(333 + i), blk_hash_t(444 + i)}, trx_hashes,
-                 sig_t(7777 + i), blk_hash_t(888 + i), addr_t(999 + i));
-    dag_blocks.emplace_back(std::make_shared<DagBlock>(blk));
-  }
-
-  // add one valid as last
+  // add one valid block
   auto dag_genesis = nodes[0]->getConfig().chain.dag_genesis_block.getHash();
   SortitionConfig vdf_config(node_cfgs[0].chain.sortition);
   vdf_sortition::VdfSortition vdf(vdf_config, nodes[0]->getVrfSecretKey(), getRlpBytes(1));
@@ -111,6 +104,13 @@ TEST_F(NetworkTest, transfer_lot_of_blocks) {
 
   auto block_hash = blk.getHash();
   dag_blocks.emplace_back(std::make_shared<DagBlock>(blk));
+
+  // creating lot of non valid blocks just for size
+  for (int i = 0; i < 100; ++i) {
+    DagBlock blk(blk_hash_t(1111 + i), 0, {blk_hash_t(222 + i), blk_hash_t(333 + i), blk_hash_t(444 + i)}, trx_hashes,
+                 sig_t(7777 + i), blk_hash_t(888 + i), addr_t(999 + i));
+    dag_blocks.emplace_back(std::make_shared<DagBlock>(blk));
+  }
 
   nodes[0]->getNetwork()->onNewTransactions(std::move(trxs));
   taraxa::thisThreadSleepForSeconds(1);
@@ -127,7 +127,7 @@ TEST_F(NetworkTest, send_pbft_block) {
   auto nw1 = nodes[0]->getNetwork();
   auto nw2 = nodes[1]->getNetwork();
 
-  auto pbft_block = make_simple_pbft_block(blk_hash_t(1), 2);
+  auto pbft_block = make_simple_pbft_block(blk_hash_t(1), 2, node_cfgs[0].chain.dag_genesis_block.getHash());
   uint64_t chain_size = 111;
 
   nw2->sendPbftBlock(nw1->getNodeId(), pbft_block, chain_size);

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -349,16 +349,16 @@ TEST_F(NetworkTest, node_sync) {
   }
 
   EXPECT_HAPPENS({30s, 500ms}, [&](auto& ctx) {
-    WAIT_EXPECT_EQ(ctx, node1->getDagManager()->getNumVerticesInDag().first, 7)
-    WAIT_EXPECT_EQ(ctx, node1->getDagManager()->getNumEdgesInDag().first, 8)
+    WAIT_EXPECT_LT(ctx, 6, node1->getDagManager()->getNumVerticesInDag().first)
+    WAIT_EXPECT_LT(ctx, 7, node1->getDagManager()->getNumEdgesInDag().first)
   });
 
   auto node2 = create_nodes({node_cfgs[1]}, true /*start*/).front();
 
   std::cout << "Waiting Sync..." << std::endl;
   EXPECT_HAPPENS({45s, 1500ms}, [&](auto& ctx) {
-    WAIT_EXPECT_EQ(ctx, node2->getDagManager()->getNumVerticesInDag().first, 7)
-    WAIT_EXPECT_EQ(ctx, node2->getDagManager()->getNumEdgesInDag().first, 8)
+    WAIT_EXPECT_LT(ctx, 6, node2->getDagManager()->getNumVerticesInDag().first)
+    WAIT_EXPECT_LT(ctx, 7, node2->getDagManager()->getNumEdgesInDag().first)
   });
 }
 

--- a/tests/p2p_test.cpp
+++ b/tests/p2p_test.cpp
@@ -214,6 +214,10 @@ TEST_F(P2PTest, capability_send_block) {
 
   SharedTransactions transactions{g_signed_trx_samples[0], g_signed_trx_samples[1]};
   thc2->onNewTransactions(std::move(transactions));
+  std::vector<taraxa::bytes> transactions_raw;
+  transactions_raw.push_back(*g_signed_trx_samples[0]->rlp());
+  transactions_raw.push_back(*g_signed_trx_samples[1]->rlp());
+  thc2->sendTransactions(host1->id(), transactions_raw);
   thc2->sendBlock(host1->id(), blk, {});
 
   std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -329,6 +333,12 @@ TEST_F(P2PTest, block_propagate) {
   thc1->onNewTransactions(std::move(transactions2));
   thc1->onNewBlockReceived(std::move(blk));
 
+  std::vector<taraxa::bytes> transactions_raw;
+  transactions_raw.push_back(*g_signed_trx_samples[0]->rlp());
+  transactions_raw.push_back(*g_signed_trx_samples[1]->rlp());
+  for (int i = 0; i < nodeCount; i++) {
+    thc1->sendTransactions(vHosts[i]->id(), transactions_raw);
+  }
   for (int i = 0; i < 50; i++) {
     std::this_thread::sleep_for(std::chrono::seconds(1));
     bool synced = true;

--- a/tests/p2p_test.cpp
+++ b/tests/p2p_test.cpp
@@ -214,7 +214,7 @@ TEST_F(P2PTest, capability_send_block) {
 
   SharedTransactions transactions{g_signed_trx_samples[0], g_signed_trx_samples[1]};
   thc2->onNewTransactions(std::move(transactions));
-  thc2->sendBlock(host1->id(), blk);
+  thc2->sendBlock(host1->id(), blk, {});
 
   std::this_thread::sleep_for(std::chrono::seconds(1));
   auto blocks = thc1->test_state_->getBlocks();

--- a/tests/tarcap_threadpool_test.cpp
+++ b/tests/tarcap_threadpool_test.cpp
@@ -200,8 +200,6 @@ TEST_F(TarcapTpTest, block_free_packets) {
                                    createDummyPacketHandler(init_data, "TEST_PH", 20));
   packets_handler->registerHandler(tarcap::SubprotocolPacketType::StatusPacket,
                                    createDummyPacketHandler(init_data, "STATUS_PH", 20));
-  packets_handler->registerHandler(tarcap::SubprotocolPacketType::SyncedPacket,
-                                   createDummyPacketHandler(init_data, "SYNCED_PH", 20));
   packets_handler->registerHandler(tarcap::SubprotocolPacketType::VotePacket,
                                    createDummyPacketHandler(init_data, "VOTE_PH", 20));
   packets_handler->registerHandler(tarcap::SubprotocolPacketType::GetVotesSyncPacket,
@@ -244,11 +242,6 @@ TEST_F(TarcapTpTest, block_free_packets) {
       tp.push(createPacket(init_data.copySender(), tarcap::SubprotocolPacketType::StatusPacket, {})).value();
   const auto packet9_status_id =
       tp.push(createPacket(init_data.copySender(), tarcap::SubprotocolPacketType::StatusPacket, {})).value();
-
-  const auto packet10_synced_id =
-      tp.push(createPacket(init_data.copySender(), tarcap::SubprotocolPacketType::SyncedPacket, {})).value();
-  const auto packet11_synced_id =
-      tp.push(createPacket(init_data.copySender(), tarcap::SubprotocolPacketType::SyncedPacket, {})).value();
 
   const auto packet12_vote_id =
       tp.push(createPacket(init_data.copySender(), tarcap::SubprotocolPacketType::VotePacket, {})).value();
@@ -314,9 +307,6 @@ TEST_F(TarcapTpTest, block_free_packets) {
   const auto packet8_status_proc_info = packets_proc_info->getPacketProcessingTimes(packet8_status_id);
   const auto packet9_status_proc_info = packets_proc_info->getPacketProcessingTimes(packet9_status_id);
 
-  const auto packet10_synced_proc_info = packets_proc_info->getPacketProcessingTimes(packet10_synced_id);
-  const auto packet11_synced_proc_info = packets_proc_info->getPacketProcessingTimes(packet11_synced_id);
-
   const auto packet12_vote_proc_info = packets_proc_info->getPacketProcessingTimes(packet12_vote_id);
   const auto packet13_vote_proc_info = packets_proc_info->getPacketProcessingTimes(packet13_vote_id);
 
@@ -341,8 +331,6 @@ TEST_F(TarcapTpTest, block_free_packets) {
       {packet7_test_proc_info, "packet7_test"},
       {packet8_status_proc_info, "packet8_status"},
       {packet9_status_proc_info, "packet9_status"},
-      {packet10_synced_proc_info, "packet10_synced"},
-      {packet11_synced_proc_info, "packet10_synced"},
       {packet12_vote_proc_info, "packet12_vote"},
       {packet13_vote_proc_info, "packet13_vote"},
       {packet14_get_pbft_next_votes_proc_info, "packet14_get_pbft_next_votes"},

--- a/tests/util_test/util.hpp
+++ b/tests/util_test/util.hpp
@@ -282,8 +282,8 @@ inline auto own_effective_genesis_bal(FullNodeConfig const& cfg) {
   return cfg.chain.final_chain.state.effective_genesis_balance(dev::toAddress(dev::Secret(cfg.node_secret)));
 }
 
-inline auto make_simple_pbft_block(h256 const& hash, uint64_t period) {
-  return PbftBlock(hash, blk_hash_t(0), blk_hash_t(), period, addr_t(0), secret_t::random());
+inline auto make_simple_pbft_block(h256 const& hash, uint64_t period, h256 const& anchor_hash = blk_hash_t(0)) {
+  return PbftBlock(hash, anchor_hash, blk_hash_t(), period, addr_t(0), secret_t::random());
 }
 
 inline std::vector<blk_hash_t> getOrderedDagBlocks(std::shared_ptr<DbStorage> const& db) {


### PR DESCRIPTION
This PR is missing a more consistent and comprehensive handling of malicious nodes which I believe is another large task that needs to be done. As part of this PR I have left a lot of TODO: for places where such malicious node handling might be needed. 

Changes are:

**PBFT syncing**

Pbft manager no longer controls the syncing process. Status messages are used for restarting pbft syncing if needed. Previously a lot of time restartSyncing was called in cases where there was no need for it. Pbft syncing is started only if:
1. There is a node at least 2 pbft periods ahead
2. There is a node 1 pbft period ahead for the same period for two consecutive status messages  


**DAG syncing**

DAG syncing is refactored and simplified:
Each connected peer will request all the missing DAG blocks level from a connected peer in only one of these two cases:
1. On connecting if the pbft periods of both nodes are matching
2. On receiving a first dag block with mising tip/pivot if node is pbft synced

This request can only be performed once. After this is performed it is expected that nodes are DAG synced. If after this sync, another block with missing tip/pivot is received a node is disconnected.

Main difference to what we had before is that there is no global dag_syncing flag anymore. We are now ensuring dag syncing state between each connected peer. As long as this is true DAG gossiping should work without any missing tip/pivot errors.


