### PR TITLE
chore: dag expiry and light node tests improvements

### DIFF
--- a/libraries/common/include/common/constants.hpp
+++ b/libraries/common/include/common/constants.hpp
@@ -17,6 +17,7 @@ static const blk_hash_t kNullBlockHash = blk_hash_t(0);
 
 constexpr uint16_t kOnePercent = 100;
 constexpr uint16_t kMaxLevelsPerPeriod = 100;
+constexpr uint32_t kDagExpiryLevelLimit = 1000;
 
 // The various denominations; here for ease of use where needed within code.
 static const u256 kOneTara = dev::exp10<18>();

--- a/libraries/config/include/config/config.hpp
+++ b/libraries/config/include/config/config.hpp
@@ -98,8 +98,10 @@ struct FullNodeConfig {
   ChainConfig chain = ChainConfig::predefined();
   state_api::Opts opts_final_chain;
   std::vector<logger::Config> log_configs;
-  bool is_light_node = false;       // Is light node
-  uint64_t light_node_history = 0;  // Number of periods to keep in history for a light node
+  bool is_light_node = false;                            // Is light node
+  uint64_t light_node_history = 0;                       // Number of periods to keep in history for a light node
+  uint32_t dag_expiry_limit = kDagExpiryLevelLimit;      // For unit tests only
+  uint32_t max_levels_per_period = kMaxLevelsPerPeriod;  // For unit tests only
 
   auto net_file_path() const { return data_path / "net"; }
 

--- a/libraries/core_libs/consensus/include/dag/dag.hpp
+++ b/libraries/core_libs/consensus/include/dag/dag.hpp
@@ -132,7 +132,9 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
 
   explicit DagManager(blk_hash_t const &genesis, addr_t node_addr, std::shared_ptr<TransactionManager> trx_mgr,
                       std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<DagBlockManager> dag_blk_mgr,
-                      std::shared_ptr<DbStorage> db, logger::Logger log_time);
+                      std::shared_ptr<DbStorage> db, logger::Logger log_time, bool is_light_node = false,
+                      uint64_t light_node_history = 0, uint32_t max_levels_per_period = kMaxLevelsPerPeriod,
+                      uint32_t dag_expiry_limit = kDagExpiryLevelLimit);
   virtual ~DagManager() { stop(); }
 
   DagManager(const DagManager &) = delete;
@@ -148,7 +150,7 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
   blk_hash_t const &get_genesis() { return genesis_; }
 
   bool pivotAndTipsAvailable(DagBlock const &blk);
-  void addDagBlock(DagBlock &&blk, SharedTransactions &&trxs = {}, bool proposed = false,
+  bool addDagBlock(DagBlock &&blk, SharedTransactions &&trxs = {}, bool proposed = false,
                    bool save = true);  // insert to buffer if fail
 
   // return block order
@@ -166,6 +168,9 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
    * @return number of dag blocks finalized
    */
   uint setDagBlockOrder(blk_hash_t const &anchor, uint64_t period, vec_blk_t const &dag_order);
+
+  uint64_t getLightNodeHistory() const { return light_node_history_; }
+  bool isLightNode() const { return is_light_node_; }
 
   std::optional<std::pair<blk_hash_t, std::vector<blk_hash_t>>> getLatestPivotAndTips() const;
 
@@ -192,6 +197,13 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
     SharedLock lock(mutex_);
     return std::make_pair(old_anchor_, anchor_);
   }
+
+  /**
+   * @brief Retrieves Dag expiry limit
+   *
+   * @return limit
+   */
+  uint32_t getDagExpiryLimit() const { return dag_expiry_limit_; }
 
   const std::pair<uint64_t, std::map<uint64_t, std::unordered_set<blk_hash_t>>> getNonFinalizedBlocks() const;
 
@@ -228,6 +240,7 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
   bool validateBlockNotExpired(const std::shared_ptr<DagBlock> &dag_block,
                                std::unordered_map<blk_hash_t, std::shared_ptr<DagBlock>> &expired_dag_blocks_to_remove);
   void handleExpiredDagBlocksTransactions(const std::vector<trx_hash_t> &transactions_from_expired_dag_blocks) const;
+  void clearLightNodeHistory();
 
   void worker();
   std::pair<blk_hash_t, std::vector<blk_hash_t>> getFrontier() const;  // return pivot and tips
@@ -250,6 +263,13 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
   DagFrontier frontier_;
   std::atomic<bool> stopped_ = true;
   std::thread block_worker_;
