### PR TITLE
chore: changing initial difficulty

### DIFF
--- a/libraries/cli/include/cli/devnet_config.hpp
+++ b/libraries/cli/include/cli/devnet_config.hpp
@@ -147,7 +147,7 @@ const char *devnet_json = R"foo({
       "dag_efficiency_targets": ["0x12C0", "0x1450"],
       "computation_interval": "0xC8",
       "vrf": {
-        "threshold_upper": "0x2fff",
+        "threshold_upper": "0xafff",
         "threshold_range": "0x1800"
       },
       "vdf": {


### PR DESCRIPTION
Initial difficulty is changed to higher value to avoid possible low blocks production on devnet initial startup