### PR TITLE
fix: improve async cancellation

### DIFF
--- a/libraries/core_libs/consensus/src/pbft/block_proposer.cpp
+++ b/libraries/core_libs/consensus/src/pbft/block_proposer.cpp
@@ -53,30 +53,28 @@ bool SortitionPropose::propose() {
       return false;
     }
   }
-
-  std::future<void> result = std::async(std::launch::async, &vdf_sortition::VdfSortition::computeVdfSolution, &vdf,
-                                        sortition_params, frontier.pivot.asBytes());
-  bool vdf_computation_cancel = false;
+  std::atomic_bool cancellation_token = false;
+  std::future<void> result = std::async(std::launch::async, &vdf_sortition::VdfSortition::computeVdfSolutionCancellable,
+                                        &vdf, sortition_params, frontier.pivot.asBytes(), std::ref(cancellation_token));
   while (result.wait_for(std::chrono::milliseconds(100)) != std::future_status::ready) {
     auto latest_frontier = dag_mgr_->getDagFrontier();
     if (!latest_frontier.isEqual(frontier)) {
       if (vdf.isStale(sortition_params)) {
-        vdf_computation_cancel = true;
+        cancellation_token = true;
         break;
       } else {
         const auto latest_level = proposer->getProposeLevel(latest_frontier.pivot, latest_frontier.tips) + 1;
         if (latest_level > propose_level) {
-          vdf_computation_cancel = true;
+          cancellation_token = true;
           break;
         }
       }
     }
   }
 
