### PR TITLE
fix: syncing stall

### DIFF
--- a/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
@@ -73,6 +73,7 @@ void PbftSyncPacketHandler::process(const PacketData &packet_data, const std::sh
   if (sync_block.pbft_blk->getPeriod() != pbft_mgr_->pbftSyncingPeriod() + 1) {
     LOG(log_dg_) << "Block " << pbft_blk_hash << " period unexpected: " << sync_block.pbft_blk->getPeriod()
                  << ". Expected period: " << pbft_mgr_->pbftSyncingPeriod() + 1;
+    restartSyncingPbft(true);
     return;
   }
   // Update peer's pbft period if outdated


### PR DESCRIPTION
This condition happens often if one block behind and at the same time a pbft block is pushed by pbft consensus and syncing at the same time. Unless restartSyincingPbft is called, node gets stuck in syncing state.