### PR TITLE
chore: omit vdf config change and testnet timestamp change

### DIFF
--- a/libraries/cli/include/cli/default_config.hpp
+++ b/libraries/cli/include/cli/default_config.hpp
@@ -212,7 +212,7 @@ const char *default_json = R"foo({
       "computation_interval": 50,
       "vrf": {
         "threshold_upper": "0xafff",
-        "threshold_range": 50
+        "threshold_range": 80
       },
       "vdf": {
         "difficulty_max": 21,

--- a/libraries/cli/include/cli/devnet_config.hpp
+++ b/libraries/cli/include/cli/devnet_config.hpp
@@ -243,7 +243,7 @@ const char *devnet_json = R"foo({
       "computation_interval": 50,
       "vrf": {
         "threshold_upper": "0xafff",
-        "threshold_range": 50
+        "threshold_range": 80
       },
       "vdf": {
         "difficulty_max": 21,

--- a/libraries/cli/include/cli/mainnet_config.hpp
+++ b/libraries/cli/include/cli/mainnet_config.hpp
@@ -263,7 +263,7 @@ const char *mainnet_json = R"foo({
       "computation_interval": 50,
       "vrf": {
         "threshold_upper": "0xafff",
-        "threshold_range": 50
+        "threshold_range": 80
       },
       "vdf": {
         "difficulty_max": 21,

--- a/libraries/cli/include/cli/testnet_config.hpp
+++ b/libraries/cli/include/cli/testnet_config.hpp
@@ -174,14 +174,14 @@ const char *testnet_json = R"foo({
       "level": "0x0",
       "pivot": "0x0000000000000000000000000000000000000000000000000000000000000000",
       "sig": "0xb7e22d46c1ba94d5e8347b01d137b5c428fcbbeaf0a77fb024cbbf1517656ff00d04f7f25be608c321b0d7483c402c294ff46c49b265305d046a52236c0a363701",
-      "timestamp": "0x6218FD00",
+      "timestamp": "0x6241D67F",
       "tips": [],
       "transactions": []
     },
     "final_chain": {
       "genesis_block_fields": {
         "author": "0x0000000000000000000000000000000000000000",
-        "timestamp": "0x6218FD00"
+        "timestamp": "0x6241D67F"
       },
       "state": {
         "disable_block_rewards": true,
@@ -245,7 +245,7 @@ const char *testnet_json = R"foo({
       "computation_interval": 50,
       "vrf": {
         "threshold_upper": "0xafff",
-        "threshold_range": 50
+        "threshold_range": 80
       },
       "vdf": {
         "difficulty_max": 21,

--- a/libraries/config/src/chain_config.cpp
+++ b/libraries/config/src/chain_config.cpp
@@ -82,7 +82,7 @@ decltype(ChainConfig::predefined_) const ChainConfig::predefined_([] {
     dpos.vote_eligibility_balance_step = 1000000000;
     // VDF config
     cfg.sortition.vrf.threshold_upper = 0xafff;
-    cfg.sortition.vrf.threshold_range = 50;
+    cfg.sortition.vrf.threshold_range = 80;
     cfg.sortition.vdf.difficulty_min = 16;
     cfg.sortition.vdf.difficulty_max = 21;
     cfg.sortition.vdf.difficulty_stale = 23;

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -1481,7 +1481,7 @@ TEST_F(FullNodeTest, chain_config_json) {
       "computation_interval": 50,
       "vrf": {
         "threshold_upper": "0xafff",
-        "threshold_range": 50
+        "threshold_range": 80
       },
       "vdf": {
         "difficulty_max": 21,


### PR DESCRIPTION
Change threshold range from 50% to 80% which reduces the chance for omit vdf block from 50% to 20%. This should make the dag block production more smooth

Update testnet config timestamp