-  if (vdf_computation_cancel) {
+  if (cancellation_token) {
     last_frontier_ = frontier;
     num_tries_ = 0;
-    vdf.cancelCompute();
     result.wait();
     // Since compute was canceled there is a chance to propose a new block immediately, return true to skip sleep
     return true;

--- a/libraries/core_libs/consensus/src/pbft/block_proposer.cpp
+++ b/libraries/core_libs/consensus/src/pbft/block_proposer.cpp
@@ -54,8 +54,8 @@ bool SortitionPropose::propose() {
     }
   }
   std::atomic_bool cancellation_token = false;
-  std::future<void> result = std::async(std::launch::async, &vdf_sortition::VdfSortition::computeVdfSolutionCancellable,
-                                        &vdf, sortition_params, frontier.pivot.asBytes(), std::ref(cancellation_token));
+  std::future<void> result = std::async(std::launch::async, &vdf_sortition::VdfSortition::computeVdfSolution, &vdf,
+                                        sortition_params, frontier.pivot.asBytes(), std::ref(cancellation_token));
   while (result.wait_for(std::chrono::milliseconds(100)) != std::future_status::ready) {
     auto latest_frontier = dag_mgr_->getDagFrontier();
     if (!latest_frontier.isEqual(frontier)) {

--- a/libraries/vdf/include/vdf/sortition.hpp
+++ b/libraries/vdf/include/vdf/sortition.hpp
@@ -27,8 +27,12 @@ class VdfSortition : public vrf_wrapper::VrfSortitionBase {
   explicit VdfSortition(bytes const& b);
   explicit VdfSortition(Json::Value const& json);
 
-  void computeVdfSolution(SortitionParams const& config, dev::bytes const& msg);
-  void cancelCompute();
+  // Only for testing
+  void computeVdfSolution(const SortitionParams& config, const bytes& msg);
+
+  void computeVdfSolutionCancellable(const SortitionParams& config, const bytes& msg,
+                                     const std::atomic_bool& cancelled);
+
   void verifyVdf(SortitionParams const& config, bytes const& vrf_input, bytes const& vdf_input) const;
 
   bytes rlp() const;
@@ -66,7 +70,6 @@ class VdfSortition : public vrf_wrapper::VrfSortitionBase {
   std::pair<bytes, bytes> vdf_sol_;
   unsigned long vdf_computation_time_ = 0;
   uint16_t difficulty_ = 0;
-  std::shared_ptr<ProverWesolowski> prover_;
 };
 
 }  // namespace taraxa::vdf_sortition

--- a/libraries/vdf/include/vdf/sortition.hpp
+++ b/libraries/vdf/include/vdf/sortition.hpp
@@ -27,11 +27,7 @@ class VdfSortition : public vrf_wrapper::VrfSortitionBase {
   explicit VdfSortition(bytes const& b);
   explicit VdfSortition(Json::Value const& json);
 
-  // Only for testing
-  void computeVdfSolution(const SortitionParams& config, const bytes& msg);
-
-  void computeVdfSolutionCancellable(const SortitionParams& config, const bytes& msg,
-                                     const std::atomic_bool& cancelled);
+  void computeVdfSolution(const SortitionParams& config, const bytes& msg, const std::atomic_bool& cancelled);
 
   void verifyVdf(SortitionParams const& config, bytes const& vrf_input, bytes const& vdf_input) const;
 

--- a/libraries/vdf/src/sortition.cpp
+++ b/libraries/vdf/src/sortition.cpp
@@ -68,15 +68,17 @@ Json::Value VdfSortition::getJson() const {
   return res;
 }
 
-void VdfSortition::cancelCompute() { prover_->cancel(); }
+void VdfSortition::computeVdfSolution(const SortitionParams& config, const bytes& msg) {
+  computeVdfSolutionCancellable(config, msg, false);
+}
 
-void VdfSortition::computeVdfSolution(SortitionParams const& config, bytes const& msg) {
+void VdfSortition::computeVdfSolutionCancellable(const SortitionParams& config, const bytes& msg,
+                                                 const std::atomic_bool& cancelled) {
   if (!isOmitVdf(config)) {
     auto t1 = getCurrentTimeMilliSeconds();
     VerifierWesolowski verifier(config.vdf.lambda_bound, difficulty_, msg, N);
-
-    prover_ = std::static_pointer_cast<ProverWesolowski>(std::make_shared<ProverWesolowski>());
-    vdf_sol_ = (*prover_)(verifier);  // this line takes time ...
+    ProverWesolowski prover;
+    vdf_sol_ = prover(verifier, cancelled);  // this line takes time ...
     auto t2 = getCurrentTimeMilliSeconds();
     vdf_computation_time_ = t2 - t1;
   }

--- a/libraries/vdf/src/sortition.cpp
+++ b/libraries/vdf/src/sortition.cpp
@@ -68,12 +68,8 @@ Json::Value VdfSortition::getJson() const {
   return res;
 }
 
-void VdfSortition::computeVdfSolution(const SortitionParams& config, const bytes& msg) {
-  computeVdfSolutionCancellable(config, msg, false);
-}
-
-void VdfSortition::computeVdfSolutionCancellable(const SortitionParams& config, const bytes& msg,
-                                                 const std::atomic_bool& cancelled) {
+void VdfSortition::computeVdfSolution(const SortitionParams& config, const bytes& msg,
+                                      const std::atomic_bool& cancelled) {
   if (!isOmitVdf(config)) {
     auto t1 = getCurrentTimeMilliSeconds();
     VerifierWesolowski verifier(config.vdf.lambda_bound, difficulty_, msg, N);

--- a/tests/crypto_test.cpp
+++ b/tests/crypto_test.cpp
@@ -117,8 +117,8 @@ TEST_F(CryptoTest, vdf_sortition) {
   blk_hash_t vdf_input = blk_hash_t(200);
   VdfSortition vdf(sortition_params, sk, getRlpBytes(level));
   VdfSortition vdf2(sortition_params, sk, getRlpBytes(level));
-  vdf.computeVdfSolution(sortition_params, vdf_input.asBytes());
-  vdf2.computeVdfSolution(sortition_params, vdf_input.asBytes());
+  vdf.computeVdfSolution(sortition_params, vdf_input.asBytes(), false);
+  vdf2.computeVdfSolution(sortition_params, vdf_input.asBytes(), false);
   auto b = vdf.rlp();
   VdfSortition vdf3(b);
   EXPECT_NO_THROW(vdf3.verifyVdf(sortition_params, getRlpBytes(level), vdf_input.asBytes()));
@@ -151,9 +151,10 @@ TEST_F(CryptoTest, vdf_solution) {
   blk_hash_t vdf_input = blk_hash_t(200);
 
   std::thread th1(
-      [&vdf, vdf_input, sortition_params]() { vdf.computeVdfSolution(sortition_params, vdf_input.asBytes()); });
-  std::thread th2(
-      [&vdf2, vdf_input, sortition_params]() { vdf2.computeVdfSolution(sortition_params, vdf_input.asBytes()); });
+      [&vdf, vdf_input, sortition_params]() { vdf.computeVdfSolution(sortition_params, vdf_input.asBytes(), false); });
+  std::thread th2([&vdf2, vdf_input, sortition_params]() {
+    vdf2.computeVdfSolution(sortition_params, vdf_input.asBytes(), false);
+  });
   th1.join();
   th2.join();
   EXPECT_NE(vdf, vdf2);
@@ -170,7 +171,7 @@ TEST_F(CryptoTest, vdf_proof_verify) {
   VdfSortition vdf(sortition_params, sk, getRlpBytes(level));
   blk_hash_t vdf_input = blk_hash_t(200);
 
-  vdf.computeVdfSolution(sortition_params, vdf_input.asBytes());
+  vdf.computeVdfSolution(sortition_params, vdf_input.asBytes(), false);
   EXPECT_NO_THROW(vdf.verifyVdf(sortition_params, getRlpBytes(level), vdf_input.asBytes()));
   VdfSortition vdf2(sortition_params, sk, getRlpBytes(level));
   EXPECT_THROW(vdf2.verifyVdf(sortition_params, getRlpBytes(level), vdf_input.asBytes()),
@@ -199,15 +200,15 @@ TEST_F(CryptoTest, DISABLED_compute_vdf_solution_cost_time) {
     SortitionParams sortition_params(threshold_upper, threshold_range, difficulty_min, difficulty_max, difficulty_stale,
                                      lambda_bound);
     VdfSortition vdf(sortition_params, sk, getRlpBytes(level));
-    vdf.computeVdfSolution(sortition_params, proposal_dag_block_pivot_hash1.asBytes());
+    vdf.computeVdfSolution(sortition_params, proposal_dag_block_pivot_hash1.asBytes(), false);
     vdf_computation_time = vdf.getComputationTime();
     std::cout << "VDF message " << proposal_dag_block_pivot_hash1 << ", lambda bits " << lambda_bound << ", difficulty "
               << vdf.getDifficulty() << ", computation cost time " << vdf_computation_time << "(ms)" << std::endl;
-    vdf.computeVdfSolution(sortition_params, proposal_dag_block_pivot_hash2.asBytes());
+    vdf.computeVdfSolution(sortition_params, proposal_dag_block_pivot_hash2.asBytes(), false);
     vdf_computation_time = vdf.getComputationTime();
     std::cout << "VDF message " << proposal_dag_block_pivot_hash2 << ", lambda bits " << lambda_bound << ", difficulty "
               << vdf.getDifficulty() << ", computation cost time " << vdf_computation_time << "(ms)" << std::endl;
-    vdf.computeVdfSolution(sortition_params, proposal_dag_block_pivot_hash3.asBytes());
+    vdf.computeVdfSolution(sortition_params, proposal_dag_block_pivot_hash3.asBytes(), false);
     vdf_computation_time = vdf.getComputationTime();
     std::cout << "VDF message " << proposal_dag_block_pivot_hash3 << ", lambda bits " << lambda_bound << ", difficulty "
               << vdf.getDifficulty() << ", computation cost time " << vdf_computation_time << "(ms)" << std::endl;
@@ -219,15 +220,15 @@ TEST_F(CryptoTest, DISABLED_compute_vdf_solution_cost_time) {
     SortitionParams sortition_params(threshold_upper, threshold_range, difficulty_min, difficulty_max, difficulty_stale,
                                      lambda);
     VdfSortition vdf(sortition_params, sk, getRlpBytes(level));
-    vdf.computeVdfSolution(sortition_params, proposal_dag_block_pivot_hash1.asBytes());
+    vdf.computeVdfSolution(sortition_params, proposal_dag_block_pivot_hash1.asBytes(), false);
     vdf_computation_time = vdf.getComputationTime();
     std::cout << "VDF message " << proposal_dag_block_pivot_hash1 << ", lambda bits " << lambda << ", difficulty "
               << vdf.getDifficulty() << ", computation cost time " << vdf_computation_time << "(ms)" << std::endl;
-    vdf.computeVdfSolution(sortition_params, proposal_dag_block_pivot_hash2.asBytes());
+    vdf.computeVdfSolution(sortition_params, proposal_dag_block_pivot_hash2.asBytes(), false);
     vdf_computation_time = vdf.getComputationTime();
     std::cout << "VDF message " << proposal_dag_block_pivot_hash2 << ", lambda bits " << lambda << ", difficulty "
               << vdf.getDifficulty() << ", computation cost time " << vdf_computation_time << "(ms)" << std::endl;
-    vdf.computeVdfSolution(sortition_params, proposal_dag_block_pivot_hash3.asBytes());
+    vdf.computeVdfSolution(sortition_params, proposal_dag_block_pivot_hash3.asBytes(), false);
     vdf_computation_time = vdf.getComputationTime();
     std::cout << "VDF message " << proposal_dag_block_pivot_hash3 << ", lambda bits " << lambda << ", difficulty "
               << vdf.getDifficulty() << ", computation cost time " << vdf_computation_time << "(ms)" << std::endl;

--- a/tests/dag_block_test.cpp
+++ b/tests/dag_block_test.cpp
@@ -46,7 +46,7 @@ TEST_F(DagBlockTest, serialize_deserialize) {
   level_t level = 3;
   VdfSortition vdf(sortition_params, sk, getRlpBytes(level));
   blk_hash_t vdf_input(200);
-  vdf.computeVdfSolution(sortition_params, vdf_input.asBytes());
+  vdf.computeVdfSolution(sortition_params, vdf_input.asBytes(), false);
   DagBlock blk1(blk_hash_t(1), 2, {}, {}, vdf, secret_t::random());
   auto b = blk1.rlp(true);
   DagBlock blk2(b);

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -102,7 +102,7 @@ TEST_F(NetworkTest, DISABLED_transfer_lot_of_blocks) {
   vdf_sortition::VdfSortition vdf(sortition_params, node1->getVrfSecretKey(),
                                   VrfSortitionBase::makeVrfInput(proposal_level, period_block_hash));
   auto dag_genesis = node1->getConfig().chain.dag_genesis_block.getHash();
-  vdf.computeVdfSolution(sortition_params, dag_genesis.asBytes());
+  vdf.computeVdfSolution(sortition_params, dag_genesis.asBytes(), false);
   DagBlock blk(dag_genesis, proposal_level, {}, {samples::createSignedTrxSamples(0, 1, g_secret)[0]->getHash()}, vdf,
                node1->getSecretKey());
   auto block_hash = blk.getHash();
@@ -398,37 +398,37 @@ TEST_F(NetworkTest, node_sync) {
   const auto period_block_hash = node1->getDB()->getPeriodBlockHash(propose_level);
   vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes());
+  vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
   DagBlock blk1(dag_genesis, propose_level, {}, {g_signed_trx_samples[1]->getHash()}, vdf1, sk);
 
   propose_level = 2;
   vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf2.computeVdfSolution(vdf_config, blk1.getHash().asBytes());
+  vdf2.computeVdfSolution(vdf_config, blk1.getHash().asBytes(), false);
   DagBlock blk2(blk1.getHash(), propose_level, {}, {g_signed_trx_samples[2]->getHash()}, vdf2, sk);
 
   propose_level = 3;
   vdf_sortition::VdfSortition vdf3(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf3.computeVdfSolution(vdf_config, blk2.getHash().asBytes());
+  vdf3.computeVdfSolution(vdf_config, blk2.getHash().asBytes(), false);
   DagBlock blk3(blk2.getHash(), propose_level, {}, {g_signed_trx_samples[3]->getHash()}, vdf3, sk);
 
   propose_level = 4;
   vdf_sortition::VdfSortition vdf4(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf4.computeVdfSolution(vdf_config, blk3.getHash().asBytes());
+  vdf4.computeVdfSolution(vdf_config, blk3.getHash().asBytes(), false);
   DagBlock blk4(blk3.getHash(), propose_level, {}, {g_signed_trx_samples[4]->getHash()}, vdf4, sk);
 
   propose_level = 5;
   vdf_sortition::VdfSortition vdf5(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf5.computeVdfSolution(vdf_config, blk4.getHash().asBytes());
+  vdf5.computeVdfSolution(vdf_config, blk4.getHash().asBytes(), false);
   DagBlock blk5(blk4.getHash(), propose_level, {}, {g_signed_trx_samples[5]->getHash()}, vdf5, sk);
 
   propose_level = 6;
   vdf_sortition::VdfSortition vdf6(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf6.computeVdfSolution(vdf_config, blk5.getHash().asBytes());
+  vdf6.computeVdfSolution(vdf_config, blk5.getHash().asBytes(), false);
   DagBlock blk6(blk5.getHash(), propose_level, {blk4.getHash(), blk3.getHash()}, {g_signed_trx_samples[6]->getHash()},
                 vdf6, sk);
 
@@ -484,7 +484,7 @@ TEST_F(NetworkTest, node_pbft_sync) {
 
   level_t level = 1;
   vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk, getRlpBytes(level));
-  vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes());
+  vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
   DagBlock blk1(dag_genesis, 1, {}, {g_signed_trx_samples[0]->getHash(), g_signed_trx_samples[1]->getHash()}, vdf1, sk);
   SharedTransactions txs1({g_signed_trx_samples[0], g_signed_trx_samples[1]});
 
@@ -536,7 +536,7 @@ TEST_F(NetworkTest, node_pbft_sync) {
 
   level = 2;
   vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk, getRlpBytes(level));
-  vdf2.computeVdfSolution(vdf_config, blk1.getHash().asBytes());
+  vdf2.computeVdfSolution(vdf_config, blk1.getHash().asBytes(), false);
   DagBlock blk2(blk1.getHash(), 2, {}, {g_signed_trx_samples[2]->getHash(), g_signed_trx_samples[3]->getHash()}, vdf2,
                 sk);
   SharedTransactions txs2({g_signed_trx_samples[2], g_signed_trx_samples[3]});
@@ -646,7 +646,7 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   addr_t beneficiary(876);
   level_t level = 1;
   vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk, getRlpBytes(level));
-  vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes());
+  vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
   DagBlock blk1(dag_genesis, 1, {}, {g_signed_trx_samples[0]->getHash(), g_signed_trx_samples[1]->getHash()}, vdf1, sk);
   SharedTransactions tr1({g_signed_trx_samples[0], g_signed_trx_samples[1]});
   node1->getTransactionManager()->insertValidatedTransactions(tr1);
@@ -689,7 +689,7 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   beneficiary = addr_t(543);
   level = 2;
   vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk, getRlpBytes(level));
-  vdf2.computeVdfSolution(vdf_config, blk1.getHash().asBytes());
+  vdf2.computeVdfSolution(vdf_config, blk1.getHash().asBytes(), false);
   DagBlock blk2(blk1.getHash(), 2, {}, {g_signed_trx_samples[2]->getHash(), g_signed_trx_samples[3]->getHash()}, vdf2,
                 sk);
   SharedTransactions tr2({g_signed_trx_samples[2], g_signed_trx_samples[3]});
@@ -979,7 +979,7 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
   const auto period_block_hash = node1->getDB()->getPeriodBlockHash(propose_level);
   vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes());
+  vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
   DagBlock blk1(dag_genesis, propose_level, {},
                 {g_signed_trx_samples[0]->getHash(), g_signed_trx_samples[1]->getHash()}, vdf1, sk);
   SharedTransactions tr1({g_signed_trx_samples[0], g_signed_trx_samples[1]});
@@ -987,28 +987,28 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
   propose_level = 2;
   vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf2.computeVdfSolution(vdf_config, blk1.getHash().asBytes());
+  vdf2.computeVdfSolution(vdf_config, blk1.getHash().asBytes(), false);
   DagBlock blk2(blk1.getHash(), propose_level, {}, {g_signed_trx_samples[2]->getHash()}, vdf2, sk);
   SharedTransactions tr2({g_signed_trx_samples[2]});
 
   propose_level = 3;
   vdf_sortition::VdfSortition vdf3(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf3.computeVdfSolution(vdf_config, blk2.getHash().asBytes());
+  vdf3.computeVdfSolution(vdf_config, blk2.getHash().asBytes(), false);
   DagBlock blk3(blk2.getHash(), propose_level, {}, {g_signed_trx_samples[3]->getHash()}, vdf3, sk);
   SharedTransactions tr3{g_signed_trx_samples[3]};
 
   propose_level = 4;
   vdf_sortition::VdfSortition vdf4(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf4.computeVdfSolution(vdf_config, blk3.getHash().asBytes());
+  vdf4.computeVdfSolution(vdf_config, blk3.getHash().asBytes(), false);
   DagBlock blk4(blk3.getHash(), propose_level, {}, {g_signed_trx_samples[4]->getHash()}, vdf4, sk);
   SharedTransactions tr4({g_signed_trx_samples[3], g_signed_trx_samples[4]});
 
   propose_level = 5;
   vdf_sortition::VdfSortition vdf5(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf5.computeVdfSolution(vdf_config, blk4.getHash().asBytes());
+  vdf5.computeVdfSolution(vdf_config, blk4.getHash().asBytes(), false);
   DagBlock blk5(blk4.getHash(), propose_level, {},
                 {g_signed_trx_samples[5]->getHash(), g_signed_trx_samples[6]->getHash(),
                  g_signed_trx_samples[7]->getHash(), g_signed_trx_samples[8]->getHash()},
@@ -1019,7 +1019,7 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
   propose_level = 6;
   vdf_sortition::VdfSortition vdf6(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf6.computeVdfSolution(vdf_config, blk5.getHash().asBytes());
+  vdf6.computeVdfSolution(vdf_config, blk5.getHash().asBytes(), false);
   DagBlock blk6(blk5.getHash(), propose_level, {blk4.getHash(), blk3.getHash()}, {g_signed_trx_samples[9]->getHash()},
                 vdf6, sk);
   SharedTransactions tr6({g_signed_trx_samples[9]});
@@ -1071,42 +1071,42 @@ TEST_F(NetworkTest, node_sync2) {
   const auto period_block_hash = node1->getDB()->getPeriodBlockHash(propose_level);
   vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes());
+  vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
   DagBlock blk1(dag_genesis, propose_level, {}, {transactions[0]->getHash(), transactions[1]->getHash()}, vdf1, sk);
   SharedTransactions tr1({transactions[0], transactions[1]});
   // DAG block2
   propose_level = 1;
   vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf2.computeVdfSolution(vdf_config, dag_genesis.asBytes());
+  vdf2.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
   DagBlock blk2(dag_genesis, propose_level, {}, {transactions[2]->getHash(), transactions[3]->getHash()}, vdf2, sk);
   SharedTransactions tr2({transactions[2], transactions[3]});
   // DAG block3
   propose_level = 2;
   vdf_sortition::VdfSortition vdf3(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf3.computeVdfSolution(vdf_config, blk1.getHash().asBytes());
+  vdf3.computeVdfSolution(vdf_config, blk1.getHash().asBytes(), false);
   DagBlock blk3(blk1.getHash(), propose_level, {}, {transactions[4]->getHash(), transactions[5]->getHash()}, vdf3, sk);
   SharedTransactions tr3({transactions[4], transactions[5]});
   // DAG block4
   propose_level = 3;
   vdf_sortition::VdfSortition vdf4(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf4.computeVdfSolution(vdf_config, blk3.getHash().asBytes());
+  vdf4.computeVdfSolution(vdf_config, blk3.getHash().asBytes(), false);
   DagBlock blk4(blk3.getHash(), propose_level, {}, {transactions[6]->getHash(), transactions[7]->getHash()}, vdf4, sk);
   SharedTransactions tr4({transactions[6], transactions[7]});
   // DAG block5
   propose_level = 2;
   vdf_sortition::VdfSortition vdf5(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf5.computeVdfSolution(vdf_config, blk2.getHash().asBytes());
+  vdf5.computeVdfSolution(vdf_config, blk2.getHash().asBytes(), false);
   DagBlock blk5(blk2.getHash(), propose_level, {}, {transactions[8]->getHash(), transactions[9]->getHash()}, vdf5, sk);
   SharedTransactions tr5({transactions[8], transactions[9]});
   // DAG block6
   propose_level = 2;
   vdf_sortition::VdfSortition vdf6(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf6.computeVdfSolution(vdf_config, blk1.getHash().asBytes());
+  vdf6.computeVdfSolution(vdf_config, blk1.getHash().asBytes(), false);
   DagBlock blk6(blk1.getHash(), propose_level, {}, {transactions[10]->getHash(), transactions[11]->getHash()}, vdf6,
                 sk);
   SharedTransactions tr6({transactions[10], transactions[11]});
@@ -1114,7 +1114,7 @@ TEST_F(NetworkTest, node_sync2) {
   propose_level = 3;
   vdf_sortition::VdfSortition vdf7(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf7.computeVdfSolution(vdf_config, blk6.getHash().asBytes());
+  vdf7.computeVdfSolution(vdf_config, blk6.getHash().asBytes(), false);
   DagBlock blk7(blk6.getHash(), propose_level, {}, {transactions[12]->getHash(), transactions[13]->getHash()}, vdf7,
                 sk);
   SharedTransactions tr7({transactions[12], transactions[13]});
@@ -1122,7 +1122,7 @@ TEST_F(NetworkTest, node_sync2) {
   propose_level = 4;
   vdf_sortition::VdfSortition vdf8(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf8.computeVdfSolution(vdf_config, blk1.getHash().asBytes());
+  vdf8.computeVdfSolution(vdf_config, blk1.getHash().asBytes(), false);
   DagBlock blk8(blk1.getHash(), propose_level, {blk7.getHash()},
                 {transactions[14]->getHash(), transactions[15]->getHash()}, vdf8, sk);
   SharedTransactions tr8({transactions[14], transactions[15]});
@@ -1130,7 +1130,7 @@ TEST_F(NetworkTest, node_sync2) {
   propose_level = 2;
   vdf_sortition::VdfSortition vdf9(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf9.computeVdfSolution(vdf_config, blk1.getHash().asBytes());
+  vdf9.computeVdfSolution(vdf_config, blk1.getHash().asBytes(), false);
   DagBlock blk9(blk1.getHash(), propose_level, {}, {transactions[16]->getHash(), transactions[17]->getHash()}, vdf9,
                 sk);
   SharedTransactions tr9({transactions[16], transactions[17]});
@@ -1138,7 +1138,7 @@ TEST_F(NetworkTest, node_sync2) {
   propose_level = 5;
   vdf_sortition::VdfSortition vdf10(vdf_config, vrf_sk,
                                     VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf10.computeVdfSolution(vdf_config, blk8.getHash().asBytes());
+  vdf10.computeVdfSolution(vdf_config, blk8.getHash().asBytes(), false);
   DagBlock blk10(blk8.getHash(), propose_level, {}, {transactions[18]->getHash(), transactions[19]->getHash()}, vdf10,
                  sk);
   SharedTransactions tr10({transactions[18], transactions[19]});
@@ -1146,7 +1146,7 @@ TEST_F(NetworkTest, node_sync2) {
   propose_level = 3;
   vdf_sortition::VdfSortition vdf11(vdf_config, vrf_sk,
                                     VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf11.computeVdfSolution(vdf_config, blk3.getHash().asBytes());
+  vdf11.computeVdfSolution(vdf_config, blk3.getHash().asBytes(), false);
   DagBlock blk11(blk3.getHash(), propose_level, {}, {transactions[20]->getHash(), transactions[21]->getHash()}, vdf11,
                  sk);
   SharedTransactions tr11({transactions[20], transactions[21]});
@@ -1154,7 +1154,7 @@ TEST_F(NetworkTest, node_sync2) {
   propose_level = 3;
   vdf_sortition::VdfSortition vdf12(vdf_config, vrf_sk,
                                     VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf12.computeVdfSolution(vdf_config, blk5.getHash().asBytes());
+  vdf12.computeVdfSolution(vdf_config, blk5.getHash().asBytes(), false);
   DagBlock blk12(blk5.getHash(), propose_level, {}, {transactions[22]->getHash(), transactions[23]->getHash()}, vdf12,
                  sk);
   SharedTransactions tr12({transactions[22], transactions[23]});

--- a/tests/pbft_chain_test.cpp
+++ b/tests/pbft_chain_test.cpp
@@ -51,7 +51,7 @@ TEST_F(PbftChainTest, pbft_db_test) {
   blk_hash_t prev_block_hash(0);
   level_t level = 1;
   vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk, getRlpBytes(level));
-  vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes());
+  vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
   DagBlock blk1(dag_genesis, 1, {}, {}, vdf1, sk);
 
   uint64_t period = 1;


### PR DESCRIPTION
## Purpose
Fixes: #1659 
Please check also https://github.com/Taraxa-project/taraxa-vdf/pull/9

I can not say for sure if this was the case, but I know exact spot. So I think flow was like this:

1. We execute std::sync
2. async is still not executed ...
3. some of the condition applied
4. we want to cancel execution but pointer is empty
5. Segfault

## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
