### PR TITLE
fix: efficiency cache

### DIFF
--- a/libraries/core_libs/consensus/include/dag/sortition_params_manager.hpp
+++ b/libraries/core_libs/consensus/include/dag/sortition_params_manager.hpp
@@ -49,6 +49,12 @@ class SortitionParamsManager {
    */
   uint16_t averageDagEfficiency();
 
+  /**
+   * Get memory params changes, used only for unit tests
+   * @returns params changes
+   */
+  const std::deque<SortitionParamsChange>& getParamsChanges() const { return params_changes_; }
+
  protected:
   SortitionConfig config_;
   std::shared_ptr<DbStorage> db_;

--- a/libraries/core_libs/consensus/src/dag/sortition_params_manager.cpp
+++ b/libraries/core_libs/consensus/src/dag/sortition_params_manager.cpp
@@ -118,6 +118,7 @@ void SortitionParamsManager::pbftBlockPushed(const SyncBlock& block, DbStorage::
       params_changes_.push_back(params_change);
       db_->saveSortitionParamsChange(period, std::move(params_change), batch);
       cleanup();
+      ignored_efficiency_counter_ = 0;
     }
   } else {
     ignored_efficiency_counter_++;


### PR DESCRIPTION
Efficiency was not correctly populated because ignored_efficiency_counter_ was not getting reset after each changing_interval. This made the calculation be based on full changing_interval and not just computation_interval. On restart it was reset which made nodes that restarted have different efficiency data which corrupted difficulty calculation.

The fix is only reseting the ignored_efficiency_counter_ to 0 but it also contains added tests to make sure that both efficiencies and params_changes_ that are kept in memory have same values before and after the restart.