### PR TITLE
Improved discovery

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,7 @@ commands:
         - run:
            name: Get repo and install helm/kubectl
            command: |
-              git clone --branch development https://github.com/Taraxa-project/taraxa-testnet.git
+              git clone --branch enable-nat-traversal https://github.com/Taraxa-project/taraxa-testnet.git
               mkdir -p $HOME/.kube
               echo -n "<< parameters.kubeconfig >>" | base64 --decode > $HOME/.kube/config
               curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
@@ -583,7 +583,7 @@ jobs:
          command: |
             if [[ ${PR} != "false" ]];then
               docker push ${GCP_IMAGE}:${DOCKER_BRANCH_TAG}-${CIRCLE_BUILD_NUM}
-              git clone --branch development https://github.com/Taraxa-project/taraxa-testnet.git
+              git clone --branch enable-nat-traversal https://github.com/Taraxa-project/taraxa-testnet.git
               mkdir -p $HOME/.kube
               echo -n "${KUBE_CONFIG}" | base64 --decode > $HOME/.kube/config
               curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash

--- a/libraries/aleth/libp2p/NodeTable.cpp
+++ b/libraries/aleth/libp2p/NodeTable.cpp
@@ -354,6 +354,10 @@ void NodeTable::dropNode(shared_ptr<NodeEntry> _n) {
   }
 
   DEV_GUARDED(x_nodes) { m_allNodes.erase(_n->id()); }
+  DEV_GUARDED(x_ips) {
+    m_ipMappings.erase(m_id2IpMap[_n->id()]);
+    m_id2IpMap.erase(_n->id());
+  }
 
   // notify host
   LOG(m_logger) << "p2p.nodes.drop " << _n->id();