+
+  const bool is_light_node_ = false;
+  const uint64_t light_node_history_ = 0;
+  const uint32_t max_levels_per_period_;
+  const uint32_t dag_expiry_limit_;  // Any non finalized dag block with a level smaller by
+                                     // dag_expiry_limit_ than the current period anchor level is considered
+                                     // expired and it should be ignored or removed from DAG
 
   logger::Logger log_time_;
   LOG_OBJECTS_DEFINE

--- a/libraries/core_libs/consensus/include/pbft/pbft_chain.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_chain.hpp
@@ -30,7 +30,6 @@ class PbftChain {
   uint64_t getPbftChainSize() const;
   uint64_t getPbftChainSizeExcludingEmptyPbftBlocks() const;
   blk_hash_t getLastPbftBlockHash() const;
-  uint64_t getDagExpiryPeriod() const;
 
   PbftBlock getPbftBlockInChain(blk_hash_t const& pbft_block_hash);
   std::shared_ptr<PbftBlock> getUnverifiedPbftBlock(blk_hash_t const& pbft_block_hash);
@@ -65,8 +64,6 @@ class PbftChain {
   uint64_t size_;                // PBFT chain size, includes both executed and unexecuted PBFT blocks
   uint64_t non_empty_size_;  // PBFT chain size excluding blocks with null anchor, includes both executed and unexecuted
                              // PBFT blocks
-  uint64_t dag_expiry_period_;       // Proposal period limit on which dag blocks are considered expired, it's value is
-                                     // always current period minus kDagExpiryPeriodLimit of non empty pbft periods
   blk_hash_t last_pbft_block_hash_;  // last PBFT block hash in PBFT chain, may not execute yet
 
   std::shared_ptr<DbStorage> db_ = nullptr;
@@ -74,11 +71,6 @@ class PbftChain {
   // <prev block hash, vector<PBFT proposed blocks waiting for vote>>
   std::unordered_map<blk_hash_t, std::vector<blk_hash_t>> unverified_blocks_map_;
   std::unordered_map<blk_hash_t, std::shared_ptr<PbftBlock>> unverified_blocks_;
-
-  static const uint32_t kDagExpiryPeriodLimit =
-      1000;  // Any non finalized dag block with a propose period smaller by
-             // kDagExpiryPeriodLimit of non empty PBFT periods than the current period is considered
-             // expired and it should be ignored or removed from DAG
 
   LOG_OBJECTS_DEFINE
 };

--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -38,7 +38,8 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
               std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<VoteManager> vote_mgr,
               std::shared_ptr<NextVotesManager> next_votes_mgr, std::shared_ptr<DagManager> dag_mgr,
               std::shared_ptr<DagBlockManager> dag_blk_mgr, std::shared_ptr<TransactionManager> trx_mgr,
-              std::shared_ptr<FinalChain> final_chain, secret_t node_sk, vrf_sk_t vrf_sk);
+              std::shared_ptr<FinalChain> final_chain, secret_t node_sk, vrf_sk_t vrf_sk,
+              uint32_t max_levels_per_period = kMaxLevelsPerPeriod);
   ~PbftManager();
   PbftManager(const PbftManager &) = delete;
   PbftManager(PbftManager &&) = delete;
@@ -255,6 +256,8 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   std::mutex stop_mtx_;
 
   SyncBlockQueue sync_queue_;
+
+  const uint32_t max_levels_per_period_;
 
   // TODO: will remove later, TEST CODE
   void countVotes_();

