### PR TITLE
feature: protect syncing PBFT blocks

### DIFF
--- a/libraries/core_libs/network/include/network/tarcap/shared_states/pbft_syncing_state.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/shared_states/pbft_syncing_state.hpp
@@ -69,27 +69,18 @@ class PbftSyncingState {
    *
    * @param peer_id
    * @param period peer asking sync period
-   *
-   * @return true if table not include peer or asking sync period greater than saving value or has excessed the
-   * kPeerAskingPeriodTimeout for peer restart/rebuild DB situation. Otherwise return false.
    */
-  bool updatePeerAskingPeriod(const dev::p2p::NodeID& peer_id, uint64_t period);
+  void updatePeerAskingPeriod(const dev::p2p::NodeID& peer_id, uint64_t period);
 
   /**
    * @brief Update peers sending sync blocks period
    *
    * @param peer_id
    * @param period peer sending sync block period
-   *
-   * @return true if table not include peer or sending sync block period greater than saving value. Otherwise return
-   * false
    */
-  bool updatePeerSyncingPeriod(const dev::p2p::NodeID& peer_id, uint64_t period);
+  void updatePeerSyncingPeriod(const dev::p2p::NodeID& peer_id, uint64_t period);
 
  private:
-  using UpgradableLock = boost::upgrade_lock<boost::shared_mutex>;
-  using UpgradeLock = boost::upgrade_to_unique_lock<boost::shared_mutex>;
-
   std::atomic<bool> deep_pbft_syncing_{false};
   std::atomic<bool> pbft_syncing_{false};
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/get_pbft_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/get_pbft_sync_packet_handler.cpp
@@ -32,6 +32,12 @@ void GetPbftSyncPacketHandler::process(const PacketData &packet_data,
   LOG(log_tr_) << "Received GetPbftSyncPacket Block";
 
   const size_t height_to_sync = packet_data.rlp_[0].toInt();
+  if (!pbft_syncing_state_->updatePeerAskingPeriod(packet_data.from_node_id_, height_to_sync)) {
+    std::ostringstream err_msg;
+    err_msg << "Peer " << packet_data.from_node_id_ << " request syncing asked previoud period " << height_to_sync;
+    throw MaliciousPeerException(err_msg.str());
+  }
+
   // Here need PBFT chain size, not synced period since synced blocks has not verified yet.
   const size_t my_chain_size = pbft_chain_->getPbftChainSize();
   if (height_to_sync > my_chain_size) {

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/get_pbft_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/get_pbft_sync_packet_handler.cpp
@@ -32,10 +32,10 @@ void GetPbftSyncPacketHandler::process(const PacketData &packet_data,
   LOG(log_tr_) << "Received GetPbftSyncPacket Block";
 
   const size_t height_to_sync = packet_data.rlp_[0].toInt();
-  if (!pbft_syncing_state_->updatePeerAskingPeriod(packet_data.from_node_id_, height_to_sync)) {
-    std::ostringstream err_msg;
-    err_msg << "Peer " << packet_data.from_node_id_ << " request syncing asked previoud period " << height_to_sync;
-    throw MaliciousPeerException(err_msg.str());
+  try {
+    pbft_syncing_state_->updatePeerAskingPeriod(packet_data.from_node_id_, height_to_sync);
+  } catch (const std::logic_error &e) {
+    throw MaliciousPeerException(e.what());
   }
 
   // Here need PBFT chain size, not synced period since synced blocks has not verified yet.

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
@@ -51,13 +51,12 @@ void PbftSyncPacketHandler::process(const PacketData &packet_data, const std::sh
     throw MaliciousPeerException("Unable to parse SyncBlock: " + std::string(e.what()));
   }
 
-  auto sync_period = sync_block.pbft_blk->getPeriod();
+  const auto sync_period = sync_block.pbft_blk->getPeriod();
 
-  if (!pbft_syncing_state_->updatePeerSyncingPeriod(packet_data.from_node_id_, sync_period)) {
-    std::ostringstream err_msg;
-    err_msg << "PbftSyncPacket received from peer " << packet_data.from_node_id_ << " sending previous period "
-            << sync_period << " PBFT block";
-    throw MaliciousPeerException(err_msg.str());
+  try {
+    pbft_syncing_state_->updatePeerSyncingPeriod(packet_data.from_node_id_, sync_period);
+  } catch (const std::logic_error &e) {
+    throw MaliciousPeerException(e.what());
   }
 
   if (pbft_syncing_state_->syncingPeer() != packet_data.from_node_id_) {


### PR DESCRIPTION
Fix https://github.com/Taraxa-project/taraxa-node/issues/1619

Protect PBFT blocks syncing from malicious players in both side:

Peers keep asking for same period block again and again
Peers send same period blocks again and again