### PR TITLE
fix: dag sync deadlock

### DIFF
--- a/libraries/core_libs/consensus/include/dag/dag.hpp
+++ b/libraries/core_libs/consensus/include/dag/dag.hpp
@@ -28,6 +28,9 @@
 #include "pbft/pbft_chain.hpp"
 #include "storage/storage.hpp"
 #include "transaction_manager/transaction_manager.hpp"
+namespace taraxa::network::tarcap {
+class TaraxaPeer;
+}
 namespace taraxa {
 
 /**
@@ -164,6 +167,16 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
   }
 
   const std::pair<uint64_t, std::map<uint64_t, std::vector<blk_hash_t>>> getNonFinalizedBlocks() const;
+
+  /**
+   * @brief Sends non finalized dag blocks excluding the known block to the peer
+   *
+   * @param blocks_hashes Blocks known to the peer
+   * @param peer Peer to send the blocks to
+   * @param peer_period Peer period
+   */
+  void sendNonFinalizedBlocks(std::unordered_set<blk_hash_t> &&blocks_hashes,
+                              const std::shared_ptr<network::tarcap::TaraxaPeer> &peer, uint64_t peer_period);
 
   DagFrontier getDagFrontier();
 

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
@@ -74,9 +74,6 @@ class TaraxaPeer : public boost::noncopyable {
   std::atomic_bool peer_dag_synced_ = false;
   std::atomic_bool peer_dag_syncing_ = false;
 
-  // Mutex used to prevent race condition between dag syncing and gossiping
-  mutable boost::shared_mutex mutex_for_sending_dag_blocks_;
-
  private:
   dev::p2p::NodeID id_;
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/dag_block_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/dag_block_packet_handler.cpp
@@ -74,9 +74,6 @@ void DagBlockPacketHandler::sendBlock(dev::p2p::NodeID const &peer_id, taraxa::D
     return;
   }
 
-  // This lock prevents race condition between syncing and gossiping dag blocks
-  std::unique_lock lock(peer->mutex_for_sending_dag_blocks_);
-
   SharedTransactions transactions_to_send;
   for (const auto &trx : trxs) {
     if (peer->isTransactionKnown(trx->getHash())) {


### PR DESCRIPTION
On devnet one of the nodes experienced a deadlock which blocked some of the threads and the process ran out of memory.
This was caused by DagManager::mutex_ and TaraxaPeer::mutex_for_sending_dag_blocks_ mutexes which were invoked in reverse order on gossiping the blocks compared to syncing dag blocks.

I have refactored this code that the functionality of both mutexes is now handled by mutex in DagManager and mutex_for_sending_dag_blocks_ is no longer needed. The purpose of mutex in DagManager now is:
1. Protect any multi threaded access to DagManager class members
2. Ensures that dag blocks are added into DAG in correct order
3. Ensures that dag blocks are gossiped in the correct order (pivot/tip is always sent before the block) 
4. Ensures that any dag syncing request is processed and sent out before any new dag block is gossiped - prevent race condition between gossiping and syncing