### PR TITLE
chore: mark failed transaction as known

### DIFF
--- a/libraries/core_libs/consensus/src/dag/sortition_params_manager.cpp
+++ b/libraries/core_libs/consensus/src/dag/sortition_params_manager.cpp
@@ -55,9 +55,9 @@ SortitionParamsManager::SortitionParamsManager(const addr_t& node_addr, Sortitio
     period++;
     SyncBlock sync_block(data);
     if (sync_block.pbft_blk->getPivotDagBlockHash() != kNullBlockHash) {
-      if (ignored_efficiency_counter_ >= config_.changing_interval - config_.computation_interval) {
-        uint16_t dag_efficiency = calculateDagEfficiency(sync_block);
-        dag_efficiencies_.push_back(dag_efficiency);
+      if (ignored_efficiency_counter_ >=
+          static_cast<uint32_t>(config_.changing_interval - config_.computation_interval)) {
+        dag_efficiencies_.push_back(calculateDagEfficiency(sync_block));
       } else {
         ignored_efficiency_counter_++;
       }
@@ -107,10 +107,10 @@ void SortitionParamsManager::pbftBlockPushed(const SyncBlock& block, DbStorage::
   if (config_.changing_interval == 0) {
     return;
   }
-  if (ignored_efficiency_counter_ >= config_.changing_interval - config_.computation_interval) {
-    uint16_t dag_efficiency = calculateDagEfficiency(block);
+  if (ignored_efficiency_counter_ >= static_cast<uint32_t>(config_.changing_interval - config_.computation_interval)) {
+    const auto dag_efficiency = calculateDagEfficiency(block);
     dag_efficiencies_.push_back(dag_efficiency);
-    const auto& period = block.pbft_blk->getPeriod();
+    const auto period = block.pbft_blk->getPeriod();
     LOG(log_dg_) << period << " pbftBlockPushed, efficiency: " << dag_efficiency / 100. << "%";
 
     if (non_empty_pbft_chain_size % config_.changing_interval == 0) {

--- a/libraries/core_libs/consensus/src/transaction_manager/transaction_manager.cpp
+++ b/libraries/core_libs/consensus/src/transaction_manager/transaction_manager.cpp
@@ -89,6 +89,8 @@ std::pair<bool, std::string> TransactionManager::insertTransaction(const Transac
 
   const auto trx_ptr = std::make_shared<Transaction>(trx);
   if (const auto [is_valid, reason] = verifyTransaction(trx_ptr); !is_valid) {
+    // We need to mark even failed transactions
+    markTransactionKnown(trx_ptr->getHash());
     return {false, reason};
   }
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/dag_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/dag_sync_packet_handler.cpp
@@ -76,6 +76,8 @@ void DagSyncPacketHandler::process(const PacketData& packet_data, const std::sha
     }
 
     if (const auto [is_valid, reason] = trx_mgr_->verifyTransaction(trx); !is_valid) {
+      // We need to mark even failed transactions
+      trx_mgr_->isTransactionKnown(trx->getHash());
       std::ostringstream err_msg;
       err_msg << "DagBlock transaction " << trx->getHash() << " validation failed: " << reason;
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/transaction_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/transaction_packet_handler.cpp
@@ -43,6 +43,8 @@ inline void TransactionPacketHandler::process(const PacketData &packet_data, con
         continue;
       }
       if (const auto [is_valid, reason] = trx_mgr_->verifyTransaction(transaction); !is_valid) {
+        // We need to mark even failed transactions
+        trx_mgr_->markTransactionKnown(transaction->getHash());
         std::ostringstream err_msg;
         err_msg << "Transaction " << transaction->getHash() << " validation failed: " << reason;
 


### PR DESCRIPTION
## Purpose
I think @JakubFornadel  fix #1634 is not correct, as we do not mark failed transaction as known. That could lead to attack when we could verified failed transaction N times 


## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
