### PR TITLE
feat: light node

### DIFF
--- a/libraries/cli/include/cli/default_config.hpp
+++ b/libraries/cli/include/cli/default_config.hpp
@@ -16,6 +16,7 @@ const char *default_json = R"foo({
   "network_sync_level_size": 25,
   "network_packets_processing_threads": 14,
   "network_peer_blacklist_timeout" : 600,
+  "is_light_node" : false,
   "deep_syncing_threshold" : 10,
   "network_boot_nodes": [
   ],

--- a/libraries/cli/include/cli/devnet_config.hpp
+++ b/libraries/cli/include/cli/devnet_config.hpp
@@ -16,6 +16,7 @@ const char *devnet_json = R"foo({
   "network_sync_level_size": 25,
   "network_packets_processing_threads": 14,
   "network_peer_blacklist_timeout" : 600,
+  "is_light_node" : false,
   "deep_syncing_threshold" : 10,
   "network_boot_nodes": [
     {

--- a/libraries/cli/include/cli/mainnet_config.hpp
+++ b/libraries/cli/include/cli/mainnet_config.hpp
@@ -16,6 +16,7 @@ const char *mainnet_json = R"foo({
   "network_sync_level_size": 10,
   "network_packets_processing_threads": 14,
   "network_peer_blacklist_timeout" : 600,
+  "is_light_node" : false,
   "deep_syncing_threshold" : 10,
   "network_boot_nodes": [
     {

--- a/libraries/cli/include/cli/testnet_config.hpp
+++ b/libraries/cli/include/cli/testnet_config.hpp
@@ -16,6 +16,7 @@ const char *testnet_json = R"foo({
   "network_sync_level_size": 10,
   "network_packets_processing_threads": 14,
   "network_peer_blacklist_timeout" : 600,
+  "is_light_node" : false,
   "deep_syncing_threshold" : 10,
   "network_boot_nodes": [
     {

--- a/libraries/config/include/config/config.hpp
+++ b/libraries/config/include/config/config.hpp
@@ -75,6 +75,8 @@ struct TestParamsConfig {
 };
 
 struct FullNodeConfig {
+  static const uint32_t kDefaultLightNodeHistoryDays = 7;
+
   FullNodeConfig() = default;
   // The reason of using Json::Value as a union is that in the tests
   // there are attempts to pass char const* to this constructor, which
@@ -96,6 +98,8 @@ struct FullNodeConfig {
   ChainConfig chain = ChainConfig::predefined();
   state_api::Opts opts_final_chain;
   std::vector<logger::Config> log_configs;
+  bool is_light_node = false;       // Is light node
+  uint64_t light_node_history = 0;  // Number of periods to keep in history for a light node
 
   auto net_file_path() const { return data_path / "net"; }
 

--- a/libraries/config/src/config.cpp
+++ b/libraries/config/src/config.cpp
@@ -238,6 +238,16 @@ FullNodeConfig::FullNodeConfig(Json::Value const &string_or_object, Json::Value 
     chain = ChainConfig::predefined();
   }
 
+  is_light_node = getConfigDataAsBoolean(root, {"is_light_node"}, true, false);
+  if (is_light_node) {
+    uint64_t min_light_node_history =
+        (uint64_t)kDefaultLightNodeHistoryDays * 24 * 60 * 60000 / (chain.pbft.lambda_ms_min * 6);
+    light_node_history = getConfigDataAsUInt(root, {"light_node_history"}, true, min_light_node_history);
+    if (light_node_history < min_light_node_history) {
+      light_node_history = min_light_node_history;
+    }
+  }
+
   node_secret = wallet["node_secret"].asString();
   vrf_secret = vrf_wrapper::vrf_sk_t(wallet["vrf_secret"].asString());
 

--- a/libraries/core_libs/consensus/include/dag/dag.hpp
+++ b/libraries/core_libs/consensus/include/dag/dag.hpp
@@ -206,8 +206,13 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
   void recoverDag();
   void addToDag(blk_hash_t const &hash, blk_hash_t const &pivot, std::vector<blk_hash_t> const &tips, uint64_t level,
                 bool finalized = false);
+  bool validateBlockNotExpired(const std::shared_ptr<DagBlock> &dag_block,
+                               std::unordered_map<blk_hash_t, std::shared_ptr<DagBlock>> &expired_dag_blocks_to_remove);
+  void handleExpiredDagBlocksTransactions(const std::vector<trx_hash_t> &transactions_from_expired_dag_blocks) const;
+
   void worker();
   std::pair<blk_hash_t, std::vector<blk_hash_t>> getFrontier() const;  // return pivot and tips
+  void updateFrontier();
   std::atomic<level_t> max_level_ = 0;
   mutable std::shared_mutex mutex_;
   mutable std::shared_mutex order_dag_blocks_mutex_;

--- a/libraries/core_libs/consensus/include/dag/dag_block_manager.hpp
+++ b/libraries/core_libs/consensus/include/dag/dag_block_manager.hpp
@@ -24,7 +24,8 @@ class DagBlockManager {
     AheadBlock,
     FailedVdfVerification,
     FutureBlock,
-    NotEligible
+    NotEligible,
+    ExpiredBlock
   };
 
   DagBlockManager(addr_t node_addr, SortitionConfig const &sortition_config, std::shared_ptr<DbStorage> db,

--- a/libraries/core_libs/consensus/include/pbft/pbft_chain.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_chain.hpp
@@ -30,6 +30,7 @@ class PbftChain {
   uint64_t getPbftChainSize() const;
   uint64_t getPbftChainSizeExcludingEmptyPbftBlocks() const;
   blk_hash_t getLastPbftBlockHash() const;
+  uint64_t getDagExpiryPeriod() const;
 
   PbftBlock getPbftBlockInChain(blk_hash_t const& pbft_block_hash);
   std::shared_ptr<PbftBlock> getUnverifiedPbftBlock(blk_hash_t const& pbft_block_hash);
@@ -64,6 +65,8 @@ class PbftChain {
   uint64_t size_;                // PBFT chain size, includes both executed and unexecuted PBFT blocks
   uint64_t non_empty_size_;  // PBFT chain size excluding blocks with null anchor, includes both executed and unexecuted
                              // PBFT blocks
+  uint64_t dag_expiry_period_;       // Proposal period limit on which dag blocks are considered expired, it's value is
+                                     // always current period minus kDagExpiryPeriodLimit of non empty pbft periods
   blk_hash_t last_pbft_block_hash_;  // last PBFT block hash in PBFT chain, may not execute yet
 
   std::shared_ptr<DbStorage> db_ = nullptr;
@@ -71,6 +74,11 @@ class PbftChain {
   // <prev block hash, vector<PBFT proposed blocks waiting for vote>>
   std::unordered_map<blk_hash_t, std::vector<blk_hash_t>> unverified_blocks_map_;
   std::unordered_map<blk_hash_t, std::shared_ptr<PbftBlock>> unverified_blocks_;
+
+  static const uint32_t kDagExpiryPeriodLimit =
+      1000;  // Any non finalized dag block with a propose period smaller by
+             // kDagExpiryPeriodLimit of non empty PBFT periods than the current period is considered
+             // expired and it should be ignored or removed from DAG
 
   LOG_OBJECTS_DEFINE
 };

--- a/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
+++ b/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
@@ -96,6 +96,15 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
   void updateFinalizedTransactionsStatus(SyncBlock const &sync_block);
 
   /**
+   * @brief Moves non-finalized transactions from discarded old dag blocks back to transactions pool
+   * IMPORTANT: This method is invoked on finalizing a pbft block, it needs to be protected with transactions_mutex_ but
+   * the mutex is locked from pbft manager for the entire pbft finalization process to make the finalization atomic
+   *
+   * @param transactions transactions to move
+   */
+  void moveNonFinalizedTransactionsToTransactionsPool(std::unordered_set<trx_hash_t> &&transactions);
+
+  /**
    * @brief Retrieves transactions mutex, only to be used when finalizing pbft block
    *
    * @return mutex

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -45,6 +45,7 @@ PbftManager::PbftManager(PbftConfig const &conf, blk_hash_t const &genesis, addr
       RUN_COUNT_VOTES(conf.run_count_votes),
       dag_genesis_(genesis) {
   LOG_OBJECTS_CREATE("PBFT_MGR");
+  db_->clearPeriodDataHistory(pbft_chain_->getPbftChainSize(), pbft_chain_->getDagExpiryPeriod(), true);
 }
 
 PbftManager::~PbftManager() { stop(); }
@@ -1631,6 +1632,8 @@ bool PbftManager::pushPbftBlock_(SyncBlock &&sync_block, vec_blk_t &&dag_blocks_
     // update PBFT chain size
     pbft_chain_->updatePbftChain(pbft_block_hash, null_anchor);
   }
+
+  db_->clearPeriodDataHistory(sync_block.pbft_blk->getPeriod(), pbft_chain_->getDagExpiryPeriod());
 
   last_cert_voted_value_ = NULL_BLOCK_HASH;
 

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_pbft_sync_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_pbft_sync_packet_handler.hpp
@@ -15,7 +15,8 @@ class GetPbftSyncPacketHandler : public PacketHandler {
  public:
   GetPbftSyncPacketHandler(std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
                            std::shared_ptr<SyncingState> syncing_state, std::shared_ptr<PbftChain> pbft_chain,
-                           std::shared_ptr<DbStorage> db, size_t network_sync_level_size, const addr_t& node_addr);
+                           std::shared_ptr<DbStorage> db, size_t network_sync_level_size, const addr_t& node_addr,
+                           bool is_light_node = false, uint64_t light_node_history = 0);
 
   virtual ~GetPbftSyncPacketHandler() = default;
 
@@ -32,6 +33,9 @@ class GetPbftSyncPacketHandler : public PacketHandler {
 
   // Initialized from network config
   const size_t network_sync_level_size_;
+
+  const bool is_light_node_ = false;
+  const uint64_t light_node_history_ = 0;
 };
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/status_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/status_packet_handler.hpp
@@ -29,7 +29,7 @@ class StatusPacketHandler : public ExtSyncingPacketHandler {
                             size_t pbft_previous_round_next_votes_size);
   void syncPbftNextVotes(uint64_t pbft_round, size_t pbft_previous_round_next_votes_size);
 
-  static constexpr uint16_t kInitialStatusPacketItemsCount = 10;
+  static constexpr uint16_t kInitialStatusPacketItemsCount = 12;
   static constexpr uint16_t kStandardStatusPacketItemsCount = 5;
   const uint64_t conf_network_id_;
 

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
@@ -74,6 +74,8 @@ class TaraxaPeer : public boost::noncopyable {
   std::atomic_bool peer_dag_synced_ = false;
   std::atomic_bool peer_dag_syncing_ = false;
   std::atomic_bool peer_requested_dag_syncing_ = false;
+  std::atomic_bool peer_light_node = false;
+  std::atomic<uint64_t> peer_light_node_history = 0;
 
   // Mutex used to prevent race condition between dag syncing and gossiping
   mutable boost::shared_mutex mutex_for_sending_dag_blocks_;

--- a/libraries/core_libs/network/rpc/Test.cpp
+++ b/libraries/core_libs/network/rpc/Test.cpp
@@ -47,11 +47,17 @@ Json::Value Test::get_dag_block(const Json::Value &param1) {
   try {
     if (auto node = full_node_.lock()) {
       blk_hash_t hash = blk_hash_t(param1["hash"].asString());
-      auto blk = node->getDagBlockManager()->getDagBlock(hash);
-      if (!blk) {
-        res = "Block not available \n";
+      const auto &dag_blk_mgr = node->getDagBlockManager();
+      auto known_block = dag_blk_mgr->isDagBlockKnown(hash);
+      if (known_block) {
+        auto blk = dag_blk_mgr->getDagBlock(hash);
+        if (!blk) {
+          res["status"] = "Light node - Block could not be retrieved";
+        } else {
+          res = blk->getJsonStr();
+        }
       } else {
-        res = node->getDagBlockManager()->getDagBlock(hash)->getJsonStr();
+        res["status"] = "Unknown block";
       }
     }
   } catch (std::exception &e) {

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/dag_block_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/dag_block_packet_handler.cpp
@@ -147,6 +147,7 @@ void DagBlockPacketHandler::onNewBlockReceived(DagBlock &&block, const std::shar
         break;
       case DagBlockManager::InsertAndVerifyBlockReturnType::InsertedAndVerified:
       case DagBlockManager::InsertAndVerifyBlockReturnType::AlreadyKnown:
+      case DagBlockManager::InsertAndVerifyBlockReturnType::ExpiredBlock:
         break;
     }
   } else if (!test_state_->hasBlock(block.getHash())) {

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/status_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/status_packet_handler.cpp
@@ -58,6 +58,19 @@ void StatusPacketHandler::process(const PacketData& packet_data, const std::shar
     auto const node_major_version = (*it++).toInt<unsigned>();
     auto const node_minor_version = (*it++).toInt<unsigned>();
     auto const node_patch_version = (*it++).toInt<unsigned>();
+    auto const is_light_node = (*it++).toInt();
+    auto const node_history = (*it++).toInt<uint64_t>();
+
+    // If this is a light node and it cannot serve our sync request disconnect from it
+    if (is_light_node) {
+      selected_peer->peer_light_node = true;
+      selected_peer->peer_light_node_history = node_history;
+      if (pbft_synced_period + node_history < peer_pbft_chain_size) {
+        LOG(log_nf_) << "Light node is not able to serve our syncing request. " << packet_data.from_node_id_.abridged()
+                     << " peer will be disconnected";
+        disconnect(peer->getId(), dev::p2p::UserReason);
+      }
+    }
 
     // We need logic when some different node versions might still be compatible
     if (node_major_version != TARAXA_MAJOR_VERSION || node_minor_version != TARAXA_MINOR_VERSION) {
@@ -175,12 +188,13 @@ bool StatusPacketHandler::sendStatus(const dev::p2p::NodeID& node_id, bool initi
     auto pbft_previous_round_next_votes_size = next_votes_mgr_->getNextVotesWeight();
 
     if (initial) {
-      success = sealAndSend(
-          node_id, StatusPacket,
-          std::move(dev::RLPStream(kInitialStatusPacketItemsCount)
-                    << conf_network_id_ << dag_max_level << dag_mgr_->get_genesis() << pbft_chain_size
-                    << syncing_state_->is_pbft_syncing() << pbft_round << pbft_previous_round_next_votes_size
-                    << TARAXA_MAJOR_VERSION << TARAXA_MINOR_VERSION << TARAXA_PATCH_VERSION));
+      success =
+          sealAndSend(node_id, StatusPacket,
+                      std::move(dev::RLPStream(kInitialStatusPacketItemsCount)
+                                << conf_network_id_ << dag_max_level << dag_mgr_->get_genesis() << pbft_chain_size
+                                << syncing_state_->is_pbft_syncing() << pbft_round
+                                << pbft_previous_round_next_votes_size << TARAXA_MAJOR_VERSION << TARAXA_MINOR_VERSION
+                                << TARAXA_PATCH_VERSION << db_->isLightNode() << db_->getLightNodeHistory()));
     } else {
       success = sealAndSend(node_id, StatusPacket,
                             std::move(dev::RLPStream(kStandardStatusPacketItemsCount)

--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -252,6 +252,7 @@ void TaraxaCapability::onConnect(std::weak_ptr<dev::p2p::Session> session, u256 
     LOG(log_wr_) << "Node " << node_id << " connection dropped - malicious node";
     return;
   }
+
   peers_state_->addPendingPeer(node_id);
   LOG(log_nf_) << "Node " << node_id << " connected";
 

--- a/libraries/core_libs/node/src/node.cpp
+++ b/libraries/core_libs/node/src/node.cpp
@@ -59,13 +59,14 @@ void FullNode::init() {
     if (conf_.test_params.rebuild_db) {
       old_db_ = std::make_shared<DbStorage>(conf_.db_path, conf_.test_params.db_snapshot_each_n_pbft_block,
                                             conf_.test_params.db_max_open_files, conf_.test_params.db_max_snapshots,
-                                            conf_.test_params.db_revert_to_period, node_addr, true);
+                                            conf_.test_params.db_revert_to_period, node_addr, conf_.is_light_node,
+                                            conf_.light_node_history, true);
     }
 
     db_ = std::make_shared<DbStorage>(conf_.db_path, conf_.test_params.db_snapshot_each_n_pbft_block,
                                       conf_.test_params.db_max_open_files, conf_.test_params.db_max_snapshots,
-                                      conf_.test_params.db_revert_to_period, node_addr, false,
-                                      conf_.test_params.rebuild_db_columns);
+                                      conf_.test_params.db_revert_to_period, node_addr, conf_.is_light_node,
+                                      conf_.light_node_history, false, conf_.test_params.rebuild_db_columns);
 
     if (db_->hasMinorVersionChanged()) {
       LOG(log_si_) << "Minor DB version has changed. Rebuilding Db";
@@ -73,10 +74,12 @@ void FullNode::init() {
       db_ = nullptr;
       old_db_ = std::make_shared<DbStorage>(conf_.db_path, conf_.test_params.db_snapshot_each_n_pbft_block,
                                             conf_.test_params.db_max_open_files, conf_.test_params.db_max_snapshots,
-                                            conf_.test_params.db_revert_to_period, node_addr, true);
+                                            conf_.test_params.db_revert_to_period, node_addr, conf_.is_light_node,
+                                            conf_.light_node_history, true);
       db_ = std::make_shared<DbStorage>(conf_.db_path, conf_.test_params.db_snapshot_each_n_pbft_block,
                                         conf_.test_params.db_max_open_files, conf_.test_params.db_max_snapshots,
-                                        conf_.test_params.db_revert_to_period, node_addr);
+                                        conf_.test_params.db_revert_to_period, node_addr, conf_.is_light_node,
+                                        conf_.light_node_history);
     }
 
     if (db_->getNumDagBlocks() == 0) {

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -90,7 +90,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
     // do not change/move
     COLUMN(default_column);
     // Contains full data for an executed PBFT block including PBFT block, cert votes, dag blocks and transactions
-    COLUMN(period_data);
+    COLUMN_W_COMP(period_data, getIntComparator<uint64_t>());
     COLUMN(dag_blocks);
     COLUMN(dag_blocks_index);
     COLUMN(transactions);
@@ -143,6 +143,8 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   bool snapshot_enable_ = true;
   uint32_t db_max_snapshots_ = 0;
   std::set<uint64_t> snapshots_;
+  const bool is_light_node_ = false;
+  const uint64_t light_node_history_ = 0;
 
   bool minor_version_changed_ = false;
 
@@ -156,7 +158,8 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
 
   explicit DbStorage(fs::path const& base_path, uint32_t db_snapshot_each_n_pbft_block = 0, uint32_t max_open_files = 0,
                      uint32_t db_max_snapshots = 0, uint32_t db_revert_to_period = 0, addr_t node_addr = addr_t(),
-                     bool rebuild = false, bool rebuild_columns = false);
+                     bool is_light_node = false, uint64_t light_node_history = 0, bool rebuild = false,
+                     bool rebuild_columns = false);
   ~DbStorage();
 
   auto const& path() const { return path_; }
@@ -176,10 +179,13 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
 
   // Period data
   void savePeriodData(const SyncBlock& sync_block, Batch& write_batch);
+  void clearPeriodDataHistory(uint64_t period, uint64_t dag_expiry_period, bool force = false);
   dev::bytes getPeriodDataRaw(uint64_t period) const;
   std::optional<PbftBlock> getPbftBlock(uint64_t period) const;
   blk_hash_t getPeriodBlockHash(uint64_t period) const;
   std::optional<std::vector<Transaction>> getPeriodTransactions(uint64_t period) const;
+  uint64_t getLightNodeHistory() const { return light_node_history_; }
+  bool isLightNode() const { return is_light_node_; }
 
   // DAG
   void saveDagBlock(DagBlock const& blk, Batch* write_batch_p = nullptr);

--- a/libraries/core_libs/storage/src/storage.cpp
+++ b/libraries/core_libs/storage/src/storage.cpp
@@ -18,12 +18,14 @@ static constexpr uint16_t DAG_BLOCKS_POS_IN_PERIOD_DATA = 2;
 static constexpr uint16_t TRANSACTIONS_POS_IN_PERIOD_DATA = 3;
 
 DbStorage::DbStorage(fs::path const& path, uint32_t db_snapshot_each_n_pbft_block, uint32_t max_open_files,
-                     uint32_t db_max_snapshots, uint32_t db_revert_to_period, addr_t node_addr, bool rebuild,
-                     bool rebuild_columns)
+                     uint32_t db_max_snapshots, uint32_t db_revert_to_period, addr_t node_addr, bool is_light_node,
+                     uint64_t light_node_history, bool rebuild, bool rebuild_columns)
     : path_(path),
       handles_(Columns::all.size()),
       db_snapshot_each_n_pbft_block_(db_snapshot_each_n_pbft_block),
-      db_max_snapshots_(db_max_snapshots) {
+      db_max_snapshots_(db_max_snapshots),
+      is_light_node_(is_light_node),
+      light_node_history_(light_node_history) {
   db_path_ = (path / db_dir);
   state_db_path_ = (path / state_db_dir);
 
@@ -415,6 +417,18 @@ std::optional<SortitionParamsChange> DbStorage::getParamsChangeForPeriod(uint64_
   return SortitionParamsChange::from_rlp(dev::RLP(it->value().ToString()));
 }
 
+void DbStorage::clearPeriodDataHistory(uint64_t period, uint64_t dag_expiry_period, bool force) {
+  // Actual history size will be between 100% and 110% of light_node_history_ to avoid deleting on every period
+  if (is_light_node_ && ((period % (std::max(light_node_history_ / 10, (uint64_t)1)) == 0) || force) &&
+      period > light_node_history_) {
+    const uint64_t start = 0;
+    // This prevents deleting any data needed for dag blocks proposal period, we only delete periods for the expired dag
+    // blocks
+    const uint64_t end = std::min(period - light_node_history_, dag_expiry_period - 1);
+    db_->DeleteRange(write_options_, handle(Columns::period_data), toSlice(start), toSlice(end));
+  }
+}
+
 void DbStorage::savePeriodData(const SyncBlock& sync_block, Batch& write_batch) {
   uint64_t period = sync_block.pbft_blk->getPeriod();
   addPbftBlockPeriodToBatch(period, sync_block.pbft_blk->getBlockHash(), write_batch);
@@ -529,11 +543,11 @@ std::shared_ptr<Transaction> DbStorage::getTransaction(trx_hash_t const& hash) {
   auto res = getTransactionPeriod(hash);
   if (res) {
     auto period_data = getPeriodDataRaw(res->first);
-    // DB is corrupted if status point to missing or incorrect transaction
-    assert(period_data.size() > 0);
-    auto period_data_rlp = dev::RLP(period_data);
-    auto transaction_data = period_data_rlp[TRANSACTIONS_POS_IN_PERIOD_DATA];
-    return std::make_shared<Transaction>(transaction_data[res->second]);
+    if (period_data.size() > 0) {
+      auto period_data_rlp = dev::RLP(period_data);
+      auto transaction_data = period_data_rlp[TRANSACTIONS_POS_IN_PERIOD_DATA];
+      return std::make_shared<Transaction>(transaction_data[res->second]);
+    }
   }
   return nullptr;
 }

--- a/tests/dag_test.cpp
+++ b/tests/dag_test.cpp
@@ -138,10 +138,11 @@ TEST_F(DagTest, compute_epoch) {
   const blk_hash_t GENESIS("0000000000000000000000000000000000000000000000000000000000000001");
   auto db_ptr = std::make_shared<DbStorage>(data_dir / "db");
   auto trx_mgr = std::make_shared<TransactionManager>(FullNodeConfig(), db_ptr, nullptr, addr_t());
+  auto pbft_chain = std::make_shared<PbftChain>(GENESIS, addr_t(), db_ptr);
   auto mgr =
-      std::make_shared<DagManager>(GENESIS, addr_t(), trx_mgr, nullptr,
+      std::make_shared<DagManager>(GENESIS, addr_t(), trx_mgr, pbft_chain,
                                    std::make_shared<DagBlockManager>(addr_t(), node_cfgs[0].chain.sortition, db_ptr,
-                                                                     nullptr, nullptr, nullptr, time_log),
+                                                                     nullptr, nullptr, pbft_chain, time_log),
                                    db_ptr, logger::Logger());
   DagBlock blkA(blk_hash_t(1), 0, {}, {trx_hash_t(2)}, sig_t(1), blk_hash_t(2), addr_t(1));
   DagBlock blkB(blk_hash_t(1), 0, {}, {trx_hash_t(3), trx_hash_t(4)}, sig_t(1), blk_hash_t(3), addr_t(1));
@@ -222,11 +223,12 @@ TEST_F(DagTest, compute_epoch) {
 TEST_F(DagTest, receive_block_in_order) {
   const blk_hash_t GENESIS("000000000000000000000000000000000000000000000000000000000000000a");
   auto db_ptr = std::make_shared<DbStorage>(data_dir / "db");
+  auto pbft_chain = std::make_shared<PbftChain>(GENESIS, addr_t(), db_ptr);
   auto trx_mgr = std::make_shared<TransactionManager>(FullNodeConfig(), db_ptr, nullptr, addr_t());
   auto mgr =
-      std::make_shared<DagManager>(GENESIS, addr_t(), trx_mgr, nullptr,
+      std::make_shared<DagManager>(GENESIS, addr_t(), trx_mgr, pbft_chain,
                                    std::make_shared<DagBlockManager>(addr_t(), node_cfgs[0].chain.sortition, db_ptr,
-                                                                     nullptr, nullptr, nullptr, time_log),
+                                                                     nullptr, nullptr, pbft_chain, time_log),
                                    db_ptr, logger::Logger());
   DagBlock genesis_block(blk_hash_t(0), 0, {}, {}, sig_t(777), blk_hash_t(10), addr_t(15));
   DagBlock blk1(blk_hash_t(10), 0, {}, {}, sig_t(777), blk_hash_t(1), addr_t(15));
@@ -256,11 +258,12 @@ TEST_F(DagTest, receive_block_in_order) {
 TEST_F(DagTest, compute_epoch_2) {
   const blk_hash_t GENESIS("0000000000000000000000000000000000000000000000000000000000000001");
   auto db_ptr = std::make_shared<DbStorage>(data_dir / "db");
+  auto pbft_chain = std::make_shared<PbftChain>(GENESIS, addr_t(), db_ptr);
   auto trx_mgr = std::make_shared<TransactionManager>(FullNodeConfig(), db_ptr, nullptr, addr_t());
   auto mgr =
-      std::make_shared<DagManager>(GENESIS, addr_t(), trx_mgr, nullptr,
+      std::make_shared<DagManager>(GENESIS, addr_t(), trx_mgr, pbft_chain,
                                    std::make_shared<DagBlockManager>(addr_t(), node_cfgs[0].chain.sortition, db_ptr,
-                                                                     nullptr, nullptr, nullptr, time_log),
+                                                                     nullptr, nullptr, pbft_chain, time_log),
                                    db_ptr, logger::Logger());
   DagBlock blkA(blk_hash_t(1), 0, {}, {trx_hash_t(2)}, sig_t(1), blk_hash_t(2), addr_t(1));
   DagBlock blkB(blk_hash_t(1), 0, {}, {trx_hash_t(3), trx_hash_t(4)}, sig_t(1), blk_hash_t(3), addr_t(1));
@@ -334,10 +337,11 @@ TEST_F(DagTest, get_latest_pivot_tips) {
   const blk_hash_t GENESIS("0000000000000000000000000000000000000000000000000000000000000001");
   auto db_ptr = std::make_shared<DbStorage>(data_dir / "db");
   auto trx_mgr = std::make_shared<TransactionManager>(FullNodeConfig(), db_ptr, nullptr, addr_t());
+  auto pbft_chain = std::make_shared<PbftChain>(GENESIS, addr_t(), db_ptr);
   auto mgr =
-      std::make_shared<DagManager>(GENESIS, addr_t(), trx_mgr, nullptr,
+      std::make_shared<DagManager>(GENESIS, addr_t(), trx_mgr, pbft_chain,
                                    std::make_shared<DagBlockManager>(addr_t(), node_cfgs[0].chain.sortition, db_ptr,
-                                                                     nullptr, nullptr, nullptr, time_log),
+                                                                     nullptr, nullptr, pbft_chain, time_log),
                                    db_ptr, logger::Logger());
   DagBlock blk1(blk_hash_t(0), 0, {}, {}, sig_t(0), blk_hash_t(1), addr_t(15));
   DagBlock blk2(blk_hash_t(1), 0, {}, {}, sig_t(1), blk_hash_t(2), addr_t(15));

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -948,12 +948,14 @@ TEST_F(FullNodeTest, sync_two_nodes1) {
   auto num_vertices1 = nodes[0]->getDagManager()->getNumVerticesInDag();
   auto num_vertices2 = nodes[1]->getDagManager()->getNumVerticesInDag();
   for (unsigned i = 0; i < SYNC_TIMEOUT; i++) {
-    if (num_vertices1.first >= 3 && num_vertices2.first >= 3 && num_vertices1 == num_vertices2) break;
+    if (nodes[0]->getTransactionManager()->getTransactionPoolSize() == 0 &&
+        nodes[1]->getTransactionManager()->getTransactionPoolSize() == 0 && num_vertices1 == num_vertices2)
+      break;
     taraxa::thisThreadSleepForMilliSeconds(500);
     num_vertices1 = nodes[0]->getDagManager()->getNumVerticesInDag();
     num_vertices2 = nodes[1]->getDagManager()->getNumVerticesInDag();
   }
-  EXPECT_GE(num_vertices1.first, 3);
+  EXPECT_GE(num_vertices1.first, 2);
   EXPECT_EQ(num_vertices1, num_vertices2);
 }
 
@@ -1542,6 +1544,33 @@ TEST_F(FullNodeTest, transaction_validation) {
                     str2bytes("00FEDCBA9876543210000000"), g_secret, addr_t::random());
   // FAIL on BALANCE
   EXPECT_FALSE(nodes[0]->getTransactionManager()->insertTransaction(trx).first);
+}
+
+TEST_F(FullNodeTest, light_node) {
+  auto node_cfgs = make_node_cfgs<20, true>(2);
+  node_cfgs[0].is_light_node = true;
+  node_cfgs[0].light_node_history = 10;
+  auto nodes = launch_nodes(node_cfgs);
+  uint64_t nonce = 0;
+  while (nodes[0]->getPbftChain()->getPbftChainSize() < 40) {
+    Transaction dummy_trx(nonce++, 0, 2, 100000, bytes(), nodes[0]->getSecretKey(), nodes[0]->getAddress());
+    // broadcast dummy transaction
+    nodes[0]->getTransactionManager()->insertTransaction(dummy_trx);
+    thisThreadSleepForMilliSeconds(200);
+  }
+  EXPECT_HAPPENS({10s, 1s}, [&](auto &ctx) {
+    // Verify full node and light node sync without any issues
+    WAIT_EXPECT_EQ(ctx, nodes[0]->getPbftChain()->getPbftChainSize(), nodes[1]->getPbftChain()->getPbftChainSize())
+  });
+  uint32_t min_period_in_db = 0;
+  for (uint64_t i = 0; i < nodes[0]->getPbftChain()->getPbftChainSize(); i++) {
+    if (nodes[0]->getDB()->getPeriodDataRaw(i).size() > 0) {
+      min_period_in_db = i;
+      break;
+    }
+  }
+  // Verify light node stores only expected number of period_data
+  EXPECT_GT(min_period_in_db, nodes[0]->getPbftChain()->getPbftChainSize() - node_cfgs[0].light_node_history - 1);
 }
 
 }  // namespace taraxa::core_tests


### PR DESCRIPTION
Implements light node functionality by deleting old data from period_data column which takes most of the disk space in the database.

light-node-history parameter in the config file defines how much period_data history is kept in the database. The rest is deleted.

As part of this a new feature of limiting inclusion of old/expired dag blocks into pbft is implemented.