### PR TITLE
fix: race condition in retrieving blocks with transactions

### DIFF
--- a/libraries/core_libs/consensus/include/dag/dag.hpp
+++ b/libraries/core_libs/consensus/include/dag/dag.hpp
@@ -134,7 +134,18 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
 
   // return block order
   vec_blk_t getDagBlockOrder(blk_hash_t const &anchor, uint64_t period);
-  // receive pbft-pivot-blk, update periods and finalized, return size of ordered blocks
+
+  /**
+   * @brief Sets the dag block order on finalizing PBFT block
+   * IMPORTANT: This method is invoked on finalizing a pbft block, it needs to be protected with mutex_ but the mutex is
+   * locked from pbft manager for the entire pbft finalization to make the finalization atomic
+   *
+   * @param anchor Anchor of the finalized pbft block
+   * @param period Period finalized
+   * @param dag_order Dag order of the finalized pbft block
+   *
+   * @return number of dag blocks finalized
+   */
   uint setDagBlockOrder(blk_hash_t const &anchor, uint64_t period, vec_blk_t const &dag_order);
 
   std::optional<std::pair<blk_hash_t, std::vector<blk_hash_t>>> getLatestPivotAndTips() const;
@@ -184,6 +195,11 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
 
   util::Event<DagManager, DagBlock> const block_verified_{};
 
+  /**
+   * @brief Retrieves Dag Manager mutex, only to be used when finalizing pbft block
+   *
+   * @return mutex
+   */
   std::shared_mutex &getDagMutex() { return mutex_; }
 
  private:

--- a/libraries/core_libs/consensus/include/dag/dag.hpp
+++ b/libraries/core_libs/consensus/include/dag/dag.hpp
@@ -165,6 +165,16 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
 
   const std::pair<uint64_t, std::map<uint64_t, std::unordered_set<blk_hash_t>>> getNonFinalizedBlocks() const;
 
+  /**
+   * @brief Retrieves current period together with non finalized blocks with the unique list of non finalized
+   * transactions from these blocks
+   *
+   * @param known_hashes excludes known hashes from result
+   * @return Period, blocks and transactions
+   */
+  const std::tuple<uint64_t, std::vector<std::shared_ptr<DagBlock>>, SharedTransactions>
+  getNonFinalizedBlocksWithTransactions(const std::unordered_set<blk_hash_t> &known_hashes) const;
+
   DagFrontier getDagFrontier();
 
   /**

--- a/libraries/core_libs/consensus/include/dag/dag.hpp
+++ b/libraries/core_libs/consensus/include/dag/dag.hpp
@@ -184,6 +184,8 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
 
   util::Event<DagManager, DagBlock> const block_verified_{};
 
+  std::shared_mutex &getDagMutex() { return mutex_; }
+
  private:
   void recoverDag();
   void addToDag(blk_hash_t const &hash, blk_hash_t const &pivot, std::vector<blk_hash_t> const &tips, uint64_t level,

--- a/libraries/core_libs/consensus/include/transaction_manager/transaction_manager.hpp
+++ b/libraries/core_libs/consensus/include/transaction_manager/transaction_manager.hpp
@@ -72,9 +72,24 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
   // Check transactions are present in broadcasted blocks
   bool checkBlockTransactions(DagBlock const &blk);
 
-  // Update the status of transactions to finalized and remove from transactions column
+  /**
+   * @brief Updates the status of transactions to finalized
+   * IMPORTANT: This method is invoked on finalizing a pbft block, it needs to be protected with transactions_mutex_ but
+   * the mutex is locked from pbft manager for the entire pbft finalization process to make the finalization atomic
+   *
+   * @param anchor Anchor of the finalized pbft block
+   * @param period Period finalized
+   * @param dag_order Dag order of the finalized pbft block
+   *
+   * @return number of dag blocks finalized
+   */
   void updateFinalizedTransactionsStatus(SyncBlock const &sync_block);
 
