### PR TITLE
chore: move extensive network logs from info to debug level

### DIFF
--- a/libraries/cli/include/cli/config.hpp
+++ b/libraries/cli/include/cli/config.hpp
@@ -48,6 +48,7 @@ class Config {
   static constexpr const char* BOOT_NODES = "boot-nodes";
   static constexpr const char* PUBLIC_IP = "public-ip";
   static constexpr const char* LOG_CHANNELS = "log-channels";
+  static constexpr const char* LOG_CONFIGURATIONS = "log-configurations";
   static constexpr const char* BOOT_NODES_APPEND = "boot-nodes-append";
   static constexpr const char* LOG_CHANNELS_APPEND = "log-channels-append";
   static constexpr const char* NODE_SECRET = "node-secret";

--- a/libraries/cli/include/cli/default_config.hpp
+++ b/libraries/cli/include/cli/default_config.hpp
@@ -107,6 +107,79 @@ const char *default_json = R"foo({
             "max_size": 1000000000
           }
         ]
+      },
+      {
+        "name": "network",
+        "on": false,
+        "verbosity": "ERROR",
+        "channels": [
+          {
+            "name": "PBFT_CHAIN",
+            "verbosity": "INFO"
+          },
+          {
+            "name": "PBFT_MGR",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "GET_PBFT_SYNC_PH",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "PBFT_SYNC_PH",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "GET_DAG_SYNC_PH",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "DAG_SYNC_PH",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "DAG_BLOCK_PH",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "PBFT_BLOCK_PH",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "TARCAP",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "NETWORK",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "TRANSACTION_PH",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "DAGBLKMGR",
+            "verbosity": "INFO"
+          },
+          {
+            "name": "DAGMGR",
+            "verbosity": "INFO"
+          }
+        ],
+        "outputs": [
+          {
+            "type": "console",
+            "format": "%ThreadID% %Channel% [%TimeStamp%] %SeverityStr%: %Message%"
+          },
+          {
+            "type": "file",
+            "file_name": "TaraxaNetwork_N1_%m%d%Y_%H%M%S_%5N.log",
+            "rotation_size": 10000000,
+            "time_based_rotation": "0,0,0",
+            "format": "%ThreadID% %ShortNodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%",
+            "max_size": 1000000000
+          }
+        ]
       }
     ]
   },

--- a/libraries/cli/include/cli/devnet_config.hpp
+++ b/libraries/cli/include/cli/devnet_config.hpp
@@ -80,6 +80,80 @@ const char *devnet_json = R"foo({
             "max_size": 1000000000
           }
         ]
+      },
+      ,
+      {
+        "name": "network",
+        "on": false,
+        "verbosity": "ERROR",
+        "channels": [
+          {
+            "name": "PBFT_CHAIN",
+            "verbosity": "INFO"
+          },
+          {
+            "name": "PBFT_MGR",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "GET_PBFT_SYNC_PH",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "PBFT_SYNC_PH",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "GET_DAG_SYNC_PH",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "DAG_SYNC_PH",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "DAG_BLOCK_PH",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "PBFT_BLOCK_PH",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "TARCAP",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "NETWORK",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "TRANSACTION_PH",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "DAGBLKMGR",
+            "verbosity": "INFO"
+          },
+          {
+            "name": "DAGMGR",
+            "verbosity": "INFO"
+          }
+        ],
+        "outputs": [
+          {
+            "type": "console",
+            "format": "%ThreadID% %Channel% [%TimeStamp%] %SeverityStr%: %Message%"
+          },
+          {
+            "type": "file",
+            "file_name": "TaraxaNetwork_N1_%m%d%Y_%H%M%S_%5N.log",
+            "rotation_size": 10000000,
+            "time_based_rotation": "0,0,0",
+            "format": "%ThreadID% %ShortNodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%",
+            "max_size": 1000000000
+          }
+        ]
       }
     ]
   },

