### PR TITLE
 stabilize  tests

### DIFF
--- a/libraries/core_libs/network/src/tarcap/packets_handlers/common/packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/common/packet_handler.cpp
@@ -18,8 +18,8 @@ void PacketHandler::checkPacketRlpIsList(const PacketData& packet_data) const {
 
 void PacketHandler::processPacket(const PacketData& packet_data) {
   try {
-    SinglePacketStats packet_stats{packet_data.from_node_id_, packet_data.rlp_.data().size(), std::chrono::microseconds(0),
-                                   std::chrono::microseconds(0)};
+    SinglePacketStats packet_stats{packet_data.from_node_id_, packet_data.rlp_.data().size(),
+                                   std::chrono::microseconds(0), std::chrono::microseconds(0)};
     const auto begin = std::chrono::steady_clock::now();
 
     auto tmp_peer = peers_state_->getPeer(packet_data.from_node_id_);

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -450,7 +450,7 @@ TEST_F(FullNodeTest, db_test) {
   EXPECT_EQ(period_1_levels_from_db.levels_interval.second, 110);
 }
 
-TEST_F(FullNodeTest, DISABLED_sync_five_nodes) {
+TEST_F(FullNodeTest, sync_five_nodes) {
   using namespace std;
 
   auto node_cfgs = make_node_cfgs<20>(5);
@@ -475,15 +475,6 @@ TEST_F(FullNodeTest, DISABLED_sync_five_nodes) {
     auto getIssuedTrxCount() {
       shared_lock l(m);
       return issued_trx_count;
-    }
-
-    void dummy_transaction() {
-      {
-        unique_lock l(m);
-        ++issued_trx_count;
-      }
-      auto result = trx_clients[0].coinTransfer(KeyPair::create().address(), 0, KeyPair::create(), false);
-      transactions.emplace(result.trx.getHash());
     }
 
     void coin_transfer(int sender_node_i, addr_t const &to, val_t const &amount, bool verify_executed = true) {
@@ -528,7 +519,6 @@ TEST_F(FullNodeTest, DISABLED_sync_five_nodes) {
             }
           }
         }
-        dummy_transaction();
       });
     }
 
@@ -590,8 +580,6 @@ TEST_F(FullNodeTest, DISABLED_sync_five_nodes) {
                 << " Node 4: Dag size = " << num_vertices4.first << " Trx count = " << num_trx4 << std::endl
                 << " Node 5: Dag size = " << num_vertices5.first << " Trx count = " << num_trx5 << std::endl
                 << " Issued transaction count = " << issued_trx_count << std::endl;
-      std::cout << "Send a dummy transaction to coverge DAG" << std::endl;
-      context.dummy_transaction();
     }
 
     taraxa::thisThreadSleepForMilliSeconds(500);

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -77,7 +77,8 @@ TEST_F(NetworkTest, transfer_block) {
 }
 
 // Test creates two Network setup and verifies sending blocks between is successfull
-TEST_F(NetworkTest, transfer_lot_of_blocks) {
+// This test can not work anymore as we are marking other nodes as malicous becasue of invalid dag blocks
+TEST_F(NetworkTest, DISABLED_transfer_lot_of_blocks) {
   auto node_cfgs = make_node_cfgs<20>(2);
   auto nodes = launch_nodes(node_cfgs);
   const auto& node1 = nodes[0];

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -1256,7 +1256,8 @@ TEST_F(NetworkTest, node_full_sync) {
     for (int j = 1; j < numberOfNodes - 1; j++) {
       WAIT_EXPECT_EQ(ctx, nodes[j]->getDagManager()->getNumVerticesInDag().first,
                      nodes[0]->getDagManager()->getNumVerticesInDag().first);
-      ctx.fail_if(nodes[j]->getNetwork()->pbft_syncing());
+      WAIT_EXPECT_EQ(ctx, nodes[j]->getPbftChain()->getPbftChainSizeExcludingEmptyPbftBlocks(),
+                     nodes[0]->getPbftChain()->getPbftChainSizeExcludingEmptyPbftBlocks());
     }
   });
 
@@ -1283,7 +1284,8 @@ TEST_F(NetworkTest, node_full_sync) {
       for (int j = 1; j < numberOfNodes - 1; j++) {
         WAIT_EXPECT_EQ(ctx, nodes[j]->getDagManager()->getNumVerticesInDag().first,
                        nodes[0]->getDagManager()->getNumVerticesInDag().first);
-        ctx.fail_if(nodes[j]->getNetwork()->pbft_syncing());
+        WAIT_EXPECT_EQ(ctx, nodes[j]->getPbftChain()->getPbftChainSizeExcludingEmptyPbftBlocks(),
+                       nodes[0]->getPbftChain()->getPbftChainSizeExcludingEmptyPbftBlocks());
       }
     });
   }
@@ -1296,7 +1298,6 @@ TEST_F(NetworkTest, node_full_sync) {
               nodes[0]->getDagManager()->getNumVerticesInDag().first);
     EXPECT_EQ(nodes[i]->getDagManager()->getNumVerticesInDag().first, nodes[i]->getDB()->getNumDagBlocks());
     EXPECT_EQ(nodes[i]->getDagManager()->getNumEdgesInDag().first, nodes[0]->getDagManager()->getNumEdgesInDag().first);
-    EXPECT_TRUE(!nodes[i]->getNetwork()->pbft_syncing());
   }
 
   // Bootstrapping node5 join the network
