### PR TITLE
Exponential backoff testnet

### DIFF
--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -169,6 +169,7 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   u_long const LAMBDA_ms_MIN;
   u_long LAMBDA_ms = 0;
   u_long LAMBDA_backoff_multiple = 1;
+  const u_long kMaxLambda = 3600000;  // in ms, max lambda is 1 hour
 
   std::default_random_engine random_engine_{std::random_device{}()};
 

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -328,8 +328,8 @@ void PbftManager::setPbftStep(size_t const pbft_step) {
     std::uniform_int_distribution<u_long> distribution(0, step_ - MAX_STEPS);
     auto lambda_random_count = distribution(random_engine_);
     LAMBDA_backoff_multiple = 2 * LAMBDA_backoff_multiple;
-    LAMBDA_ms = LAMBDA_ms_MIN * (LAMBDA_backoff_multiple + lambda_random_count);
-    LOG(log_si_) << "Surpassed max steps, exponentially backing off lambda to " << LAMBDA_ms << " ms in round "
+    LAMBDA_ms = std::min(kMaxLambda, LAMBDA_ms_MIN * (LAMBDA_backoff_multiple + lambda_random_count));
+    LOG(log_dg_) << "Surpassed max steps, exponentially backing off lambda to " << LAMBDA_ms << " ms in round "
                  << getPbftRound() << ", step " << step_;
   } else {
     LAMBDA_ms = LAMBDA_ms_MIN;

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -325,12 +325,12 @@ void PbftManager::setPbftStep(size_t const pbft_step) {
   if (step_ > MAX_STEPS && LAMBDA_backoff_multiple < 8) {
     // Note: We calculate the lambda for a step independently of prior steps
     //       in case missed earlier steps.
-    // std::uniform_int_distribution<u_long> distribution(0, step_ - MAX_STEPS);
-    // auto lambda_random_count = distribution(random_engine_);
-    // LAMBDA_backoff_multiple = 2 * LAMBDA_backoff_multiple;
-    // LAMBDA_ms = LAMBDA_ms_MIN * (LAMBDA_backoff_multiple + lambda_random_count);
-    // LOG(log_si_) << "Surpassed max steps, exponentially backing off lambda to " << LAMBDA_ms << " ms in round "
-    //             << getPbftRound() << ", step " << step_;
+    std::uniform_int_distribution<u_long> distribution(0, step_ - MAX_STEPS);
+    auto lambda_random_count = distribution(random_engine_);
+    LAMBDA_backoff_multiple = 2 * LAMBDA_backoff_multiple;
+    LAMBDA_ms = LAMBDA_ms_MIN * (LAMBDA_backoff_multiple + lambda_random_count);
+    LOG(log_si_) << "Surpassed max steps, exponentially backing off lambda to " << LAMBDA_ms << " ms in round "
+                 << getPbftRound() << ", step " << step_;
   } else {
     LAMBDA_ms = LAMBDA_ms_MIN;
     LAMBDA_backoff_multiple = 1;


### PR DESCRIPTION
Hi @justinsnapp, as your request, I cherry pick the PBFT exponential backoff and generate PR for Testnet branch.
In our case, for example like one node CN4 down many hours and cause PBFT stalled. Then restart CN4 and want to catch up with others nodes steps. This cannot help, and may need take longer time.

The benefits: could save space for many votes when PBFT stalled
The disadvantage: when more than 1/3 weighted nodes down, and restart nodes want to catch up. That may take longer time because votes not send often as before (in old approach, send out 2 votes every 2 seconds for each node)