--- a/libraries/cli/include/cli/devnet_config.hpp
+++ b/libraries/cli/include/cli/devnet_config.hpp
@@ -81,7 +81,6 @@ const char *devnet_json = R"foo({
           }
         ]
       },
-      ,
       {
         "name": "network",
         "on": false,

--- a/libraries/cli/include/cli/testnet_config.hpp
+++ b/libraries/cli/include/cli/testnet_config.hpp
@@ -81,7 +81,6 @@ const char *testnet_json = R"foo({
           }
         ]
       },
-      ,
       {
         "name": "network",
         "on": false,

--- a/libraries/cli/include/cli/testnet_config.hpp
+++ b/libraries/cli/include/cli/testnet_config.hpp
@@ -80,6 +80,80 @@ const char *testnet_json = R"foo({
             "max_size": 1000000000
           }
         ]
+      },
+      ,
+      {
+        "name": "network",
+        "on": false,
+        "verbosity": "ERROR",
+        "channels": [
+          {
+            "name": "PBFT_CHAIN",
+            "verbosity": "INFO"
+          },
+          {
+            "name": "PBFT_MGR",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "GET_PBFT_SYNC_PH",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "PBFT_SYNC_PH",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "GET_DAG_SYNC_PH",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "DAG_SYNC_PH",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "DAG_BLOCK_PH",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "PBFT_BLOCK_PH",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "TARCAP",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "NETWORK",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "TRANSACTION_PH",
+            "verbosity": "DEBUG"
+          },
+          {
+            "name": "DAGBLKMGR",
+            "verbosity": "INFO"
+          },
+          {
+            "name": "DAGMGR",
+            "verbosity": "INFO"
+          }
+        ],
+        "outputs": [
+          {
+            "type": "console",
+            "format": "%ThreadID% %Channel% [%TimeStamp%] %SeverityStr%: %Message%"
+          },
+          {
+            "type": "file",
+            "file_name": "TaraxaNetwork_N1_%m%d%Y_%H%M%S_%5N.log",
+            "rotation_size": 10000000,
+            "time_based_rotation": "0,0,0",
+            "format": "%ThreadID% %ShortNodeId% %Channel% [%TimeStamp%] %SeverityStr%: %Message%",
+            "max_size": 1000000000
+          }
+        ]
       }
     ]
   },

