### PR TITLE
chore: small updates after clang-tidy

### DIFF
--- a/libraries/core_libs/network/rpc/eth/Eth.h
+++ b/libraries/core_libs/network/rpc/eth/Eth.h
@@ -25,8 +25,10 @@ struct Eth : virtual ::taraxa::net::EthFace {
   Eth(const Eth&) = default;
   Eth(Eth&&) = default;
   Eth& operator=(const Eth&) = default;
-  Eth& operator=(Eth&&) = default;
-
+  Eth& operator=(Eth&& rhs) {
+    ::taraxa::net::EthFace::operator=(std::move(rhs));
+    return *this;
+  }
   virtual void note_block_executed(final_chain::BlockHeader const&, Transactions const&,
                                    final_chain::TransactionReceipts const&) = 0;
   virtual void note_pending_transaction(h256 const& trx_hash) = 0;

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -1001,7 +1001,7 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
   vdf4.computeVdfSolution(vdf_config, blk3.getHash().asBytes(), false);
   DagBlock blk4(blk3.getHash(), propose_level, {}, {g_signed_trx_samples[4]->getHash()}, vdf4, sk);
-  SharedTransactions tr4({g_signed_trx_samples[3], g_signed_trx_samples[4]});
+  SharedTransactions tr4({g_signed_trx_samples[4]});
 
   propose_level = 5;
   vdf_sortition::VdfSortition vdf5(vdf_config, vrf_sk,


### PR DESCRIPTION
## Purpose
after recent clang tidy clean-up I have and issue to build latest develop

```
/home/matus/dev/taraxa-node/libraries/core_libs/network/rpc/eth/Eth.h:21:8: error: defaulted move assignment for ‘taraxa::net::rpc::eth::Eth’ calls a non-trivial move assignment operator for virtual base ‘taraxa::net::EthFace’ [-Werror=virtual-move-assign]
   21 | struct Eth : virtual ::taraxa::net::EthFace {
```

second change should improve test

## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
