### PR TITLE
chore: check stale block proposal by frontier

### DIFF
--- a/libraries/core_libs/consensus/include/pbft/block_proposer.hpp
+++ b/libraries/core_libs/consensus/include/pbft/block_proposer.hpp
@@ -55,7 +55,7 @@ class SortitionPropose : public ProposeModelFace {
  private:
   int num_tries_ = 0;
   int max_num_tries_ = 20;  // Wait 2000(ms)
-  level_t last_propose_level_ = 0;
+  DagFrontier last_frontier_;
   std::shared_ptr<DagManager> dag_mgr_;
   std::shared_ptr<DagBlockManager> dag_blk_mgr_;
   std::shared_ptr<TransactionManager> trx_mgr_;

--- a/libraries/types/dag_block/include/dag/dag_block.hpp
+++ b/libraries/types/dag_block/include/dag/dag_block.hpp
@@ -97,21 +97,11 @@ struct DagFrontier {
   }
 
   bool isEqual(const DagFrontier &frontier) {
-    if (pivot == frontier.pivot && tips.size() == frontier.tips.size()) {
-      bool tips_changed = false;
-      for (uint32_t i = 0; i < tips.size(); i++) {
-        if (tips[i] != frontier.tips[i]) {
-          tips_changed = true;
-          break;
-        }
-      }
-      if (tips_changed) {
-        return false;
-      }
-    } else {
+    if (pivot != frontier.pivot) {
       return false;
     }
-    return true;
+
+    return std::equal(tips.begin(), tips.end(), frontier.tips.begin(), frontier.tips.end());
   }
 
   blk_hash_t pivot;

--- a/libraries/types/dag_block/include/dag/dag_block.hpp
+++ b/libraries/types/dag_block/include/dag/dag_block.hpp
@@ -95,6 +95,25 @@ struct DagFrontier {
     pivot.clear();
     tips.clear();
   }
+
+  bool isEqual(const DagFrontier &frontier) {
+    if (pivot == frontier.pivot && tips.size() == frontier.tips.size()) {
+      bool tips_changed = false;
+      for (uint32_t i = 0; i < tips.size(); i++) {
+        if (tips[i] != frontier.tips[i]) {
+          tips_changed = true;
+          break;
+        }
+      }
+      if (tips_changed) {
+        return false;
+      }
+    } else {
+      return false;
+    }
+    return true;
+  }
+
   blk_hash_t pivot;
   vec_blk_t tips;
 };


### PR DESCRIPTION
Use frontier(pivot and tips) for stale block selection. Using proposal period as before, stale block would be computed even if new blocks appear on the network.