--- a/libraries/cli/include/cli/tools.hpp
+++ b/libraries/cli/include/cli/tools.hpp
@@ -35,6 +35,7 @@ class Tools {
   // Override existing config and wallet files
   static Json::Value overrideConfig(Json::Value& config, std::string& data_dir, bool boot_node,
                                     std::vector<std::string> boot_nodes, std::vector<std::string> log_channels,
+                                    std::vector<std::string> log_configurations,
                                     const std::vector<std::string>& boot_nodes_append,
                                     const std::vector<std::string>& log_channels_append);
   static Json::Value overrideWallet(Json::Value& wallet, const std::string& node_key, const std::string& vrf_key);

--- a/libraries/cli/src/config.cpp
+++ b/libraries/cli/src/config.cpp
@@ -24,6 +24,7 @@ Config::Config(int argc, const char* argv[]) {
   vector<string> boot_nodes;
   string public_ip;
   vector<string> log_channels;
+  vector<string> log_configurations;
   vector<string> boot_nodes_append;
   vector<string> log_channels_append;
   string node_secret;
@@ -97,6 +98,8 @@ Config::Config(int argc, const char* argv[]) {
   node_command_options.add_options()(
       LOG_CHANNELS_APPEND, bpo::value<vector<string>>(&log_channels_append)->multitoken(),
       "Log channels to log in addition to log channels defined in config: [channel:level, ....]");
+  node_command_options.add_options()(LOG_CONFIGURATIONS, bpo::value<vector<string>>(&log_configurations)->multitoken(),
+                                     "Log confifugrations to use: [channel:level, ....]");
   node_command_options.add_options()(NODE_SECRET, bpo::value<string>(&node_secret), "Nose secret key to use");
 
   node_command_options.add_options()(VRF_SECRET, bpo::value<string>(&vrf_secret), "Vrf secret key to use");
@@ -160,8 +163,8 @@ Config::Config(int argc, const char* argv[]) {
     Json::Value wallet_json = Tools::readJsonFromFile(wallet);
 
     // Override config values with values from CLI
-    config_json = Tools::overrideConfig(config_json, data_dir, boot_node, boot_nodes, log_channels, boot_nodes_append,
-                                        log_channels_append);
+    config_json = Tools::overrideConfig(config_json, data_dir, boot_node, boot_nodes, log_channels, log_configurations,
+                                        boot_nodes_append, log_channels_append);
     wallet_json = Tools::overrideWallet(wallet_json, node_secret, vrf_secret);
 
     // Create data directory

--- a/libraries/cli/src/tools.cpp
+++ b/libraries/cli/src/tools.cpp
@@ -54,8 +54,8 @@ Json::Value Tools::generateConfig(Config::NetworkIdType network_id) {
 }
 
 Json::Value Tools::overrideConfig(Json::Value& conf, std::string& data_dir, bool boot_node, vector<string> boot_nodes,
-                                  vector<string> log_channels, const vector<string>& boot_nodes_append,
-                                  const vector<string>& log_channels_append) {
+                                  vector<string> log_channels, vector<string> log_configurations,
+                                  const vector<string>& boot_nodes_append, const vector<string>& log_channels_append) {
   if (data_dir.empty()) {
     if (conf["data_path"].asString().empty()) {
       conf["data_path"] = getTaraxaDataDefaultDir();
@@ -109,6 +109,17 @@ Json::Value Tools::overrideConfig(Json::Value& conf, std::string& data_dir, bool
   // Override log channels
   if (log_channels.size() > 0) {
     conf["logging"]["configurations"][0u]["channels"] = Json::Value(Json::arrayValue);
+  }
+
+  // Turn on logging configurations
+  if (log_configurations.size() > 0) {
+    for (Json::Value& node : conf["logging"]["configurations"]) {
+      for (const auto& log_conf : log_configurations) {
+        if (node["name"].asString() == log_conf) {
+          node["on"] = true;
+        }
+      }
+    }
   }
   if (log_channels_append.size() > 0) {
     log_channels = log_channels_append;

--- a/libraries/core_libs/network/src/network.cpp
+++ b/libraries/core_libs/network/src/network.cpp
@@ -90,7 +90,7 @@ void Network::onNewBlockVerified(DagBlock const &blk, bool proposed, SharedTrans
 
 void Network::onNewTransactions(SharedTransactions &&transactions) {
   taraxa_capability_->onNewTransactions(std::move(transactions));
-  LOG(log_dg_) << "On new transactions" << transactions.size();
+  LOG(log_tr_) << "On new transactions" << transactions.size();
 }
 
 void Network::restartSyncingPbft(bool force) {
@@ -112,7 +112,7 @@ void Network::handleMaliciousSyncPeer(dev::p2p::NodeID const &id) { taraxa_capab
 
 void Network::onNewPbftVotes(std::vector<std::shared_ptr<Vote>> &&votes) {
   for (auto &vote : votes) {
-    LOG(log_dg_) << "Network broadcast PBFT vote: " << vote->getHash();
+    LOG(log_tr_) << "Network broadcast PBFT vote: " << vote->getHash();
     taraxa_capability_->onNewPbftVote(std::move(vote));
   }
 }
@@ -168,7 +168,7 @@ void Network::sendPbftBlock(dev::p2p::NodeID const &id, PbftBlock const &pbft_bl
 }
 
 void Network::sendPbftVote(dev::p2p::NodeID const &id, std::shared_ptr<Vote> const &vote) {
-  LOG(log_dg_) << "Network sent PBFT vote: " << vote->getHash() << " to: " << id;
+  LOG(log_tr_) << "Network sent PBFT vote: " << vote->getHash() << " to: " << id;
   taraxa_capability_->sendPbftVote(id, vote);
 }
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/dag_block_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/dag_block_packet_handler.cpp
@@ -35,18 +35,18 @@ void DagBlockPacketHandler::process(const PacketData &packet_data, const std::sh
   if (dag_blk_mgr_) {
     // Do not process this block in case we already have it
     if (dag_blk_mgr_->isDagBlockKnown(block.getHash())) {
-      LOG(log_dg_) << "Received known DagBlockPacket " << hash << "from: " << peer->getId();
+      LOG(log_tr_) << "Received known DagBlockPacket " << hash << "from: " << peer->getId();
       return;
     }
 
-    LOG(log_nf_) << "Received DagBlockPacket " << hash << "from: " << peer->getId();
+    LOG(log_dg_) << "Received DagBlockPacket " << hash << "from: " << peer->getId();
 
     if (auto status = checkDagBlockValidation(block); !status.first) {
       // Ignore new block packets when pbft syncing
       if (syncing_state_->is_pbft_syncing()) {
-        LOG(log_nf_) << "Ignore new dag block " << hash << ", pbft syncing is on";
+        LOG(log_dg_) << "Ignore new dag block " << hash << ", pbft syncing is on";
       } else if (peer->peer_dag_syncing_) {
-        LOG(log_nf_) << "Ignore new dag block " << hash << ", dag syncing is on";
+        LOG(log_dg_) << "Ignore new dag block " << hash << ", dag syncing is on";
       } else {
         if (peer->peer_dag_synced_) {
           LOG(log_er_) << "DagBlock" << block.getHash() << " has missing pivot or/and tips " << status.second
@@ -111,7 +111,7 @@ void DagBlockPacketHandler::onNewBlockReceived(DagBlock &&block) {
     onNewBlockVerified(block, false, {});
 
   } else {
-    LOG(log_dg_) << "Received NewBlock " << block.getHash() << "that is already known";
+    LOG(log_tr_) << "Received NewBlock " << block.getHash() << "that is already known";
     return;
   }
 }
@@ -124,7 +124,7 @@ void DagBlockPacketHandler::onNewBlockVerified(DagBlock const &block, bool propo
   }
 
   const auto &block_hash = block.getHash();
-  LOG(log_dg_) << "Verified NewBlock " << block_hash.toString();
+  LOG(log_tr_) << "Verified NewBlock " << block_hash.toString();
 
   std::vector<dev::p2p::NodeID> peers_to_send;
   for (auto const &peer : peers_state_->getAllPeers()) {
@@ -152,7 +152,7 @@ void DagBlockPacketHandler::onNewBlockVerified(DagBlock const &block, bool propo
       peer->markDagBlockAsKnown(block_hash);
     }
   }
-  LOG(log_nf_) << "Send DagBlock " << block.getHash() << " to peers: " << peer_and_transactions_to_log;
-  if (!peers_to_send.empty()) LOG(log_dg_) << "Sent block to " << peers_to_send.size() << " peers";
+  LOG(log_dg_) << "Send DagBlock " << block.getHash() << " to peers: " << peer_and_transactions_to_log;
+  if (!peers_to_send.empty()) LOG(log_tr_) << "Sent block to " << peers_to_send.size() << " peers";
 }
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/dag_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/dag_sync_packet_handler.cpp
@@ -29,7 +29,7 @@ void DagSyncPacketHandler::process(const PacketData& packet_data, const std::sha
 
   // If the periods did not match restart syncing
   if (response_period > request_period) {
-    LOG(log_nf_) << "Received DagSyncPacket with mismatching periods: " << response_period << " " << request_period
+    LOG(log_dg_) << "Received DagSyncPacket with mismatching periods: " << response_period << " " << request_period
                  << " from " << packet_data.from_node_id_.abridged();
     if (peer->pbft_chain_size_ < response_period) {
       peer->pbft_chain_size_ = response_period;
@@ -94,7 +94,7 @@ void DagSyncPacketHandler::process(const PacketData& packet_data, const std::sha
   peer->peer_dag_synced_ = true;
   peer->peer_dag_syncing_ = false;
 
-  LOG(log_nf_) << "Received DagSyncPacket with blocks: " << received_dag_blocks_str
+  LOG(log_dg_) << "Received DagSyncPacket with blocks: " << received_dag_blocks_str
                << " Transactions: " << transactions_to_log << " from " << packet_data.from_node_id_;
 }
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/get_dag_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/get_dag_sync_packet_handler.cpp
@@ -43,7 +43,7 @@ void GetDagSyncPacketHandler::process(const PacketData &packet_data,
     blocks_hashes.emplace(std::move(hash));
   }
 
-  LOG(log_nf_) << "Received GetDagSyncPacket: " << blocks_hashes_to_log << " from " << peer->getId();
+  LOG(log_dg_) << "Received GetDagSyncPacket: " << blocks_hashes_to_log << " from " << peer->getId();
 
   auto [period, blocks, transactions] = dag_mgr_->getNonFinalizedBlocksWithTransactions(blocks_hashes);
   if (peer_period == period) {
@@ -92,7 +92,7 @@ void GetDagSyncPacketHandler::sendBlocks(const dev::p2p::NodeID &peer_id,
     s.appendRaw(block->rlp(true));
   }
   sealAndSend(peer_id, SubprotocolPacketType::DagSyncPacket, std::move(s));
-  LOG(log_nf_) << "Send DagSyncPacket with " << dag_blocks_to_send << "# Trx: " << transactions_to_log << " from "
+  LOG(log_dg_) << "Send DagSyncPacket with " << dag_blocks_to_send << "# Trx: " << transactions_to_log << " from "
                << peer->getId();
 }
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/get_pbft_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/get_pbft_sync_packet_handler.cpp
@@ -20,7 +20,7 @@ GetPbftSyncPacketHandler::GetPbftSyncPacketHandler(std::shared_ptr<PeersState> p
 
 void GetPbftSyncPacketHandler::process(const PacketData &packet_data,
                                        [[maybe_unused]] const std::shared_ptr<TaraxaPeer> &peer) {
-  LOG(log_dg_) << "Received GetPbftSyncPacket Block";
+  LOG(log_tr_) << "Received GetPbftSyncPacket Block";
 
   const size_t height_to_sync = packet_data.rlp_[0].toInt();
   // Here need PBFT chain size, not synced period since synced blocks has not verified yet.
@@ -29,7 +29,7 @@ void GetPbftSyncPacketHandler::process(const PacketData &packet_data,
   if (my_chain_size >= height_to_sync) {
     blocks_to_transfer = std::min(network_sync_level_size_, (my_chain_size - (height_to_sync - 1)));
   }
-  LOG(log_dg_) << "Will send " << blocks_to_transfer << " PBFT blocks to " << packet_data.from_node_id_;
+  LOG(log_tr_) << "Will send " << blocks_to_transfer << " PBFT blocks to " << packet_data.from_node_id_;
 
   sendPbftBlocks(packet_data.from_node_id_, height_to_sync, blocks_to_transfer);
 }
@@ -37,11 +37,11 @@ void GetPbftSyncPacketHandler::process(const PacketData &packet_data,
 // api for pbft syncing
 void GetPbftSyncPacketHandler::sendPbftBlocks(dev::p2p::NodeID const &peer_id, size_t height_to_sync,
                                               size_t blocks_to_transfer) {
-  LOG(log_dg_) << "sendPbftBlocks: peer want to sync from pbft chain height " << height_to_sync
+  LOG(log_tr_) << "sendPbftBlocks: peer want to sync from pbft chain height " << height_to_sync
                << ", will send at most " << blocks_to_transfer << " pbft blocks to " << peer_id;
   uint64_t current_period = height_to_sync;
   if (blocks_to_transfer == 0) {
-    LOG(log_nf_) << "Sending empty PbftSyncPacket to " << peer_id;
+    LOG(log_dg_) << "Sending empty PbftSyncPacket to " << peer_id;
     sealAndSend(peer_id, SubprotocolPacketType::PbftSyncPacket, dev::RLPStream(0));
     return;
   }
@@ -60,7 +60,7 @@ void GetPbftSyncPacketHandler::sendPbftBlocks(dev::p2p::NodeID const &peer_id, s
     s.appendList(2);
     s << last_block;
     s.appendRaw(data);
-    LOG(log_nf_) << "Sending PbftSyncPacket period " << current_period << " to " << peer_id;
+    LOG(log_dg_) << "Sending PbftSyncPacket period " << current_period << " to " << peer_id;
     sealAndSend(peer_id, SubprotocolPacketType::PbftSyncPacket, std::move(s));
     current_period++;
   }

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/transaction_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/transaction_packet_handler.cpp
@@ -46,9 +46,9 @@ inline void TransactionPacketHandler::process(const PacketData &packet_data, con
   }
 
   if (transaction_count > 0) {
-    LOG(log_dg_) << "Received TransactionPacket with " << packet_data.rlp_.itemCount() << " transactions";
+    LOG(log_tr_) << "Received TransactionPacket with " << packet_data.rlp_.itemCount() << " transactions";
     if (transactions.size() > 0) {
-      LOG(log_nf_) << "Received TransactionPacket with " << transactions.size()
+      LOG(log_dg_) << "Received TransactionPacket with " << transactions.size()
                    << " unseen transactions:" << received_transactions << " from: " << peer->getId().abridged();
     }
 
@@ -66,9 +66,9 @@ void TransactionPacketHandler::onNewTransactions(SharedTransactions &&transactio
         auto trx_hash = trx->getHash();
         if (!test_state_->hasTransaction(trx_hash)) {
           test_state_->insertTransaction(*trx);
-          LOG(log_dg_) << "Received New Transaction " << trx_hash;
+          LOG(log_tr_) << "Received New Transaction " << trx_hash;
         } else {
-          LOG(log_dg_) << "Received New Transaction" << trx_hash << "that is already known";
+          LOG(log_tr_) << "Received New Transaction" << trx_hash << "that is already known";
         }
       }
     }
@@ -105,7 +105,7 @@ void TransactionPacketHandler::onNewTransactions(SharedTransactions &&transactio
       }
     }
 
-    LOG(log_dg_) << "Sending Transactions " << transactions_to_log << " to " << peers_to_log;
+    LOG(log_tr_) << "Sending Transactions " << transactions_to_log << " to " << peers_to_log;
 
     for (auto &it : transactions_to_send) {
       sendTransactions(it.first, it.second);
@@ -120,7 +120,7 @@ void TransactionPacketHandler::onNewTransactions(SharedTransactions &&transactio
 
 void TransactionPacketHandler::sendTransactions(dev::p2p::NodeID const &peer_id,
                                                 std::vector<taraxa::bytes> const &transactions) {
-  LOG(log_dg_) << "sendTransactions " << transactions.size() << " to " << peer_id;
+  LOG(log_tr_) << "sendTransactions " << transactions.size() << " to " << peer_id;
 
   dev::RLPStream s(transactions.size());
   taraxa::bytes trx_bytes;


### PR DESCRIPTION
Moving gossip/syncing logs from INFO to DEBUG and DEBUG to TRACE to avoid extensive logging on INFO level.
Added additional configuration that is off by default where these networking debug logs can easily be turned on.