### PR TITLE
feat: new generic architecture for processing packets rlp that would …

### DIFF
--- a/libraries/core_libs/network/include/network/tarcap/packets_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handler.hpp
@@ -3,7 +3,7 @@
 #include <memory>
 #include <unordered_map>
 
-#include "network/tarcap/packets_handlers/common/packet_handler.hpp"
+#include "network/tarcap/packets_handlers/common/i_packet_handler.hpp"
 
 namespace taraxa::network::tarcap {
 
@@ -20,7 +20,7 @@ class PacketsHandler {
    * @param packet_type
    * @return reference to std::shared_ptr<PacketsHandler>
    */
-  std::shared_ptr<PacketHandler>& getSpecificHandler(SubprotocolPacketType packet_type);
+  std::shared_ptr<IPacketHandler>& getSpecificHandler(SubprotocolPacketType packet_type);
 
   /**
    * @brief Registers handler for specific packet type
@@ -28,11 +28,11 @@ class PacketsHandler {
    * @param packet_type
    * @param handler
    */
-  void registerHandler(SubprotocolPacketType packet_type, std::shared_ptr<PacketHandler> handler);
+  void registerHandler(SubprotocolPacketType packet_type, std::shared_ptr<IPacketHandler> handler);
 
  private:
   // Map of all packets handlers, factory method selects specific packet handler for processing based on packet type
-  std::unordered_map<SubprotocolPacketType, std::shared_ptr<PacketHandler>> packets_handlers_;
+  std::unordered_map<SubprotocolPacketType, std::shared_ptr<IPacketHandler>> packets_handlers_;
 };
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/alt_transaction_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/alt_transaction_packet_handler.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "dag/dag_block.hpp"
+#include "network/tarcap/packets_handlers/common/templated_packet_handler.hpp"
+#include "transaction/alt_transaction_packet_data.hpp"
+
+namespace taraxa {
+class DagBlockManager;
+class TransactionManager;
+}  // namespace taraxa
+
+namespace taraxa::network::tarcap {
+
+class TestState;
+
+class AltTransactionPacketHandler : public TemplatedPacketHandler<TransactionPacketData> {
+ public:
+  AltTransactionPacketHandler(std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
+                              std::shared_ptr<TransactionManager> trx_mgr, std::shared_ptr<DagBlockManager> dag_blk_mgr,
+                              std::shared_ptr<TestState> test_state, uint16_t network_transaction_interval,
+                              const addr_t& node_addr);
+
+  virtual ~AltTransactionPacketHandler() = default;
+
+  void onNewTransactions(SharedTransactions&& transactions, bool fromNetwork);
+  void sendTransactions(dev::p2p::NodeID const& peer_id, std::vector<taraxa::bytes> const& transactions);
+
+ private:
+  void process(TransactionPacketData&& packet_data, const std::shared_ptr<TaraxaPeer>& from_peer) override;
+
+  std::shared_ptr<TransactionManager> trx_mgr_;
+
+  // FOR TESTING ONLY
+  std::shared_ptr<DagBlockManager> dag_blk_mgr_;
+  std::shared_ptr<TestState> test_state_;
+
+  const uint16_t network_transaction_interval_;
+  std::atomic<uint64_t> received_trx_count_{0};
+  std::atomic<uint64_t> unique_received_trx_count_{0};
+
+  const uint32_t MAX_TRANSACTIONS_IN_PACKET{1000};
+};
+
+}  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/i_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/i_packet_handler.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "network/tarcap/threadpool/packet_data.hpp"
+
+namespace taraxa::network::tarcap {
+
+/**
+ * @brief PacketHandler interface (abstract class) used in tarcap_threadpool
+ */
+class IPacketHandler {
+ public:
+  virtual ~IPacketHandler() = default;
+
+  /**
+   * @brief Main packet processing function
+   *
+   * @param packet_data
+   */
+  virtual void processPacket(const PacketData& packet_data) = 0;
+};
+
+}  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/packet_handler.hpp
@@ -5,6 +5,7 @@
 #include "libdevcore/RLP.h"
 #include "logger/logger.hpp"
 #include "network/tarcap/packet_types.hpp"
+#include "network/tarcap/packets_handlers/common/i_packet_handler.hpp"
 #include "network/tarcap/shared_states/peers_state.hpp"
 #include "network/tarcap/taraxa_peer.hpp"
 #include "network/tarcap/threadpool/packet_data.hpp"
@@ -19,17 +20,12 @@ class PacketsStats;
 /**
  * @brief Packet handler base class that consists of shared state and some commonly used functions
  */
-class PacketHandler {
+class PacketHandler : public IPacketHandler {
  public:
   PacketHandler(std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
                 const addr_t& node_addr, const std::string& log_channel_name);
 
-  /**
-   * @brief Packet processing function wrapper that logs packet stats and calls process function
-   *
-   * @param packet_data
-   */
-  void processPacket(const PacketData& packet_data);
+  void processPacket(const PacketData& packet_data) override;
 
  private:
   void handle_read_exception(const PacketData& packet_data);

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/templated_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/templated_packet_handler.hpp
@@ -1,0 +1,156 @@
+#pragma once
+
+#include <memory>
+
+#include "libdevcore/RLP.h"
+#include "logger/logger.hpp"
+#include "network/tarcap/packet_types.hpp"
+#include "network/tarcap/packets_handlers/common/i_packet_handler.hpp"
+#include "network/tarcap/shared_states/peers_state.hpp"
+#include "network/tarcap/taraxa_peer.hpp"
+#include "network/tarcap/threadpool/packet_data.hpp"
+
+namespace taraxa::network::tarcap {
+
+class PacketsStats;
+
+// TODO: remove Templated
+template <typename Packet>
+class TemplatedPacketHandler : public IPacketHandler {
+ public:
+  virtual ~TemplatedPacketHandler() = default;
+  TemplatedPacketHandler(std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
+                         const addr_t& node_addr, const std::string& log_channel_name);
+
+  // TODO: rename PacketData to RawPacketData and packet_data to raw_packet_data
+  void processPacket(const PacketData& raw_packet_data) override;
+
+ private:
+  /**
+   * @brief Parses packed data (rlp)
+   *
+   * @param packet_data
+   * @throws InvalidEncodingSize in case actual packet rlp items count != expected items count
+   * @returns parsed Packet object
+   */
+  virtual Packet parsePacket(const PacketData& raw_packet_data);
+
+  /**
+   * @brief Main packet processing function
+   *
+   * @param packet
+   * @param from_peer packet sender
+   */
+  virtual void process(Packet&& packet_data, const std::shared_ptr<TaraxaPeer>& from_peer) = 0;
+
+ protected:
+  bool sealAndSend(const dev::p2p::NodeID& nodeID, SubprotocolPacketType packet_type, dev::RLPStream&& rlp);
+  void disconnect(dev::p2p::NodeID const& node_id, dev::p2p::DisconnectReason reason);
+
+ protected:
+  std::shared_ptr<PeersState> peers_state_{nullptr};
+
+  // Shared packet stats
+  std::shared_ptr<PacketsStats> packets_stats_;
+
+  // Declare logger instances
+  LOG_OBJECTS_DEFINE
+};
+
+template <typename Packet>
+TemplatedPacketHandler<Packet>::TemplatedPacketHandler(std::shared_ptr<PeersState> peers_state,
+                                                       std::shared_ptr<PacketsStats> packets_stats,
+                                                       const addr_t& node_addr, const std::string& log_channel_name)
+    : peers_state_(std::move(peers_state)), packets_stats_(std::move(packets_stats)) {
+  LOG_OBJECTS_CREATE(log_channel_name);
+}
+
+template <typename Packet>
+Packet TemplatedPacketHandler<Packet>::parsePacket(const PacketData& packet_data) {
+  return util::encoding_rlp::rlp_dec<Packet>(util::RLPDecoderRef(packet_data.rlp_, true));
+}
+
+template <typename Packet>
+void TemplatedPacketHandler<Packet>::processPacket(const PacketData& packet_data) {
+  try {
+    SinglePacketStats packet_stats{packet_data.from_node_id_, packet_data.rlp_.data().size(),
+                                   std::chrono::microseconds(0), std::chrono::microseconds(0)};
+    const auto begin = std::chrono::steady_clock::now();
+
+    auto tmp_peer = peers_state_->getPeer(packet_data.from_node_id_);
+    if (!tmp_peer && packet_data.type_ != SubprotocolPacketType::StatusPacket) {
+      LOG(log_er_) << "Peer " << packet_data.from_node_id_.abridged()
+                   << " not in peers map. He probably did not send initial status message - will be disconnected.";
+      disconnect(packet_data.from_node_id_, dev::p2p::UserReason);
+      return;
+    }
+
+    // Main processing function
+    process(parsePacket(packet_data), tmp_peer);
+
+    auto processing_duration =
+        std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - begin);
+    auto tp_wait_duration = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() -
+                                                                                  packet_data.receive_time_);
+    packet_stats.processing_duration_ = processing_duration;
+    packet_stats.tp_wait_duration_ = tp_wait_duration;
+
+    packets_stats_->addReceivedPacket(packet_data.type_str_, packet_stats);
+  } catch (const std::exception& e) {
+    // TODO: maybe we should not catch the exception here and disconnect peer ???
+    LOG(log_er_) << "Processing packet " << packet_data.type_str_ << " (" << packet_data.type_
+                 << ") exception: " << e.what();
+    disconnect(packet_data.from_node_id_, dev::p2p::DisconnectReason::BadProtocol);
+  } catch (...) {
+    LOG(log_er_) << "Processing packet " << packet_data.type_str_ << " (" << packet_data.type_
+                 << ") unknown exception.";
+    disconnect(packet_data.from_node_id_, dev::p2p::DisconnectReason::BadProtocol);
+  }
+}
+
+template <typename Packet>
+bool TemplatedPacketHandler<Packet>::sealAndSend(const dev::p2p::NodeID& node_id, SubprotocolPacketType packet_type,
+                                                 dev::RLPStream&& rlp) {
+  auto host = peers_state_->host_.lock();
+  if (!host) {
+    LOG(log_er_) << "sealAndSend failed to obtain host";
+    return false;
+  }
+
+  const auto [peer, is_pending] = peers_state_->getAnyPeer(node_id);
+  if (!peer) [[unlikely]] {
+    LOG(log_wr_) << "sealAndSend failed to find peer";
+    return false;
+  }
+
+  if (is_pending && packet_type != SubprotocolPacketType::StatusPacket) [[unlikely]] {
+    LOG(log_wr_) << "sealAndSend failed initial status check, peer " << node_id.abridged() << " will be disconnected";
+    host->disconnect(node_id, dev::p2p::UserReason);
+    return false;
+  }
+
+  const auto begin = std::chrono::steady_clock::now();
+  const size_t packet_size = rlp.out().size();
+
+  // TODO: use TARAXA_CAPABILITY_NAME instead of "taraxa"
+  host->send(node_id, "taraxa", packet_type, rlp.invalidate(), [begin, node_id, packet_size, packet_type, this]() {
+    SinglePacketStats packet_stats{
+        node_id, packet_size,
+        std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - begin),
+        std::chrono::microseconds{0}};
+    packets_stats_->addSentPacket(convertPacketTypeToString(packet_type), packet_stats);
+  });
+
+  return true;
+}
+
+template <typename Packet>
+void TemplatedPacketHandler<Packet>::disconnect(dev::p2p::NodeID const& node_id, dev::p2p::DisconnectReason reason) {
+  if (auto host = peers_state_->host_.lock(); host) {
+    host->disconnect(node_id, reason);
+  } else {
+    LOG(log_wr_) << "Invalid host " << node_id.abridged();
+  }
+}
+
+}  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/src/tarcap/packets_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handler.cpp
@@ -2,13 +2,13 @@
 
 namespace taraxa::network::tarcap {
 
-void PacketsHandler::registerHandler(SubprotocolPacketType packet_type, std::shared_ptr<PacketHandler> handler) {
+void PacketsHandler::registerHandler(SubprotocolPacketType packet_type, std::shared_ptr<IPacketHandler> handler) {
   assert(packets_handlers_.find(packet_type) == packets_handlers_.end());
 
   packets_handlers_.emplace(packet_type, std::move(handler));
 }
 
-std::shared_ptr<PacketHandler>& PacketsHandler::getSpecificHandler(SubprotocolPacketType packet_type) {
+std::shared_ptr<IPacketHandler>& PacketsHandler::getSpecificHandler(SubprotocolPacketType packet_type) {
   auto selected_handler = packets_handlers_.find(packet_type);
 
   if (selected_handler == packets_handlers_.end()) {

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/alt_transaction_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/alt_transaction_packet_handler.cpp
@@ -1,0 +1,137 @@
+#include "network/tarcap/packets_handlers/alt_transaction_packet_handler.hpp"
+
+#include "dag/dag_block_manager.hpp"
+#include "network/tarcap/shared_states/test_state.hpp"
+#include "transaction/transaction.hpp"
+#include "transaction_manager/transaction_manager.hpp"
+
+namespace taraxa::network::tarcap {
+
+AltTransactionPacketHandler::AltTransactionPacketHandler(std::shared_ptr<PeersState> peers_state,
+                                                         std::shared_ptr<PacketsStats> packets_stats,
+                                                         std::shared_ptr<TransactionManager> trx_mgr,
+                                                         std::shared_ptr<DagBlockManager> dag_blk_mgr,
+                                                         std::shared_ptr<TestState> test_state,
+                                                         uint16_t network_transaction_interval, const addr_t &node_addr)
+    : TemplatedPacketHandler<TransactionPacketData>(std::move(peers_state), std::move(packets_stats), node_addr,
+                                                    "TRANSACTION_PH"),
+      trx_mgr_(std::move(trx_mgr)),
+      dag_blk_mgr_(std::move(dag_blk_mgr)),
+      test_state_(std::move(test_state)),
+      network_transaction_interval_(network_transaction_interval) {}
+
+inline void AltTransactionPacketHandler::process(TransactionPacketData &&packet_data,
+                                                 const std::shared_ptr<TaraxaPeer> &peer) {
+  std::string received_transactions;
+  const auto transaction_count = packet_data.transactions.size();
+
+  SharedTransactions transactions;
+  transactions.reserve(transaction_count);
+
+  for (auto &packet_tx : packet_data.transactions) {
+    const auto transaction = std::make_shared<Transaction>(std::move(packet_tx));
+
+    if (dag_blk_mgr_) [[likely]] {  // ONLY FOR TESTING
+      if (trx_mgr_->markTransactionSeen(transaction->getHash())) {
+        continue;
+      }
+      if (const auto [is_valid, reason] = trx_mgr_->verifyTransaction(transaction); !is_valid) {
+        LOG(log_er_) << "Transaction " << transaction->getHash() << " validation falied: " << reason << " . Peer "
+                     << peer->getId() << " will be disconnected.";
+        peers_state_->set_peer_malicious(peer->getId());
+        disconnect(peer->getId(), dev::p2p::UserReason);
+        return;
+      }
+    }
+    received_transactions += transaction->getHash().abridged() + " ";
+    peer->markTransactionAsKnown(transaction->getHash());
+    transactions.push_back(std::move(transaction));
+  }
+
+  if (transaction_count > 0) {
+    LOG(log_dg_) << "Received TransactionPacket with " << transaction_count << " transactions";
+    if (transactions.size() > 0) {
+      LOG(log_nf_) << "Received TransactionPacket with " << transactions.size()
+                   << " unseen transactions:" << received_transactions << " from: " << peer->getId().abridged();
+    }
+
+    onNewTransactions(std::move(transactions), true);
+  }
+}
+
+void AltTransactionPacketHandler::onNewTransactions(SharedTransactions &&transactions, bool fromNetwork) {
+  if (fromNetwork) {
+    if (dag_blk_mgr_) {
+      received_trx_count_ += transactions.size();
+      unique_received_trx_count_ += trx_mgr_->insertValidatedTransactions(transactions);
+    } else {  // ONLY FOR TESTING
+      for (auto const &trx : transactions) {
+        auto trx_hash = trx->getHash();
+        if (!test_state_->hasTransaction(trx_hash)) {
+          test_state_->insertTransaction(*trx);
+          LOG(log_dg_) << "Received New Transaction " << trx_hash;
+        } else {
+          LOG(log_dg_) << "Received New Transaction" << trx_hash << "that is already known";
+        }
+      }
+    }
+  }
+
+  if (!fromNetwork || network_transaction_interval_ == 0) {
+    std::unordered_map<dev::p2p::NodeID, std::vector<taraxa::bytes>> transactions_to_send;
+    std::unordered_map<dev::p2p::NodeID, std::vector<trx_hash_t>> transactions_hash_to_send;
+
+    auto peers = peers_state_->getAllPeers();
+    std::string transactions_to_log;
+    std::string peers_to_log;
+    for (auto const &trx : transactions) {
+      transactions_to_log += trx->getHash().abridged();
+    }
+    for (const auto &peer : peers) {
+      // Confirm that status messages were exchanged otherwise message might be ignored and node would
+      // incorrectly markTransactionAsKnown
+      if (!peer.second->syncing_) {
+        peers_to_log += peer.first.abridged();
+        for (auto const &trx : transactions) {
+          auto trx_hash = trx->getHash();
+          if (peer.second->isTransactionKnown(trx_hash)) {
+            continue;
+          }
+
+          if (transactions_to_send[peer.first].size() > MAX_TRANSACTIONS_IN_PACKET) {
+            break;
+          }
+
+          transactions_to_send[peer.first].push_back(trx->rlp());
+          transactions_hash_to_send[peer.first].push_back(trx_hash);
+        }
+      }
+    }
+
+    LOG(log_dg_) << "Sending Transactions " << transactions_to_log << " to " << peers_to_log;
+
+    for (auto &it : transactions_to_send) {
+      sendTransactions(it.first, it.second);
+    }
+    for (auto &it : transactions_hash_to_send) {
+      for (auto &it2 : it.second) {
+        peers[it.first]->markTransactionAsKnown(it2);
+      }
+    }
+  }
+}
+
+void AltTransactionPacketHandler::sendTransactions(dev::p2p::NodeID const &peer_id,
+                                                   std::vector<taraxa::bytes> const &transactions) {
+  LOG(log_dg_) << "sendTransactions " << transactions.size() << " to " << peer_id;
+
+  dev::RLPStream s(transactions.size());
+  taraxa::bytes trx_bytes;
+  for (const auto &transaction : transactions) {
+    trx_bytes.insert(trx_bytes.end(), std::begin(transaction), std::end(transaction));
+  }
+  s.appendRaw(trx_bytes, transactions.size());
+  sealAndSend(peer_id, TransactionPacket, std::move(s));
+}
+
+}  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/common/templated_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/common/templated_packet_handler.cpp
@@ -1,0 +1,5 @@
+#include "network/tarcap/packets_handlers/common/templated_packet_handler.hpp"
+
+#include "network/tarcap/stats/packets_stats.hpp"
+
+namespace taraxa::network::tarcap {}  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -13,7 +13,8 @@
 #include "network/tarcap/packets_handlers/pbft_sync_packet_handler.hpp"
 #include "network/tarcap/packets_handlers/status_packet_handler.hpp"
 #include "network/tarcap/packets_handlers/test_packet_handler.hpp"
-#include "network/tarcap/packets_handlers/transaction_packet_handler.hpp"
+//#include "network/tarcap/packets_handlers/transaction_packet_handler.hpp"
+#include "network/tarcap/packets_handlers/alt_transaction_packet_handler.hpp"
 #include "network/tarcap/packets_handlers/vote_packet_handler.hpp"
 #include "network/tarcap/packets_handlers/votes_sync_packet_handler.hpp"
 #include "network/tarcap/shared_states/syncing_state.hpp"
@@ -107,7 +108,7 @@ void TaraxaCapability::initPeriodicEvents(const NetworkConfig &conf, const std::
 
   // Send new txs periodic event
   const auto &tx_handler = packets_handlers_->getSpecificHandler(SubprotocolPacketType::TransactionPacket);
-  auto tx_packet_handler = std::static_pointer_cast<TransactionPacketHandler>(tx_handler);
+  auto tx_packet_handler = std::static_pointer_cast<AltTransactionPacketHandler>(tx_handler);
   if (trx_mgr /* just because of tests */ && conf.network_transaction_interval > 0) {
     periodic_events_tp_.post_loop({conf.network_transaction_interval},
                                   [tx_packet_handler = std::move(tx_packet_handler), trx_mgr = std::move(trx_mgr)] {
@@ -202,8 +203,8 @@ void TaraxaCapability::registerPacketHandlers(
 
   packets_handlers_->registerHandler(
       SubprotocolPacketType::TransactionPacket,
-      std::make_shared<TransactionPacketHandler>(peers_state_, packets_stats, trx_mgr, dag_blk_mgr, test_state_,
-                                                 conf.network_transaction_interval, node_addr));
+      std::make_shared<AltTransactionPacketHandler>(peers_state_, packets_stats, trx_mgr, dag_blk_mgr, test_state_,
+                                                    conf.network_transaction_interval, node_addr));
 
   // Non critical packets with low processing priority
   packets_handlers_->registerHandler(SubprotocolPacketType::TestPacket,
@@ -375,7 +376,7 @@ void TaraxaCapability::onNewBlockVerified(DagBlock const &blk, bool proposed, Sh
 }
 
 void TaraxaCapability::onNewTransactions(SharedTransactions &&transactions) {
-  std::static_pointer_cast<TransactionPacketHandler>(
+  std::static_pointer_cast<AltTransactionPacketHandler>(
       packets_handlers_->getSpecificHandler(SubprotocolPacketType::TransactionPacket))
       ->onNewTransactions(std::move(transactions), true);
 }
@@ -404,7 +405,7 @@ void TaraxaCapability::broadcastPreviousRoundNextVotesBundle() {
 }
 
 void TaraxaCapability::sendTransactions(dev::p2p::NodeID const &id, std::vector<taraxa::bytes> const &transactions) {
-  std::static_pointer_cast<TransactionPacketHandler>(
+  std::static_pointer_cast<AltTransactionPacketHandler>(
       packets_handlers_->getSpecificHandler(SubprotocolPacketType::TransactionPacket))
       ->sendTransactions(id, transactions);
 }

--- a/libraries/types/dag_block/include/dag/dag_block.hpp
+++ b/libraries/types/dag_block/include/dag/dag_block.hpp
@@ -2,6 +2,7 @@
 
 #include "common/default_construct_copyable_movable.hpp"
 #include "vdf/sortition.hpp"
+//#include "common/encoding_rlp.hpp"
 
 namespace taraxa {
 
@@ -64,6 +65,8 @@ class DagBlock {
     str << "	sender		= " << u.getSender().abridged() << std::endl;
     str << "  vdf = " << u.vdf_ << std::endl;
     return str;
+
+    // RLP_FIELDS_DEFINE_INPLACE
   }
   bool operator==(DagBlock const &other) const { return this->sha3(true) == other.sha3(true); }
 

--- a/libraries/types/transaction/CMakeLists.txt
+++ b/libraries/types/transaction/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(HEADERS
     include/transaction/transaction.hpp
 )
-set(SOURCES src/transaction.cpp)
+set(SOURCES src/transaction.cpp src/alt_transaction_packet_data.cpp)
 
 add_library(transaction ${SOURCES} ${HEADERS})
 target_include_directories(transaction PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/libraries/types/transaction/include/transaction/alt_transaction_packet_data.hpp
+++ b/libraries/types/transaction/include/transaction/alt_transaction_packet_data.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <optional>
+#include <vector>
+
+#include "common/encoding_rlp.hpp"
+
+namespace taraxa {
+
+/**
+ * @brief Transaction packet data parsed from rlp
+ */
+struct TransactionPacketData {
+  struct SingleTransaction {
+    uint64_t nonce_;
+    val_t gas_price_;
+    uint64_t gas_;
+    std::optional<addr_t> receiver_;
+    val_t value_;
+    bytes data_;
+    u256 v, r, s;
+
+    HAS_RLP_FIELDS
+  };
+
+  std::vector<SingleTransaction> transactions;
+
+  RLP_FIELDS_DEFINE_INPLACE(transactions)
+};
+
+}  // namespace taraxa

--- a/libraries/types/transaction/include/transaction/transaction.hpp
+++ b/libraries/types/transaction/include/transaction/transaction.hpp
@@ -4,6 +4,7 @@
 #include <libdevcore/RLP.h>
 #include <libdevcore/SHA3.h>
 
+#include "alt_transaction_packet_data.hpp"
 #include "common/default_construct_copyable_movable.hpp"
 #include "common/types.hpp"
 
@@ -47,6 +48,8 @@ struct Transaction {
   explicit Transaction(dev::RLP const &_rlp, bool verify_strict = false, h256 const &hash = {});
   explicit Transaction(bytes const &_rlp, bool verify_strict = false, h256 const &hash = {})
       : Transaction(dev::RLP(_rlp), verify_strict, hash) {}
+
+  Transaction(TransactionPacketData::SingleTransaction &&packet_data, const h256 &hash = {});
 
   auto isZero() const { return is_zero_; }
   trx_hash_t const &getHash() const;

--- a/libraries/types/transaction/src/alt_transaction_packet_data.cpp
+++ b/libraries/types/transaction/src/alt_transaction_packet_data.cpp
@@ -1,0 +1,7 @@
+#include "transaction/alt_transaction_packet_data.hpp"
+
+namespace taraxa {
+
+RLP_FIELDS_DEFINE(TransactionPacketData::SingleTransaction, nonce_, gas_price_, gas_, receiver_, value_, data_, v, r, s)
+
+}  // namespace taraxa

--- a/tests/tarcap_threadpool_test.cpp
+++ b/tests/tarcap_threadpool_test.cpp
@@ -5,6 +5,7 @@
 #include "dag/dag_block.hpp"
 #include "logger/logger.hpp"
 #include "network/tarcap/packets_handler.hpp"
+#include "network/tarcap/packets_handlers/common/packet_handler.hpp"
 #include "network/tarcap/threadpool/tarcap_thread_pool.hpp"
 
 namespace taraxa::core_tests {


### PR DESCRIPTION
## Purpose
<!-- Provide any information reviewers might need to have context on your changes. -->

This is a new generic architecture that would allow us to parse packet rlp. I have created POC and adjusted TransactionPacketHandler according to this new design, but it would take multple days to transform all other packet handlers...


Pros of such desing:

- no need to parse packets manually
- automatic ddos protection - there is a struct representation of each packet rlp and when it is parsed, number of rlp items (and types) must be equal to number of this struct variables (and types)  
- rlp parsing at 1 place. Currently almost all types that we use (e.g. Transaction, DagBlock, etc...) must support constructors with rlp as argument because we create them from rlp -> this would be eliminated as each packet would be automatically parsed to its structure representation before it is even sent to the specific packet handler...  

Cons (all the cons are basically related tot he amount of work that would be required for such change)

- each packet handler must be a separate class (now we have multiple packets handlers in 1 class)
- some packets rlp's would have to be changed so it can be parsed automatically. For example if we would like to parse struct

```
struct DagsPacket {
  struct DagBlock {
    hash_type hash;
    std::vector<Trsansation> transactions;
  }

  std::vector<DagBlock> dags;
}
```

each struct must be represented by a list inside rlp, which we dont enforce at the moment... Rlp for this example would look like this:
`[  [dag1_hash, [dag1_tx1, dag1_tx2]],  [dag2_hash, [dag2_tx1, dag2_tx2]] ]`

- rlp numeric fields would be almost always copied. Our internal types (e.g. Transaction, DagBlock, etc...) would not support constructors with rlp bytes anymore, but they would have to support constructors with packet rlp struct representation (e.g. DagsPacket from above) because these constructors usually dont just set parsed rlp data, they also process them somehow and then set other class member based on these values and this is simply impossible to do automatically (see for example Transaction ctor). 

## How does the solution address the problem
<!-- Describe your solution. -->

Here is simplified new design:
```
// IPacketHandler.hpp
class IPacketHandler {
public:
    virtual ~IPacketHandler() = default;
    virtual void processPacket() = 0;
};


// PacketHandler.hpp
template<typename PacketData>
class PacketHandler : public IPacketHandler {
public:
    virtual ~PacketHandler() = default;

    void processPacket() override {
        auto packet_data = parsePacketRlp();
        process(std::move(packet_data));
    }

    virtual PacketData parsePacketRlp(const RawPacketData& raw_packet_data) {
      // here will be simply called 
      // return util::encoding_rlp::rlp_dec<PacketData>(util::RLPDecoderRef(raw_packet_data.rlp_, true));
    };

    virtual void process(PacketData&& packet_data) = 0;
};



// StatusPacketHandler.hpp
class StatusPacketData {
public:
    std::string msg_;
    
   RLP_FIELDS_DEFINE_INPLACE(msg_) // this is enough for automatic parsing
};

class StatusPacketHandler : public PacketHandler<StatusPacketData> {
public:
    ~StatusPacketHandler() = default;

    StatusPacketData parsePacketRlp(const RawPacketData& raw_packet_data) override {
        // In case it is needed, automatic parsing can be overridden here
    }

    void process(StatusPacketData&& packet_data) override {
        std::cout << "StatusPacketHandler processing: " << packet_data.msg_ << std::endl;
    }
};


main.cpp

std::shared_ptr<IPacketHandler> handler = std::make_shared<StatusPacketHandler>();
handler.processPacket(rlp);

```

## Changes made
<!-- Summary or changes that have been made. -->