--- a/libraries/core_libs/consensus/src/pbft/pbft_chain.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_chain.cpp
@@ -14,7 +14,6 @@ PbftChain::PbftChain(blk_hash_t const& dag_genesis_hash, addr_t node_addr, std::
       dag_genesis_hash_(dag_genesis_hash),
       size_(0),
       non_empty_size_(0),
-      dag_expiry_period_(0),
       last_pbft_block_hash_(blk_hash_t(0)),
       db_(move(db)) {
   LOG_OBJECTS_CREATE("PBFT_CHAIN");
@@ -32,7 +31,6 @@ PbftChain::PbftChain(blk_hash_t const& dag_genesis_hash, addr_t node_addr, std::
   head_hash_ = blk_hash_t(doc["head_hash"].asString());
   size_ = doc["size"].asUInt64();
   non_empty_size_ = doc["non_empty_size"].asUInt64();
-  dag_expiry_period_ = doc["dag_expiry_period"].asUInt64();
   last_pbft_block_hash_ = blk_hash_t(doc["last_pbft_block_hash"].asString());
   auto dag_genesis_hash_db = blk_hash_t(doc["dag_genesis_hash"].asString());
   assert(dag_genesis_hash_ == dag_genesis_hash_db);
@@ -52,11 +50,6 @@ uint64_t PbftChain::getPbftChainSize() const {
 uint64_t PbftChain::getPbftChainSizeExcludingEmptyPbftBlocks() const {
   SharedLock lock(chain_head_access_);
   return non_empty_size_;
-}
-
-uint64_t PbftChain::getDagExpiryPeriod() const {
-  SharedLock lock(chain_head_access_);
-  return dag_expiry_period_;
 }
 
 blk_hash_t PbftChain::getLastPbftBlockHash() const {
@@ -114,9 +107,6 @@ void PbftChain::updatePbftChain(blk_hash_t const& pbft_block_hash, bool null_anc
   size_++;
   if (!null_anchor) {
     non_empty_size_++;
-    if ((dag_expiry_period_ == 0 && non_empty_size_ > kDagExpiryPeriodLimit) || dag_expiry_period_ > 0) {
-      dag_expiry_period_++;
-    }
   }
   last_pbft_block_hash_ = pbft_block_hash;
 }
@@ -192,7 +182,6 @@ std::string PbftChain::getJsonStr() const {
   json["dag_genesis_hash"] = dag_genesis_hash_.toString();
   json["size"] = (Json::Value::UInt64)size_;
   json["non_empty_size"] = (Json::Value::UInt64)non_empty_size_;
-  json["dag_expiry_period"] = (Json::Value::UInt64)dag_expiry_period_;
   json["last_pbft_block_hash"] = last_pbft_block_hash_.toString();
   return json.toStyledString();
 }
@@ -208,7 +197,6 @@ std::string PbftChain::getJsonStrForBlock(blk_hash_t const& block_hash, bool nul
     non_empty_size++;
   }
   json["non_empty_size"] = (Json::Value::UInt64)non_empty_size;
-  json["dag_expiry_period"] = (Json::Value::UInt64)dag_expiry_period_;
   json["last_pbft_block_hash"] = block_hash.toString();
   return json.toStyledString();
 }

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/status_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/status_packet_handler.cpp
@@ -68,7 +68,8 @@ void StatusPacketHandler::process(const PacketData& packet_data, const std::shar
       if (pbft_synced_period + node_history < peer_pbft_chain_size) {
         LOG(log_nf_) << "Light node is not able to serve our syncing request. " << packet_data.from_node_id_.abridged()
                      << " peer will be disconnected";
-        disconnect(peer->getId(), dev::p2p::UserReason);
+        disconnect(packet_data.from_node_id_, dev::p2p::UserReason);
+        return;
       }
     }
 
@@ -194,7 +195,7 @@ bool StatusPacketHandler::sendStatus(const dev::p2p::NodeID& node_id, bool initi
                                 << conf_network_id_ << dag_max_level << dag_mgr_->get_genesis() << pbft_chain_size
                                 << pbft_syncing_state_->isPbftSyncing() << pbft_round
                                 << pbft_previous_round_next_votes_size << TARAXA_MAJOR_VERSION << TARAXA_MINOR_VERSION
-                                << TARAXA_PATCH_VERSION << db_->isLightNode() << db_->getLightNodeHistory()));
+                                << TARAXA_PATCH_VERSION << dag_mgr_->isLightNode() << dag_mgr_->getLightNodeHistory()));
     } else {
       success = sealAndSend(node_id, StatusPacket,
                             std::move(dev::RLPStream(kStandardStatusPacketItemsCount)

--- a/libraries/core_libs/node/src/node.cpp
+++ b/libraries/core_libs/node/src/node.cpp
@@ -59,14 +59,13 @@ void FullNode::init() {
     if (conf_.test_params.rebuild_db) {
       old_db_ = std::make_shared<DbStorage>(conf_.db_path, conf_.test_params.db_snapshot_each_n_pbft_block,
                                             conf_.test_params.db_max_open_files, conf_.test_params.db_max_snapshots,
-                                            conf_.test_params.db_revert_to_period, node_addr, conf_.is_light_node,
-                                            conf_.light_node_history, true);
+                                            conf_.test_params.db_revert_to_period, node_addr, true);
     }
 
     db_ = std::make_shared<DbStorage>(conf_.db_path, conf_.test_params.db_snapshot_each_n_pbft_block,
                                       conf_.test_params.db_max_open_files, conf_.test_params.db_max_snapshots,
-                                      conf_.test_params.db_revert_to_period, node_addr, conf_.is_light_node,
-                                      conf_.light_node_history, false, conf_.test_params.rebuild_db_columns);
+                                      conf_.test_params.db_revert_to_period, node_addr, false,
+                                      conf_.test_params.rebuild_db_columns);
 
     if (db_->hasMinorVersionChanged()) {
       LOG(log_si_) << "Minor DB version has changed. Rebuilding Db";
@@ -74,12 +73,10 @@ void FullNode::init() {
       db_ = nullptr;
       old_db_ = std::make_shared<DbStorage>(conf_.db_path, conf_.test_params.db_snapshot_each_n_pbft_block,
                                             conf_.test_params.db_max_open_files, conf_.test_params.db_max_snapshots,
-                                            conf_.test_params.db_revert_to_period, node_addr, conf_.is_light_node,
-                                            conf_.light_node_history, true);
+                                            conf_.test_params.db_revert_to_period, node_addr, true);
       db_ = std::make_shared<DbStorage>(conf_.db_path, conf_.test_params.db_snapshot_each_n_pbft_block,
                                         conf_.test_params.db_max_open_files, conf_.test_params.db_max_snapshots,
-                                        conf_.test_params.db_revert_to_period, node_addr, conf_.is_light_node,
-                                        conf_.light_node_history);
+                                        conf_.test_params.db_revert_to_period, node_addr);
     }
 
     if (db_->getNumDagBlocks() == 0) {
@@ -103,13 +100,16 @@ void FullNode::init() {
 
   pbft_chain_ = std::make_shared<PbftChain>(genesis_hash, node_addr, db_);
   next_votes_mgr_ = std::make_shared<NextVotesManager>(node_addr, db_, final_chain_);
-  dag_blk_mgr_ = std::make_shared<DagBlockManager>(node_addr, conf_.chain.sortition, db_, trx_mgr_, final_chain_,
-                                                   pbft_chain_, log_time_, conf_.test_params.max_block_queue_warn);
-  dag_mgr_ = std::make_shared<DagManager>(genesis_hash, node_addr, trx_mgr_, pbft_chain_, dag_blk_mgr_, db_, log_time_);
+  dag_blk_mgr_ =
+      std::make_shared<DagBlockManager>(node_addr, conf_.chain.sortition, db_, trx_mgr_, final_chain_, pbft_chain_,
+                                        log_time_, conf_.test_params.max_block_queue_warn, conf_.max_levels_per_period);
+  dag_mgr_ = std::make_shared<DagManager>(genesis_hash, node_addr, trx_mgr_, pbft_chain_, dag_blk_mgr_, db_, log_time_,
+                                          conf_.is_light_node, conf_.light_node_history, conf_.max_levels_per_period,
+                                          conf_.dag_expiry_limit);
   vote_mgr_ = std::make_shared<VoteManager>(node_addr, db_, final_chain_, next_votes_mgr_);
   pbft_mgr_ = std::make_shared<PbftManager>(conf_.chain.pbft, genesis_hash, node_addr, db_, pbft_chain_, vote_mgr_,
                                             next_votes_mgr_, dag_mgr_, dag_blk_mgr_, trx_mgr_, final_chain_,
-                                            kp_.secret(), conf_.vrf_secret);
+                                            kp_.secret(), conf_.vrf_secret, conf_.max_levels_per_period);
   blk_proposer_ = std::make_shared<BlockProposer>(conf_.test_params.block_proposer, dag_mgr_, trx_mgr_, dag_blk_mgr_,
                                                   final_chain_, db_, node_addr, getSecretKey(), getVrfSecretKey());
   network_ = std::make_shared<Network>(conf_.network, conf_.net_file_path().string(), kp_, db_, pbft_mgr_, pbft_chain_,

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -148,8 +148,6 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   bool snapshot_enable_ = true;
   uint32_t db_max_snapshots_ = 0;
   std::set<uint64_t> snapshots_;
-  const bool is_light_node_ = false;
-  const uint64_t light_node_history_ = 0;
 
   bool minor_version_changed_ = false;
 
@@ -160,8 +158,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
  public:
   explicit DbStorage(fs::path const& base_path, uint32_t db_snapshot_each_n_pbft_block = 0, uint32_t max_open_files = 0,
                      uint32_t db_max_snapshots = 0, uint32_t db_revert_to_period = 0, addr_t node_addr = addr_t(),
-                     bool is_light_node = false, uint64_t light_node_history = 0, bool rebuild = false,
-                     bool rebuild_columns = false);
+                     bool rebuild = false, bool rebuild_columns = false);
   ~DbStorage();
 
   DbStorage(const DbStorage&) = delete;
@@ -186,13 +183,11 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
 
   // Period data
   void savePeriodData(const SyncBlock& sync_block, Batch& write_batch);
-  void clearPeriodDataHistory(uint64_t period, uint64_t dag_expiry_period, bool force = false);
+  void clearPeriodDataHistory(uint64_t period);
   dev::bytes getPeriodDataRaw(uint64_t period) const;
   std::optional<PbftBlock> getPbftBlock(uint64_t period) const;
   blk_hash_t getPeriodBlockHash(uint64_t period) const;
   std::optional<std::vector<Transaction>> getPeriodTransactions(uint64_t period) const;
-  uint64_t getLightNodeHistory() const { return light_node_history_; }
-  bool isLightNode() const { return is_light_node_; }
 
   // DAG
   void saveDagBlock(DagBlock const& blk, Batch* write_batch_p = nullptr);

--- a/libraries/core_libs/storage/src/storage.cpp
+++ b/libraries/core_libs/storage/src/storage.cpp
@@ -18,14 +18,12 @@ static constexpr uint16_t DAG_BLOCKS_POS_IN_PERIOD_DATA = 2;
 static constexpr uint16_t TRANSACTIONS_POS_IN_PERIOD_DATA = 3;
 
 DbStorage::DbStorage(fs::path const& path, uint32_t db_snapshot_each_n_pbft_block, uint32_t max_open_files,
-                     uint32_t db_max_snapshots, uint32_t db_revert_to_period, addr_t node_addr, bool is_light_node,
-                     uint64_t light_node_history, bool rebuild, bool rebuild_columns)
+                     uint32_t db_max_snapshots, uint32_t db_revert_to_period, addr_t node_addr, bool rebuild,
+                     bool rebuild_columns)
     : path_(path),
       handles_(Columns::all.size()),
       db_snapshot_each_n_pbft_block_(db_snapshot_each_n_pbft_block),
-      db_max_snapshots_(db_max_snapshots),
-      is_light_node_(is_light_node),
-      light_node_history_(light_node_history) {
+      db_max_snapshots_(db_max_snapshots) {
   db_path_ = (path / db_dir);
   state_db_path_ = (path / state_db_dir);
 
@@ -417,16 +415,9 @@ std::optional<SortitionParamsChange> DbStorage::getParamsChangeForPeriod(uint64_
   return SortitionParamsChange::from_rlp(dev::RLP(it->value().ToString()));
 }
 
-void DbStorage::clearPeriodDataHistory(uint64_t period, uint64_t dag_expiry_period, bool force) {
-  // Actual history size will be between 100% and 110% of light_node_history_ to avoid deleting on every period
-  if (is_light_node_ && ((period % (std::max(light_node_history_ / 10, (uint64_t)1)) == 0) || force) &&
-      period > light_node_history_) {
-    const uint64_t start = 0;
-    // This prevents deleting any data needed for dag blocks proposal period, we only delete periods for the expired dag
-    // blocks
-    const uint64_t end = std::min(period - light_node_history_, dag_expiry_period - 1);
-    db_->DeleteRange(write_options_, handle(Columns::period_data), toSlice(start), toSlice(end));
-  }
+void DbStorage::clearPeriodDataHistory(uint64_t period) {
+  const uint64_t start = 0;
+  db_->DeleteRange(write_options_, handle(Columns::period_data), toSlice(start), toSlice(period));
 }
 
 void DbStorage::savePeriodData(const SyncBlock& sync_block, Batch& write_batch) {


### PR DESCRIPTION
There were several issues related to using period limit for dag blocks expiry. New approach is using a dag block level limit which is much cleaner and easier to check without a need to pull proposal period from the database for each dag block. Level limit is based on the level of the last anchor from the last pbft block in the chain.

Dag expiry limit and max dag levels per period can now be configured to be able to test them without a need to have a large dag and large pbft chain.  This allowed for simpler light node tests and creation of additional test in dag_test which tests dag expiry.