### PR TITLE
fix: initial vote sync

### DIFF
--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -103,6 +103,7 @@ class VoteManager {
   uint64_t roundDeterminedFromVotes(size_t two_t_plus_one);
 
  private:
+  std::atomic<bool> stopped_ = true;
   void retreieveVotes_();
 
   using UniqueLock = boost::unique_lock<boost::shared_mutex>;

--- a/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
+++ b/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
@@ -34,6 +34,14 @@ void VoteManager::retreieveVotes_() {
   auto verified_votes = db_->getVerifiedVotes();
   const auto pbft_step = db_->getPbftMgrField(PbftMgrRoundStep::PbftStep);
   for (auto const& v : verified_votes) {
+    addVerifiedVote(v);
+    LOG(log_dg_) << "Retrieved verified vote " << *v;
+  }
+
+  // TODO: Implement votes sync properly
+  // Since this is invoked on startup no peers are connected yet, invoke two minutes after startup
+  thisThreadSleepForSeconds(120);
+  for (auto const& v : verified_votes) {
     // Rebroadcast our own next votes in case we were partitioned...
     if (v->getStep() >= FIRST_FINISH_STEP && pbft_step > EXTENDED_PARTITION_STEPS) {
       std::vector<std::shared_ptr<Vote>> votes = {v};
@@ -41,9 +49,6 @@ void VoteManager::retreieveVotes_() {
         net->onNewPbftVotes(std::move(votes));
       }
     }
-
-    addVerifiedVote(v);
-    LOG(log_dg_) << "Retrieved verified vote " << *v;
   }
 }
 

--- a/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
+++ b/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
@@ -20,12 +20,18 @@ VoteManager::VoteManager(addr_t node_addr, std::shared_ptr<DbStorage> db, std::s
   LOG_OBJECTS_CREATE("VOTE_MGR");
 
   // Retrieve votes from DB
-  daemon_ = std::make_unique<std::thread>([this]() { retreieveVotes_(); });
+  daemon_ = std::make_unique<std::thread>([this]() {
+    stopped_ = false;
+    retreieveVotes_();
+  });
 
   current_period_final_chain_block_hash_ = final_chain_->block_header()->hash;
 }
 
-VoteManager::~VoteManager() { daemon_->join(); }
+VoteManager::~VoteManager() {
+  stopped_ = true;
+  daemon_->join();
+}
 
 void VoteManager::setNetwork(std::weak_ptr<Network> network) { network_ = std::move(network); }
 
@@ -40,7 +46,12 @@ void VoteManager::retreieveVotes_() {
 
   // TODO: Implement votes sync properly
   // Since this is invoked on startup no peers are connected yet, invoke two minutes after startup
-  thisThreadSleepForSeconds(120);
+  for (int i = 0; i < 120; i++) {
+    if (stopped_ == false) {
+      thisThreadSleepForSeconds(1);
+    } else
+      return;
+  }
   for (auto const& v : verified_votes) {
     // Rebroadcast our own next votes in case we were partitioned...
     if (v->getStep() >= FIRST_FINISH_STEP && pbft_step > EXTENDED_PARTITION_STEPS) {


### PR DESCRIPTION
Verified votes retrieved from db on startup were broadcasted with net->onNewPbftVotes but on startup no peer is actually connected yet. As a temporary fix I delay the broadcast for 2 minutes when it is expected that there will be peers connected. A better fix is needed on develop. 