### PR TITLE
Improve tests

### DIFF
--- a/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
+++ b/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
@@ -45,7 +45,7 @@ std::pair<bool, std::string> TransactionManager::verifyTransaction(const std::sh
   const auto account = final_chain_->get_account(trx->getSender()).value_or(taraxa::state_api::ZeroAccount);
 
   // Ensure the transaction adheres to nonce ordering
-  if (account.nonce && account.nonce >= trx->getNonce()) {
+  if (account.nonce && account.nonce > trx->getNonce()) {
     return {false, "nonce too low"};
   }
 

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -1044,10 +1044,11 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
   auto node2 = create_nodes({node_cfgs[1]}, true /*start*/).front();
 
   std::cout << "Waiting Sync for up to 20000 milliseconds ..." << std::endl;
-  wait({20s, 200ms}, [&](auto& ctx) { WAIT_EXPECT_GT(ctx, node2->getDagManager()->getNumVerticesInDag().first, 6) });
-
-  EXPECT_GT(node2->getDagManager()->getNumVerticesInDag().first, 6);
-  EXPECT_GT(node2->getDagManager()->getNumEdgesInDag().first, 7);
+  wait({20s, 100ms}, [&](auto& ctx) {
+    WAIT_EXPECT_EQ(ctx, node2->getDagManager()->getNumVerticesInDag().first,
+                   node1->getDagManager()->getNumVerticesInDag().first)
+  });
+  EXPECT_EQ(node2->getDagManager()->getNumEdgesInDag().first, node1->getDagManager()->getNumEdgesInDag().first);
 }
 
 // Test creates a complex DAG on one node and verifies


### PR DESCRIPTION
## Purpose

- Improved execution of one problematic network_test
- fix condition for nonce checking, after lot of debugging I found out that EVM does not return nonce, but number of transactions execute so basically lastNonce - 1


## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
