### PR TITLE
chore: remove ahead block from queue

### DIFF
--- a/libraries/core_libs/consensus/src/dag/dag_block_manager.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_block_manager.cpp
@@ -243,11 +243,10 @@ void DagBlockManager::verifyBlock() {
     auto propose_period = getProposalPeriod(blk.getLevel());
     // Verify DPOS
     if (!propose_period.second) {
-      // Cannot find the proposal period in DB yet. The slow node gets an ahead block, puts back.
+      // Cannot find the proposal period in DB yet. The slow node gets an ahead block, remove from seen_blocks
       LOG(log_nf_) << "Cannot find proposal period " << propose_period.first << " in DB for DAG block "
                    << blk.getHash();
-      uLock lock(shared_mutex_for_unverified_qu_);
-      unverified_qu_[blk.getLevel()].emplace_back(blk);
+      seen_blocks_.erase(block_hash);
       continue;
     }
 


### PR DESCRIPTION
When processing a gossiped dag block for which we do not have a proposal period yet, it is safe to assume that we are not pbft synced in which case there is no need to keep this block in the queue which creates a loop that creates a lot of unneeded logs as well as it eats up CPU. Drop this block and expect to receive it again when fully pbft synced.