@@ -363,49 +367,55 @@ void NodeTable::dropNode(shared_ptr<NodeEntry> _n) {
 NodeTable::NodeBucket& NodeTable::bucket_UNSAFE(NodeEntry const* _n) { return m_buckets[_n->distance - 1]; }
 
 void NodeTable::onPacketReceived(UDPSocketFace*, bi::udp::endpoint const& _from, bytesConstRef _packet) {
+  auto node_ip = _from;
+  {
+    Guard l(x_ips);
+    if (m_ipMappings.contains(_from)) {
+      node_ip = m_ipMappings[_from];
+    }
+  }
   try {
-    unique_ptr<DiscoveryDatagram> packet = DiscoveryDatagram::interpretUDP(_from, _packet);
+    unique_ptr<DiscoveryDatagram> packet = DiscoveryDatagram::interpretUDP(node_ip, _packet);
     if (!packet) return;
     if (packet->isExpired()) {
-      LOG(m_logger) << "Expired " << packet->typeName() << " from " << packet->sourceid << "@" << _from;
+      LOG(m_logger) << "Expired " << packet->typeName() << " from " << packet->sourceid << "@" << node_ip;
       return;
     }
-
-    LOG(m_logger) << packet->typeName() << " from " << packet->sourceid << "@" << _from;
+    LOG(m_logger) << packet->typeName() << " from " << packet->sourceid << "@" << node_ip;
 
     shared_ptr<NodeEntry> sourceNodeEntry;
     switch (packet->packetType()) {
       case Pong::type:
-        sourceNodeEntry = handlePong(_from, *packet);
+        sourceNodeEntry = handlePong(node_ip, *packet);
         break;
 
       case Neighbours::type:
-        sourceNodeEntry = handleNeighbours(_from, *packet);
+        sourceNodeEntry = handleNeighbours(node_ip, *packet);
         break;
 
       case FindNode::type:
-        sourceNodeEntry = handleFindNode(_from, *packet);
+        sourceNodeEntry = handleFindNode(node_ip, *packet);
         break;
 
       case PingNode::type:
-        sourceNodeEntry = handlePingNode(_from, *packet);
+        sourceNodeEntry = handlePingNode(node_ip, *packet);
         break;
 
       case ENRRequest::type:
-        sourceNodeEntry = handleENRRequest(_from, *packet);
+        sourceNodeEntry = handleENRRequest(node_ip, *packet);
         break;
 
       case ENRResponse::type:
-        sourceNodeEntry = handleENRResponse(_from, *packet);
+        sourceNodeEntry = handleENRResponse(node_ip, *packet);
         break;
     }
 
     if (sourceNodeEntry) noteActiveNode(move(sourceNodeEntry));
   } catch (exception const& _e) {
-    LOG(m_logger) << "Exception processing message from " << _from.address().to_string() << ":" << _from.port() << ": "
-                  << _e.what();
+    LOG(m_logger) << "Exception processing message from " << node_ip.address().to_string() << ":" << node_ip.port()
+                  << ": " << _e.what();
   } catch (...) {
-    LOG(m_logger) << "Exception processing message from " << _from.address().to_string() << ":" << _from.port();
+    LOG(m_logger) << "Exception processing message from " << node_ip.address().to_string() << ":" << node_ip.port();
   }
 }
 
@@ -543,7 +553,17 @@ std::shared_ptr<NodeEntry> NodeTable::handleFindNode(bi::udp::endpoint const& _f
 NodeIPEndpoint NodeTable::getSourceEndpoint(bi::udp::endpoint const& from, PingNode const& packet) {
   if (from.address() != packet.source.address() && !isLocalHostAddress(packet.source.address())) {
     if (isPrivateAddress(from.address()) && !isPrivateAddress(packet.source.address())) {
-      return {packet.source.address(), packet.source.udpPort(), packet.source.tcpPort()};
+      Guard l(x_ips);
+      if (m_id2IpMap.contains(packet.sourceid)) {
+        if (m_id2IpMap[packet.sourceid] != from) {
+          m_ipMappings.erase(m_id2IpMap[packet.sourceid]);
+          m_id2IpMap[packet.sourceid] = from;
+        }
+      } else {
+        m_id2IpMap[packet.sourceid] = from;
+      }
+      m_ipMappings[from] = {packet.source.address(), packet.source.udpPort(), packet.source.tcpPort()};
+      return m_ipMappings[from];
     }
   }
   return {from.address(), from.port(), packet.source.tcpPort()};
@@ -565,7 +585,7 @@ std::shared_ptr<NodeEntry> NodeTable::handlePingNode(bi::udp::endpoint const& _f
 
   // Send PONG response.
   Pong p(sourceEndpoint);
-  LOG(m_logger) << p.typeName() << " to " << in.sourceid << "@" << _from;
+  LOG(m_logger) << p.typeName() << " to " << in.sourceid << "@" << sourceEndpoint;
   p.expiration = nextRequestExpirationTime();
   p.echo = in.echo;
   p.seq = m_hostENR.sequenceNumber();

--- a/libraries/aleth/libp2p/NodeTable.h
+++ b/libraries/aleth/libp2p/NodeTable.h
@@ -354,6 +354,12 @@ class NodeTable : UDPSocketEvents {
   mutable Mutex x_state;  ///< LOCK x_state first if both x_nodes and x_state
                           ///< locks are required.
 
+  /// This map is used for maping between node id and real network IP
+  std::unordered_map<NodeID, bi::udp::endpoint> m_id2IpMap;
+  /// This map keeps tracking between real IP and IP reported by node (external IP)
+  std::unordered_map<bi::udp::endpoint, NodeIPEndpoint> m_ipMappings;
+  mutable Mutex x_ips;
+
   /// State of p2p node network. Only includes nodes for which we've completed
   /// the endpoint proof
   std::array<NodeBucket, s_bins> m_buckets;

--- a/libraries/aleth/libp2p/NodeTable.h
+++ b/libraries/aleth/libp2p/NodeTable.h
@@ -60,6 +60,7 @@ inline std::ostream& operator<<(std::ostream& _out, NodeTable const& _nodeTable)
 
 struct NodeEntry;
 struct DiscoveryDatagram;
+struct PingNode;
 
 /**
  * NodeTable using modified kademlia for node discovery and preference.
@@ -324,6 +325,8 @@ class NodeTable : UDPSocketEvents {
   bool isAllowedEndpoint(NodeIPEndpoint const& _endpointToCheck) const {
     return dev::p2p::isAllowedEndpoint(m_allowLocalDiscovery, _endpointToCheck);
   }
+
+  NodeIPEndpoint getSourceEndpoint(bi::udp::endpoint const& from, PingNode const& packet);
 
   ba::strand<ba::io_context::executor_type> strand_;
 

--- a/libraries/cli/include/cli/config.hpp
+++ b/libraries/cli/include/cli/config.hpp
@@ -46,6 +46,7 @@ class Config {
   static constexpr const char* VRF_COMMAND = "vrf";
   static constexpr const char* CONFIG_COMMAND = "config";
   static constexpr const char* BOOT_NODES = "boot-nodes";
+  static constexpr const char* PUBLIC_IP = "public-ip";
   static constexpr const char* LOG_CHANNELS = "log-channels";
   static constexpr const char* BOOT_NODES_APPEND = "boot-nodes-append";
   static constexpr const char* LOG_CHANNELS_APPEND = "log-channels-append";

--- a/libraries/cli/include/cli/default_config.hpp
+++ b/libraries/cli/include/cli/default_config.hpp
@@ -5,7 +5,7 @@ const char *default_json = R"foo({
   "vrf_secret": "",
   "data_path": "",
   "network_is_boot_node": false,
-  "network_address": "0.0.0.0",
+  "network_listen_ip": "0.0.0.0",
   "network_tcp_port": 10002,
   "network_udp_port": 10002,
   "network_simulated_delay": 0,

--- a/libraries/cli/include/cli/devnet_config.hpp
+++ b/libraries/cli/include/cli/devnet_config.hpp
@@ -5,7 +5,7 @@ const char *devnet_json = R"foo({
   "vrf_secret": "",
   "data_path": "",
   "network_is_boot_node": false,
-  "network_address": "0.0.0.0",
+  "network_listen_ip": "0.0.0.0",
   "network_tcp_port": 10002,
   "network_udp_port": 10002,
   "network_simulated_delay": 0,

--- a/libraries/cli/include/cli/testnet_config.hpp
+++ b/libraries/cli/include/cli/testnet_config.hpp
@@ -5,7 +5,7 @@ const char *testnet_json = R"foo({
   "vrf_secret": "",
   "data_path": "",
   "network_is_boot_node": false,
-  "network_address": "0.0.0.0",
+  "network_listen_ip": "0.0.0.0",
   "network_tcp_port": 10002,
   "network_udp_port": 10002,
   "network_simulated_delay": 0,

--- a/libraries/cli/src/config.cpp
+++ b/libraries/cli/src/config.cpp
@@ -21,6 +21,7 @@ Config::Config(int argc, const char* argv[]) {
   string data_dir;
   vector<string> command;
   vector<string> boot_nodes;
+  string public_ip;
   vector<string> log_channels;
   vector<string> boot_nodes_append;
   vector<string> log_channels_append;
@@ -88,6 +89,8 @@ Config::Config(int argc, const char* argv[]) {
   node_command_options.add_options()(
       BOOT_NODES_APPEND, bpo::value<vector<string>>(&boot_nodes_append)->multitoken(),
       "Boot nodes to connect to in addition to boot nodes defined in config: [ip_address:port_number/node_id, ....]");
+  node_command_options.add_options()(PUBLIC_IP, bpo::value<string>(&public_ip),
+                                     "Force advertised public IP to the given IP (default: auto)");
   node_command_options.add_options()(LOG_CHANNELS, bpo::value<vector<string>>(&log_channels)->multitoken(),
                                      "Log channels to log: [channel:level, ....]");
   node_command_options.add_options()(
@@ -184,6 +187,9 @@ Config::Config(int argc, const char* argv[]) {
     }
     if (rebuild_network) {
       fs::remove_all(node_config_.net_file_path());
+    }
+    if (!public_ip.empty()) {
+      node_config_.network.network_public_ip = public_ip;
     }
     node_config_.test_params.db_revert_to_period = revert_to_period;
     node_config_.test_params.rebuild_db = rebuild_db;

--- a/libraries/config/include/config/config.hpp
+++ b/libraries/config/include/config/config.hpp
@@ -29,7 +29,8 @@ struct NodeConfig {
 struct NetworkConfig {
   std::string json_file_name;
   bool network_is_boot_node = 0;
-  std::string network_address;
+  std::string network_public_ip;
+  std::string network_listen_ip;
   uint16_t network_tcp_port = 0;
   std::vector<NodeConfig> network_boot_nodes;
   uint16_t network_simulated_delay = 0;

--- a/libraries/config/src/config.cpp
+++ b/libraries/config/src/config.cpp
@@ -23,10 +23,19 @@ Json::Value getConfigData(Json::Value root, std::vector<string> const &path, boo
   return root;
 }
 
-std::string getConfigDataAsString(Json::Value const &root, std::vector<string> const &path) {
+std::string getConfigDataAsString(Json::Value const &root, std::vector<string> const &path, bool optional = false,
+                                  std::string value = {}) {
   try {
-    return getConfigData(root, path).asString();
+    Json::Value ret = getConfigData(root, path, optional);
+    if (ret.isNull()) {
+      return value;
+    } else {
+      return ret.asString();
+    }
   } catch (Json::Exception &e) {
+    if (optional) {
+      return value;
+    }
     throw ConfigException(getConfigErr(path) + e.what());
   }
 }
@@ -95,7 +104,8 @@ FullNodeConfig::FullNodeConfig(Json::Value const &string_or_object, Json::Value 
   if (auto n = getConfigData(root, {"network_is_boot_node"}, true); !n.isNull()) {
     network.network_is_boot_node = n.asBool();
   }
-  network.network_address = getConfigDataAsString(root, {"network_address"});
+  network.network_listen_ip = getConfigDataAsString(root, {"network_listen_ip"});
+  network.network_public_ip = getConfigDataAsString(root, {"network_public_ip"}, true);
   network.network_tcp_port = getConfigDataAsUInt(root, {"network_tcp_port"});
   network.network_simulated_delay = getConfigDataAsUInt(root, {"network_simulated_delay"});
   network.network_performance_log_interval =
@@ -121,7 +131,7 @@ FullNodeConfig::FullNodeConfig(Json::Value const &string_or_object, Json::Value 
     rpc = RpcConfig();
 
     // ip address
-    rpc->address = boost::asio::ip::address::from_string(network.network_address);
+    rpc->address = boost::asio::ip::address::from_string(network.network_listen_ip);
 
     // http port
     if (auto http_port = getConfigData(rpc_config, {"http_port"}, true); !http_port.isNull()) {
@@ -266,7 +276,8 @@ std::ostream &operator<<(std::ostream &strm, NetworkConfig const &conf) {
   strm << "[Network Config] " << std::endl;
   strm << "  json_file_name: " << conf.json_file_name << std::endl;
   strm << "  network_is_boot_node: " << conf.network_is_boot_node << std::endl;
-  strm << "  network_address: " << conf.network_address << std::endl;
+  strm << "  network_listen_ip: " << conf.network_listen_ip << std::endl;
+  strm << "  network_public_ip: " << conf.network_public_ip << std::endl;
   strm << "  network_tcp_port: " << conf.network_tcp_port << std::endl;
   strm << "  network_simulated_delay: " << conf.network_simulated_delay << std::endl;
   strm << "  network_transaction_interval: " << conf.network_transaction_interval << std::endl;

--- a/libraries/core_libs/network/src/network.cpp
+++ b/libraries/core_libs/network/src/network.cpp
@@ -20,12 +20,12 @@ Network::Network(NetworkConfig const &config, std::filesystem::path const &netwo
 
   // TODO make all these properties configurable
   dev::p2p::NetworkConfig net_conf;
-  net_conf.listenIPAddress = conf_.network_address;
+  net_conf.listenIPAddress = conf_.network_listen_ip;
   net_conf.listenPort = conf_.network_tcp_port;
   net_conf.discovery = true;
   net_conf.allowLocalDiscovery = true;
   net_conf.traverseNAT = false;
-  net_conf.publicIPAddress = {};
+  net_conf.publicIPAddress = conf_.network_public_ip;
   net_conf.pin = false;
   dev::p2p::TaraxaNetworkConfig taraxa_net_conf;
   taraxa_net_conf.ideal_peer_count = conf_.network_ideal_peer_count;
@@ -63,7 +63,7 @@ Network::~Network() {
 void Network::start() {
   tp_.start();
   taraxa_capability_->start();
-  LOG(log_nf_) << "Started Network address: " << conf_.network_address << ":" << conf_.network_tcp_port << std::endl;
+  LOG(log_nf_) << "Started Network address: " << conf_.network_listen_ip << ":" << conf_.network_tcp_port << std::endl;
   LOG(log_nf_) << "Started Node id: " << host_->id();
 }
 

--- a/tests/util_test/conf/conf_taraxa1.json
+++ b/tests/util_test/conf/conf_taraxa1.json
@@ -1,7 +1,7 @@
 {
   "data_path": "/tmp/taraxa",
   "network_is_boot_node": true,
-  "network_address": "0.0.0.0",
+  "network_listen_ip": "0.0.0.0",
   "network_tcp_port": 10007,
   "network_udp_port": 10007,
   "network_simulated_delay": 0,

--- a/tests/util_test/conf/conf_taraxa2.json
+++ b/tests/util_test/conf/conf_taraxa2.json
@@ -1,6 +1,6 @@
 {
   "data_path": "/tmp/taraxa2",
-  "network_address": "127.0.0.1",
+  "network_listen_ip": "127.0.0.1",
   "network_tcp_port": 10003,
   "network_udp_port": 10003,
   "network_simulated_delay": 0,

--- a/tests/util_test/conf/conf_taraxa3.json
+++ b/tests/util_test/conf/conf_taraxa3.json
@@ -1,6 +1,6 @@
 {
   "data_path": "/tmp/taraxa3",
-  "network_address": "127.0.0.1",
+  "network_listen_ip": "127.0.0.1",
   "network_tcp_port": 10004,
   "network_udp_port": 10004,
   "network_simulated_delay": 0,

--- a/tests/util_test/conf/conf_taraxa4.json
+++ b/tests/util_test/conf/conf_taraxa4.json
@@ -1,6 +1,6 @@
 {
   "data_path": "/tmp/taraxa4",
-  "network_address": "127.0.0.1",
+  "network_listen_ip": "127.0.0.1",
   "network_tcp_port": 10005,
   "network_udp_port": 10005,
   "network_simulated_delay": 0,

--- a/tests/util_test/conf/conf_taraxa5.json
+++ b/tests/util_test/conf/conf_taraxa5.json
@@ -1,6 +1,6 @@
 {
   "data_path": "/tmp/taraxa5",
-  "network_address": "127.0.0.1",
+  "network_listen_ip": "127.0.0.1",
   "network_tcp_port": 10006,
   "network_udp_port": 10006,
   "network_simulated_delay": 0,


### PR DESCRIPTION
So idea is that node can report different IP (external IP), that should be use for discovery. I implemented basic mappings that will keep track of node ID and it's real ip (this could change) and real IP with external IP, so we know what should we report to the rest of the network 