### PR TITLE
fix(syncing_state): fixed race condition inside set_pbft_syncing

### DIFF
--- a/libraries/core_libs/network/include/network/tarcap/shared_states/syncing_state.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/shared_states/syncing_state.hpp
@@ -49,9 +49,6 @@ class SyncingState {
   const dev::p2p::NodeID syncing_peer() const;
 
  private:
-  void set_peer(std::shared_ptr<TaraxaPeer> &&peer);
-
- private:
   std::atomic<bool> deep_pbft_syncing_{false};
   std::atomic<bool> pbft_syncing_{false};
 


### PR DESCRIPTION
## Purpose
<!-- Provide any information reviewers might need to have context on your changes. -->


## How does the solution address the problem
<!-- Describe your solution. -->

Based on core dump from issue, it is obvious that it crashed inside atomic that was accessed from line:
`deep_pbft_syncing_ = (peer_->pbft_chain_size_ - current_period >= kDeepSyncingThreshold);`

that means it can be only `peer_->pbft_chain_size_`, but gdb printed valid value for this variable. In the next frame it has weird address though and then we found out that `peer_` could have been overridden in the meantime and thats how we found out the race condition for peer_ variable...

## Changes made
<!-- Summary or changes that have been made. -->
