### PR TITLE
Missing transaction fix

### DIFF
--- a/libraries/core_libs/consensus/include/transaction_manager/transaction_manager.hpp
+++ b/libraries/core_libs/consensus/include/transaction_manager/transaction_manager.hpp
@@ -52,14 +52,6 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
    */
   uint32_t insertValidatedTransactions(const SharedTransactions &txs);
 
-  /**
-   * @brief Marks transaction as seen and returns if was seen before
-   *
-   * @param trx_hash transaction hash
-   * @return true if seen
-   */
-  bool markTransactionSeen(const trx_hash_t &trx_hash);
-
   size_t getTransactionPoolSize() const;
 
   size_t getNonfinalizedTrxSize() const;
@@ -108,6 +100,15 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
       const std::vector<trx_hash_t> &trx_to_query) const;
 
   std::shared_ptr<Transaction> getTransaction(trx_hash_t const &hash) const;
+
+  /**
+   * @brief returns if transaction seen and verified
+   *
+   * @param trx_hash transaction hash
+   * @return true if seen
+   */
+  bool isTransactionKnown(trx_hash_t const &hash) const;
+
   std::shared_ptr<Transaction> getNonFinalizedTransaction(trx_hash_t const &hash) const;
   unsigned long getTransactionCount() const;
   void recoverNonfinalizedTransactions();

--- a/libraries/core_libs/consensus/include/transaction_manager/transaction_manager.hpp
+++ b/libraries/core_libs/consensus/include/transaction_manager/transaction_manager.hpp
@@ -137,8 +137,6 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
   std::unordered_map<trx_hash_t, std::shared_ptr<Transaction>> nonfinalized_transactions_in_dag_;
   uint64_t trx_count_ = 0;
 
-  ExpirationCache<trx_hash_t> seen_txs_;
-
   std::shared_ptr<DbStorage> db_{nullptr};
   std::shared_ptr<FinalChain> final_chain_{nullptr};
 

--- a/libraries/core_libs/consensus/src/transaction_manager/transaction_manager.cpp
+++ b/libraries/core_libs/consensus/src/transaction_manager/transaction_manager.cpp
@@ -10,7 +10,7 @@
 namespace taraxa {
 TransactionManager::TransactionManager(FullNodeConfig const &conf, std::shared_ptr<DbStorage> db,
                                        std::shared_ptr<FinalChain> final_chain, addr_t node_addr)
-    : conf_(conf), seen_txs_(200000 /*capacity*/, 2000 /*delete step*/), db_(db), final_chain_(final_chain) {
+    : conf_(conf), db_(db), final_chain_(final_chain) {
   LOG_OBJECTS_CREATE("TRXMGR");
   {
     std::unique_lock transactions_lock(transactions_mutex_);

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/dag_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/dag_sync_packet_handler.cpp
@@ -71,9 +71,6 @@ void DagSyncPacketHandler::process(const PacketData& packet_data, const std::sha
 
     peer->markTransactionAsKnown(trx->getHash());
     transactions_to_log += trx->getHash().abridged();
-    if (trx_mgr_->markTransactionSeen(trx->getHash())) {
-      continue;
-    }
 
     if (const auto [is_valid, reason] = trx_mgr_->verifyTransaction(trx); !is_valid) {
       std::ostringstream err_msg;

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/transaction_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/transaction_packet_handler.cpp
@@ -39,7 +39,7 @@ inline void TransactionPacketHandler::process(const PacketData &packet_data, con
     }
 
     if (dag_blk_mgr_) [[likely]] {  // ONLY FOR TESTING
-      if (trx_mgr_->markTransactionSeen(transaction->getHash())) {
+      if (trx_mgr_->isTransactionKnown(transaction->getHash())) {
         continue;
       }
       if (const auto [is_valid, reason] = trx_mgr_->verifyTransaction(transaction); !is_valid) {


### PR DESCRIPTION
Removing seen_txs_ cache because it was causing the issue where we would mark transaction as known before it was actually part of the transaction pool or database, so transaction would be marked as known but it was actually missing causing a race condition which led to the missing transaction error and incorrectly marking peer as malicious.

I believe that this cache is not really needed but if we find some performance issues we might think of some smarter was to create some cache of this type. For now this does fix the issue.

The actual race condition causing the error:
Node 1 sends transaction T to Node 3
Node 2 sends the same transaction T to node 3
Node 2 sends dag block D that depends on transaction T to node 3
Node 3 receives message from Node 1 and marks transaction as known before inserting it in the pool
Node 3 receives transactions from Node 2 and since transactions is "known" discards it
Node 3 receives dag block D before transaction is actually in the memory pool and reports this error 