### PR TITLE
chore: malicious nodes handling

### DIFF
--- a/libraries/cli/include/cli/default_config.hpp
+++ b/libraries/cli/include/cli/default_config.hpp
@@ -16,6 +16,7 @@ const char *default_json = R"foo({
   "network_max_peer_count": 50,
   "network_sync_level_size": 10,
   "network_packets_processing_threads": 10,
+  "network_peer_blacklist_timeout" : 600,
   "deep_syncing_threshold" : 10,
   "network_boot_nodes": [
     {

--- a/libraries/cli/include/cli/devnet_config.hpp
+++ b/libraries/cli/include/cli/devnet_config.hpp
@@ -16,6 +16,7 @@ const char *devnet_json = R"foo({
   "network_max_peer_count": 15,
   "network_sync_level_size": 25,
   "network_packets_processing_threads": 10,
+  "network_peer_blacklist_timeout" : 600,
   "deep_syncing_threshold" : 10,
   "network_boot_nodes": [
     {

--- a/libraries/cli/include/cli/testnet_config.hpp
+++ b/libraries/cli/include/cli/testnet_config.hpp
@@ -16,6 +16,7 @@ const char *testnet_json = R"foo({
   "network_max_peer_count": 15,
   "network_sync_level_size": 25,
   "network_packets_processing_threads": 10,
+  "network_peer_blacklist_timeout" : 600,
   "deep_syncing_threshold" : 10,
   "network_boot_nodes": [
     {

--- a/libraries/common/include/common/util.hpp
+++ b/libraries/common/include/common/util.hpp
@@ -450,6 +450,16 @@ class ThreadSafeMap {
     return values;
   }
 
+  void erase(std::function<bool(Value)> condition) {
+    std::unique_lock lck(mtx_);
+    for (auto it = map_.cbegin(), next_it = it; it != map_.cend(); it = next_it) {
+      ++next_it;
+      if (condition(it->second)) {
+        map_.erase(it);
+      }
+    }
+  }
+
   void clear() {
     std::unique_lock lck(mtx_);
     map_.clear();

--- a/libraries/config/include/config/config.hpp
+++ b/libraries/config/include/config/config.hpp
@@ -27,6 +27,8 @@ struct NodeConfig {
 };
 
 struct NetworkConfig {
+  static constexpr uint16_t kBlacklistTimeoutDefaultInSeconds = 600;
+
   std::string json_file_name;
   bool network_is_boot_node = 0;
   std::string network_public_ip;
@@ -43,6 +45,8 @@ struct NetworkConfig {
   uint16_t network_performance_log_interval = 0;
   uint16_t network_num_threads = std::max(uint(1), uint(std::thread::hardware_concurrency() / 2));
   uint16_t network_packets_processing_threads = 10;
+  uint16_t network_peer_blacklist_timeout = kBlacklistTimeoutDefaultInSeconds;
+  bool disable_peer_blacklist = false;
   uint16_t deep_syncing_threshold = 10;
 };
 

--- a/libraries/config/src/config.cpp
+++ b/libraries/config/src/config.cpp
@@ -65,10 +65,19 @@ uint64_t getConfigDataAsUInt64(Json::Value const &root, std::vector<string> cons
   }
 }
 
-bool getConfigDataAsBoolean(Json::Value const &root, std::vector<string> const &path) {
+bool getConfigDataAsBoolean(Json::Value const &root, std::vector<string> const &path, bool optional = false,
+                            bool value = false) {
   try {
-    return getConfigData(root, path).asBool();
+    Json::Value ret = getConfigData(root, path, optional);
+    if (ret.isNull()) {
+      return value;
+    } else {
+      return ret.asBool();
+    }
   } catch (Json::Exception &e) {
+    if (optional) {
+      return value;
+    }
     throw ConfigException(getConfigErr(path) + e.what());
   }
 }
@@ -116,6 +125,9 @@ FullNodeConfig::FullNodeConfig(Json::Value const &string_or_object, Json::Value 
   network.network_max_peer_count = getConfigDataAsUInt(root, {"network_max_peer_count"});
   network.network_sync_level_size = getConfigDataAsUInt(root, {"network_sync_level_size"});
   network.network_packets_processing_threads = getConfigDataAsUInt(root, {"network_packets_processing_threads"});
+  network.network_peer_blacklist_timeout = getConfigDataAsUInt(root, {"network_peer_blacklist_timeout"}, true,
+                                                               NetworkConfig::kBlacklistTimeoutDefaultInSeconds);
+  network.disable_peer_blacklist = getConfigDataAsBoolean(root, {"disable_peer_blacklist"}, true, false);
   network.deep_syncing_threshold =
       getConfigDataAsUInt(root, {"deep_syncing_threshold"}, true, network.deep_syncing_threshold);
   for (auto &item : root["network_boot_nodes"]) {

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_dag_sync_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_dag_sync_packet_handler.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "network/tarcap/packets_handlers/common/packet_handler.hpp"
-#include "network/tarcap/shared_states/syncing_state.hpp"
 
 namespace taraxa {
 class DagManager;

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_dag_sync_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_dag_sync_packet_handler.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "network/tarcap/packets_handlers/common/packet_handler.hpp"
+#include "network/tarcap/shared_states/syncing_state.hpp"
 
 namespace taraxa {
 class DagManager;
@@ -11,12 +12,14 @@ class TransactionManager;
 
 namespace taraxa::network::tarcap {
 
+class SyncingState;
+
 class GetDagSyncPacketHandler : public PacketHandler {
  public:
   GetDagSyncPacketHandler(std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
-                          std::shared_ptr<TransactionManager> trx_mgr, std::shared_ptr<DagManager> dag_mgr,
-                          std::shared_ptr<DagBlockManager> dag_blk_mgr, std::shared_ptr<DbStorage> db,
-                          const addr_t& node_addr);
+                          std::shared_ptr<SyncingState> syncing_state, std::shared_ptr<TransactionManager> trx_mgr,
+                          std::shared_ptr<DagManager> dag_mgr, std::shared_ptr<DagBlockManager> dag_blk_mgr,
+                          std::shared_ptr<DbStorage> db, const addr_t& node_addr);
 
   virtual ~GetDagSyncPacketHandler() = default;
 
@@ -26,6 +29,7 @@ class GetDagSyncPacketHandler : public PacketHandler {
  private:
   void process(const PacketData& packet_data, const std::shared_ptr<TaraxaPeer>& peer) override;
 
+  std::shared_ptr<SyncingState> syncing_state_;
   std::shared_ptr<TransactionManager> trx_mgr_;
   std::shared_ptr<DagManager> dag_mgr_;
   std::shared_ptr<DagBlockManager> dag_blk_mgr_;

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_dag_sync_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_dag_sync_packet_handler.hpp
@@ -12,14 +12,12 @@ class TransactionManager;
 
 namespace taraxa::network::tarcap {
 
-class SyncingState;
-
 class GetDagSyncPacketHandler : public PacketHandler {
  public:
   GetDagSyncPacketHandler(std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
-                          std::shared_ptr<SyncingState> syncing_state, std::shared_ptr<TransactionManager> trx_mgr,
-                          std::shared_ptr<DagManager> dag_mgr, std::shared_ptr<DagBlockManager> dag_blk_mgr,
-                          std::shared_ptr<DbStorage> db, const addr_t& node_addr);
+                          std::shared_ptr<TransactionManager> trx_mgr, std::shared_ptr<DagManager> dag_mgr,
+                          std::shared_ptr<DagBlockManager> dag_blk_mgr, std::shared_ptr<DbStorage> db,
+                          const addr_t& node_addr);
 
   virtual ~GetDagSyncPacketHandler() = default;
 
@@ -29,7 +27,6 @@ class GetDagSyncPacketHandler : public PacketHandler {
  private:
   void process(const PacketData& packet_data, const std::shared_ptr<TaraxaPeer>& peer) override;
 
-  std::shared_ptr<SyncingState> syncing_state_;
   std::shared_ptr<TransactionManager> trx_mgr_;
   std::shared_ptr<DagManager> dag_mgr_;
   std::shared_ptr<DagBlockManager> dag_blk_mgr_;

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/transaction_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/transaction_packet_handler.hpp
@@ -12,13 +12,14 @@ class TransactionManager;
 namespace taraxa::network::tarcap {
 
 class TestState;
+class SyncingState;
 
 class TransactionPacketHandler : public PacketHandler {
  public:
   TransactionPacketHandler(std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
-                           std::shared_ptr<TransactionManager> trx_mgr, std::shared_ptr<DagBlockManager> dag_blk_mgr,
-                           std::shared_ptr<TestState> test_state, uint16_t network_transaction_interval,
-                           const addr_t& node_addr);
+                           std::shared_ptr<SyncingState> syncing_state, std::shared_ptr<TransactionManager> trx_mgr,
+                           std::shared_ptr<DagBlockManager> dag_blk_mgr, std::shared_ptr<TestState> test_state,
+                           uint16_t network_transaction_interval, const addr_t& node_addr);
 
   virtual ~TransactionPacketHandler() = default;
 
@@ -28,6 +29,7 @@ class TransactionPacketHandler : public PacketHandler {
  private:
   void process(const PacketData& packet_data, const std::shared_ptr<TaraxaPeer>& peer) override;
 
+  std::shared_ptr<SyncingState> syncing_state_;
   std::shared_ptr<TransactionManager> trx_mgr_;
 
   // FOR TESTING ONLY

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/transaction_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/transaction_packet_handler.hpp
@@ -12,14 +12,13 @@ class TransactionManager;
 namespace taraxa::network::tarcap {
 
 class TestState;
-class SyncingState;
 
 class TransactionPacketHandler : public PacketHandler {
  public:
   TransactionPacketHandler(std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
-                           std::shared_ptr<SyncingState> syncing_state, std::shared_ptr<TransactionManager> trx_mgr,
-                           std::shared_ptr<DagBlockManager> dag_blk_mgr, std::shared_ptr<TestState> test_state,
-                           uint16_t network_transaction_interval, const addr_t& node_addr);
+                           std::shared_ptr<TransactionManager> trx_mgr, std::shared_ptr<DagBlockManager> dag_blk_mgr,
+                           std::shared_ptr<TestState> test_state, uint16_t network_transaction_interval,
+                           const addr_t& node_addr);
 
   virtual ~TransactionPacketHandler() = default;
 
@@ -29,7 +28,6 @@ class TransactionPacketHandler : public PacketHandler {
  private:
   void process(const PacketData& packet_data, const std::shared_ptr<TaraxaPeer>& peer) override;
 
-  std::shared_ptr<SyncingState> syncing_state_;
   std::shared_ptr<TransactionManager> trx_mgr_;
 
   // FOR TESTING ONLY

--- a/libraries/core_libs/network/include/network/tarcap/shared_states/peers_state.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/shared_states/peers_state.hpp
@@ -57,7 +57,7 @@ class PeersState {
   std::unordered_map<dev::p2p::NodeID, std::shared_ptr<TaraxaPeer>> pending_peers_;
 
   ThreadSafeMap<dev::p2p::NodeID, std::chrono::steady_clock::time_point> malicious_peers_;
-  NetworkConfig conf_;
+  const NetworkConfig conf_;
 };
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/include/network/tarcap/shared_states/peers_state.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/shared_states/peers_state.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "common/util.hpp"
+#include "config/config.hpp"
 #include "dag/dag_block.hpp"
 #include "libp2p/Common.h"
 #include "libp2p/Host.h"
@@ -16,7 +18,7 @@ namespace taraxa::network::tarcap {
  */
 class PeersState {
  public:
-  PeersState(std::weak_ptr<dev::p2p::Host> host, const dev::p2p::NodeID& own_node_id);
+  PeersState(std::weak_ptr<dev::p2p::Host> host, const dev::p2p::NodeID& own_node_id, const NetworkConfig& conf);
 
   std::shared_ptr<TaraxaPeer> getPeer(const dev::p2p::NodeID& node_id) const;
   std::shared_ptr<TaraxaPeer> getPendingPeer(const dev::p2p::NodeID& node_id) const;
@@ -33,6 +35,18 @@ class PeersState {
   std::shared_ptr<TaraxaPeer> setPeerAsReadyToSendMessages(dev::p2p::NodeID const& node_id,
                                                            std::shared_ptr<TaraxaPeer> peer);
 
+  /**
+   * @brief Marks peer as malicious
+   * @param peer_id
+   */
+  void set_peer_malicious(const dev::p2p::NodeID& peer_id);
+
+  /**
+   * @brief Checks if peer is in malicious peers list
+   * @return returns true if peer is in malicious peer list
+   */
+  bool is_peer_malicious(const dev::p2p::NodeID& peer_id);
+
  public:
   const std::weak_ptr<dev::p2p::Host> host_;
   const dev::p2p::NodeID node_id_;
@@ -41,6 +55,9 @@ class PeersState {
   mutable std::shared_mutex peers_mutex_;
   std::unordered_map<dev::p2p::NodeID, std::shared_ptr<TaraxaPeer>> peers_;
   std::unordered_map<dev::p2p::NodeID, std::shared_ptr<TaraxaPeer>> pending_peers_;
+
+  ThreadSafeMap<dev::p2p::NodeID, std::chrono::steady_clock::time_point> malicious_peers_;
+  NetworkConfig conf_;
 };
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/include/network/tarcap/shared_states/syncing_state.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/shared_states/syncing_state.hpp
@@ -3,6 +3,7 @@
 #include <atomic>
 
 #include "common/util.hpp"
+#include "config/config.hpp"
 #include "libp2p/Common.h"
 
 namespace taraxa::network::tarcap {
@@ -14,7 +15,7 @@ class TaraxaPeer;
  */
 class SyncingState {
  public:
-  SyncingState(uint16_t deep_syncing_threshold);
+  SyncingState(const NetworkConfig &conf);
 
   /**
    * @brief Set pbft syncing
@@ -53,7 +54,7 @@ class SyncingState {
    * @param peer_id
    */
   void set_peer_malicious(const std::optional<dev::p2p::NodeID> &peer_id = {});
-  bool is_peer_malicious(const dev::p2p::NodeID &peer_id) const;
+  bool is_peer_malicious(const dev::p2p::NodeID &peer_id);
 
  private:
   void set_peer(std::shared_ptr<TaraxaPeer> &&peer);
@@ -62,9 +63,9 @@ class SyncingState {
   std::atomic<bool> deep_pbft_syncing_{false};
   std::atomic<bool> pbft_syncing_{false};
 
-  ExpirationCache<dev::p2p::NodeID> malicious_peers_;
+  std::unordered_map<dev::p2p::NodeID, std::chrono::steady_clock::time_point> malicious_peers_;
 
-  const uint16_t kDeepSyncingThreshold;
+  NetworkConfig conf_;
 
   // Number of seconds needed for ongoing syncing to be declared as inactive
   static constexpr std::chrono::seconds SYNCING_INACTIVITY_THRESHOLD{60};

--- a/libraries/core_libs/network/include/network/tarcap/shared_states/syncing_state.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/shared_states/syncing_state.hpp
@@ -3,7 +3,6 @@
 #include <atomic>
 
 #include "common/util.hpp"
-#include "config/config.hpp"
 #include "libp2p/Common.h"
 
 namespace taraxa::network::tarcap {
@@ -15,7 +14,7 @@ class TaraxaPeer;
  */
 class SyncingState {
  public:
-  SyncingState(const NetworkConfig &conf);
+  SyncingState(uint16_t deep_syncing_threshold);
 
   /**
    * @brief Set pbft syncing
@@ -49,13 +48,6 @@ class SyncingState {
 
   const dev::p2p::NodeID syncing_peer() const;
 
-  /**
-   * @brief Marks peer as malicious, in case none is provided, peer_id_ (node that we currently syncing with) is marked
-   * @param peer_id
-   */
-  void set_peer_malicious(const std::optional<dev::p2p::NodeID> &peer_id = {});
-  bool is_peer_malicious(const dev::p2p::NodeID &peer_id);
-
  private:
   void set_peer(std::shared_ptr<TaraxaPeer> &&peer);
 
@@ -63,9 +55,7 @@ class SyncingState {
   std::atomic<bool> deep_pbft_syncing_{false};
   std::atomic<bool> pbft_syncing_{false};
 
-  std::unordered_map<dev::p2p::NodeID, std::chrono::steady_clock::time_point> malicious_peers_;
-
-  NetworkConfig conf_;
+  const uint16_t kDeepSyncingThreshold;
 
   // Number of seconds needed for ongoing syncing to be declared as inactive
   static constexpr std::chrono::seconds SYNCING_INACTIVITY_THRESHOLD{60};

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
@@ -73,6 +73,7 @@ class TaraxaPeer : public boost::noncopyable {
   std::atomic<uint64_t> last_status_pbft_chain_size_ = 0;
   std::atomic_bool peer_dag_synced_ = false;
   std::atomic_bool peer_dag_syncing_ = false;
+  std::atomic_bool peer_requested_dag_syncing_ = false;
 
   // Mutex used to prevent race condition between dag syncing and gossiping
   mutable boost::shared_mutex mutex_for_sending_dag_blocks_;

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_syncing_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_syncing_packet_handler.cpp
@@ -175,8 +175,7 @@ std::pair<bool, std::unordered_set<blk_hash_t>> ExtSyncingPacketHandler::checkDa
 }
 
 void ExtSyncingPacketHandler::handleMaliciousSyncPeer(dev::p2p::NodeID const &id) {
-  // TODO: enable once malicious issues are resolved
-  // syncing_state_->set_peer_malicious(id);
+  syncing_state_->set_peer_malicious(id);
 
   if (auto host = peers_state_->host_.lock(); host) {
     host->disconnect(id, dev::p2p::UserReason);

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_syncing_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_syncing_packet_handler.cpp
@@ -175,7 +175,7 @@ std::pair<bool, std::unordered_set<blk_hash_t>> ExtSyncingPacketHandler::checkDa
 }
 
 void ExtSyncingPacketHandler::handleMaliciousSyncPeer(dev::p2p::NodeID const &id) {
-  syncing_state_->set_peer_malicious(id);
+  peers_state_->set_peer_malicious(id);
 
   if (auto host = peers_state_->host_.lock(); host) {
     host->disconnect(id, dev::p2p::UserReason);

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/dag_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/dag_sync_packet_handler.cpp
@@ -42,7 +42,7 @@ void DagSyncPacketHandler::process(const PacketData& packet_data, const std::sha
     // This should not be possible for honest node
     LOG(log_er_) << "Received DagSyncPacket with mismatching periods: " << response_period << " " << request_period
                  << " from " << packet_data.from_node_id_.abridged() << " peer will be disconnected";
-    syncing_state_->set_peer_malicious(peer->getId());
+    peers_state_->set_peer_malicious(peer->getId());
     disconnect(peer->getId(), dev::p2p::UserReason);
     return;
   }
@@ -61,7 +61,7 @@ void DagSyncPacketHandler::process(const PacketData& packet_data, const std::sha
     if (const auto [is_valid, reason] = trx_mgr_->verifyTransaction(trx); !is_valid) {
       LOG(log_er_) << "DagBlock transaction " << trx->getHash() << " validation falied: " << reason << " . Peer "
                    << packet_data.from_node_id_ << " will be disconnected.";
-      syncing_state_->set_peer_malicious(peer->getId());
+      peers_state_->set_peer_malicious(peer->getId());
       disconnect(packet_data.from_node_id_, dev::p2p::UserReason);
       return;
     }
@@ -81,7 +81,7 @@ void DagSyncPacketHandler::process(const PacketData& packet_data, const std::sha
       // This should only happen with a malicious node or a fork
       LOG(log_er_) << "DagBlock" << block.getHash() << " Validation failed " << status.second << " . Peer "
                    << packet_data.from_node_id_ << " will be disconnected.";
-      syncing_state_->set_peer_malicious(peer->getId());
+      peers_state_->set_peer_malicious(peer->getId());
       disconnect(peer->getId(), dev::p2p::UserReason);
       return;
     }

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/get_dag_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/get_dag_sync_packet_handler.cpp
@@ -1,20 +1,17 @@
 #include "network/tarcap/packets_handlers/get_dag_sync_packet_handler.hpp"
 
 #include "dag/dag.hpp"
-#include "network/tarcap/shared_states/syncing_state.hpp"
 #include "transaction_manager/transaction_manager.hpp"
 
 namespace taraxa::network::tarcap {
 
 GetDagSyncPacketHandler::GetDagSyncPacketHandler(std::shared_ptr<PeersState> peers_state,
                                                  std::shared_ptr<PacketsStats> packets_stats,
-                                                 std::shared_ptr<SyncingState> syncing_state,
                                                  std::shared_ptr<TransactionManager> trx_mgr,
                                                  std::shared_ptr<DagManager> dag_mgr,
                                                  std::shared_ptr<DagBlockManager> dag_blk_mgr,
                                                  std::shared_ptr<DbStorage> db, const addr_t &node_addr)
     : PacketHandler(std::move(peers_state), std::move(packets_stats), node_addr, "GET_DAG_SYNC_PH"),
-      syncing_state_(std::move(syncing_state)),
       trx_mgr_(std::move(trx_mgr)),
       dag_mgr_(std::move(dag_mgr)),
       dag_blk_mgr_(std::move(dag_blk_mgr)),
@@ -27,7 +24,7 @@ void GetDagSyncPacketHandler::process(const PacketData &packet_data,
     // Each node should perform dag syncing only once
     LOG(log_er_) << "Received multiple GetDagSyncPackets from " << packet_data.from_node_id_.abridged()
                  << " peer will be disconnected";
-    syncing_state_->set_peer_malicious(peer->getId());
+    peers_state_->set_peer_malicious(peer->getId());
     disconnect(peer->getId(), dev::p2p::UserReason);
     return;
   }

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/transaction_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/transaction_packet_handler.cpp
@@ -1,7 +1,6 @@
 #include "network/tarcap/packets_handlers/transaction_packet_handler.hpp"
 
 #include "dag/dag_block_manager.hpp"
-#include "network/tarcap/shared_states/syncing_state.hpp"
 #include "network/tarcap/shared_states/test_state.hpp"
 #include "transaction_manager/transaction_manager.hpp"
 
@@ -9,13 +8,11 @@ namespace taraxa::network::tarcap {
 
 TransactionPacketHandler::TransactionPacketHandler(std::shared_ptr<PeersState> peers_state,
                                                    std::shared_ptr<PacketsStats> packets_stats,
-                                                   std::shared_ptr<SyncingState> syncing_state,
                                                    std::shared_ptr<TransactionManager> trx_mgr,
                                                    std::shared_ptr<DagBlockManager> dag_blk_mgr,
                                                    std::shared_ptr<TestState> test_state,
                                                    uint16_t network_transaction_interval, const addr_t &node_addr)
     : PacketHandler(std::move(peers_state), std::move(packets_stats), node_addr, "TRANSACTION_PH"),
-      syncing_state_(std::move(syncing_state)),
       trx_mgr_(std::move(trx_mgr)),
       dag_blk_mgr_(std::move(dag_blk_mgr)),
       test_state_(std::move(test_state)),
@@ -38,7 +35,7 @@ inline void TransactionPacketHandler::process(const PacketData &packet_data, con
       if (const auto [is_valid, reason] = trx_mgr_->verifyTransaction(transaction); !is_valid) {
         LOG(log_er_) << "Transaction " << transaction->getHash() << " validation falied: " << reason << " . Peer "
                      << packet_data.from_node_id_ << " will be disconnected.";
-        syncing_state_->set_peer_malicious(peer->getId());
+        peers_state_->set_peer_malicious(peer->getId());
         disconnect(packet_data.from_node_id_, dev::p2p::UserReason);
         return;
       }

--- a/libraries/core_libs/network/src/tarcap/shared_states/peers_state.cpp
+++ b/libraries/core_libs/network/src/tarcap/shared_states/peers_state.cpp
@@ -125,7 +125,7 @@ bool PeersState::is_peer_malicious(const dev::p2p::NodeID& peer_id) {
 
   // Delete any expired item from the list
   if (conf_.network_peer_blacklist_timeout > 0) {
-    malicious_peers_.erase([this](std::chrono::steady_clock::time_point value) {
+    malicious_peers_.erase([this](const std::chrono::steady_clock::time_point& value) {
       return std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - value).count() >
              conf_.network_peer_blacklist_timeout;
     });

--- a/libraries/core_libs/network/src/tarcap/shared_states/peers_state.cpp
+++ b/libraries/core_libs/network/src/tarcap/shared_states/peers_state.cpp
@@ -2,8 +2,9 @@
 
 namespace taraxa::network::tarcap {
 
-PeersState::PeersState(std::weak_ptr<dev::p2p::Host> host, const dev::p2p::NodeID& own_node_id)
-    : host_(std::move(host)), node_id_(own_node_id) {}
+PeersState::PeersState(std::weak_ptr<dev::p2p::Host> host, const dev::p2p::NodeID& own_node_id,
+                       const NetworkConfig& conf)
+    : host_(std::move(host)), node_id_(own_node_id), conf_(conf) {}
 
 std::shared_ptr<TaraxaPeer> PeersState::getPeer(const dev::p2p::NodeID& node_id) const {
   std::shared_lock lock(peers_mutex_);
@@ -100,6 +101,37 @@ std::shared_ptr<TaraxaPeer> PeersState::setPeerAsReadyToSendMessages(dev::p2p::N
   }
 
   return ret.first->second;
+}
+
+void PeersState::set_peer_malicious(const dev::p2p::NodeID& peer_id) {
+  malicious_peers_.emplace(peer_id, std::chrono::steady_clock::now());
+}
+
+bool PeersState::is_peer_malicious(const dev::p2p::NodeID& peer_id) {
+  if (conf_.disable_peer_blacklist) {
+    return false;
+  }
+
+  // Peers are marked malicious for the time defined in conf_.network_peer_blacklist_timeout
+  if (auto i = malicious_peers_.get(peer_id); i.second) {
+    if (conf_.network_peer_blacklist_timeout == 0 ||
+        std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - i.first).count() <=
+            conf_.network_peer_blacklist_timeout) {
+      return true;
+    } else {
+      malicious_peers_.erase(peer_id);
+    }
+  }
+
+  // Delete any expired item from the list
+  if (conf_.network_peer_blacklist_timeout > 0) {
+    malicious_peers_.erase([this](std::chrono::steady_clock::time_point value) {
+      return std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - value).count() >
+             conf_.network_peer_blacklist_timeout;
+    });
+  }
+
+  return false;
 }
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/src/tarcap/shared_states/syncing_state.cpp
+++ b/libraries/core_libs/network/src/tarcap/shared_states/syncing_state.cpp
@@ -5,8 +5,7 @@
 
 namespace taraxa::network::tarcap {
 
-SyncingState::SyncingState(uint16_t deep_syncing_threshold)
-    : malicious_peers_(300, 50), kDeepSyncingThreshold(deep_syncing_threshold) {}
+SyncingState::SyncingState(const NetworkConfig &conf) : conf_(conf) {}
 
 void SyncingState::set_peer(std::shared_ptr<TaraxaPeer> &&peer) {
   std::unique_lock lock(peer_mutex_);
@@ -28,7 +27,7 @@ const dev::p2p::NodeID SyncingState::syncing_peer() const {
 void SyncingState::setSyncStatePeriod(uint64_t period) {
   if (pbft_syncing_) {
     std::shared_lock lock(peer_mutex_);
-    deep_pbft_syncing_ = (peer_->pbft_chain_size_ - period >= kDeepSyncingThreshold);
+    deep_pbft_syncing_ = (peer_->pbft_chain_size_ - period >= conf_.deep_syncing_threshold);
   } else {
     deep_pbft_syncing_ = false;
   }
@@ -42,7 +41,7 @@ void SyncingState::set_pbft_syncing(bool syncing, uint64_t current_period,
 
   if (syncing) {
     std::shared_lock lock(peer_mutex_);
-    deep_pbft_syncing_ = (peer_->pbft_chain_size_ - current_period >= kDeepSyncingThreshold);
+    deep_pbft_syncing_ = (peer_->pbft_chain_size_ - current_period >= conf_.deep_syncing_threshold);
     // Reset last sync packet time when syncing is restarted/fresh syncing flag is set
     set_last_sync_packet_time();
   } else {
@@ -65,16 +64,31 @@ bool SyncingState::is_actively_syncing() const {
 
 void SyncingState::set_peer_malicious(const std::optional<dev::p2p::NodeID> &peer_id) {
   if (peer_id.has_value()) {
-    malicious_peers_.insert(peer_id.value());
+    malicious_peers_[peer_id.value()] = std::chrono::steady_clock::now();
     return;
   }
 
   // this lock is for peer_id_ not the malicious_peers_
   std::shared_lock lock(peer_mutex_);
-  malicious_peers_.insert(peer_->getId());
+  malicious_peers_[peer_->getId()] = std::chrono::steady_clock::now();
 }
 
-bool SyncingState::is_peer_malicious(const dev::p2p::NodeID &peer_id) const { return malicious_peers_.count(peer_id); }
+bool SyncingState::is_peer_malicious(const dev::p2p::NodeID &peer_id) {
+  if (conf_.disable_peer_blacklist) {
+    return false;
+  }
+
+  // Peers are marked malicious for the time defined in conf_.network_peer_blacklist_timeout
+  if (auto i = malicious_peers_.find(peer_id); i != malicious_peers_.end()) {
+    if (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - i->second).count() <=
+        conf_.network_peer_blacklist_timeout) {
+      return true;
+    } else {
+      malicious_peers_.erase(i);
+    }
+  }
+  return false;
+}
 
 bool SyncingState::is_syncing() { return is_pbft_syncing(); }
 

--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -37,7 +37,7 @@ TaraxaCapability::TaraxaCapability(std::weak_ptr<dev::p2p::Host> host, const dev
                                    std::shared_ptr<TransactionManager> trx_mgr, addr_t const &node_addr)
     : test_state_(std::make_shared<TestState>()),
       peers_state_(nullptr),
-      syncing_state_(std::make_shared<SyncingState>(conf.deep_syncing_threshold)),
+      syncing_state_(std::make_shared<SyncingState>(conf)),
       node_stats_(nullptr),
       packets_handlers_(std::make_shared<PacketsHandler>()),
       thread_pool_(std::make_shared<TarcapThreadPool>(conf.network_packets_processing_threads, node_addr)),
@@ -202,8 +202,8 @@ void TaraxaCapability::registerPacketHandlers(
 
   packets_handlers_->registerHandler(
       SubprotocolPacketType::TransactionPacket,
-      std::make_shared<TransactionPacketHandler>(peers_state_, packets_stats, trx_mgr, dag_blk_mgr, test_state_,
-                                                 conf.network_transaction_interval, node_addr));
+      std::make_shared<TransactionPacketHandler>(peers_state_, packets_stats, syncing_state_, trx_mgr, dag_blk_mgr,
+                                                 test_state_, conf.network_transaction_interval, node_addr));
 
   // Non critical packets with low processing priority
   packets_handlers_->registerHandler(SubprotocolPacketType::TestPacket,
@@ -212,9 +212,10 @@ void TaraxaCapability::registerPacketHandlers(
       SubprotocolPacketType::StatusPacket,
       std::make_shared<StatusPacketHandler>(peers_state_, packets_stats, syncing_state_, pbft_chain, pbft_mgr, dag_mgr,
                                             dag_blk_mgr, next_votes_mgr, db, conf.network_id, node_addr));
-  packets_handlers_->registerHandler(SubprotocolPacketType::GetDagSyncPacket,
-                                     std::make_shared<GetDagSyncPacketHandler>(peers_state_, packets_stats, trx_mgr,
-                                                                               dag_mgr, dag_blk_mgr, db, node_addr));
+  packets_handlers_->registerHandler(
+      SubprotocolPacketType::GetDagSyncPacket,
+      std::make_shared<GetDagSyncPacketHandler>(peers_state_, packets_stats, syncing_state_, trx_mgr, dag_mgr,
+                                                dag_blk_mgr, db, node_addr));
 
   packets_handlers_->registerHandler(
       SubprotocolPacketType::DagSyncPacket,

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -780,8 +780,11 @@ TEST_F(FullNodeTest, insert_anchor_and_compute_order) {
     EXPECT_EQ(order[4], blk_hash_t(5));
     EXPECT_EQ(order[5], blk_hash_t(7));
   }
-  auto num_blks_set = node->getDagManager()->setDagBlockOrder(ret->first, period, order);
-  EXPECT_EQ(num_blks_set, 6);
+  {
+    std::unique_lock dag_lock(node->getDagManager()->getDagMutex());
+    auto num_blks_set = node->getDagManager()->setDagBlockOrder(ret->first, period, order);
+    EXPECT_EQ(num_blks_set, 6);
+  }
   // -------- second period ----------
 
   for (int i = 10; i <= 16; i++) {
@@ -800,8 +803,11 @@ TEST_F(FullNodeTest, insert_anchor_and_compute_order) {
     EXPECT_EQ(order[5], blk_hash_t(14));
     EXPECT_EQ(order[6], blk_hash_t(15));
   }
-  num_blks_set = node->getDagManager()->setDagBlockOrder(ret->first, period, order);
-  EXPECT_EQ(num_blks_set, 7);
+  {
+    std::unique_lock dag_lock(node->getDagManager()->getDagMutex());
+    auto num_blks_set = node->getDagManager()->setDagBlockOrder(ret->first, period, order);
+    EXPECT_EQ(num_blks_set, 7);
+  }
 
   // -------- third period ----------
 
@@ -819,8 +825,11 @@ TEST_F(FullNodeTest, insert_anchor_and_compute_order) {
     EXPECT_EQ(order[3], blk_hash_t(18));
     EXPECT_EQ(order[4], blk_hash_t(19));
   }
-  num_blks_set = node->getDagManager()->setDagBlockOrder(ret->first, period, order);
-  EXPECT_EQ(num_blks_set, 5);
+  {
+    std::unique_lock dag_lock(node->getDagManager()->getDagMutex());
+    auto num_blks_set = node->getDagManager()->setDagBlockOrder(ret->first, period, order);
+    EXPECT_EQ(num_blks_set, 5);
+  }
 }
 
 TEST_F(FullNodeTest, destroy_db) {

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -427,7 +427,10 @@ TEST_F(NetworkTest, node_pbft_sync) {
 
   vec_blk_t order1;
   order1.push_back(blk1.getHash());
-  node1->getDagManager()->setDagBlockOrder(blk1.getHash(), level, order1);
+  {
+    std::unique_lock dag_lock(node1->getDagManager()->getDagMutex());
+    node1->getDagManager()->setDagBlockOrder(blk1.getHash(), level, order1);
+  }
 
   uint64_t expect_pbft_chain_size = 1;
   EXPECT_EQ(node1->getPbftChain()->getPbftChainSize(), expect_pbft_chain_size);
@@ -482,7 +485,10 @@ TEST_F(NetworkTest, node_pbft_sync) {
 
   vec_blk_t order2;
   order2.push_back(blk2.getHash());
-  node1->getDagManager()->setDagBlockOrder(blk2.getHash(), level, order2);
+  {
+    std::unique_lock dag_lock(node1->getDagManager()->getDagMutex());
+    node1->getDagManager()->setDagBlockOrder(blk2.getHash(), level, order2);
+  }
 
   expect_pbft_chain_size = 2;
   EXPECT_EQ(node1->getPbftChain()->getPbftChainSize(), expect_pbft_chain_size);

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -138,6 +138,53 @@ TEST_F(NetworkTest, send_pbft_block) {
                  [&](auto& ctx) { WAIT_EXPECT_EQ(ctx, nw1->getPeer(node2_id)->pbft_chain_size_, chain_size) });
 }
 
+TEST_F(NetworkTest, malicious_peers) {
+  NetworkConfig conf;
+  conf.network_peer_blacklist_timeout = 2;
+  std::shared_ptr<dev::p2p::Host> host;
+  EXPECT_EQ(conf.disable_peer_blacklist, false);
+  network::tarcap::PeersState state1(host, dev::p2p::NodeID(), conf);
+  dev::p2p::NodeID id1(1);
+  dev::p2p::NodeID id2(2);
+  state1.set_peer_malicious(id1);
+  EXPECT_EQ(state1.is_peer_malicious(id1), true);
+  EXPECT_EQ(state1.is_peer_malicious(id2), false);
+
+  conf.network_peer_blacklist_timeout = 0;
+  network::tarcap::PeersState state2(host, dev::p2p::NodeID(), conf);
+  state2.set_peer_malicious(id1);
+  EXPECT_EQ(state2.is_peer_malicious(id1), true);
+  EXPECT_EQ(state2.is_peer_malicious(id2), false);
+
+  conf.network_peer_blacklist_timeout = 2;
+  conf.disable_peer_blacklist = true;
+  network::tarcap::PeersState state3(host, dev::p2p::NodeID(), conf);
+  state1.set_peer_malicious(id1);
+  EXPECT_EQ(state3.is_peer_malicious(id1), false);
+  EXPECT_EQ(state3.is_peer_malicious(id2), false);
+
+  conf.network_peer_blacklist_timeout = 0;
+  conf.disable_peer_blacklist = true;
+  network::tarcap::PeersState state4(host, dev::p2p::NodeID(), conf);
+  state1.set_peer_malicious(id1);
+  EXPECT_EQ(state4.is_peer_malicious(id1), false);
+  EXPECT_EQ(state4.is_peer_malicious(id2), false);
+
+  thisThreadSleepForMilliSeconds(3100);
+
+  EXPECT_EQ(state1.is_peer_malicious(id1), false);
+  EXPECT_EQ(state1.is_peer_malicious(id2), false);
+
+  EXPECT_EQ(state2.is_peer_malicious(id1), true);
+  EXPECT_EQ(state2.is_peer_malicious(id2), false);
+
+  EXPECT_EQ(state3.is_peer_malicious(id1), false);
+  EXPECT_EQ(state3.is_peer_malicious(id2), false);
+
+  EXPECT_EQ(state4.is_peer_malicious(id1), false);
+  EXPECT_EQ(state4.is_peer_malicious(id2), false);
+}
+
 TEST_F(NetworkTest, sync_large_pbft_block) {
   const uint32_t MAX_PACKET_SIZE = 15 * 1024 * 1024;  // 15 MB -> 15 * 1024 * 1024 B
   auto node_cfgs = make_node_cfgs<5>(2);

--- a/tests/tarcap_threadpool_test.cpp
+++ b/tests/tarcap_threadpool_test.cpp
@@ -108,7 +108,7 @@ HandlersInitData createHandlersInitData() {
   ret_init_data.own_node_id = dev::p2p::NodeID(2);
   ret_init_data.own_node_addr = addr_t(2);
   ret_init_data.peers_state =
-      std::make_shared<tarcap::PeersState>(std::weak_ptr<dev::p2p::Host>(), ret_init_data.own_node_id);
+      std::make_shared<tarcap::PeersState>(std::weak_ptr<dev::p2p::Host>(), ret_init_data.own_node_id, NetworkConfig());
   ret_init_data.packets_stats = std::make_shared<tarcap::PacketsStats>(ret_init_data.own_node_addr);
   ret_init_data.packets_processing_info = std::make_shared<PacketsProcessingInfo>();
 


### PR DESCRIPTION
Malicious nodes are now marked as malicious for a specific amount of time defined in network_peer_blacklist_timeout. The default is 600 seconds(10 minutes). It is also possible to disable blacklisting with disable_peer_blacklist flag. Main reason for this is that we had cases that nodes were acting malicious because of a bug or an old version. It could be even because of the config file misconfigured. Any such node could in time be corrected and it should not be blacklisted forever.

All of the blacklisting is memory bases so any node restart will clear it as well.

PR handles most of the cases where invalid data is sent, like invalid blocks, transactions with incorrect difficulty and similar. Node sending blocks with missing transactions. The PR does not handle DDOS attacks where valid data is sent too many times.