+  /**
+   * @brief Retrieves transactions mutex, only to be used when finalizing pbft block
+   *
+   * @return mutex
+   */
   std::shared_mutex &getTransactionsMutex() { return transactions_mutex_; }
 
   /**

--- a/libraries/core_libs/consensus/include/transaction_manager/transaction_manager.hpp
+++ b/libraries/core_libs/consensus/include/transaction_manager/transaction_manager.hpp
@@ -75,6 +75,8 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
   // Update the status of transactions to finalized and remove from transactions column
   void updateFinalizedTransactionsStatus(SyncBlock const &sync_block);
 
+  std::shared_mutex &getTransactionsMutex() { return transactions_mutex_; }
+
   /**
    * @brief Gets transactions from transactions pool
    *

--- a/libraries/core_libs/consensus/src/dag/dag.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag.cpp
@@ -422,13 +422,6 @@ void DagManager::addDagBlock(DagBlock const &blk, SharedTransactions &&trxs, boo
         trx_mgr_->saveTransactionsFromDagBlock(trxs);
         // Save the dag block
         db_->saveDagBlock(blk);
-
-        // TODO: This is an ugly temporary fix for testnet, a better solution is needed for dag block race condition
-        if (db_->getDagBlockPeriod(blk.getHash()) != nullptr) {
-          db_->removeDagBlock(blk.getHash());
-          LOG(log_er_) << "Block already in DB: " << blk.getHash();
-          return;
-        }
       }
       auto blk_hash = blk.getHash();
       auto pivot_hash = blk.getPivot();

--- a/libraries/core_libs/consensus/src/dag/dag.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag.cpp
@@ -542,7 +542,6 @@ std::vector<blk_hash_t> DagManager::getDagBlockOrder(blk_hash_t const &anchor, u
 }
 
 uint DagManager::setDagBlockOrder(blk_hash_t const &new_anchor, uint64_t period, vec_blk_t const &dag_order) {
-  ULock lock(mutex_);
   LOG(log_dg_) << "setDagBlockOrder called with anchor " << new_anchor << " and period " << period;
   if (period != period_ + 1) {
     LOG(log_er_) << " Inserting period (" << period << ") anchor " << new_anchor

--- a/libraries/core_libs/consensus/src/dag/dag.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag.cpp
@@ -654,7 +654,6 @@ DagManager::getNonFinalizedBlocksWithTransactions(const std::unordered_set<blk_h
   std::vector<std::shared_ptr<DagBlock>> dag_blocks;
   std::unordered_set<trx_hash_t> unique_trxs;
   std::vector<trx_hash_t> trx_to_query;
-  SharedTransactions transactions;
   for (const auto &level_blocks : non_finalized_blks_) {
     for (const auto &hash : level_blocks.second) {
       if (known_hashes.count(hash) == 0) {
@@ -675,10 +674,7 @@ DagManager::getNonFinalizedBlocksWithTransactions(const std::unordered_set<blk_h
     }
   }
   auto trxs = db_->getNonfinalizedTransactions(trx_to_query);
-  for (auto t : trxs) {
-    transactions.emplace_back(t);
-  }
-  return {period_, std::move(dag_blocks), std::move(transactions)};
+  return {period_, std::move(dag_blocks), std::move(trxs)};
 }
 
 std::pair<size_t, size_t> DagManager::getNonFinalizedBlocksSize() const {

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1580,8 +1580,8 @@ bool PbftManager::pushPbftBlock_(SyncBlock &&sync_block, vec_blk_t &&dag_blocks_
   {
     // This makes sure that no DAG block or transaction can be added or change state in transaction and dag manager when
     // finalizing pbft block with dag blocks and transactions
-    std::unique_lock(dag_mgr_->getDagMutex());
-    std::unique_lock(trx_mgr_->getTransactionsMutex());
+    std::unique_lock dag_lock(dag_mgr_->getDagMutex());
+    std::unique_lock trx_lock(trx_mgr_->getTransactionsMutex());
 
     // Commit DB
     db_->commitWriteBatch(batch);

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1577,14 +1577,21 @@ bool PbftManager::pushPbftBlock_(SyncBlock &&sync_block, vec_blk_t &&dag_blocks_
   // pass pbft with dag blocks and transactions to adjust difficulty
   dag_blk_mgr_->sortitionParamsManager().pbftBlockPushed(sync_block, batch);
 
-  // Commit DB
-  db_->commitWriteBatch(batch);
+  {
+    // This makes sure that no DAG block or transaction can be added or change state in transaction and dag manager when
+    // finalizing pbft block with dag blocks and transactions
+    std::unique_lock(dag_mgr_->getDagMutex());
+    std::unique_lock(trx_mgr_->getTransactionsMutex());
 
-  // Set DAG blocks period
-  auto const &anchor_hash = sync_block.pbft_blk->getPivotDagBlockHash();
-  dag_mgr_->setDagBlockOrder(anchor_hash, pbft_period, dag_blocks_order);
+    // Commit DB
+    db_->commitWriteBatch(batch);
 
-  trx_mgr_->updateFinalizedTransactionsStatus(sync_block);
+    // Set DAG blocks period
+    auto const &anchor_hash = sync_block.pbft_blk->getPivotDagBlockHash();
+    dag_mgr_->setDagBlockOrder(anchor_hash, pbft_period, dag_blocks_order);
+
+    trx_mgr_->updateFinalizedTransactionsStatus(sync_block);
+  }
 
   // update PBFT chain size
   pbft_chain_->updatePbftChain(pbft_block_hash);

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1591,10 +1591,10 @@ bool PbftManager::pushPbftBlock_(SyncBlock &&sync_block, vec_blk_t &&dag_blocks_
     dag_mgr_->setDagBlockOrder(anchor_hash, pbft_period, dag_blocks_order);
 
     trx_mgr_->updateFinalizedTransactionsStatus(sync_block);
-  }
 
-  // update PBFT chain size
-  pbft_chain_->updatePbftChain(pbft_block_hash);
+    // update PBFT chain size
+    pbft_chain_->updatePbftChain(pbft_block_hash);
+  }
 
   last_cert_voted_value_ = NULL_BLOCK_HASH;
 

--- a/libraries/core_libs/consensus/src/transaction_manager/transaction_manager.cpp
+++ b/libraries/core_libs/consensus/src/transaction_manager/transaction_manager.cpp
@@ -230,9 +230,6 @@ SharedTransactions TransactionManager::packTrxs(uint16_t max_trx_to_pack) {
  * Update transaction counters and state, it only has effect when PBFT syncing
  */
 void TransactionManager::updateFinalizedTransactionsStatus(SyncBlock const &sync_block) {
-  // This lock synchronizes inserting and removing transactions from transactions memory pool with database insertion.
-  // Unique lock here makes sure that transactions we are removing are not reinserted in transactions_pool_
-  std::unique_lock transactions_lock(transactions_mutex_);
   for (auto const &trx : sync_block.transactions) {
     if (!nonfinalized_transactions_in_dag_.erase(trx.getHash())) {
       trx_count_++;

--- a/libraries/core_libs/network/include/network/network.hpp
+++ b/libraries/core_libs/network/include/network/network.hpp
@@ -64,8 +64,8 @@ class Network {
 
   // METHODS USED IN TESTS ONLY
   void sendBlock(dev::p2p::NodeID const &id, DagBlock const &blk, const SharedTransactions &trxs);
-  void sendBlocks(const dev::p2p::NodeID &id, std::vector<std::shared_ptr<DagBlock>> &&blocks, uint64_t request_period,
-                  uint64_t period);
+  void sendBlocks(const dev::p2p::NodeID &id, std::vector<std::shared_ptr<DagBlock>> &&blocks,
+                  SharedTransactions &&transactions, uint64_t request_period, uint64_t period);
   void sendTransactions(dev::p2p::NodeID const &_id, std::vector<taraxa::bytes> const &transactions);
   void setPendingPeersToReady();
   dev::p2p::NodeID getNodeId() const;

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_dag_sync_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_dag_sync_packet_handler.hpp
@@ -21,7 +21,7 @@ class GetDagSyncPacketHandler : public PacketHandler {
   virtual ~GetDagSyncPacketHandler() = default;
 
   void sendBlocks(const dev::p2p::NodeID& peer_id, std::vector<std::shared_ptr<DagBlock>>&& blocks,
-                  uint64_t request_period, uint64_t period);
+                  SharedTransactions&& transactions, uint64_t request_period, uint64_t period);
 
  private:
   void process(const PacketData& packet_data, const std::shared_ptr<TaraxaPeer>& peer) override;

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
@@ -83,8 +83,8 @@ class TaraxaCapability : public dev::p2p::CapabilityFace {
 
   // METHODS USED IN TESTS ONLY
   void sendBlock(dev::p2p::NodeID const &id, DagBlock const &blk, const SharedTransactions &trxs);
-  void sendBlocks(const dev::p2p::NodeID &id, std::vector<std::shared_ptr<DagBlock>> &&blocks, uint64_t request_period,
-                  uint64_t period);
+  void sendBlocks(const dev::p2p::NodeID &id, std::vector<std::shared_ptr<DagBlock>> &&blocks,
+                  SharedTransactions &&transactions, uint64_t request_period, uint64_t period);
   size_t getReceivedBlocksCount() const;
   size_t getReceivedTransactionsCount() const;
 

--- a/libraries/core_libs/network/src/network.cpp
+++ b/libraries/core_libs/network/src/network.cpp
@@ -129,9 +129,9 @@ void Network::sendBlock(dev::p2p::NodeID const &id, DagBlock const &blk, const S
 }
 
 void Network::sendBlocks(const dev::p2p::NodeID &id, std::vector<std::shared_ptr<DagBlock>> &&blocks,
-                         uint64_t request_period, uint64_t period) {
+                         SharedTransactions &&transactions, uint64_t request_period, uint64_t period) {
   LOG(log_dg_) << "Sending Blocks:" << blocks.size();
-  taraxa_capability_->sendBlocks(id, std::move(blocks), request_period, period);
+  taraxa_capability_->sendBlocks(id, std::move(blocks), std::move(transactions), request_period, period);
 }
 
 void Network::sendTransactions(dev::p2p::NodeID const &_id, std::vector<taraxa::bytes> const &transactions) {

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/get_dag_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/get_dag_sync_packet_handler.cpp
@@ -40,8 +40,9 @@ void GetDagSyncPacketHandler::process(const PacketData &packet_data,
   if (peer_period == period) {
     peer->syncing_ = false;
   } else {
-    // There is no point in sending blocks if periods do not match
+    // There is no point in sending blocks if periods do not match, but an empty packet should be sent
     blocks.clear();
+    transactions.clear();
   }
   sendBlocks(packet_data.from_node_id_, std::move(blocks), std::move(transactions), peer_period, period);
 }

--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -425,10 +425,10 @@ void TaraxaCapability::sendBlock(dev::p2p::NodeID const &id, DagBlock const &blk
 }
 
 void TaraxaCapability::sendBlocks(const dev::p2p::NodeID &id, std::vector<std::shared_ptr<DagBlock>> &&blocks,
-                                  uint64_t request_period, uint64_t period) {
+                                  SharedTransactions &&transactions, uint64_t request_period, uint64_t period) {
   std::static_pointer_cast<GetDagSyncPacketHandler>(
       packets_handlers_->getSpecificHandler(SubprotocolPacketType::GetDagSyncPacket))
-      ->sendBlocks(id, std::move(blocks), request_period, period);
+      ->sendBlocks(id, std::move(blocks), std::move(transactions), request_period, period);
 }
 
 size_t TaraxaCapability::getReceivedBlocksCount() const { return test_state_->getBlocksSize(); }

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -1096,13 +1096,15 @@ TEST_F(NetworkTest, node_sync2) {
   auto node2 = create_nodes({node_cfgs[1]}, true /*start*/).front();
 
   EXPECT_HAPPENS({10s, 100ms}, [&](auto& ctx) {
-    WAIT_EXPECT_EQ(ctx, node1->getDagManager()->getNumVerticesInDag().first, 13)
-    WAIT_EXPECT_EQ(ctx, node1->getDagManager()->getNumEdgesInDag().first, 13)
+    WAIT_EXPECT_LT(ctx, 12, node1->getDagManager()->getNumVerticesInDag().first)
+    WAIT_EXPECT_LT(ctx, 12, node1->getDagManager()->getNumEdgesInDag().first)
   });
 
   EXPECT_HAPPENS({50s, 300ms}, [&](auto& ctx) {
-    WAIT_EXPECT_EQ(ctx, node2->getDagManager()->getNumVerticesInDag().first, 13)
-    WAIT_EXPECT_EQ(ctx, node2->getDagManager()->getNumEdgesInDag().first, 13)
+    WAIT_EXPECT_EQ(ctx, node1->getDagManager()->getNumVerticesInDag().first,
+                   node2->getDagManager()->getNumVerticesInDag().first)
+    WAIT_EXPECT_EQ(ctx, node1->getDagManager()->getNumEdgesInDag().first,
+                   node2->getDagManager()->getNumEdgesInDag().first)
   });
 }
 

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -115,7 +115,7 @@ TEST_F(NetworkTest, transfer_lot_of_blocks) {
   nodes[0]->getNetwork()->onNewTransactions(std::move(trxs));
   for (auto block : dag_blocks) nodes[0]->getDagBlockManager()->insertBroadcastedBlock(*block);
   taraxa::thisThreadSleepForSeconds(1);
-  nodes[0]->getNetwork()->sendBlocks(nodes[1]->getNetwork()->getNodeId(), std::move(dag_blocks), 1, 1);
+  nodes[0]->getNetwork()->sendBlocks(nodes[1]->getNetwork()->getNodeId(), std::move(dag_blocks), {}, 1, 1);
 
   std::cout << "Waiting Sync ..." << std::endl;
   wait({30s, 200ms},

--- a/tests/util_test/util.hpp
+++ b/tests/util_test/util.hpp
@@ -105,7 +105,7 @@ inline bool wait(wait_opts const& opts, std::function<void(wait_ctx&)> const& po
   }
 
 #define WAIT_EXPECT_LT(ctx, o1, o2)         \
-  if (o1 < o2) {                            \
+  if (o1 >= o2) {                           \
     if (ctx.fail(); !ctx.is_last_attempt) { \
       return;                               \
     }                                       \


### PR DESCRIPTION
When processing a getDagSyncPacket non finalized blocks are sent only with unique set of transactions that are not finalized or included in a previous DAG block. Other transactions should already be present on the peer requesting it.

There was a race condition where it was possible that between requesting dag blocks with getNonFinalizedBlocks and transactions with db_->getNonfinalizedTransactions(trx_to_query), some blocks were actually finalized which would lead to sending some missing transactions in the packet. This has been fixed that now blocks and transactions are retrieved with a new method DagManager::getNonFinalizedBlocksWithTransactions which ensures that blocks are retrieved under the DagManager mutex which ensures that blocks cannot be finalized while retrieving this data.

At the same time I have made block finalization in pbft manager atomic by putting all the db and memory pbft finalization of dag blocks and transactions under the transaction and dag manager mutex. Previously when I proposed the same, I know that there were comments that this might hurt performance but I do not believe that this will cause performance issues. I have tested this on devnet which currently had a large blockchain with 40GB database and 270000 blocks. I measured the finalization time which took only about 8 milliseconds on average. The finalization happens every 4 seconds so I do not believe that this should have any significant impact on processing transactions/dag blocks.