@@ -1338,7 +1339,8 @@ TEST_F(NetworkTest, node_full_sync) {
       for (int j = 1; j < numberOfNodes; j++) {
         WAIT_EXPECT_EQ(ctx, nodes[j]->getDagManager()->getNumVerticesInDag().first,
                        nodes[0]->getDagManager()->getNumVerticesInDag().first);
-        ctx.fail_if(nodes[j]->getNetwork()->pbft_syncing());
+        WAIT_EXPECT_EQ(ctx, nodes[j]->getPbftChain()->getPbftChainSizeExcludingEmptyPbftBlocks(),
+                       nodes[0]->getPbftChain()->getPbftChainSizeExcludingEmptyPbftBlocks());
       }
     });
   }

--- a/tests/util_test/samples.hpp
+++ b/tests/util_test/samples.hpp
@@ -24,10 +24,6 @@ class TxGenerator {
     return secret;
   }
 
-  auto getWithRandomUniqueSender(val_t const &value = 0, addr_t const &to = addr_t::random(),
-                                 bytes const &data = str2bytes("00FEDCBA9876543210000000")) const {
-    return Transaction(0, value, 0, TEST_TX_GAS_LIMIT, data, getRandomUniqueSenderSecret(), to);
-  }
   auto getSerialTrxWithSameSender(uint trx_num, uint64_t const &start_nonce, val_t const &value,
                                   addr_t const &receiver = addr_t::random()) const {
     std::vector<Transaction> trxs;
@@ -136,7 +132,7 @@ inline SharedTransactions createSignedTrxSamples(unsigned start, unsigned num, s
   assert(start + num < std::numeric_limits<unsigned>::max());
   SharedTransactions trxs;
   for (auto i = start; i < num; ++i) {
-    trxs.emplace_back(std::make_shared<Transaction>(i, i * 100, 0, 1000000, data, sk, addr_t((i + 1) * 100)));
+    trxs.emplace_back(std::make_shared<Transaction>(i, i * 100, 0, 1000000, data, sk, addr_t::random()));
   }
   return trxs;
 }

--- a/tests/util_test/util.hpp
+++ b/tests/util_test/util.hpp
@@ -332,15 +332,10 @@ inline auto make_addr(uint8_t i) {
 using expected_balances_map_t = std::map<addr_t, u256>;
 inline void wait_for_balances(const std::vector<std::shared_ptr<FullNode>>& nodes,
                               const expected_balances_map_t& balances, wait_opts to_wait = {10s, 500ms}) {
-  TransactionClient trx_client(nodes[0]);
-  auto sendDummyTransaction = [&]() {
-    trx_client.coinTransfer(KeyPair::create().address(), 0, KeyPair::create(), false);
-  };
   wait(to_wait, [&](auto& ctx) {
     for (const auto& node : nodes) {
       for (const auto& b : balances) {
         if (node->getFinalChain()->getBalance(b.first).first != b.second) {
-          sendDummyTransaction();
           WAIT_EXPECT_EQ(ctx, node->getFinalChain()->getBalance(b.first).first, b.second);
         }
       }

--- a/tests/util_test/util.hpp
+++ b/tests/util_test/util.hpp
@@ -332,16 +332,21 @@ inline auto make_addr(uint8_t i) {
 using expected_balances_map_t = std::map<addr_t, u256>;
 inline void wait_for_balances(const std::vector<std::shared_ptr<FullNode>>& nodes,
                               const expected_balances_map_t& balances, wait_opts to_wait = {10s, 500ms}) {
+  auto sendDummyTransaction = [&](const auto& trx_client) {
+    trx_client.coinTransfer(KeyPair::create().address(), 0, KeyPair::create(), false);
+  };
   wait(to_wait, [&](auto& ctx) {
     for (const auto& node : nodes) {
       for (const auto& b : balances) {
         if (node->getFinalChain()->getBalance(b.first).first != b.second) {
+          sendDummyTransaction(TransactionClient(node));
           WAIT_EXPECT_EQ(ctx, node->getFinalChain()->getBalance(b.first).first, b.second);
         }
       }
       // wait for the same chain size on all nodes
       for (const auto& n : nodes) {
-        WAIT_EXPECT_EQ(ctx, node->getPbftChain()->getPbftChainSize(), n->getPbftChain()->getPbftChainSize());
+        WAIT_EXPECT_EQ(ctx, node->getPbftChain()->getPbftChainSizeExcludingEmptyPbftBlocks(),
+                       n->getPbftChain()->getPbftChainSizeExcludingEmptyPbftBlocks());
       }
     }
   });


### PR DESCRIPTION
## Purpose
Fixes: #1588
Fixes: #1568

- sync_five_nodes -> now we are waiting until initial transaction are executed before we continue with the test
- DISABLED_transfer_lot_of_blocks -> @mfrankovi PR should fix that
- node_full_sync -> now not checking for syncing due to empty PBFT blocks but checking non empty blocks
- pbft_manager_run_multi_nodes -> checking for non-empty blocks and increase timeouts because of execution can takes more time 

## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
