### PR TITLE
chore: dag block validation

### DIFF
--- a/libraries/core_libs/consensus/src/dag/dag_block_manager.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_block_manager.cpp
@@ -85,7 +85,7 @@ bool DagBlockManager::pivotAndTipsValid(DagBlock const &blk) {
     return false;
   }
 
-  if (seen_blocks_.count(blk.getPivot()) == 0) {
+  if (seen_blocks_.count(blk.getPivot()) == 0 && !db_->dagBlockInDb(blk.getPivot())) {
     seen_blocks_.erase(blk.getHash());
     LOG(log_wr_) << "DAG Block " << blk.getHash() << " pivot " << blk.getPivot() << " is unavailable";
     return false;
@@ -101,7 +101,7 @@ bool DagBlockManager::pivotAndTipsValid(DagBlock const &blk) {
   }
 
   for (auto const &tip : blk.getTips()) {
-    if (seen_blocks_.count(tip) == 0) {
+    if (seen_blocks_.count(tip) == 0 && !db_->dagBlockInDb(tip)) {
       seen_blocks_.erase(blk.getHash());
       LOG(log_wr_) << "DAG Block " << blk.getHash() << " tip " << tip << " is unavailable";
       return false;

--- a/libraries/core_libs/consensus/src/transaction_manager/transaction_manager.cpp
+++ b/libraries/core_libs/consensus/src/transaction_manager/transaction_manager.cpp
@@ -129,7 +129,7 @@ uint32_t TransactionManager::insertValidatedTransactions(const SharedTransaction
   // This lock synchronizes inserting and removing transactions from transactions memory pool with database insertion.
   // It is very important to lock checking the db state of transaction together with transaction pool checking to be
   // protected from new DAG block and Sync block transactions insertions which are inserted directly in the database.
-  std::shared_lock shared_transactions_lock(transactions_mutex_);
+  std::unique_lock transactions_lock(transactions_mutex_);
 
   // Check the db with a multiquery if transactions are really new
   auto db_seen = db_->transactionsInDb(txs_hashes);


### PR DESCRIPTION
Any dag block that was saved in the db on syncing will not be in the seen_blocks cache. Checking db for valid tips/pivot is needed. This should not hurt performance since pivotAndTipsValid is called very rarely on a race condition in verifying both a block and it's tip/pivot at the same time. This only happens on the initial dag sync.