### PR TITLE
chore: improve logging

### DIFF
--- a/libraries/cli/include/cli/default_config.hpp
+++ b/libraries/cli/include/cli/default_config.hpp
@@ -42,30 +42,6 @@ const char *default_json = R"foo({
         "verbosity": "ERROR",
         "channels": [
           {
-            "name": "DAG_BLOCK_PH",
-            "verbosity": "INFO"
-          },{
-            "name": "DAG_SYNC_PH",
-            "verbosity": "INFO"
-          },{
-            "name": "GET_DAG_SYNC_PH",
-            "verbosity": "INFO"
-          },{
-            "name": "GET_PBFT_SYNC_PH",
-            "verbosity": "INFO"
-          },{
-            "name": "PBFT_BLOCK_PH",
-            "verbosity": "INFO"
-          },{
-            "name": "TRANSACTION_PH",
-            "verbosity": "INFO"
-          },{
-            "name": "DAGBLKMGR",
-            "verbosity": "INFO"
-          },{
-            "name": "DAGMGR",
-            "verbosity": "INFO"
-          },{
             "name": "SUMMARY",
             "verbosity": "INFO"
           }

--- a/libraries/cli/include/cli/default_config.hpp
+++ b/libraries/cli/include/cli/default_config.hpp
@@ -42,6 +42,30 @@ const char *default_json = R"foo({
         "verbosity": "ERROR",
         "channels": [
           {
+            "name": "DAG_BLOCK_PH",
+            "verbosity": "INFO"
+          },{
+            "name": "DAG_SYNC_PH",
+            "verbosity": "INFO"
+          },{
+            "name": "GET_DAG_SYNC_PH",
+            "verbosity": "INFO"
+          },{
+            "name": "GET_PBFT_SYNC_PH",
+            "verbosity": "INFO"
+          },{
+            "name": "PBFT_BLOCK_PH",
+            "verbosity": "INFO"
+          },{
+            "name": "TRANSACTION_PH",
+            "verbosity": "INFO"
+          },{
+            "name": "DAGBLKMGR",
+            "verbosity": "INFO"
+          },{
+            "name": "DAGMGR",
+            "verbosity": "INFO"
+          },{
             "name": "SUMMARY",
             "verbosity": "INFO"
           }

--- a/libraries/core_libs/consensus/include/transaction_manager/transaction_manager.hpp
+++ b/libraries/core_libs/consensus/include/transaction_manager/transaction_manager.hpp
@@ -53,6 +53,14 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
   uint32_t insertBroadcastedTransactions(const SharedTransactions &txs);
 
   /**
+   * @brief Checks the cache if transaction is already seen
+   *
+   * @param trx_hash transaction hash
+   * @return true if seen
+   */
+  bool transactionSeen(const trx_hash_t &trx_hash);
+
+  /**
    * Returns a copy of transactions pool
    */
   SharedTransactions getTransactionsSnapShot() const;

--- a/libraries/core_libs/consensus/include/transaction_manager/transaction_manager.hpp
+++ b/libraries/core_libs/consensus/include/transaction_manager/transaction_manager.hpp
@@ -58,7 +58,7 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
    * @param trx_hash transaction hash
    * @return true if seen
    */
-  bool transactionSeen(const trx_hash_t &trx_hash);
+  bool transactionSeen(const trx_hash_t &trx_hash) const;
 
   /**
    * Returns a copy of transactions pool

--- a/libraries/core_libs/consensus/src/dag/dag.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag.cpp
@@ -339,13 +339,13 @@ bool DagManager::pivotAndTipsAvailable(DagBlock const &blk) {
   auto dag_blk_pivot = blk.getPivot();
 
   if (!db_->dagBlockInDb(dag_blk_pivot)) {
-    LOG(log_dg_) << "DAG Block " << dag_blk_hash << " pivot " << dag_blk_pivot << " unavailable";
+    LOG(log_nf_) << "DAG Block " << dag_blk_hash << " pivot " << dag_blk_pivot << " unavailable";
     return false;
   }
 
   for (auto const &t : blk.getTips()) {
     if (!db_->dagBlockInDb(t)) {
-      LOG(log_dg_) << "DAG Block " << dag_blk_hash << " tip " << t << " unavailable";
+      LOG(log_nf_) << "DAG Block " << dag_blk_hash << " tip " << t << " unavailable";
       return false;
     }
   }
@@ -453,7 +453,7 @@ void DagManager::addDagBlock(DagBlock const &blk, SharedTransactions &&trxs, boo
       }
     }
   }
-  LOG(log_dg_) << " Update frontier after adding block " << blk.getHash() << "anchor " << anchor_
+  LOG(log_nf_) << " Update frontier after adding block " << blk.getHash() << "anchor " << anchor_
                << " pivot = " << frontier_.pivot << " tips: " << frontier_.tips;
 }
 

--- a/libraries/core_libs/consensus/src/dag/dag_block_manager.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_block_manager.cpp
@@ -20,7 +20,7 @@ DagBlockManager::DagBlockManager(addr_t node_addr, SortitionConfig const &sortit
       queue_limit_(queue_limit),
       sortition_params_manager_(node_addr, sortition_config, db_),
       dpos_config_(dpos_config) {
-  LOG_OBJECTS_CREATE("BLKQU");
+  LOG_OBJECTS_CREATE("DAGBLKMGR");
 
   // Set DAG level proposal period map
   current_max_proposal_period_ =
@@ -295,7 +295,7 @@ void DagBlockManager::verifyBlock() {
       verified_qu_[blk.getLevel()].emplace_back(blk);
     }
     cond_for_verified_qu_.notify_one();
-    LOG(log_dg_) << "Verified block: " << block_hash;
+    LOG(log_nf_) << "Verified block: " << block_hash;
   }
 }
 

--- a/libraries/core_libs/consensus/src/dag/dag_block_manager.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_block_manager.cpp
@@ -244,7 +244,8 @@ void DagBlockManager::verifyBlock() {
     // Verify DPOS
     if (!propose_period.second) {
       // Cannot find the proposal period in DB yet. The slow node gets an ahead block, puts back.
-      LOG(log_nf_) << "Cannot find proposal period " << propose_period.first << " in DB for DAG block " << blk.getHash();
+      LOG(log_nf_) << "Cannot find proposal period " << propose_period.first << " in DB for DAG block "
+                   << blk.getHash();
       uLock lock(shared_mutex_for_unverified_qu_);
       unverified_qu_[blk.getLevel()].emplace_back(blk);
       continue;

--- a/libraries/core_libs/consensus/src/dag/dag_block_manager.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_block_manager.cpp
@@ -244,7 +244,7 @@ void DagBlockManager::verifyBlock() {
     // Verify DPOS
     if (!propose_period.second) {
       // Cannot find the proposal period in DB yet. The slow node gets an ahead block, puts back.
-      LOG(log_nf_) << "Cannot find proposal period " << propose_period.first << " in DB for DAG block " << blk;
+      LOG(log_nf_) << "Cannot find proposal period " << propose_period.first << " in DB for DAG block " << blk.getHash();
       uLock lock(shared_mutex_for_unverified_qu_);
       unverified_qu_[blk.getLevel()].emplace_back(blk);
       continue;

--- a/libraries/core_libs/consensus/src/transaction_manager/transaction_manager.cpp
+++ b/libraries/core_libs/consensus/src/transaction_manager/transaction_manager.cpp
@@ -53,6 +53,8 @@ bool TransactionManager::checkMemoryPoolOverflow() {
   return false;
 }
 
+bool TransactionManager::transactionSeen(const trx_hash_t &trx_hash) { return seen_txs_.count(trx_hash) != 0; }
+
 std::pair<bool, std::string> TransactionManager::insertTransaction(const Transaction &trx) {
   auto inserted = insertBroadcastedTransactions({std::make_shared<Transaction>(trx)});
   if (inserted) {

--- a/libraries/core_libs/consensus/src/transaction_manager/transaction_manager.cpp
+++ b/libraries/core_libs/consensus/src/transaction_manager/transaction_manager.cpp
@@ -53,7 +53,7 @@ bool TransactionManager::checkMemoryPoolOverflow() {
   return false;
 }
 
-bool TransactionManager::transactionSeen(const trx_hash_t &trx_hash) { return seen_txs_.count(trx_hash) != 0; }
+bool TransactionManager::transactionSeen(const trx_hash_t &trx_hash) const { return seen_txs_.count(trx_hash) != 0; }
 
 std::pair<bool, std::string> TransactionManager::insertTransaction(const Transaction &trx) {
   auto inserted = insertBroadcastedTransactions({std::make_shared<Transaction>(trx)});

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/get_pbft_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/get_pbft_sync_packet_handler.cpp
@@ -41,6 +41,7 @@ void GetPbftSyncPacketHandler::sendPbftBlocks(dev::p2p::NodeID const &peer_id, s
                << ", will send at most " << blocks_to_transfer << " pbft blocks to " << peer_id;
   uint64_t current_period = height_to_sync;
   if (blocks_to_transfer == 0) {
+    LOG(log_nf_) << "Sending empty PbftSyncPacket to " << peer_id;
     sealAndSend(peer_id, SubprotocolPacketType::PbftSyncPacket, dev::RLPStream(0));
     return;
   }
@@ -59,7 +60,7 @@ void GetPbftSyncPacketHandler::sendPbftBlocks(dev::p2p::NodeID const &peer_id, s
     s.appendList(2);
     s << last_block;
     s.appendRaw(data);
-    LOG(log_dg_) << "Sending PbftSyncPacket period " << current_period << " to " << peer_id;
+    LOG(log_nf_) << "Sending PbftSyncPacket period " << current_period << " to " << peer_id;
     sealAndSend(peer_id, SubprotocolPacketType::PbftSyncPacket, std::move(s));
     current_period++;
   }

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
@@ -29,7 +29,7 @@ void PbftSyncPacketHandler::process(const PacketData &packet_data, const std::sh
   // disabled on priority_queue blocking dependencies level
 
   if (syncing_state_->syncing_peer() != packet_data.from_node_id_) {
-    LOG(log_dg_) << "PbftSyncPacket received from unexpected peer " << packet_data.from_node_id_.abridged()
+    LOG(log_wr_) << "PbftSyncPacket received from unexpected peer " << packet_data.from_node_id_.abridged()
                  << " current syncing peer " << syncing_state_->syncing_peer().abridged();
     return;
   }
@@ -56,7 +56,7 @@ void PbftSyncPacketHandler::process(const PacketData &packet_data, const std::sh
   }
 
   LOG(log_nf_) << "PbftSyncPacket received. Period: " << sync_block.pbft_blk->getPeriod()
-               << ", dag Blocks: " << received_dag_blocks_str;
+               << ", dag Blocks: " << received_dag_blocks_str << " from " << packet_data.from_node_id_;
 
   auto pbft_blk_hash = sync_block.pbft_blk->getBlockHash();
   peer->markPbftBlockAsKnown(pbft_blk_hash);
@@ -73,7 +73,7 @@ void PbftSyncPacketHandler::process(const PacketData &packet_data, const std::sh
     peer->pbft_chain_size_ = sync_block.pbft_blk->getPeriod();
   }
 
-  LOG(log_nf_) << "Synced PBFT block hash " << pbft_blk_hash << " with " << sync_block.cert_votes.size()
+  LOG(log_dg_) << "Synced PBFT block hash " << pbft_blk_hash << " with " << sync_block.cert_votes.size()
                << " cert votes";
   LOG(log_dg_) << "Synced PBFT block " << sync_block;
   pbft_mgr_->syncBlockQueuePush(std::move(sync_block), packet_data.from_node_id_);
@@ -104,7 +104,7 @@ void PbftSyncPacketHandler::pbftSyncComplete() {
                  << pbft_mgr_->syncBlockQueueSize();
     delayed_sync_events_tp_.post(1000, [this] { pbftSyncComplete(); });
   } else {
-    LOG(log_dg_) << "Syncing PBFT is completed";
+    LOG(log_nf_) << "Syncing PBFT is completed";
     // We are pbft synced with the node we are connected to but
     // calling restartSyncingPbft will check if some nodes have
     // greater pbft chain size and we should continue syncing with


### PR DESCRIPTION
I have refactored logging for the following log channels:
DAG_BLOCK_PH
DAG_SYNC_PH
GET_DAG_SYNC_PH
GET_PBFT_SYNC_PH
PBFT_BLOCK_PH
PBFT_SYNC_PH
TRANSACTION_PH
DAGBLKMGR
DAGMGR

Main focus is on logging on INFO level and any level above(WARN, ERROR)
These channels will now on INFO level provide all the data needed to track gossip and syncing for transactions, dag blocks and pbft blocks. INFO level logs are made to be as minimal as possible with no repetitions. Only new transactions and blocks are logged, any packets containing data that is already known are not logged on INFO level.
