### PR TITLE
fix: dag sync

### DIFF
--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_syncing_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_syncing_packet_handler.hpp
@@ -45,7 +45,7 @@ class ExtSyncingPacketHandler : public PacketHandler {
   std::pair<bool, std::unordered_set<blk_hash_t>> checkDagBlockValidation(const DagBlock &block) const;
 
  private:
-  void requestPendingDagBlocks();
+  void requestPendingDagBlocks(const dev::p2p::NodeID &node_id);
 
  protected:
   std::shared_ptr<SyncingState> syncing_state_{nullptr};

--- a/libraries/core_libs/network/src/tarcap/shared_states/syncing_state.cpp
+++ b/libraries/core_libs/network/src/tarcap/shared_states/syncing_state.cpp
@@ -38,7 +38,7 @@ void SyncingState::set_pbft_syncing(bool syncing, uint64_t current_period,
                                     std::shared_ptr<TaraxaPeer> peer /*=nullptr*/) {
   assert((syncing && peer) || !syncing);
   pbft_syncing_ = syncing;
-  peer_ = std::move(peer);
+  set_peer(std::move(peer));
 
   if (syncing) {
     std::shared_lock lock(peer_mutex_);


### PR DESCRIPTION
requestPendingDagBlocks was not getting the correct node id to send the request for dag blocks because of a race condition in setting the syncing peer