### PR TITLE
chore: optimize dag sync

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(TARAXA_PATCH_VERSION 0)
 set(TARAXA_VERSION ${TARAXA_MAJOR_VERSION}.${TARAXA_MINOR_VERSION}.${TARAXA_PATCH_VERSION})
 
 # Any time a change in the network protocol is introduced this version should be increased
-set(TARAXA_NET_VERSION 18)
+set(TARAXA_NET_VERSION 19)
 # Major version is modified when DAG blocks, pbft blocks and any basic building blocks of our blockchan is modified
 # in the db
 set(TARAXA_DB_MAJOR_VERSION 2)

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -208,6 +208,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   // Transaction
   void saveTransaction(Transaction const& trx, bool verified = false);
   std::shared_ptr<Transaction> getTransaction(trx_hash_t const& hash);
+  std::vector<std::shared_ptr<Transaction>> getTransactions(std::vector<trx_hash_t> const& trx_hashes);
   SharedTransactions getNonfinalizedTransactions();
   bool transactionInDb(trx_hash_t const& hash);
   bool transactionFinalized(trx_hash_t const& hash);


### PR DESCRIPTION
On dag sync requests, eliminate sending duplicate transactions and transactions that are already finalized. Get transactions from db in a batch query only from column containing non-finalized transactions.