### PR TITLE
Add Reward Votes in PBFT Proposal Blocks

### DIFF
--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -141,7 +141,7 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
 
   bool syncRequestedAlreadyThisStep_() const;
 
-  void syncPbftChainFromPeers_(PbftSyncRequestReason reason, taraxa::blk_hash_t const &relevant_blk_hash);
+  void syncPbftChainFromPeers_(PbftSyncRequestReason reason, const blk_hash_t &relevant_blk_hash);
 
   bool broadcastAlreadyThisStep_() const;
 

--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -145,10 +145,10 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
 
   bool broadcastAlreadyThisStep_() const;
 
-  bool comparePbftBlockScheduleWithDAGblocks_(blk_hash_t const &pbft_block_hash);
-  std::pair<vec_blk_t, bool> comparePbftBlockScheduleWithDAGblocks_(std::shared_ptr<PbftBlock> pbft_block);
+  bool compareDagBlocksAndRewardVotes_(const blk_hash_t &pbft_block_hash);
+  std::pair<vec_blk_t, bool> compareDagBlocksAndRewardVotes_(std::shared_ptr<PbftBlock> pbft_block);
 
-  bool pushCertVotedPbftBlockIntoChain_(blk_hash_t const &cert_voted_block_hash,
+  bool pushCertVotedPbftBlockIntoChain_(const blk_hash_t &cert_voted_block_hash,
                                         std::vector<std::shared_ptr<Vote>> &&cert_votes_for_round);
 
   void finalize_(SyncBlock &&sync_block, std::vector<h256> &&finalized_dag_blk_hashes, bool sync = false);

--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -119,7 +119,7 @@ class VoteManager {
    *
    * @return true if add successful
    */
-  bool AddRewardVote(const std::shared_ptr<Vote>& vote);
+  bool addRewardVote(const std::shared_ptr<Vote>& vote);
 
   /**
    * @brief Verify reward vote

--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -105,10 +105,10 @@ class VoteManager {
 
   // Reward votes
   void sendRewardPeriodCertVotes(uint64_t reward_period);
-  bool AddRewardVote(std::shared_ptr<Vote>& vote);
+  bool AddRewardVote(const std::shared_ptr<Vote>& vote);
   bool verifyRewardVote(std::shared_ptr<Vote>& vote);
   void updateRewardVotes(uint64_t reward_period);
-  std::pair<std::vector<vote_hash_t>, bool> checkRewardVotes(const std::shared_ptr<PbftBlock>& proposed_pbft_block);
+  bool checkRewardVotes(const std::shared_ptr<PbftBlock>& proposed_pbft_block);
 
  private:
   void retreieveVotes_();

--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -134,17 +134,21 @@ class VoteManager {
    * @brief Update missing reward votes to previous period finalized block
    *
    * @param reward_period
+   *
+   * @return reward votes that are same as previous period cert votes
    */
-  void updateRewardVotes(uint64_t reward_period);
+  std::vector<std::shared_ptr<Vote>> updateRewardVotes(uint64_t reward_period);
 
   /**
    * @brief Check previous finalized block that includes all reward votes
    *
    * @param pbft_block
+   * @param reward_period_cert_votes
    *
    * @return true if include all reward votes
    */
-  bool checkRewardVotes(const std::shared_ptr<PbftBlock>& pbft_block);
+  bool checkRewardVotes(const std::shared_ptr<PbftBlock>& pbft_block,
+                        const std::vector<std::shared_ptr<Vote>>& reward_period_cert_votes);
 
  private:
   void retreieveVotes_();

--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -129,7 +129,7 @@ class VoteManager {
    *
    * @return true if pass vote verification
    */
-  bool verifyRewardVote(std::shared_ptr<Vote>& vote);
+  bool verifyRewardVote(const std::shared_ptr<Vote>& vote);
 
   /**
    * @brief Update missing reward votes to previous period finalized block

--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -136,20 +136,20 @@ class VoteManager {
    *
    * @param reward_period
    *
-   * @return reward votes that are same as previous period cert votes
+   * @return reward votes hashes that are same as previous period cert votes hashes
    */
-  std::vector<std::shared_ptr<Vote>> updateRewardVotes(uint64_t reward_period);
+  std::vector<vote_hash_t> updateRewardVotesAndGetBackRewardPeriodCertVotesHashes(uint64_t reward_period);
 
   /**
    * @brief Check previous finalized block that includes all reward votes
    *
    * @param pbft_block
-   * @param reward_period_cert_votes
+   * @param reward_period_cert_votes_hashes
    *
    * @return true if include all reward votes
    */
   bool checkRewardVotes(const std::shared_ptr<PbftBlock>& pbft_block,
-                        const std::vector<std::shared_ptr<Vote>>& reward_period_cert_votes);
+                        std::vector<vote_hash_t>&& reward_period_cert_votes_hashes);
 
  private:
   void retreieveVotes_();

--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -63,8 +63,9 @@ class NextVotesManager {
 
 class VoteManager {
  public:
-  VoteManager(const addr_t& node_addr, std::shared_ptr<DbStorage> db, std::shared_ptr<PbftChain> pbft_chain,
-              std::shared_ptr<FinalChain> final_chain, std::shared_ptr<NextVotesManager> next_votes_mgr);
+  VoteManager(size_t pbft_committee_size, const addr_t& node_addr, std::shared_ptr<DbStorage> db,
+              std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<FinalChain> final_chain,
+              std::shared_ptr<NextVotesManager> next_votes_mgr);
   ~VoteManager();
   VoteManager(const VoteManager&) = delete;
   VoteManager(VoteManager&&) = delete;
@@ -177,6 +178,7 @@ class VoteManager {
   mutable boost::shared_mutex unverified_votes_access_;
   mutable boost::shared_mutex verified_votes_access_;
 
+  const size_t pbft_committee_size_;
   const addr_t node_addr_;
 
   std::shared_ptr<DbStorage> db_;

--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -104,11 +104,47 @@ class VoteManager {
   uint64_t roundDeterminedFromVotes(size_t two_t_plus_one);
 
   // Reward votes
+
+  /**
+   * @brief Send reward period cert votes to peers. Reward period cert votes should be greater or equal to reward votes
+   *
+   * @param reward_period
+   */
   void sendRewardPeriodCertVotes(uint64_t reward_period);
+
+  /**
+   * @brief Add unverified incoming reward vote to reward votes table
+   *
+   * @param vote unverified incoming reward vote
+   *
+   * @return true if add successful
+   */
   bool AddRewardVote(const std::shared_ptr<Vote>& vote);
+
+  /**
+   * @brief Verify reward vote
+   *
+   * @param vote reward vote
+   *
+   * @return true if pass vote verification
+   */
   bool verifyRewardVote(std::shared_ptr<Vote>& vote);
+
+  /**
+   * @brief Update missing reward votes to previous period finalized block
+   *
+   * @param reward_period
+   */
   void updateRewardVotes(uint64_t reward_period);
-  bool checkRewardVotes(const std::shared_ptr<PbftBlock>& proposed_pbft_block);
+
+  /**
+   * @brief Check previous finalized block that includes all reward votes
+   *
+   * @param pbft_block
+   *
+   * @return true if include all reward votes
+   */
+  bool checkRewardVotes(const std::shared_ptr<PbftBlock>& pbft_block);
 
  private:
   void retreieveVotes_();

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -711,7 +711,7 @@ bool PbftManager::stateOperations_() {
 bool PbftManager::updateSoftVotedBlockForThisRound_() {
   if (soft_voted_block_for_this_round_) {
     // Have enough soft votes for current round already
-    return false;
+    return true;
   }
 
   auto round = getPbftRound();
@@ -875,9 +875,15 @@ void PbftManager::certifyBlock_() {
     // Should not happen, add log here for safety checking
     LOG(log_er_) << "PBFT Reached step 3 too quickly after only " << elapsed_time_in_round_ms_ << " (ms) in round "
                  << round;
-  } else if (go_finish_state_) {
+    return;
+  }
+
+  if (go_finish_state_) {
     LOG(log_dg_) << "Step 3 expired, will go to step 4 in round " << round;
-  } else if (!should_have_cert_voted_in_this_round_) {
+    return;
+  }
+
+  if (!should_have_cert_voted_in_this_round_) {
     LOG(log_tr_) << "In step 3";
 
     if (updateSoftVotedBlockForThisRound_() &&
@@ -1073,7 +1079,7 @@ void PbftManager::secondFinish_() {
 blk_hash_t PbftManager::generatePbftBlock(const blk_hash_t &prev_blk_hash, const blk_hash_t &anchor_hash,
                                           const blk_hash_t &order_hash) {
   auto period = pbft_chain_->getPbftChainSize();
-  auto reward_votes = db_->getCertVotes(period - 1);  // No cert votes in period 0
+  auto reward_votes = db_->getCertVotes(period);  // No cert votes in period 0
   std::vector<vote_hash_t> reward_votes_hash;
   std::transform(reward_votes.begin(), reward_votes.end(), std::back_inserter(reward_votes_hash),
                  [](const auto &v) { return v->getHash(); });
@@ -1139,15 +1145,17 @@ blk_hash_t PbftManager::calculateOrderHash(const std::vector<blk_hash_t> &dag_bl
   if (dag_block_hashes.empty()) {
     return NULL_BLOCK_HASH;
   }
+
   dev::RLPStream order_stream(2);
   order_stream.appendList(dag_block_hashes.size());
-  for (auto const &blk_hash : dag_block_hashes) {
+  for (const auto &blk_hash : dag_block_hashes) {
     order_stream << blk_hash;
   }
   order_stream.appendList(trx_hashes.size());
-  for (auto const &trx_hash : trx_hashes) {
+  for (const auto &trx_hash : trx_hashes) {
     order_stream << trx_hash;
   }
+
   return dev::sha3(order_stream.out());
 }
 
@@ -1155,15 +1163,17 @@ blk_hash_t PbftManager::calculateOrderHash(const std::vector<DagBlock> &dag_bloc
   if (dag_blocks.empty()) {
     return NULL_BLOCK_HASH;
   }
+
   dev::RLPStream order_stream(2);
   order_stream.appendList(dag_blocks.size());
-  for (auto const &blk : dag_blocks) {
+  for (const auto &blk : dag_blocks) {
     order_stream << blk.getHash();
   }
   order_stream.appendList(trxs.size());
-  for (auto const &trx : trxs) {
+  for (const auto &trx : trxs) {
     order_stream << trx->getHash();
   }
+
   return dev::sha3(order_stream.out());
 }
 
@@ -1401,10 +1411,11 @@ bool PbftManager::syncRequestedAlreadyThisStep_() const {
   return getPbftRound() == pbft_round_last_requested_sync_ && step_ == pbft_step_last_requested_sync_;
 }
 
-void PbftManager::syncPbftChainFromPeers_(PbftSyncRequestReason reason, taraxa::blk_hash_t const &relevant_blk_hash) {
+void PbftManager::syncPbftChainFromPeers_(PbftSyncRequestReason reason, const blk_hash_t &relevant_blk_hash) {
   if (stopped_) {
     return;
   }
+
   if (auto net = network_.lock()) {
     if (syncBlockQueueSize()) {
       LOG(log_tr_) << "PBFT synced queue is still processing so skip syncing. Synced queue size "
@@ -1440,13 +1451,12 @@ void PbftManager::syncPbftChainFromPeers_(PbftSyncRequestReason reason, taraxa::
         default:
           LOG(log_er_) << "Unknown PBFT sync request reason " << reason;
           assert(false);
-
-          LOG(log_nf_) << "Restarting sync in round " << round << ", step " << step_;
       }
 
       // TODO: Is there any need to sync here???
       // If we detect some stalled situation, a better step would be to disconnect/reconnect to nodes to try to get
       // network unstuck since reconnecting both shuffles the nodes and invokes pbft/dag syncing if needed
+      // LOG(log_nf_) << "Restarting sync in round " << round << ", step " << step_;
       // net->restartSyncingPbft();
 
       pbft_round_last_requested_sync_ = round;
@@ -1470,22 +1480,25 @@ bool PbftManager::comparePbftBlockScheduleWithDAGblocks_(blk_hash_t const &pbft_
 
 std::pair<vec_blk_t, bool> PbftManager::comparePbftBlockScheduleWithDAGblocks_(std::shared_ptr<PbftBlock> pbft_block) {
   vec_blk_t dag_blocks_order;
+  const auto proposal_block_hash = pbft_block->getBlockHash();
   // If cert sync block is already populated with this pbft block, no need to do verification again
-  if (cert_sync_block_.pbft_blk && cert_sync_block_.pbft_blk->getBlockHash() == pbft_block->getBlockHash()) {
+  if (cert_sync_block_.pbft_blk && cert_sync_block_.pbft_blk->getBlockHash() == proposal_block_hash) {
     dag_blocks_order.reserve(cert_sync_block_.dag_blocks.size());
     std::transform(cert_sync_block_.dag_blocks.begin(), cert_sync_block_.dag_blocks.end(),
                    std::back_inserter(dag_blocks_order), [](const DagBlock &dag_block) { return dag_block.getHash(); });
     return std::make_pair(std::move(dag_blocks_order), true);
   }
 
-  auto const &anchor_hash = pbft_block->getPivotDagBlockHash();
+  const auto &anchor_hash = pbft_block->getPivotDagBlockHash();
   if (anchor_hash == NULL_BLOCK_HASH) {
+    // PBFT block with NULL anchor
     cert_sync_block_.clear();
     cert_sync_block_.pbft_blk = std::move(pbft_block);
     return std::make_pair(std::move(dag_blocks_order), true);
   }
 
-  dag_blocks_order = dag_mgr_->getDagBlockOrder(anchor_hash, pbft_block->getPeriod());
+  const auto proposal_period = pbft_block->getPeriod();
+  dag_blocks_order = dag_mgr_->getDagBlockOrder(anchor_hash, proposal_period);
   if (dag_blocks_order.empty()) {
     syncPbftChainFromPeers_(missing_dag_blk, anchor_hash);
     return std::make_pair(std::move(dag_blocks_order), false);
@@ -1505,6 +1518,7 @@ std::pair<vec_blk_t, bool> PbftManager::comparePbftBlockScheduleWithDAGblocks_(s
     }
     cert_sync_block_.dag_blocks.emplace_back(std::move(*dag_block));
   }
+
   std::vector<trx_hash_t> non_finalized_transactions;
   auto trx_finalized = db_->transactionsFinalized(transactions_to_query);
   for (uint32_t i = 0; i < trx_finalized.size(); i++) {
@@ -1521,9 +1535,9 @@ std::pair<vec_blk_t, bool> PbftManager::comparePbftBlockScheduleWithDAGblocks_(s
     cert_sync_block_.transactions.push_back(trx);
   }
 
-  auto calculated_order_hash = calculateOrderHash(dag_blocks_order, non_finalized_transactions);
+  const auto calculated_order_hash = calculateOrderHash(dag_blocks_order, non_finalized_transactions);
   if (calculated_order_hash != pbft_block->getOrderHash()) {
-    LOG(log_er_) << "Order hash incorrect. Pbft block: " << pbft_block->getBlockHash()
+    LOG(log_er_) << "Order hash incorrect. Pbft block: " << proposal_block_hash
                  << ". Order hash: " << pbft_block->getOrderHash() << " . Calculated hash:" << calculated_order_hash
                  << ". Dag order: " << dag_blocks_order << ". Trx order: " << non_finalized_transactions;
     dag_blocks_order.clear();
@@ -1721,6 +1735,7 @@ void PbftManager::updateTwoTPlusOneAndThreshold_() {
   // Update 2t+1 and threshold
   auto dpos_total_votes_count = getDposTotalVotesCount();
   sortition_threshold_ = std::min<size_t>(COMMITTEE_SIZE, dpos_total_votes_count);
+  db_->savePbftSortitionThreshold(pbft_chain_->getPbftChainSize(), sortition_threshold_);
   TWO_T_PLUS_ONE = sortition_threshold_ * 2 / 3 + 1;
   LOG(log_nf_) << "Committee size " << COMMITTEE_SIZE << ", DPOS total votes count " << dpos_total_votes_count
                << ". Update 2t+1 " << TWO_T_PLUS_ONE << ", Threshold " << sortition_threshold_;

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1551,9 +1551,10 @@ std::pair<vec_blk_t, bool> PbftManager::compareDagBlocksAndRewardVotes_(std::sha
     if (ghost.size() > 1 && anchor_hash != ghost[1]) {
       if (!checkBlockWeight(cert_sync_block_)) {
         LOG(log_er_) << "PBFT block " << pbft_block->getBlockHash() << " is overweighted";
-        return std::make_pair(std::move(dag_blocks_order), false);
+        return {{}, false};
       }
     }
+  }
 
   // Check reward votes
   auto reward_votes = vote_mgr_->updateRewardVotes(proposal_period - 1);
@@ -1707,8 +1708,8 @@ bool PbftManager::pushPbftBlock_(SyncBlock &&sync_block, vec_blk_t &&dag_blocks_
                                                            pbft_chain_->getPbftChainSizeExcludingEmptyPbftBlocks() + 1);
   }
   {
-    // This makes sure that no DAG block or transaction can be added or change state in transaction and dag manager when
-    // finalizing pbft block with dag blocks and transactions
+    // This makes sure that no DAG block or transaction can be added or change state in transaction and dag manager
+    // when finalizing pbft block with dag blocks and transactions
     std::unique_lock dag_lock(dag_mgr_->getDagMutex());
     std::unique_lock trx_lock(trx_mgr_->getTransactionsMutex());
 

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -98,8 +98,7 @@ void PbftManager::run() {
   LOG(log_nf_) << "PBFT running ...";
 
   for (auto period = final_chain_->last_block_number() + 1, curr_period = pbft_chain_->getPbftChainSize();
-       period <= curr_period;  //
-       ++period) {
+       period <= curr_period; ++period) {
     auto period_raw = db_->getPeriodDataRaw(period);
     if (period_raw.size() == 0) {
       LOG(log_er_) << "DB corrupted - Cannot find PBFT block in period " << period << " in PBFT chain DB pbft_blocks.";
@@ -1073,9 +1072,13 @@ void PbftManager::secondFinish_() {
 
 blk_hash_t PbftManager::generatePbftBlock(const blk_hash_t &prev_blk_hash, const blk_hash_t &anchor_hash,
                                           const blk_hash_t &order_hash) {
-  auto propose_period = pbft_chain_->getPbftChainSize() + 1;
-  const auto pbft_block =
-      std::make_shared<PbftBlock>(prev_blk_hash, anchor_hash, order_hash, propose_period, node_addr_, node_sk_);
+  auto period = pbft_chain_->getPbftChainSize();
+  auto reward_votes = db_->getCertVotes(period - 1);  // No cert votes in period 0
+  std::vector<vote_hash_t> reward_votes_hash;
+  std::transform(reward_votes.begin(), reward_votes.end(), std::back_inserter(reward_votes_hash),
+                 [](const auto &v) { return v->getHash(); });
+  const auto pbft_block = std::make_shared<PbftBlock>(prev_blk_hash, anchor_hash, order_hash, period + 1, node_addr_,
+                                                      node_sk_, reward_votes_hash);
 
   // push pbft block
   pbft_chain_->pushUnverifiedPbftBlock(pbft_block);

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1705,10 +1705,6 @@ bool PbftManager::pushPbftBlock_(SyncBlock &&sync_block, vec_blk_t &&dag_blocks_
 
   db_->savePeriodData(sync_block, batch);
 
-  // Save PBFT sortition threshold per period for reward votes verification
-  auto sortition_threshold = std::min<size_t>(COMMITTEE_SIZE, getDposTotalVotesCount());
-  db_->addPbftSortitionThresholdToBatch(pbft_period, sortition_threshold, batch);
-
   // Reset last cert voted value to NULL_BLOCK_HASH
   db_->addPbftMgrVotedValueToBatch(PbftMgrVotedValue::LastCertVotedValue, NULL_BLOCK_HASH, batch);
 

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1077,8 +1077,8 @@ blk_hash_t PbftManager::generatePbftBlock(const blk_hash_t &prev_blk_hash, const
   std::vector<vote_hash_t> reward_votes_hash;
   std::transform(reward_votes.begin(), reward_votes.end(), std::back_inserter(reward_votes_hash),
                  [](const auto &v) { return v->getHash(); });
-  const auto pbft_block = std::make_shared<PbftBlock>(prev_blk_hash, anchor_hash, order_hash, period + 1, node_addr_,
-                                                      node_sk_, reward_votes_hash);
+  const auto pbft_block =
+      std::make_shared<PbftBlock>(prev_blk_hash, anchor_hash, order_hash, period + 1, reward_votes_hash, node_sk_);
 
   // push pbft block
   pbft_chain_->pushUnverifiedPbftBlock(pbft_block);

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1079,11 +1079,11 @@ blk_hash_t PbftManager::generatePbftBlock(const blk_hash_t &prev_blk_hash, const
                                           const blk_hash_t &order_hash) {
   const auto period = pbft_chain_->getPbftChainSize();
   const auto reward_votes = db_->getCertVotes(period);  // No cert votes in period 0
-  std::vector<vote_hash_t> reward_votes_hash;
-  std::transform(reward_votes.begin(), reward_votes.end(), std::back_inserter(reward_votes_hash),
+  std::vector<vote_hash_t> reward_votes_hashes;
+  std::transform(reward_votes.begin(), reward_votes.end(), std::back_inserter(reward_votes_hashes),
                  [](const auto &v) { return v->getHash(); });
   const auto pbft_block =
-      std::make_shared<PbftBlock>(prev_blk_hash, anchor_hash, order_hash, period + 1, reward_votes_hash, node_sk_);
+      std::make_shared<PbftBlock>(prev_blk_hash, anchor_hash, order_hash, period + 1, reward_votes_hashes, node_sk_);
 
   // push pbft block
   pbft_chain_->pushUnverifiedPbftBlock(pbft_block);
@@ -1539,8 +1539,7 @@ std::pair<vec_blk_t, bool> PbftManager::compareDagBlocksAndRewardVotes_(std::sha
     LOG(log_er_) << "Order hash incorrect. Pbft block: " << proposal_block_hash
                  << ". Order hash: " << pbft_block->getOrderHash() << " . Calculated hash:" << calculated_order_hash
                  << ". Dag order: " << dag_blocks_order << ". Trx order: " << non_finalized_transactions;
-    dag_blocks_order.clear();
-    return std::make_pair(std::move(dag_blocks_order), false);
+    return {{}, false};
   }
 
   auto last_pbft_block_hash = pbft_chain_->getLastPbftBlockHash();
@@ -1559,9 +1558,8 @@ std::pair<vec_blk_t, bool> PbftManager::compareDagBlocksAndRewardVotes_(std::sha
   // Check reward votes
   vote_mgr_->updateRewardVotes(proposal_period - 1);
   if (!vote_mgr_->checkRewardVotes(pbft_block)) {
-    LOG(log_er_) << "Failed varifying reward votes for proposed PBFT block " << proposal_block_hash;
-    dag_blocks_order.clear();
-    return std::make_pair(std::move(dag_blocks_order), false);
+    LOG(log_er_) << "Failed verifying reward votes for proposed PBFT block " << proposal_block_hash;
+    return {{}, false};
   }
 
   cert_sync_block_.pbft_blk = std::move(pbft_block);
@@ -1691,7 +1689,7 @@ bool PbftManager::pushPbftBlock_(SyncBlock &&sync_block, vec_blk_t &&dag_blocks_
   auto batch = db_->createWriteBatch();
 
   LOG(log_nf_) << "Storing cert votes of pbft blk " << pbft_block_hash;
-  LOG(log_dg_) << "In round " << round << ". Stored following cert votes:\n";
+  LOG(log_dg_) << "In round " << round << ". Stored following cert votes:";
   for (const auto &v : cert_votes) {
     LOG(log_dg_) << v->getHash();
   }
@@ -1962,7 +1960,7 @@ std::optional<SyncBlock> PbftManager::processSyncBlock() {
   // Check reward votes
   vote_mgr_->updateRewardVotes(sync_block.first.pbft_blk->getPeriod() - 1);
   if (!vote_mgr_->checkRewardVotes(sync_block.first.pbft_blk)) {
-    LOG(log_er_) << "Failed varifying reward votes. Disconnect to malicious peer " << sync_block.second;
+    LOG(log_er_) << "Failed verifying reward votes. Disconnect malicious peer " << sync_block.second;
     sync_queue_.clear();
     net->handleMaliciousSyncPeer(sync_block.second);
     return std::nullopt;

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1078,8 +1078,8 @@ void PbftManager::secondFinish_() {
 
 blk_hash_t PbftManager::generatePbftBlock(const blk_hash_t &prev_blk_hash, const blk_hash_t &anchor_hash,
                                           const blk_hash_t &order_hash) {
-  auto period = pbft_chain_->getPbftChainSize();
-  auto reward_votes = db_->getCertVotes(period);  // No cert votes in period 0
+  const auto period = pbft_chain_->getPbftChainSize();
+  const auto reward_votes = db_->getCertVotes(period);  // No cert votes in period 0
   std::vector<vote_hash_t> reward_votes_hash;
   std::transform(reward_votes.begin(), reward_votes.end(), std::back_inserter(reward_votes_hash),
                  [](const auto &v) { return v->getHash(); });

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1939,6 +1939,26 @@ std::optional<SyncBlock> PbftManager::processSyncBlock() {
     return std::nullopt;
   }
 
+  // Check reward votes
+  const auto missing_reward_votes = vote_mgr_->checkRewardVotes(sync_block.first.pbft_blk);
+  if (missing_reward_votes.second) {
+    LOG(log_er_) << "Not enough reward votes. Disconnect to malicious peer " << sync_block.second;
+    sync_queue_.clear();
+    net->handleMaliciousSyncPeer(sync_block.second);
+    return std::nullopt;
+  }
+  if (!missing_reward_votes.first.empty()) {
+    std::string missing_reward_votes_log = "Cannot find reward votes: ";
+    for (const auto &v : missing_reward_votes.first) {
+      missing_reward_votes_log += "\n" + v.toString();
+    }
+    LOG(log_er_) << missing_reward_votes_log << "\n"
+                 << "Disconnect to malicious peer " << sync_block.second;
+    sync_queue_.clear();
+    net->handleMaliciousSyncPeer(sync_block.second);
+    return std::nullopt;
+  }
+
   return std::optional<SyncBlock>(std::move(sync_block.first));
 }
 

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1580,16 +1580,9 @@ bool PbftManager::pushCertVotedPbftBlockIntoChain_(const blk_hash_t &cert_voted_
     return false;
   }
 
-<<<<<<< HEAD
-  // TODO: refactor. Call of comparePbftBlockScheduleWithDAGblocks_ fills cert_sync_block_ which is not obvious
-  auto [dag_blocks_order, ok] = comparePbftBlockScheduleWithDAGblocks_(pbft_block);
+  auto [dag_blocks_order, ok] = compareDagBlocksAndRewardVotes_(pbft_block);
   if (!ok) {
-    LOG(log_nf_) << "DAG has not build up for PBFT block " << cert_voted_block_hash;
-=======
-  auto dag_blocks_order = compareDagBlocksAndRewardVotes_(pbft_block);
-  if (!dag_blocks_order.second) {
     LOG(log_nf_) << "Failed compare DAG blocks or reward votes in block " << cert_voted_block_hash;
->>>>>>> 165edd2f (feature: fix adding reward votes several bugs and race conditions)
     return false;
   }
 

--- a/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
+++ b/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
@@ -605,7 +605,7 @@ void VoteManager::updateRewardVotes(uint64_t reward_period) {
 std::pair<std::vector<vote_hash_t>, bool> VoteManager::checkRewardVotes(
     const std::shared_ptr<PbftBlock>& proposed_pbft_block) {
   std::vector<vote_hash_t> missing_reward_votes;
-  auto reward_period = proposed_pbft_block->getPeriod() - 1;
+  const auto reward_period = proposed_pbft_block->getPeriod() - 1;
   if (!reward_period) {
     // First period no reward votes
     return std::make_pair(std::move(missing_reward_votes), false);

--- a/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
+++ b/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
@@ -628,8 +628,8 @@ void VoteManager::updateRewardVotes(uint64_t reward_period) {
   }
 }
 
-bool VoteManager::checkRewardVotes(const std::shared_ptr<PbftBlock>& proposed_pbft_block) {
-  const auto reward_period = proposed_pbft_block->getPeriod() - 1;
+bool VoteManager::checkRewardVotes(const std::shared_ptr<PbftBlock>& pbft_block) {
+  const auto reward_period = pbft_block->getPeriod() - 1;
   if (!reward_period) {
     // First period no reward votes
     return true;
@@ -642,7 +642,7 @@ bool VoteManager::checkRewardVotes(const std::shared_ptr<PbftBlock>& proposed_pb
   }
 
   std::vector<vote_hash_t> missing_reward_votes;
-  const auto& reward_votes = proposed_pbft_block->getRewardVotes();
+  const auto& reward_votes = pbft_block->getRewardVotes();
   for (const auto& v : reward_votes) {
     if (!reward_period_cert_votes_set.contains(v)) {
       missing_reward_votes.emplace_back(v);

--- a/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
+++ b/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
@@ -598,9 +598,7 @@ void VoteManager::updateRewardVotes(uint64_t reward_period) {
   }
 
   if (update) {
-    auto batch = db_->createWriteBatch();
-    db_->savePeriodData(reward_period_sync_block, batch);
-    db_->commitWriteBatch(batch);
+    db_->UpdateCertVotesInPeriodData(reward_period_sync_block);
   }
 }
 

--- a/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
+++ b/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
@@ -494,6 +494,10 @@ uint64_t VoteManager::roundDeterminedFromVotes(size_t two_t_plus_one) {
 
 void VoteManager::sendRewardPeriodCertVotes(uint64_t reward_period) {
   auto reward_period_cert_votes = db_->getCertVotes(reward_period);
+  if (reward_period_cert_votes.empty()) {
+    return;
+  }
+
   auto net = network_.lock();
   assert(net);
   net->onNewPbftVotes(std::move(reward_period_cert_votes), true);

--- a/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
+++ b/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
@@ -551,7 +551,8 @@ bool VoteManager::verifyRewardVote(std::shared_ptr<Vote>& vote) {
     return false;
   }
 
-  uint64_t dpos_period = pbft_chain_->getPbftChainSize() - 1;  // reward period - 1
+  const uint64_t pbft_chain_size = pbft_chain_->getPbftChainSize();  // reward period
+  const uint64_t dpos_period = pbft_chain_size - 1;                  // reward period - 1
   const auto& voter_account_addr = vote->getVoterAddr();
   uint64_t voter_dpos_votes_count;
   try {
@@ -569,9 +570,9 @@ bool VoteManager::verifyRewardVote(std::shared_ptr<Vote>& vote) {
 
   const uint64_t reward_period_dpos_total_votes_count = final_chain_->dpos_eligible_total_vote_count(dpos_period);
   const size_t reward_period_pbft_sortition_threshold =
-      db_->getPbftSortitionThreshold(dpos_period + 1);  // reward period
+      db_->getPbftSortitionThreshold(pbft_chain_size);  // reward period
   if (!reward_period_pbft_sortition_threshold) {
-    LOG(log_er_) << "Cannot get PBFT sortition threshold for period " << dpos_period;
+    LOG(log_er_) << "Cannot get PBFT sortition threshold for period " << pbft_chain_size;
     return false;
   }
   try {

--- a/libraries/core_libs/network/include/network/network.hpp
+++ b/libraries/core_libs/network/include/network/network.hpp
@@ -75,7 +75,7 @@ class Network {
   std::shared_ptr<network::tarcap::TaraxaPeer> getPeer(dev::p2p::NodeID const &id) const;
 
   // PBFT
-  void sendPbftBlock(dev::p2p::NodeID const &id, PbftBlock const &pbft_block, uint64_t const &pbft_chain_size);
+  void sendPbftBlock(dev::p2p::NodeID const &id, PbftBlock const &pbft_block);
   void sendPbftVote(dev::p2p::NodeID const &id, std::shared_ptr<Vote> const &vote);
   // END METHODS USED IN TESTS ONLY
 

--- a/libraries/core_libs/network/include/network/network.hpp
+++ b/libraries/core_libs/network/include/network/network.hpp
@@ -53,14 +53,14 @@ class Network {
   void onNewBlockVerified(DagBlock &&blk, bool proposed, SharedTransactions &&trxs);
   void onNewTransactions(SharedTransactions &&transactions);
   void restartSyncingPbft(bool force = false);
-  void onNewPbftBlock(std::shared_ptr<PbftBlock> const &pbft_block);
+  void onNewPbftBlock(const std::shared_ptr<PbftBlock> &pbft_block);
   bool pbft_syncing();
   uint64_t syncTimeSeconds() const;
   void setSyncStatePeriod(uint64_t period);
 
   void handleMaliciousSyncPeer(dev::p2p::NodeID const &id);
 
-  void onNewPbftVotes(std::vector<std::shared_ptr<Vote>> &&votes);
+  void onNewPbftVotes(std::vector<std::shared_ptr<Vote>> &&votes, bool reward_votes = false);
   void broadcastPreviousRoundNextVotesBundle();
 
   // METHODS USED IN TESTS ONLY
@@ -76,7 +76,7 @@ class Network {
 
   // PBFT
   void sendPbftBlock(dev::p2p::NodeID const &id, PbftBlock const &pbft_block);
-  void sendPbftVote(dev::p2p::NodeID const &id, std::shared_ptr<Vote> const &vote);
+  void sendPbftVote(dev::p2p::NodeID const &id, std::shared_ptr<Vote> const &vote, bool reward_vote = false);
   // END METHODS USED IN TESTS ONLY
 
  private:

--- a/libraries/core_libs/network/include/network/network.hpp
+++ b/libraries/core_libs/network/include/network/network.hpp
@@ -75,7 +75,7 @@ class Network {
   std::shared_ptr<network::tarcap::TaraxaPeer> getPeer(dev::p2p::NodeID const &id) const;
 
   // PBFT
-  void sendPbftBlock(dev::p2p::NodeID const &id, PbftBlock const &pbft_block);
+  void sendPbftBlock(const dev::p2p::NodeID &id, const PbftBlock &pbft_block, uint64_t pbft_chain_size);
   void sendPbftVote(dev::p2p::NodeID const &id, std::shared_ptr<Vote> const &vote, bool reward_vote = false);
   // END METHODS USED IN TESTS ONLY
 

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_votes_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_votes_packet_handler.hpp
@@ -23,8 +23,8 @@ class ExtVotesPacketHandler : public PacketHandler {
   ExtVotesPacketHandler& operator=(const ExtVotesPacketHandler&) = default;
   ExtVotesPacketHandler& operator=(ExtVotesPacketHandler&&) = default;
 
-  void onNewPbftVote(std::shared_ptr<Vote>&& vote);
-  void sendPbftVote(dev::p2p::NodeID const& peer_id, std::shared_ptr<Vote> const& vote);
+  void onNewPbftVote(std::shared_ptr<Vote>&& vote, bool reward_vote);
+  void sendPbftVote(dev::p2p::NodeID const& peer_id, std::shared_ptr<Vote> const& vote, bool reward_vote = false);
 
  protected:
   void sendPbftNextVotes(dev::p2p::NodeID const& peer_id,

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/pbft_block_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/pbft_block_packet_handler.hpp
@@ -6,6 +6,7 @@ namespace taraxa {
 class PbftBlock;
 class PbftChain;
 class PbftManager;
+class VoteManager;
 class DagBlockManager;
 }  // namespace taraxa
 
@@ -15,7 +16,7 @@ class PbftBlockPacketHandler final : public PacketHandler {
  public:
   PbftBlockPacketHandler(std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
                          std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<PbftManager> pbft_mgr,
-                         const addr_t& node_addr);
+                         std::shared_ptr<VoteManager> vote_mgr, const addr_t& node_addr);
 
   void onNewPbftBlock(PbftBlock const& pbft_block);
   void sendPbftBlock(dev::p2p::NodeID const& peer_id, PbftBlock const& pbft_block);
@@ -26,6 +27,7 @@ class PbftBlockPacketHandler final : public PacketHandler {
 
   std::shared_ptr<PbftChain> pbft_chain_;
   std::shared_ptr<PbftManager> pbft_mgr_;
+  std::shared_ptr<VoteManager> vote_mgr_;
 };
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/pbft_block_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/pbft_block_packet_handler.hpp
@@ -18,7 +18,7 @@ class PbftBlockPacketHandler final : public PacketHandler {
                          const addr_t& node_addr);
 
   void onNewPbftBlock(PbftBlock const& pbft_block);
-  void sendPbftBlock(dev::p2p::NodeID const& peer_id, PbftBlock const& pbft_block, uint64_t pbft_chain_size);
+  void sendPbftBlock(dev::p2p::NodeID const& peer_id, PbftBlock const& pbft_block);
 
  private:
   void validatePacketRlpFormat(const PacketData& packet_data) const override;

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/pbft_block_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/pbft_block_packet_handler.hpp
@@ -19,7 +19,7 @@ class PbftBlockPacketHandler final : public PacketHandler {
                          std::shared_ptr<VoteManager> vote_mgr, const addr_t& node_addr);
 
   void onNewPbftBlock(PbftBlock const& pbft_block);
-  void sendPbftBlock(dev::p2p::NodeID const& peer_id, PbftBlock const& pbft_block);
+  void sendPbftBlock(const dev::p2p::NodeID& peer_id, const PbftBlock& pbft_block, uint64_t pbft_chain_size);
 
  private:
   void validatePacketRlpFormat(const PacketData& packet_data) const override;

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
@@ -95,7 +95,7 @@ class TaraxaCapability : public dev::p2p::CapabilityFace {
   void onNewBlockReceived(DagBlock &&block);
 
   // PBFT
-  void sendPbftBlock(dev::p2p::NodeID const &id, PbftBlock const &pbft_block, uint64_t pbft_chain_size);
+  void sendPbftBlock(dev::p2p::NodeID const &id, PbftBlock const &pbft_block);
   void sendPbftVote(dev::p2p::NodeID const &id, std::shared_ptr<Vote> const &vote);
 
   // END METHODS USED IN TESTS ONLY

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
@@ -78,8 +78,8 @@ class TaraxaCapability : public dev::p2p::CapabilityFace {
   bool pbft_syncing() const;
   void onNewBlockVerified(DagBlock &&blk, bool proposed, SharedTransactions &&trxs);
   void onNewTransactions(SharedTransactions &&transactions);
-  void onNewPbftBlock(std::shared_ptr<PbftBlock> const &pbft_block);
-  void onNewPbftVote(std::shared_ptr<Vote> &&vote);
+  void onNewPbftBlock(const std::shared_ptr<PbftBlock> &pbft_block);
+  void onNewPbftVote(std::shared_ptr<Vote> &&vote, bool reward_vote);
   void broadcastPreviousRoundNextVotesBundle();
   void sendTransactions(dev::p2p::NodeID const &id, std::vector<taraxa::bytes> const &transactions);
   void handleMaliciousSyncPeer(dev::p2p::NodeID const &id);
@@ -96,7 +96,7 @@ class TaraxaCapability : public dev::p2p::CapabilityFace {
 
   // PBFT
   void sendPbftBlock(dev::p2p::NodeID const &id, PbftBlock const &pbft_block);
-  void sendPbftVote(dev::p2p::NodeID const &id, std::shared_ptr<Vote> const &vote);
+  void sendPbftVote(dev::p2p::NodeID const &id, std::shared_ptr<Vote> const &vote, bool reward_vote = false);
 
   // END METHODS USED IN TESTS ONLY
 

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
@@ -95,7 +95,7 @@ class TaraxaCapability : public dev::p2p::CapabilityFace {
   void onNewBlockReceived(DagBlock &&block);
 
   // PBFT
-  void sendPbftBlock(dev::p2p::NodeID const &id, PbftBlock const &pbft_block);
+  void sendPbftBlock(const dev::p2p::NodeID &id, const PbftBlock &pbft_block, uint64_t pbft_chain_size);
   void sendPbftVote(dev::p2p::NodeID const &id, std::shared_ptr<Vote> const &vote, bool reward_vote = false);
 
   // END METHODS USED IN TESTS ONLY

--- a/libraries/core_libs/network/src/network.cpp
+++ b/libraries/core_libs/network/src/network.cpp
@@ -97,7 +97,7 @@ void Network::restartSyncingPbft(bool force) {
   tp_.post([this, force] { taraxa_capability_->restartSyncingPbft(force); });
 }
 
-void Network::onNewPbftBlock(std::shared_ptr<PbftBlock> const &pbft_block) {
+void Network::onNewPbftBlock(const std::shared_ptr<PbftBlock> &pbft_block) {
   LOG(log_dg_) << "Network broadcast PBFT block: " << pbft_block->getBlockHash();
   taraxa_capability_->onNewPbftBlock(pbft_block);
 }
@@ -110,10 +110,10 @@ void Network::setSyncStatePeriod(uint64_t period) { taraxa_capability_->setSyncS
 
 void Network::handleMaliciousSyncPeer(dev::p2p::NodeID const &id) { taraxa_capability_->handleMaliciousSyncPeer({id}); }
 
-void Network::onNewPbftVotes(std::vector<std::shared_ptr<Vote>> &&votes) {
+void Network::onNewPbftVotes(std::vector<std::shared_ptr<Vote>> &&votes, bool reward_votes) {
   for (auto &vote : votes) {
     LOG(log_tr_) << "Network broadcast PBFT vote: " << vote->getHash();
-    taraxa_capability_->onNewPbftVote(std::move(vote));
+    taraxa_capability_->onNewPbftVote(std::move(vote), reward_votes);
   }
 }
 
@@ -167,9 +167,9 @@ void Network::sendPbftBlock(dev::p2p::NodeID const &id, PbftBlock const &pbft_bl
   taraxa_capability_->sendPbftBlock(id, pbft_block);
 }
 
-void Network::sendPbftVote(dev::p2p::NodeID const &id, std::shared_ptr<Vote> const &vote) {
+void Network::sendPbftVote(dev::p2p::NodeID const &id, std::shared_ptr<Vote> const &vote, bool reward_vote) {
   LOG(log_tr_) << "Network sent PBFT vote: " << vote->getHash() << " to: " << id;
-  taraxa_capability_->sendPbftVote(id, vote);
+  taraxa_capability_->sendPbftVote(id, vote, reward_vote);
 }
 
 }  // namespace taraxa

--- a/libraries/core_libs/network/src/network.cpp
+++ b/libraries/core_libs/network/src/network.cpp
@@ -162,9 +162,9 @@ std::shared_ptr<network::tarcap::TaraxaPeer> Network::getPeer(dev::p2p::NodeID c
   return taraxa_capability_->getPeersState()->getPeer(id);
 }
 
-void Network::sendPbftBlock(dev::p2p::NodeID const &id, PbftBlock const &pbft_block, uint64_t const &pbft_chain_size) {
+void Network::sendPbftBlock(dev::p2p::NodeID const &id, PbftBlock const &pbft_block) {
   LOG(log_dg_) << "Network send PBFT block: " << pbft_block.getBlockHash() << " to: " << id;
-  taraxa_capability_->sendPbftBlock(id, pbft_block, pbft_chain_size);
+  taraxa_capability_->sendPbftBlock(id, pbft_block);
 }
 
 void Network::sendPbftVote(dev::p2p::NodeID const &id, std::shared_ptr<Vote> const &vote) {

--- a/libraries/core_libs/network/src/network.cpp
+++ b/libraries/core_libs/network/src/network.cpp
@@ -111,6 +111,7 @@ void Network::setSyncStatePeriod(uint64_t period) { taraxa_capability_->setSyncS
 void Network::handleMaliciousSyncPeer(dev::p2p::NodeID const &id) { taraxa_capability_->handleMaliciousSyncPeer({id}); }
 
 void Network::onNewPbftVotes(std::vector<std::shared_ptr<Vote>> &&votes, bool reward_votes) {
+  // TODO[issue1700]
   for (auto &vote : votes) {
     LOG(log_tr_) << "Network broadcast PBFT vote: " << vote->getHash();
     taraxa_capability_->onNewPbftVote(std::move(vote), reward_votes);

--- a/libraries/core_libs/network/src/network.cpp
+++ b/libraries/core_libs/network/src/network.cpp
@@ -163,9 +163,9 @@ std::shared_ptr<network::tarcap::TaraxaPeer> Network::getPeer(dev::p2p::NodeID c
   return taraxa_capability_->getPeersState()->getPeer(id);
 }
 
-void Network::sendPbftBlock(dev::p2p::NodeID const &id, PbftBlock const &pbft_block) {
+void Network::sendPbftBlock(const dev::p2p::NodeID &id, const PbftBlock &pbft_block, uint64_t pbft_chain_size) {
   LOG(log_dg_) << "Network send PBFT block: " << pbft_block.getBlockHash() << " to: " << id;
-  taraxa_capability_->sendPbftBlock(id, pbft_block);
+  taraxa_capability_->sendPbftBlock(id, pbft_block, pbft_chain_size);
 }
 
 void Network::sendPbftVote(dev::p2p::NodeID const &id, std::shared_ptr<Vote> const &vote, bool reward_vote) {

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_block_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_block_packet_handler.cpp
@@ -31,6 +31,9 @@ void PbftBlockPacketHandler::process(const PacketData &packet_data, const std::s
                << ", Peer PBFT Chain size: " << peer_pbft_chain_size << " from " << peer->getId();
 
   peer->markPbftBlockAsKnown(pbft_block->getBlockHash());
+  // TODO: Update pbft_chain_size after verify PBFT block. Malicious players can send larget fake chain size
+  // to force peers syncing with him.
+  // After fix this, need refactor unit test NetworkTest.send_pbft_block
   if (peer_pbft_chain_size > peer->pbft_chain_size_) {
     peer->pbft_chain_size_ = peer_pbft_chain_size;
   }

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_block_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_block_packet_handler.cpp
@@ -26,8 +26,6 @@ void PbftBlockPacketHandler::validatePacketRlpFormat(const PacketData &packet_da
 }
 
 void PbftBlockPacketHandler::process(const PacketData &packet_data, const std::shared_ptr<TaraxaPeer> &peer) {
-  LOG(log_tr_) << "In PbftBlockPacket";
-
   auto pbft_block = std::make_shared<PbftBlock>(packet_data.rlp_[0]);
   const auto proposed_block_hash = pbft_block->getBlockHash();
   const auto proposed_period = pbft_block->getPeriod();
@@ -43,14 +41,14 @@ void PbftBlockPacketHandler::process(const PacketData &packet_data, const std::s
 
   const auto pbft_synced_period = pbft_mgr_->pbftSyncingPeriod();
   if (pbft_synced_period >= pbft_block->getPeriod()) {
-    LOG(log_tr_) << "Drop proposed PBFT block " << pbft_block->getBlockHash().abridged() << " at period "
+    LOG(log_dg_) << "Drop proposed PBFT block " << pbft_block->getBlockHash().abridged() << " at period "
                  << proposed_period << ", own PBFT chain has synced at period " << pbft_synced_period;
     return;
   }
 
   // Synchronization point in case multiple threads are processing the same block at the same time
   if (!pbft_chain_->pushUnverifiedPbftBlock(pbft_block)) {
-    LOG(log_tr_) << "Drop proposed PBFT block " << proposed_block_hash.abridged() << " at period " << proposed_period
+    LOG(log_dg_) << "Drop proposed PBFT block " << proposed_block_hash.abridged() << " at period " << proposed_period
                  << " -> already inserted in unverified queue";
     return;
   }

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_block_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_block_packet_handler.cpp
@@ -41,6 +41,7 @@ void PbftBlockPacketHandler::process(const PacketData &packet_data, const std::s
     peer->pbft_chain_size_ = peer_pbft_chain_size;
   }
 
+  // TODO: need to fix that missing proposal PBFT blocks
   const auto pbft_chain_size = pbft_chain_->getPbftChainSize();
   if (pbft_chain_size + 1 != proposed_period) {
     LOG(log_tr_) << "Drop proposed PBFT block " << proposed_block_hash.abridged() << " at period " << proposed_period

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_block_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_block_packet_handler.cpp
@@ -13,28 +13,27 @@ PbftBlockPacketHandler::PbftBlockPacketHandler(std::shared_ptr<PeersState> peers
                                                std::shared_ptr<PacketsStats> packets_stats,
                                                std::shared_ptr<PbftChain> pbft_chain,
                                                std::shared_ptr<PbftManager> pbft_mgr,
-                                               std::shared_ptr<VoteManager> vote_mgr, const addr_t &node_addr)
+                                               std::shared_ptr<VoteManager> vote_mgr, const addr_t& node_addr)
     : PacketHandler(std::move(peers_state), std::move(packets_stats), node_addr, "PBFT_BLOCK_PH"),
       pbft_chain_(std::move(pbft_chain)),
       pbft_mgr_(std::move(pbft_mgr)),
       vote_mgr_(std::move(vote_mgr)) {}
 
-void PbftBlockPacketHandler::validatePacketRlpFormat(const PacketData &packet_data) const {
-  if (constexpr size_t required_size = 1; packet_data.rlp_.itemCount() != required_size) {
+void PbftBlockPacketHandler::validatePacketRlpFormat(const PacketData& packet_data) const {
+  if (constexpr size_t required_size = 2; packet_data.rlp_.itemCount() != required_size) {
     throw InvalidRlpItemsCountException(packet_data.type_str_, packet_data.rlp_.itemCount(), required_size);
   }
 }
 
-void PbftBlockPacketHandler::process(const PacketData &packet_data, const std::shared_ptr<TaraxaPeer> &peer) {
+void PbftBlockPacketHandler::process(const PacketData& packet_data, const std::shared_ptr<TaraxaPeer>& peer) {
   auto pbft_block = std::make_shared<PbftBlock>(packet_data.rlp_[0]);
+  const uint64_t peer_pbft_chain_size = packet_data.rlp_[1].toInt();
   const auto proposed_block_hash = pbft_block->getBlockHash();
   const auto proposed_period = pbft_block->getPeriod();
-  LOG(log_tr_) << "Receive proposed PBFT Block " << proposed_block_hash.abridged() << ", for proposed period "
-               << proposed_period << " from " << peer->getId();
+  LOG(log_tr_) << "Receive proposed PBFT Block " << proposed_block_hash.abridged() << " for proposed period "
+               << proposed_period << ". Peer PBFT chain size " << peer_pbft_chain_size << " from " << peer->getId();
 
   peer->markPbftBlockAsKnown(pbft_block->getBlockHash());
-
-  const auto peer_pbft_chain_size = proposed_period - 1;
   if (peer_pbft_chain_size > peer->pbft_chain_size_) {
     peer->pbft_chain_size_ = peer_pbft_chain_size;
   }
@@ -53,17 +52,18 @@ void PbftBlockPacketHandler::process(const PacketData &packet_data, const std::s
     return;
   }
 
-  LOG(log_dg_) << "Receive proposed PBFT Block " << proposed_block_hash.abridged() << ", for proposed period "
-               << proposed_period << " from " << peer->getId();
+  LOG(log_dg_) << "Receive proposed PBFT Block " << proposed_block_hash.abridged() << " for proposed period "
+               << proposed_period << ". Peer PBFT chain size " << peer_pbft_chain_size << " from " << peer->getId();
 
   onNewPbftBlock(*pbft_block);
 }
 
-void PbftBlockPacketHandler::onNewPbftBlock(const PbftBlock &pbft_block) {
+void PbftBlockPacketHandler::onNewPbftBlock(const PbftBlock& pbft_block) {
   std::vector<std::shared_ptr<TaraxaPeer>> peers_to_send;
+  const auto my_chain_size = pbft_chain_->getPbftChainSize();
   std::string peers_to_log;
 
-  for (auto const &peer : peers_state_->getAllPeers()) {
+  for (auto const& peer : peers_state_->getAllPeers()) {
     if (!peer.second->isPbftBlockKnown(pbft_block.getBlockHash()) && !peer.second->syncing_) {
       if (!peer.second->isDagBlockKnown(pbft_block.getPivotDagBlockHash())) {
         LOG(log_tr_) << "Send PbftBlock " << pbft_block.getBlockHash() << " with missing dag anchor<"
@@ -75,18 +75,20 @@ void PbftBlockPacketHandler::onNewPbftBlock(const PbftBlock &pbft_block) {
   }
 
   LOG(log_dg_) << "sendPbftBlock " << pbft_block.getBlockHash() << " with reward period cert votes to " << peers_to_log;
-  for (auto const &peer : peers_to_send) {
+  for (auto const& peer : peers_to_send) {
     // Send reward period cert votes, that include more than reward votes in the proposed PBFT block
     vote_mgr_->sendRewardPeriodCertVotes(pbft_block.getPeriod() - 1);
-    sendPbftBlock(peer->getId(), pbft_block);
+    sendPbftBlock(peer->getId(), pbft_block, my_chain_size);
     peer->markPbftBlockAsKnown(pbft_block.getBlockHash());
   }
 }
 
-void PbftBlockPacketHandler::sendPbftBlock(dev::p2p::NodeID const &peer_id, PbftBlock const &pbft_block) {
+void PbftBlockPacketHandler::sendPbftBlock(const dev::p2p::NodeID& peer_id, const PbftBlock& pbft_block,
+                                           uint64_t pbft_chain_size) {
   LOG(log_tr_) << "sendPbftBlock " << pbft_block.getBlockHash() << " to " << peer_id;
-  dev::RLPStream s(1);
+  dev::RLPStream s(2);
   pbft_block.streamRLP(s, true);
+  s << pbft_chain_size;
   sealAndSend(peer_id, PbftBlockPacket, std::move(s));
 }
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_block_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_block_packet_handler.cpp
@@ -41,29 +41,10 @@ void PbftBlockPacketHandler::process(const PacketData &packet_data, const std::s
     peer->pbft_chain_size_ = peer_pbft_chain_size;
   }
 
-  const auto pbft_synced_period = pbft_mgr_->pbftSyncingPeriod();
-  if (pbft_synced_period + 1 != proposed_period) {
+  const auto pbft_chain_size = pbft_chain_->getPbftChainSize();
+  if (pbft_chain_size + 1 != proposed_period) {
     LOG(log_tr_) << "Drop proposed PBFT block " << proposed_block_hash.abridged() << " at period " << proposed_period
-                 << ", own PBFT chain has synced at period " << pbft_synced_period;
-    return;
-  }
-
-  // Reward votes
-  vote_mgr_->updateRewardVotes(proposed_period - 1);
-  const auto missing_reward_votes = vote_mgr_->checkRewardVotes(pbft_block);
-  if (missing_reward_votes.second) {
-    std::ostringstream err_msg;
-    err_msg << "Disconnect to malicious peer " << packet_data.from_node_id_;
-    throw MaliciousPeerException(err_msg.str());
-  }
-  if (!missing_reward_votes.first.empty()) {
-    std::ostringstream missing_reward_votes_log;
-    missing_reward_votes_log << "Missing reward votes: ";
-    for (const auto &v : missing_reward_votes.first) {
-      missing_reward_votes_log << "\n" << v.toString();
-    }
-    LOG(log_tr_) << missing_reward_votes_log.str();
-    // TODO: If see the error often, need implement reward votes syncing process.
+                 << ", own PBFT chain size is " << pbft_chain_size;
     return;
   }
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_block_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_block_packet_handler.cpp
@@ -42,8 +42,8 @@ void PbftBlockPacketHandler::process(const PacketData &packet_data, const std::s
   }
 
   const auto pbft_synced_period = pbft_mgr_->pbftSyncingPeriod();
-  if (pbft_synced_period >= proposed_period) {
-    LOG(log_tr_) << "Drop new PBFT block " << proposed_block_hash.abridged() << " at period " << proposed_period
+  if (pbft_synced_period + 1 != proposed_period) {
+    LOG(log_tr_) << "Drop proposed PBFT block " << proposed_block_hash.abridged() << " at period " << proposed_period
                  << ", own PBFT chain has synced at period " << pbft_synced_period;
     return;
   }
@@ -62,7 +62,7 @@ void PbftBlockPacketHandler::process(const PacketData &packet_data, const std::s
     for (const auto &v : missing_reward_votes.first) {
       missing_reward_votes_log << "\n" << v.toString();
     }
-    LOG(log_er_) << missing_reward_votes_log.str();
+    LOG(log_tr_) << missing_reward_votes_log.str();
     // TODO: If see the error often, need implement reward votes syncing process.
     return;
   }

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_block_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_block_packet_handler.cpp
@@ -50,7 +50,7 @@ void PbftBlockPacketHandler::process(const PacketData &packet_data, const std::s
 
   // Reward votes
   vote_mgr_->updateRewardVotes(proposed_period - 1);
-  auto missing_reward_votes = vote_mgr_->checkRewardVotes(pbft_block);
+  const auto missing_reward_votes = vote_mgr_->checkRewardVotes(pbft_block);
   if (missing_reward_votes.second) {
     std::ostringstream err_msg;
     err_msg << "Disconnect to malicious peer " << packet_data.from_node_id_;

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
@@ -26,18 +26,10 @@ void VotePacketHandler::process(const PacketData &packet_data, const std::shared
   LOG(log_dg_) << "Received PBFT vote " << vote_hash;
 
   if (reward_vote) {
-    // Synchronization point in case multiple threads are processing the same vote at the same time
-    if (!seen_votes_.insert(vote_hash)) {
-      LOG(log_dg_) << "Received reward vote " << vote_hash << " (from " << packet_data.from_node_id_.abridged()
-                   << ") already seen.";
-      return;
-    }
-
     if (vote_mgr_->AddRewardVote(vote)) {
       peer->markVoteAsKnown(vote_hash);
       onNewPbftVote(std::move(vote), reward_vote);
     }
-
     return;
   }
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
@@ -27,7 +27,7 @@ void VotePacketHandler::process(const PacketData &packet_data, const std::shared
 
   const auto vote_round = vote->getRound();
   if (reward_vote || (vote_round < pbft_mgr_->getPbftRound() && vote->getType() == cert_vote_type)) {
-    if (vote_mgr_->AddRewardVote(vote)) {
+    if (vote_mgr_->addRewardVote(vote)) {
       peer->markVoteAsKnown(vote_hash);
       onNewPbftVote(std::move(vote), reward_vote);
     }

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
@@ -74,7 +74,7 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
         continue;
       }
 
-      onNewPbftVote(std::move(vote_n));
+      onNewPbftVote(std::move(vote_n), false);
     }
   } else if (pbft_current_round == peer_pbft_round) {
     // Update previous round next votes

--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -426,11 +426,10 @@ size_t TaraxaCapability::getReceivedBlocksCount() const { return test_state_->ge
 size_t TaraxaCapability::getReceivedTransactionsCount() const { return test_state_->getTransactionsSize(); }
 
 // PBFT
-void TaraxaCapability::sendPbftBlock(dev::p2p::NodeID const &id, PbftBlock const &pbft_block,
-                                     uint64_t pbft_chain_size) {
+void TaraxaCapability::sendPbftBlock(dev::p2p::NodeID const &id, PbftBlock const &pbft_block) {
   std::static_pointer_cast<PbftBlockPacketHandler>(
       packets_handlers_->getSpecificHandler(SubprotocolPacketType::PbftBlockPacket))
-      ->sendPbftBlock(id, pbft_block, pbft_chain_size);
+      ->sendPbftBlock(id, pbft_block);
 }
 
 void TaraxaCapability::sendPbftVote(dev::p2p::NodeID const &id, std::shared_ptr<Vote> const &vote) {

--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -192,7 +192,7 @@ void TaraxaCapability::registerPacketHandlers(
   // Standard packets with mid processing priority
   packets_handlers_->registerHandler(
       SubprotocolPacketType::PbftBlockPacket,
-      std::make_shared<PbftBlockPacketHandler>(peers_state_, packets_stats, pbft_chain, pbft_mgr, node_addr));
+      std::make_shared<PbftBlockPacketHandler>(peers_state_, packets_stats, pbft_chain, pbft_mgr, vote_mgr, node_addr));
 
   const auto dag_handler =
       std::make_shared<DagBlockPacketHandler>(peers_state_, packets_stats, pbft_syncing_state_, pbft_chain, pbft_mgr,
@@ -382,15 +382,15 @@ void TaraxaCapability::onNewBlockReceived(DagBlock &&block) {
       ->onNewBlockReceived(std::move(block));
 }
 
-void TaraxaCapability::onNewPbftBlock(std::shared_ptr<PbftBlock> const &pbft_block) {
+void TaraxaCapability::onNewPbftBlock(const std::shared_ptr<PbftBlock> &pbft_block) {
   std::static_pointer_cast<PbftBlockPacketHandler>(
       packets_handlers_->getSpecificHandler(SubprotocolPacketType::PbftBlockPacket))
       ->onNewPbftBlock(*pbft_block);
 }
 
-void TaraxaCapability::onNewPbftVote(std::shared_ptr<Vote> &&vote) {
+void TaraxaCapability::onNewPbftVote(std::shared_ptr<Vote> &&vote, bool reward_vote) {
   std::static_pointer_cast<VotePacketHandler>(packets_handlers_->getSpecificHandler(SubprotocolPacketType::VotePacket))
-      ->onNewPbftVote(std::move(vote));
+      ->onNewPbftVote(std::move(vote), reward_vote);
 }
 
 void TaraxaCapability::broadcastPreviousRoundNextVotesBundle() {
@@ -432,9 +432,9 @@ void TaraxaCapability::sendPbftBlock(dev::p2p::NodeID const &id, PbftBlock const
       ->sendPbftBlock(id, pbft_block);
 }
 
-void TaraxaCapability::sendPbftVote(dev::p2p::NodeID const &id, std::shared_ptr<Vote> const &vote) {
+void TaraxaCapability::sendPbftVote(dev::p2p::NodeID const &id, std::shared_ptr<Vote> const &vote, bool reward_vote) {
   std::static_pointer_cast<VotePacketHandler>(packets_handlers_->getSpecificHandler(SubprotocolPacketType::VotePacket))
-      ->sendPbftVote(id, vote);
+      ->sendPbftVote(id, vote, reward_vote);
 }
 
 // END METHODS USED IN TESTS ONLY

--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -426,10 +426,11 @@ size_t TaraxaCapability::getReceivedBlocksCount() const { return test_state_->ge
 size_t TaraxaCapability::getReceivedTransactionsCount() const { return test_state_->getTransactionsSize(); }
 
 // PBFT
-void TaraxaCapability::sendPbftBlock(dev::p2p::NodeID const &id, PbftBlock const &pbft_block) {
+void TaraxaCapability::sendPbftBlock(const dev::p2p::NodeID &id, const PbftBlock &pbft_block,
+                                     uint64_t pbft_chain_size) {
   std::static_pointer_cast<PbftBlockPacketHandler>(
       packets_handlers_->getSpecificHandler(SubprotocolPacketType::PbftBlockPacket))
-      ->sendPbftBlock(id, pbft_block);
+      ->sendPbftBlock(id, pbft_block, pbft_chain_size);
 }
 
 void TaraxaCapability::sendPbftVote(dev::p2p::NodeID const &id, std::shared_ptr<Vote> const &vote, bool reward_vote) {

--- a/libraries/core_libs/node/src/node.cpp
+++ b/libraries/core_libs/node/src/node.cpp
@@ -106,7 +106,7 @@ void FullNode::init() {
   dag_mgr_ = std::make_shared<DagManager>(genesis_hash, node_addr, trx_mgr_, pbft_chain_, dag_blk_mgr_, db_, log_time_,
                                           conf_.is_light_node, conf_.light_node_history, conf_.max_levels_per_period,
                                           conf_.dag_expiry_limit);
-  vote_mgr_ = std::make_shared<VoteManager>(node_addr, db_, final_chain_, next_votes_mgr_);
+  vote_mgr_ = std::make_shared<VoteManager>(node_addr, db_, pbft_chain_, final_chain_, next_votes_mgr_);
   pbft_mgr_ = std::make_shared<PbftManager>(conf_.chain.pbft, genesis_hash, node_addr, db_, pbft_chain_, vote_mgr_,
                                             next_votes_mgr_, dag_mgr_, dag_blk_mgr_, trx_mgr_, final_chain_,
                                             kp_.secret(), conf_.vrf_secret, conf_.max_levels_per_period);

--- a/libraries/core_libs/node/src/node.cpp
+++ b/libraries/core_libs/node/src/node.cpp
@@ -106,7 +106,8 @@ void FullNode::init() {
   dag_mgr_ = std::make_shared<DagManager>(genesis_hash, node_addr, trx_mgr_, pbft_chain_, dag_blk_mgr_, db_, log_time_,
                                           conf_.is_light_node, conf_.light_node_history, conf_.max_levels_per_period,
                                           conf_.dag_expiry_limit);
-  vote_mgr_ = std::make_shared<VoteManager>(node_addr, db_, pbft_chain_, final_chain_, next_votes_mgr_);
+  vote_mgr_ = std::make_shared<VoteManager>(conf_.chain.pbft.committee_size, node_addr, db_, pbft_chain_, final_chain_,
+                                            next_votes_mgr_);
   pbft_mgr_ = std::make_shared<PbftManager>(conf_.chain.pbft, genesis_hash, node_addr, db_, pbft_chain_, vote_mgr_,
                                             next_votes_mgr_, dag_mgr_, dag_blk_mgr_, trx_mgr_, final_chain_,
                                             kp_.secret(), conf_.vrf_secret, conf_.max_levels_per_period);

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -183,6 +183,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   void enableSnapshots();
 
   // Period data
+  void UpdateCertVotesInPeriodData(const SyncBlock& sync_block);
   void savePeriodData(const SyncBlock& sync_block, Batch& write_batch);
   void clearPeriodDataHistory(uint64_t period);
   dev::bytes getPeriodDataRaw(uint64_t period) const;

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -183,7 +183,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   void enableSnapshots();
 
   // Period data
-  void UpdateCertVotesInPeriodData(const SyncBlock& sync_block);
+  void overridePeriodData(const SyncBlock& sync_block);
   void savePeriodData(const SyncBlock& sync_block, Batch& write_batch);
   void clearPeriodDataHistory(uint64_t period);
   dev::bytes getPeriodDataRaw(uint64_t period) const;

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -105,6 +105,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
     COLUMN(pbft_mgr_previous_round_status);
     COLUMN(pbft_mgr_round_step);
     COLUMN(pbft_round_2t_plus_1);
+    COLUMN(period_pbft_sortition_threshold);
     COLUMN(pbft_mgr_status);
     COLUMN(pbft_mgr_voted_value);
     COLUMN(pbft_cert_voted_block);
@@ -232,6 +233,10 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   size_t getPbft2TPlus1(uint64_t pbft_round);
   void savePbft2TPlus1(uint64_t pbft_round, size_t pbft_2t_plus_1);
   void addPbft2TPlus1ToBatch(uint64_t pbft_round, size_t pbft_2t_plus_1, Batch& write_batch);
+
+  size_t getPbftSortitionThreshold(uint64_t period);
+  void savePbftSortitionThreshold(uint64_t period, size_t sortition_threshold);
+  void addPbftSortitionThresholdToBatch(uint64_t period, size_t sortition_threshold, Batch& write_batch);
 
   bool getPbftMgrStatus(PbftMgrStatus field);
   void savePbftMgrStatus(PbftMgrStatus field, bool const& value);

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -235,10 +235,6 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   void savePbft2TPlus1(uint64_t pbft_round, size_t pbft_2t_plus_1);
   void addPbft2TPlus1ToBatch(uint64_t pbft_round, size_t pbft_2t_plus_1, Batch& write_batch);
 
-  size_t getPbftSortitionThreshold(uint64_t period);
-  void savePbftSortitionThreshold(uint64_t period, size_t sortition_threshold);
-  void addPbftSortitionThresholdToBatch(uint64_t period, size_t sortition_threshold, Batch& write_batch);
-
   bool getPbftMgrStatus(PbftMgrStatus field);
   void savePbftMgrStatus(PbftMgrStatus field, bool const& value);
   void addPbftMgrStatusToBatch(PbftMgrStatus field, bool const& value, Batch& write_batch);

--- a/libraries/core_libs/storage/src/storage.cpp
+++ b/libraries/core_libs/storage/src/storage.cpp
@@ -677,27 +677,6 @@ void DbStorage::addPbft2TPlus1ToBatch(uint64_t pbft_round, size_t pbft_2t_plus_1
   insert(write_batch, DbStorage::Columns::pbft_round_2t_plus_1, toSlice(pbft_round), toSlice(pbft_2t_plus_1));
 }
 
-size_t DbStorage::getPbftSortitionThreshold(uint64_t period) {
-  auto status = lookup(toSlice(period), Columns::period_pbft_sortition_threshold);
-
-  if (!status.empty()) {
-    size_t value;
-    memcpy(&value, status.data(), sizeof(size_t));
-    return value;
-  }
-
-  return 0;
-}
-
-void DbStorage::savePbftSortitionThreshold(uint64_t period, size_t sortition_threshold) {
-  insert(Columns::period_pbft_sortition_threshold, toSlice(period), toSlice(sortition_threshold));
-}
-
-void DbStorage::addPbftSortitionThresholdToBatch(uint64_t period, size_t sortition_threshold, Batch& write_batch) {
-  insert(write_batch, DbStorage::Columns::period_pbft_sortition_threshold, toSlice(period),
-         toSlice(sortition_threshold));
-}
-
 bool DbStorage::getPbftMgrStatus(PbftMgrStatus field) {
   auto status = lookup(toSlice(field), Columns::pbft_mgr_status);
   if (!status.empty()) {

--- a/libraries/core_libs/storage/src/storage.cpp
+++ b/libraries/core_libs/storage/src/storage.cpp
@@ -419,6 +419,10 @@ void DbStorage::clearPeriodDataHistory(uint64_t period) {
   db_->DeleteRange(write_options_, handle(Columns::period_data), toSlice(start), toSlice(period));
 }
 
+void DbStorage::UpdateCertVotesInPeriodData(const SyncBlock& sync_block) {
+  insert(Columns::period_data, toSlice(sync_block.pbft_blk->getPeriod()), toSlice(sync_block.rlp()));
+}
+
 void DbStorage::savePeriodData(const SyncBlock& sync_block, Batch& write_batch) {
   uint64_t period = sync_block.pbft_blk->getPeriod();
   addPbftBlockPeriodToBatch(period, sync_block.pbft_blk->getBlockHash(), write_batch);

--- a/libraries/core_libs/storage/src/storage.cpp
+++ b/libraries/core_libs/storage/src/storage.cpp
@@ -419,7 +419,7 @@ void DbStorage::clearPeriodDataHistory(uint64_t period) {
   db_->DeleteRange(write_options_, handle(Columns::period_data), toSlice(start), toSlice(period));
 }
 
-void DbStorage::UpdateCertVotesInPeriodData(const SyncBlock& sync_block) {
+void DbStorage::overridePeriodData(const SyncBlock& sync_block) {
   insert(Columns::period_data, toSlice(sync_block.pbft_blk->getPeriod()), toSlice(sync_block.rlp()));
 }
 

--- a/libraries/core_libs/storage/src/storage.cpp
+++ b/libraries/core_libs/storage/src/storage.cpp
@@ -673,6 +673,27 @@ void DbStorage::addPbft2TPlus1ToBatch(uint64_t pbft_round, size_t pbft_2t_plus_1
   insert(write_batch, DbStorage::Columns::pbft_round_2t_plus_1, toSlice(pbft_round), toSlice(pbft_2t_plus_1));
 }
 
+size_t DbStorage::getPbftSortitionThreshold(uint64_t period) {
+  auto status = lookup(toSlice(period), Columns::period_pbft_sortition_threshold);
+
+  if (!status.empty()) {
+    size_t value;
+    memcpy(&value, status.data(), sizeof(size_t));
+    return value;
+  }
+
+  return 0;
+}
+
+void DbStorage::savePbftSortitionThreshold(uint64_t period, size_t sortition_threshold) {
+  insert(Columns::period_pbft_sortition_threshold, toSlice(period), toSlice(sortition_threshold));
+}
+
+void DbStorage::addPbftSortitionThresholdToBatch(uint64_t period, size_t sortition_threshold, Batch& write_batch) {
+  insert(write_batch, DbStorage::Columns::period_pbft_sortition_threshold, toSlice(period),
+         toSlice(sortition_threshold));
+}
+
 bool DbStorage::getPbftMgrStatus(PbftMgrStatus field) {
   auto status = lookup(toSlice(field), Columns::pbft_mgr_status);
   if (!status.empty()) {

--- a/libraries/types/pbft_block/include/pbft/pbft_block.hpp
+++ b/libraries/types/pbft_block/include/pbft/pbft_block.hpp
@@ -37,13 +37,14 @@ class PbftBlock {
 
   static Json::Value toJson(const PbftBlock& b, const std::vector<blk_hash_t>& dag_blks);
 
-  auto const& getBlockHash() const { return block_hash_; }
-  auto const& getPrevBlockHash() const { return prev_block_hash_; }
-  auto const& getPivotDagBlockHash() const { return dag_block_hash_as_pivot_; }
-  auto const& getOrderHash() const { return order_hash_; }
+  const auto& getBlockHash() const { return block_hash_; }
+  const auto& getPrevBlockHash() const { return prev_block_hash_; }
+  const auto& getPivotDagBlockHash() const { return dag_block_hash_as_pivot_; }
+  const auto& getOrderHash() const { return order_hash_; }
   auto getPeriod() const { return period_; }
+  const auto& getRewardVotes() const { return reward_votes_; }
   auto getTimestamp() const { return timestamp_; }
-  auto const& getBeneficiary() const { return beneficiary_; }
+  const auto& getBeneficiary() const { return beneficiary_; }
 
  private:
   void calculateHash_();

--- a/libraries/types/pbft_block/include/pbft/pbft_block.hpp
+++ b/libraries/types/pbft_block/include/pbft/pbft_block.hpp
@@ -17,16 +17,15 @@ class PbftBlock {
   blk_hash_t prev_block_hash_;
   blk_hash_t dag_block_hash_as_pivot_;
   blk_hash_t order_hash_;
-  uint64_t period_;  // Block index, PBFT head block is period 0, first PBFT block is period 1
-  uint64_t timestamp_;
-  addr_t beneficiary_;
-  sig_t signature_;
+  uint64_t period_;                        // Block index, PBFT head block is period 0, first PBFT block is period 1
   std::vector<vote_hash_t> reward_votes_;  // Cert votes in previous period
+  uint64_t timestamp_;
+  sig_t signature_;
+  addr_t beneficiary_;
 
  public:
   PbftBlock(const blk_hash_t& prev_blk_hash, const blk_hash_t& dag_blk_hash_as_pivot, const blk_hash_t& order_hash,
-            uint64_t period, const addr_t& beneficiary, const secret_t& sk,
-            const std::vector<vote_hash_t>& reward_votes);
+            uint64_t period, const std::vector<vote_hash_t>& reward_votes, const secret_t& sk);
   explicit PbftBlock(const dev::RLP& rlp);
   explicit PbftBlock(const bytes& RLP);
 

--- a/libraries/types/pbft_block/include/pbft/pbft_block.hpp
+++ b/libraries/types/pbft_block/include/pbft/pbft_block.hpp
@@ -21,13 +21,14 @@ class PbftBlock {
   uint64_t timestamp_;
   addr_t beneficiary_;
   sig_t signature_;
+  std::vector<vote_hash_t> reward_votes_;  // Cert votes in previous period
 
  public:
-  PbftBlock(blk_hash_t const& prev_blk_hash, blk_hash_t const& dag_blk_hash_as_pivot, blk_hash_t const& order_hash,
-            uint64_t period, addr_t const& beneficiary, secret_t const& sk);
-  explicit PbftBlock(dev::RLP const& rlp);
-  explicit PbftBlock(bytes const& RLP);
-  explicit PbftBlock(std::string const& JSON);
+  PbftBlock(const blk_hash_t& prev_blk_hash, const blk_hash_t& dag_blk_hash_as_pivot, const blk_hash_t& order_hash,
+            uint64_t period, const addr_t& beneficiary, const secret_t& sk,
+            const std::vector<vote_hash_t>& reward_votes);
+  explicit PbftBlock(const dev::RLP& rlp);
+  explicit PbftBlock(const bytes& RLP);
 
   blk_hash_t sha3(bool include_sig) const;
   std::string getJsonStr() const;
@@ -35,7 +36,7 @@ class PbftBlock {
   void streamRLP(dev::RLPStream& strm, bool include_sig) const;
   bytes rlp(bool include_sig) const;
 
-  static Json::Value toJson(PbftBlock const& b, std::vector<blk_hash_t> const& dag_blks);
+  static Json::Value toJson(const PbftBlock& b, const std::vector<blk_hash_t>& dag_blks);
 
   auto const& getBlockHash() const { return block_hash_; }
   auto const& getPrevBlockHash() const { return prev_block_hash_; }

--- a/libraries/types/pbft_block/src/pbft_block.cpp
+++ b/libraries/types/pbft_block/src/pbft_block.cpp
@@ -7,39 +7,30 @@
 #include "common/jsoncpp.hpp"
 
 namespace taraxa {
-PbftBlock::PbftBlock(bytes const& b) : PbftBlock(dev::RLP(b)) {}
+PbftBlock::PbftBlock(const bytes& b) : PbftBlock(dev::RLP(b)) {}
 
-PbftBlock::PbftBlock(dev::RLP const& rlp) {
+PbftBlock::PbftBlock(const dev::RLP& rlp) {
   util::rlp_tuple(util::RLPDecoderRef(rlp, true), prev_block_hash_, dag_block_hash_as_pivot_, order_hash_, period_,
-                  timestamp_, signature_);
+                  timestamp_, beneficiary_, reward_votes_, signature_);
   calculateHash_();
 }
 
-PbftBlock::PbftBlock(blk_hash_t const& prev_blk_hash, blk_hash_t const& dag_blk_hash_as_pivot,
-                     blk_hash_t const& order_hash, uint64_t period, addr_t const& beneficiary, secret_t const& sk)
+PbftBlock::PbftBlock(const blk_hash_t& prev_blk_hash, const blk_hash_t& dag_blk_hash_as_pivot,
+                     const blk_hash_t& order_hash, uint64_t period, const addr_t& beneficiary, const secret_t& sk,
+                     const std::vector<vote_hash_t>& reward_votes)
     : prev_block_hash_(prev_blk_hash),
       dag_block_hash_as_pivot_(dag_blk_hash_as_pivot),
       order_hash_(order_hash),
       period_(period),
-      beneficiary_(beneficiary) {
+      beneficiary_(beneficiary),
+      reward_votes_(reward_votes) {
   timestamp_ = dev::utcTime();
   signature_ = dev::sign(sk, sha3(false));
   calculateHash_();
 }
 
-PbftBlock::PbftBlock(std::string const& str) {
-  auto doc = util::parse_json(str);
-  block_hash_ = blk_hash_t(doc["block_hash"].asString());
-  prev_block_hash_ = blk_hash_t(doc["prev_block_hash"].asString());
-  dag_block_hash_as_pivot_ = blk_hash_t(doc["dag_block_hash_as_pivot"].asString());
-  order_hash_ = blk_hash_t(doc["order_hash"].asString());
-  period_ = doc["period"].asUInt64();
-  timestamp_ = doc["timestamp"].asUInt64();
-  signature_ = sig_t(doc["signature"].asString());
-  beneficiary_ = addr_t(doc["beneficiary"].asString());
-}
-
-Json::Value PbftBlock::toJson(PbftBlock const& b, std::vector<blk_hash_t> const& dag_blks) {
+// RPC taraxa_getScheduleBlockByPeriod
+Json::Value PbftBlock::toJson(const PbftBlock& b, const std::vector<blk_hash_t>& dag_blks) {
   auto ret = b.getJson();
   // Legacy schema
   auto& schedule_json = ret["schedule"] = Json::Value(Json::objectValue);
@@ -52,9 +43,9 @@ Json::Value PbftBlock::toJson(PbftBlock const& b, std::vector<blk_hash_t> const&
 
 void PbftBlock::calculateHash_() {
   if (!block_hash_) {
-    block_hash_ = dev::sha3(rlp(true));
+    block_hash_ = sha3(true);
   } else {
-    // Hash sould only be calculated once
+    // Hash should only be calculated once
     assert(false);
   }
   auto p = dev::recover(signature_, sha3(false));
@@ -68,25 +59,32 @@ std::string PbftBlock::getJsonStr() const { return getJson().toStyledString(); }
 
 Json::Value PbftBlock::getJson() const {
   Json::Value json;
+  json["block_hash"] = block_hash_.toString();
   json["prev_block_hash"] = prev_block_hash_.toString();
   json["dag_block_hash_as_pivot"] = dag_block_hash_as_pivot_.toString();
   json["order_hash"] = order_hash_.toString();
   json["period"] = (Json::Value::UInt64)period_;
   json["timestamp"] = (Json::Value::UInt64)timestamp_;
-  json["block_hash"] = block_hash_.toString();
-  json["signature"] = signature_.toString();
   json["beneficiary"] = beneficiary_.toString();
+  json["reward_votes"] = Json::Value(Json::arrayValue);
+  for (const auto& v : reward_votes_) {
+    json["reward_votes"].append(v.toString());
+  }
+  json["signature"] = signature_.toString();
+
   return json;
 }
 
 // Using to setup PBFT block hash
 void PbftBlock::streamRLP(dev::RLPStream& strm, bool include_sig) const {
-  strm.appendList(include_sig ? 6 : 5);
+  strm.appendList(include_sig ? 8 : 7);
   strm << prev_block_hash_;
   strm << dag_block_hash_as_pivot_;
   strm << order_hash_;
   strm << period_;
   strm << timestamp_;
+  strm << beneficiary_;
+  strm.appendVector(reward_votes_);
   if (include_sig) {
     strm << signature_;
   }

--- a/tests/final_chain_test.cpp
+++ b/tests/final_chain_test.cpp
@@ -51,8 +51,8 @@ struct FinalChainTest : WithDataDir {
     DagBlock dag_blk({}, {}, {}, trx_hashes, {}, {}, secret_t::random());
     db->saveDagBlock(dag_blk);
     std::vector<vote_hash_t> reward_votes;
-    auto pbft_block = std::make_shared<PbftBlock>(blk_hash_t(), blk_hash_t(), blk_hash_t(), 1, addr_t::random(),
-                                                  dev::KeyPair::create().secret(), reward_votes);
+    auto pbft_block = std::make_shared<PbftBlock>(blk_hash_t(), blk_hash_t(), blk_hash_t(), 1, reward_votes,
+                                                  dev::KeyPair::create().secret());
     std::vector<std::shared_ptr<Vote>> votes;
     SyncBlock sync_block(pbft_block, votes);
     sync_block.dag_blocks.push_back(dag_blk);

--- a/tests/final_chain_test.cpp
+++ b/tests/final_chain_test.cpp
@@ -50,8 +50,9 @@ struct FinalChainTest : WithDataDir {
     }
     DagBlock dag_blk({}, {}, {}, trx_hashes, {}, {}, secret_t::random());
     db->saveDagBlock(dag_blk);
+    std::vector<vote_hash_t> reward_votes;
     auto pbft_block = std::make_shared<PbftBlock>(blk_hash_t(), blk_hash_t(), blk_hash_t(), 1, addr_t::random(),
-                                                  dev::KeyPair::create().secret());
+                                                  dev::KeyPair::create().secret(), reward_votes);
     std::vector<std::shared_ptr<Vote>> votes;
     SyncBlock sync_block(pbft_block, votes);
     sync_block.dag_blocks.push_back(dag_blk);

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -150,6 +150,16 @@ TEST_F(FullNodeTest, db_test) {
   EXPECT_EQ(db.getPbft2TPlus1(10), 6);
   EXPECT_EQ(db.getPbft2TPlus1(11), 3);
 
+  // PBFT sortition threshold
+  db.savePbftSortitionThreshold(1, 10);
+  EXPECT_EQ(db.getPbftSortitionThreshold(1), 10);
+  batch = db.createWriteBatch();
+  db.addPbftSortitionThresholdToBatch(1, 11, batch);
+  db.addPbftSortitionThresholdToBatch(2, 20, batch);
+  db.commitWriteBatch(batch);
+  EXPECT_EQ(db.getPbftSortitionThreshold(1), 11);
+  EXPECT_EQ(db.getPbftSortitionThreshold(2), 20);
+
   // PBFT manager status
   EXPECT_FALSE(db.getPbftMgrStatus(PbftMgrStatus::ExecutedBlock));
   EXPECT_FALSE(db.getPbftMgrStatus(PbftMgrStatus::ExecutedInRound));

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -150,7 +150,7 @@ TEST_F(FullNodeTest, db_test) {
   EXPECT_EQ(db.getPbft2TPlus1(10), 6);
   EXPECT_EQ(db.getPbft2TPlus1(11), 3);
 
-  // PBFT sortition threshold
+  // PBFT period sortition threshold
   db.savePbftSortitionThreshold(1, 10);
   EXPECT_EQ(db.getPbftSortitionThreshold(1), 10);
   batch = db.createWriteBatch();

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -283,7 +283,7 @@ TEST_F(FullNodeTest, db_test) {
     Vote vote(g_secret, vrf_sortition, blk_hash_t(10));
     sync_block1.cert_votes.emplace_back(std::make_shared<Vote>(vote));
   }
-  db.UpdateCertVotesInPeriodData(sync_block1);
+  db.overridePeriodData(sync_block1);
   auto period_data = db.getPeriodDataRaw(pbft_block1.getPeriod());
   EXPECT_EQ(period_data, sync_block1.rlp());
   cert_votes_from_db = db.getCertVotes(pbft_block1.getPeriod());

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -150,16 +150,6 @@ TEST_F(FullNodeTest, db_test) {
   EXPECT_EQ(db.getPbft2TPlus1(10), 6);
   EXPECT_EQ(db.getPbft2TPlus1(11), 3);
 
-  // PBFT period sortition threshold
-  db.savePbftSortitionThreshold(1, 10);
-  EXPECT_EQ(db.getPbftSortitionThreshold(1), 10);
-  batch = db.createWriteBatch();
-  db.addPbftSortitionThresholdToBatch(1, 11, batch);
-  db.addPbftSortitionThresholdToBatch(2, 20, batch);
-  db.commitWriteBatch(batch);
-  EXPECT_EQ(db.getPbftSortitionThreshold(1), 11);
-  EXPECT_EQ(db.getPbftSortitionThreshold(2), 20);
-
   // PBFT manager status
   EXPECT_FALSE(db.getPbftMgrStatus(PbftMgrStatus::ExecutedBlock));
   EXPECT_FALSE(db.getPbftMgrStatus(PbftMgrStatus::ExecutedInRound));

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -480,7 +480,6 @@ TEST_F(NetworkTest, node_pbft_sync) {
   // generate first PBFT block sample
   blk_hash_t prev_block_hash(0);
   uint64_t period = 1;
-  addr_t beneficiary(987);
 
   level_t level = 1;
   vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk, getRlpBytes(level));
@@ -498,8 +497,8 @@ TEST_F(NetworkTest, node_pbft_sync) {
   order_stream.appendList(2);
   order_stream << g_signed_trx_samples[0]->getHash() << g_signed_trx_samples[1]->getHash();
 
-  PbftBlock pbft_block1(prev_block_hash, blk1.getHash(), dev::sha3(order_stream.out()), period, beneficiary,
-                        node1->getSecretKey(), {});
+  PbftBlock pbft_block1(prev_block_hash, blk1.getHash(), dev::sha3(order_stream.out()), period, {},
+                        node1->getSecretKey());
   std::vector<std::shared_ptr<Vote>> votes_for_pbft_blk1;
   votes_for_pbft_blk1.emplace_back(
       node1->getPbftManager()->generateVote(pbft_block1.getBlockHash(), cert_vote_type, 1, 3));
@@ -547,14 +546,13 @@ TEST_F(NetworkTest, node_pbft_sync) {
 
   batch = db1->createWriteBatch();
   period = 2;
-  beneficiary = addr_t(654);
   dev::RLPStream order_stream2(2);
   order_stream2.appendList(1);
   order_stream2 << blk2.getHash();
   order_stream2.appendList(2);
   order_stream2 << g_signed_trx_samples[2]->getHash() << g_signed_trx_samples[3]->getHash();
-  PbftBlock pbft_block2(prev_block_hash, blk2.getHash(), dev::sha3(order_stream2.out()), period, beneficiary,
-                        node1->getSecretKey(), {});
+  PbftBlock pbft_block2(prev_block_hash, blk2.getHash(), dev::sha3(order_stream2.out()), period, {},
+                        node1->getSecretKey());
   std::vector<std::shared_ptr<Vote>> votes_for_pbft_blk2;
   votes_for_pbft_blk2.emplace_back(
       node1->getPbftManager()->generateVote(pbft_block2.getBlockHash(), cert_vote_type, 2, 3));
@@ -644,7 +642,6 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   // generate first PBFT block sample
   blk_hash_t prev_block_hash(0);
   uint64_t period = 1;
-  addr_t beneficiary(876);
   level_t level = 1;
   vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk, getRlpBytes(level));
   vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
@@ -660,8 +657,8 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   order_stream.appendList(2);
   order_stream << g_signed_trx_samples[0]->getHash() << g_signed_trx_samples[1]->getHash();
 
-  PbftBlock pbft_block1(prev_block_hash, blk1.getHash(), dev::sha3(order_stream.out()), period, beneficiary,
-                        node1->getSecretKey(), {});
+  PbftBlock pbft_block1(prev_block_hash, blk1.getHash(), dev::sha3(order_stream.out()), period, {},
+                        node1->getSecretKey());
   std::vector<std::shared_ptr<Vote>> votes_for_pbft_blk1;
   votes_for_pbft_blk1.emplace_back(
       node1->getPbftManager()->generateVote(pbft_block1.getBlockHash(), cert_vote_type, 1, 3));
@@ -698,16 +695,14 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
 
   batch = db1->createWriteBatch();
   period = 2;
-  beneficiary = addr_t(654);
-
   dev::RLPStream order_stream2(2);
   order_stream2.appendList(1);
   order_stream2 << blk2.getHash();
   order_stream2.appendList(2);
   order_stream2 << g_signed_trx_samples[2]->getHash() << g_signed_trx_samples[3]->getHash();
 
-  PbftBlock pbft_block2(prev_block_hash, blk2.getHash(), dev::sha3(order_stream2.out()), period, beneficiary,
-                        node1->getSecretKey(), {});
+  PbftBlock pbft_block2(prev_block_hash, blk2.getHash(), dev::sha3(order_stream2.out()), period, {},
+                        node1->getSecretKey());
   std::cout << "Use fake votes for the second PBFT block" << std::endl;
   // node1 put block2 into pbft chain and use fake votes storing into DB (malicious player)
   // Add fake votes in DB

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -147,10 +147,11 @@ TEST_F(NetworkTest, send_pbft_block) {
   auto nw1 = nodes[0]->getNetwork();
   auto nw2 = nodes[1]->getNetwork();
 
-  auto pbft_block = make_simple_pbft_block(blk_hash_t(1), 2, node_cfgs[0].chain.dag_genesis_block.getHash());
-  uint64_t chain_size = 111;
+  const uint64_t chain_size = 111;
+  auto pbft_block =
+      make_simple_pbft_block(blk_hash_t(1), chain_size + 1, node_cfgs[0].chain.dag_genesis_block.getHash());
 
-  nw2->sendPbftBlock(nw1->getNodeId(), pbft_block, chain_size);
+  nw2->sendPbftBlock(nw1->getNodeId(), pbft_block);
 
   auto node2_id = nw2->getNodeId();
   EXPECT_HAPPENS({10s, 200ms},

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -1055,6 +1055,8 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
 TEST_F(NetworkTest, DISABLED_node_sync2) {
   auto node_cfgs = make_node_cfgs<5>(2);
   auto node1 = create_nodes({node_cfgs[0]}, true /*start*/).front();
+  // Stop PBFT manager
+  node1->getPbftManager()->stop();
 
   std::vector<DagBlock> blks;
   // Generate DAG blocks
@@ -1194,6 +1196,8 @@ TEST_F(NetworkTest, DISABLED_node_sync2) {
   }
 
   auto node2 = create_nodes({node_cfgs[1]}, true /*start*/).front();
+  // Stop PBFT manager
+  node2->getPbftManager()->stop();
 
   EXPECT_HAPPENS({10s, 100ms}, [&](auto& ctx) {
     WAIT_EXPECT_LT(ctx, 12, node1->getDagManager()->getNumVerticesInDag().first)

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -147,15 +147,15 @@ TEST_F(NetworkTest, send_pbft_block) {
   auto nw1 = nodes[0]->getNetwork();
   auto nw2 = nodes[1]->getNetwork();
 
-  const uint64_t chain_size = 111;
+  const uint64_t own_pbft_chain_size = 111;
   auto pbft_block =
-      make_simple_pbft_block(blk_hash_t(1), chain_size + 1, node_cfgs[0].chain.dag_genesis_block.getHash());
+      make_simple_pbft_block(blk_hash_t(1), own_pbft_chain_size + 10, node_cfgs[0].chain.dag_genesis_block.getHash());
 
-  nw2->sendPbftBlock(nw1->getNodeId(), pbft_block);
+  nw2->sendPbftBlock(nw1->getNodeId(), pbft_block, own_pbft_chain_size);
 
   auto node2_id = nw2->getNodeId();
   EXPECT_HAPPENS({10s, 200ms},
-                 [&](auto& ctx) { WAIT_EXPECT_EQ(ctx, nw1->getPeer(node2_id)->pbft_chain_size_, chain_size) });
+                 [&](auto& ctx) { WAIT_EXPECT_EQ(ctx, nw1->getPeer(node2_id)->pbft_chain_size_, own_pbft_chain_size) });
 }
 
 TEST_F(NetworkTest, malicious_peers) {

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -499,7 +499,7 @@ TEST_F(NetworkTest, node_pbft_sync) {
   order_stream << g_signed_trx_samples[0]->getHash() << g_signed_trx_samples[1]->getHash();
 
   PbftBlock pbft_block1(prev_block_hash, blk1.getHash(), dev::sha3(order_stream.out()), period, beneficiary,
-                        node1->getSecretKey());
+                        node1->getSecretKey(), {});
   std::vector<std::shared_ptr<Vote>> votes_for_pbft_blk1;
   votes_for_pbft_blk1.emplace_back(
       node1->getPbftManager()->generateVote(pbft_block1.getBlockHash(), cert_vote_type, 1, 3));
@@ -554,7 +554,7 @@ TEST_F(NetworkTest, node_pbft_sync) {
   order_stream2.appendList(2);
   order_stream2 << g_signed_trx_samples[2]->getHash() << g_signed_trx_samples[3]->getHash();
   PbftBlock pbft_block2(prev_block_hash, blk2.getHash(), dev::sha3(order_stream2.out()), period, beneficiary,
-                        node1->getSecretKey());
+                        node1->getSecretKey(), {});
   std::vector<std::shared_ptr<Vote>> votes_for_pbft_blk2;
   votes_for_pbft_blk2.emplace_back(
       node1->getPbftManager()->generateVote(pbft_block2.getBlockHash(), cert_vote_type, 2, 3));
@@ -661,7 +661,7 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   order_stream << g_signed_trx_samples[0]->getHash() << g_signed_trx_samples[1]->getHash();
 
   PbftBlock pbft_block1(prev_block_hash, blk1.getHash(), dev::sha3(order_stream.out()), period, beneficiary,
-                        node1->getSecretKey());
+                        node1->getSecretKey(), {});
   std::vector<std::shared_ptr<Vote>> votes_for_pbft_blk1;
   votes_for_pbft_blk1.emplace_back(
       node1->getPbftManager()->generateVote(pbft_block1.getBlockHash(), cert_vote_type, 1, 3));
@@ -707,7 +707,7 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   order_stream2 << g_signed_trx_samples[2]->getHash() << g_signed_trx_samples[3]->getHash();
 
   PbftBlock pbft_block2(prev_block_hash, blk2.getHash(), dev::sha3(order_stream2.out()), period, beneficiary,
-                        node1->getSecretKey());
+                        node1->getSecretKey(), {});
   std::cout << "Use fake votes for the second PBFT block" << std::endl;
   // node1 put block2 into pbft chain and use fake votes storing into DB (malicious player)
   // Add fake votes in DB

--- a/tests/pbft_chain_test.cpp
+++ b/tests/pbft_chain_test.cpp
@@ -102,7 +102,7 @@ TEST_F(PbftChainTest, proposal_block_broadcast) {
   std::shared_ptr<Network> nw3 = node3->getNetwork();
 
   // Check all 3 nodes PBFT chain synced
-  EXPECT_HAPPENS({30s, 200ms}, [&](auto &ctx) {
+  EXPECT_HAPPENS({120s, 200ms}, [&](auto &ctx) {
     WAIT_EXPECT_EQ(ctx, pbft_chain1->getPbftChainSize(), pbft_chain2->getPbftChainSize())
     WAIT_EXPECT_EQ(ctx, pbft_chain1->getPbftChainSize(), pbft_chain3->getPbftChainSize())
     WAIT_EXPECT_EQ(ctx, pbft_chain2->getPbftChainSize(), pbft_chain3->getPbftChainSize())

--- a/tests/pbft_chain_test.cpp
+++ b/tests/pbft_chain_test.cpp
@@ -24,11 +24,11 @@ TEST_F(PbftChainTest, serialize_desiriablize_pbft_block) {
   blk_hash_t prev_block_hash(12345);
   blk_hash_t dag_block_hash_as_pivot(45678);
   uint64_t period = 1;
-  addr_t beneficiary(98765);
-  PbftBlock pbft_block1(prev_block_hash, dag_block_hash_as_pivot, blk_hash_t(), period, beneficiary, sk, {});
+  PbftBlock pbft_block1(prev_block_hash, dag_block_hash_as_pivot, blk_hash_t(0), period, {}, sk);
 
   auto rlp = pbft_block1.rlp(true);
   PbftBlock pbft_block2(rlp);
+
   EXPECT_EQ(pbft_block1.getJsonStr(), pbft_block2.getJsonStr());
 }
 
@@ -55,14 +55,12 @@ TEST_F(PbftChainTest, pbft_db_test) {
   DagBlock blk1(dag_genesis, 1, {}, {}, {}, vdf1, sk);
 
   uint64_t period = 1;
-  addr_t beneficiary(987);
-  PbftBlock pbft_block(prev_block_hash, blk1.getHash(), blk_hash_t(), period, beneficiary, node->getSecretKey(), {});
+  PbftBlock pbft_block(prev_block_hash, blk1.getHash(), blk_hash_t(), period, {}, node->getSecretKey());
 
   // put into pbft chain and store into DB
   auto batch = db->createWriteBatch();
   // Add PBFT block in DB
   std::vector<std::shared_ptr<Vote>> votes;
-
   SyncBlock sync_block(std::make_shared<PbftBlock>(pbft_block), votes);
   sync_block.dag_blocks.push_back(blk1);
   db->savePeriodData(sync_block, batch);
@@ -117,7 +115,7 @@ TEST_F(PbftChainTest, proposal_block_broadcast) {
   uint64_t propose_period = node1_pbft_chain_size + 1;
   std::vector<vote_hash_t> reward_votes;
   auto pbft_block = std::make_shared<PbftBlock>(prev_block_hash, blk_hash_t(0), blk_hash_t(0), propose_period,
-                                                node1->getAddress(), node1->getSecretKey(), reward_votes);
+                                                reward_votes, node1->getSecretKey());
 
   pbft_chain1->pushUnverifiedPbftBlock(pbft_block);
   auto block1_from_node1 = pbft_chain1->getUnverifiedPbftBlock(pbft_block->getBlockHash());

--- a/tests/pbft_chain_test.cpp
+++ b/tests/pbft_chain_test.cpp
@@ -25,7 +25,7 @@ TEST_F(PbftChainTest, serialize_desiriablize_pbft_block) {
   blk_hash_t dag_block_hash_as_pivot(45678);
   uint64_t period = 1;
   addr_t beneficiary(98765);
-  PbftBlock pbft_block1(prev_block_hash, dag_block_hash_as_pivot, blk_hash_t(), period, beneficiary, sk);
+  PbftBlock pbft_block1(prev_block_hash, dag_block_hash_as_pivot, blk_hash_t(), period, beneficiary, sk, {});
 
   auto rlp = pbft_block1.rlp(true);
   PbftBlock pbft_block2(rlp);
@@ -56,7 +56,7 @@ TEST_F(PbftChainTest, pbft_db_test) {
 
   uint64_t period = 1;
   addr_t beneficiary(987);
-  PbftBlock pbft_block(prev_block_hash, blk1.getHash(), blk_hash_t(), period, beneficiary, node->getSecretKey());
+  PbftBlock pbft_block(prev_block_hash, blk1.getHash(), blk_hash_t(), period, beneficiary, node->getSecretKey(), {});
 
   // put into pbft chain and store into DB
   auto batch = db->createWriteBatch();
@@ -115,8 +115,9 @@ TEST_F(PbftChainTest, proposal_block_broadcast) {
   // Node1 generate a PBFT block sample
   blk_hash_t prev_block_hash = pbft_chain1->getLastPbftBlockHash();
   uint64_t propose_period = node1_pbft_chain_size + 1;
+  std::vector<vote_hash_t> reward_votes;
   auto pbft_block = std::make_shared<PbftBlock>(prev_block_hash, blk_hash_t(0), blk_hash_t(0), propose_period,
-                                                node1->getAddress(), node1->getSecretKey());
+                                                node1->getAddress(), node1->getSecretKey(), reward_votes);
 
   pbft_chain1->pushUnverifiedPbftBlock(pbft_block);
   auto block1_from_node1 = pbft_chain1->getUnverifiedPbftBlock(pbft_block->getBlockHash());

--- a/tests/pbft_manager_test.cpp
+++ b/tests/pbft_manager_test.cpp
@@ -253,11 +253,10 @@ TEST_F(PbftManagerTest, terminate_bogus_dag_anchor) {
   auto dag_anchor = blk_hash_t("1234567890000000000000000000000000000000000000000000000000000000");
   auto last_pbft_block_hash = pbft_chain->getLastPbftBlockHash();
   auto propose_pbft_period = pbft_chain->getPbftChainSize() + 1;
-  auto beneficiary = nodes[0]->getAddress();
   auto node_sk = nodes[0]->getSecretKey();
   std::vector<vote_hash_t> reward_votes;
   auto propose_pbft_block = std::make_shared<PbftBlock>(last_pbft_block_hash, dag_anchor, blk_hash_t(),
-                                                        propose_pbft_period, beneficiary, node_sk, reward_votes);
+                                                        propose_pbft_period, reward_votes, node_sk);
   auto pbft_block_hash = propose_pbft_block->getBlockHash();
   pbft_chain->pushUnverifiedPbftBlock(propose_pbft_block);
 

--- a/tests/pbft_manager_test.cpp
+++ b/tests/pbft_manager_test.cpp
@@ -255,8 +255,9 @@ TEST_F(PbftManagerTest, terminate_bogus_dag_anchor) {
   auto propose_pbft_period = pbft_chain->getPbftChainSize() + 1;
   auto beneficiary = nodes[0]->getAddress();
   auto node_sk = nodes[0]->getSecretKey();
+  std::vector<vote_hash_t> reward_votes;
   auto propose_pbft_block = std::make_shared<PbftBlock>(last_pbft_block_hash, dag_anchor, blk_hash_t(),
-                                                        propose_pbft_period, beneficiary, node_sk);
+                                                        propose_pbft_period, beneficiary, node_sk, reward_votes);
   auto pbft_block_hash = propose_pbft_block->getBlockHash();
   pbft_chain->pushUnverifiedPbftBlock(propose_pbft_block);
 

--- a/tests/sortition_test.cpp
+++ b/tests/sortition_test.cpp
@@ -23,7 +23,8 @@ SyncBlock createBlock(uint64_t period, uint16_t efficiency, size_t dag_blocks_co
   // efficiency
   const size_t kTrxCount = 100 * kOnePercent;
   SyncBlock b;
-  b.pbft_blk = std::make_shared<PbftBlock>(PbftBlock{{}, anchor_hash, {}, period, {}, dev::KeyPair::create().secret()});
+  b.pbft_blk =
+      std::make_shared<PbftBlock>(PbftBlock{{}, anchor_hash, {}, period, {}, dev::KeyPair::create().secret(), {}});
   size_t effective_transactions = kTrxCount * efficiency / (100 * kOnePercent);
   auto trx_hashes = generateTrxHashes(effective_transactions);
   auto trx_per_block = effective_transactions / dag_blocks_count;

--- a/tests/sortition_test.cpp
+++ b/tests/sortition_test.cpp
@@ -23,8 +23,7 @@ SyncBlock createBlock(uint64_t period, uint16_t efficiency, size_t dag_blocks_co
   // efficiency
   const size_t kTrxCount = 100 * kOnePercent;
   SyncBlock b;
-  b.pbft_blk =
-      std::make_shared<PbftBlock>(PbftBlock{{}, anchor_hash, {}, period, {}, dev::KeyPair::create().secret(), {}});
+  b.pbft_blk = std::make_shared<PbftBlock>(PbftBlock{{}, anchor_hash, {}, period, {}, dev::KeyPair::create().secret()});
   size_t effective_transactions = kTrxCount * efficiency / (100 * kOnePercent);
   auto trx_hashes = generateTrxHashes(effective_transactions);
   auto trx_per_block = effective_transactions / dag_blocks_count;

--- a/tests/util_test/util.hpp
+++ b/tests/util_test/util.hpp
@@ -316,7 +316,7 @@ inline auto own_effective_genesis_bal(FullNodeConfig const& cfg) {
 }
 
 inline auto make_simple_pbft_block(h256 const& hash, uint64_t period, h256 const& anchor_hash = blk_hash_t(0)) {
-  return PbftBlock(hash, anchor_hash, blk_hash_t(), period, addr_t(0), secret_t::random());
+  return PbftBlock(hash, anchor_hash, blk_hash_t(), period, addr_t(0), secret_t::random(), {});
 }
 
 inline std::vector<blk_hash_t> getOrderedDagBlocks(std::shared_ptr<DbStorage> const& db) {

--- a/tests/util_test/util.hpp
+++ b/tests/util_test/util.hpp
@@ -316,7 +316,7 @@ inline auto own_effective_genesis_bal(FullNodeConfig const& cfg) {
 }
 
 inline auto make_simple_pbft_block(h256 const& hash, uint64_t period, h256 const& anchor_hash = blk_hash_t(0)) {
-  return PbftBlock(hash, anchor_hash, blk_hash_t(), period, addr_t(0), secret_t::random(), {});
+  return PbftBlock(hash, anchor_hash, blk_hash_t(), period, {}, secret_t::random());
 }
 
 inline std::vector<blk_hash_t> getOrderedDagBlocks(std::shared_ptr<DbStorage> const& db) {


### PR DESCRIPTION
Fix https://github.com/Taraxa-project/taraxa-node/issues/1604

Add previous period cert votes in proposal PBFT blocks as reward votes. Node will send reward votes object before send proposed PBFT block. Add reward votes queue in vote manager. When node get incoming reward votes, that will add into reward votes queue instead of add into DB directly for improving lots of writes in DB. In PBFT manager that will update reward votes into period data column, and check if have included all reward votes object.