### PR TITLE
chore: fixed sync five nodes test

### DIFF
--- a/tests/util_test/util.hpp
+++ b/tests/util_test/util.hpp
@@ -135,6 +135,7 @@ inline auto make_node_cfgs(uint count) {
     if constexpr (tests_speed == 1 && enable_rpc_http && enable_rpc_ws) {
       return ret;
     }
+
     for (auto& cfg : ret) {
       addr_t root_node_addr("de2b1203d72d3549ee2f733b00b2789414c7cea5");
       cfg.chain.final_chain.state.genesis_balances[root_node_addr] = 9007199254740991;
@@ -256,9 +257,13 @@ struct TransactionClient {
         TransactionStage::created,
         trx,
     };
-    if (!node_->getTransactionManager()->insertTransaction(ctx.trx).first) {
+
+    auto insert_result = node_->getTransactionManager()->insertTransaction(ctx.trx);
+    if (!insert_result.first) {
+      std::cout << "Tx insertion " << ctx.trx.getHash().toString() << " failed: " << insert_result.second << std::endl;
       return ctx;
     }
+
     ctx.stage = TransactionStage::inserted;
     auto trx_hash = ctx.trx.getHash();
     if (wait_executed) {


### PR DESCRIPTION
## Purpose
<!-- Provide any information reviewers might need to have context on your changes. -->

At the beginning we used to send 5 txs that would transfer some tokens from node0 to all other nodes so they can start sending txs too but for some reason these were not always finalized on all nodes and then when they tried to send tokens, those txs would start failing because of insufficient balance. 


## How does the solution address the problem
<!-- Describe your solution. -->

1. I am setting some initial balance through config for all five nodes instead of sending tokens from node 0 to all other nodes. It is faster and we dont need to wait until those txs are finalized as this test is not about that...
2. I am also checking if `wait_all_transactions_known` was actually successful as we did not check it before


## Changes made
<!-- Summary or changes that have been made. -->
