### PR TITLE
chore: limit number of votes in packet

### DIFF
--- a/libraries/common/include/common/constants.hpp
+++ b/libraries/common/include/common/constants.hpp
@@ -19,6 +19,11 @@ constexpr uint16_t kOnePercent = 100;
 constexpr uint16_t kMaxLevelsPerPeriod = 100;
 constexpr uint32_t kDagExpiryLevelLimit = 1000;
 
+const uint32_t kMaxVotesInPacket{1000};
+const uint32_t kMaxTransactionsInPacket{1000};
+
+const uint32_t kPeriodicEventsThreadCount{2};
+
 // The various denominations; here for ease of use where needed within code.
 static const u256 kOneTara = dev::exp10<18>();
 // static const u256 kFinney = exp10<15>();

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/packet_handler.hpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string_view>
 
+#include "common/thread_pool.hpp"
 #include "libdevcore/RLP.h"
 #include "logger/logger.hpp"
 #include "network/tarcap/packet_types.hpp"

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/pbft_sync_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/pbft_sync_packet_handler.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "common/thread_pool.hpp"
 #include "network/tarcap/packets_handlers/common/ext_syncing_packet_handler.hpp"
 
 namespace taraxa::network::tarcap {
@@ -10,7 +9,8 @@ class PbftSyncPacketHandler final : public ExtSyncingPacketHandler {
   PbftSyncPacketHandler(std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
                         std::shared_ptr<PbftSyncingState> pbft_syncing_state, std::shared_ptr<PbftChain> pbft_chain,
                         std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<DagManager> dag_mgr,
-                        std::shared_ptr<DagBlockManager> dag_blk_mgr, std::shared_ptr<DbStorage> db,
+                        std::shared_ptr<DagBlockManager> dag_blk_mgr,
+                        std::shared_ptr<util::ThreadPool> periodic_events_tp, std::shared_ptr<DbStorage> db,
                         size_t network_sync_level_size, const addr_t& node_addr);
 
   void handleMaliciousSyncPeer(dev::p2p::NodeID const& id);
@@ -22,13 +22,10 @@ class PbftSyncPacketHandler final : public ExtSyncingPacketHandler {
   void pbftSyncComplete();
   void delayedPbftSync(int counter);
 
+  std::weak_ptr<util::ThreadPool> periodic_events_tp_;
+
   // Initialized from network config
   const size_t network_sync_level_size_;
-
-  // TODO: refactor this: we could have some shared global threadpool for periodic events ?
-  // TODO: or std::async with sleep inside could be used instead ?
-  // Fake threadpool (1 thread) for delayed syncing events
-  util::ThreadPool delayed_sync_events_tp_;
 };
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/transaction_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/transaction_packet_handler.hpp
@@ -42,8 +42,6 @@ class TransactionPacketHandler final : public PacketHandler {
 
   std::atomic<uint64_t> received_trx_count_{0};
   std::atomic<uint64_t> unique_received_trx_count_{0};
-
-  const uint32_t MAX_TRANSACTIONS_IN_PACKET{1000};
 };
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
@@ -139,9 +139,8 @@ class TaraxaCapability : public dev::p2p::CapabilityFace {
   // Main Threadpool for processing packets
   std::shared_ptr<TarcapThreadPool> thread_pool_;
 
-  // TODO: refactor this: we could have some shared global threadpool for periodic events ?
-  // Fake threadpool (1 thread) for periodic events like printing summary logs, packets stats, etc...
-  util::ThreadPool periodic_events_tp_;
+  // Threadpool for periodic and delayed events
+  std::shared_ptr<util::ThreadPool> periodic_events_tp_;
 
   LOG_OBJECTS_DEFINE
 };

--- a/libraries/core_libs/network/rpc/Taraxa.cpp
+++ b/libraries/core_libs/network/rpc/Taraxa.cpp
@@ -22,7 +22,7 @@ namespace taraxa::net {
 Taraxa::Taraxa(std::shared_ptr<FullNode> const& _full_node) : full_node_(_full_node) {
   Json::CharReaderBuilder builder;
   auto reader = std::unique_ptr<Json::CharReader>(builder.newCharReader());
-  
+
   bool parsingSuccessful = reader->parse(kVersionJson, kVersionJson + strlen(kVersionJson), &version, nullptr);
   assert(parsingSuccessful);
 }

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_votes_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_votes_packet_handler.cpp
@@ -39,18 +39,27 @@ void ExtVotesPacketHandler::sendPbftNextVotes(dev::p2p::NodeID const &peer_id,
     return;
   }
 
-  dev::RLPStream s(send_next_votes_bundle.size());
-  for (auto const &next_vote : send_next_votes_bundle) {
-    s.appendRaw(next_vote->rlp(true));
-    LOG(log_dg_) << "Send out next vote " << next_vote->getHash() << " to peer " << peer_id;
-  }
+  uint32_t index = 0;
+  while (index < send_next_votes_bundle.size()) {
+    uint32_t vote_count_to_send =
+        std::min(static_cast<size_t>(kMaxVotesInPacket), send_next_votes_bundle.size() - index);
 
-  if (sealAndSend(peer_id, SubprotocolPacketType::VotesSyncPacket, std::move(s))) {
-    LOG(log_nf_) << "Send out size of " << send_next_votes_bundle.size() << " PBFT next votes to " << peer_id;
-    if (auto peer = peers_state_->getPeer(peer_id)) {
-      for (auto const &v : send_next_votes_bundle) {
-        peer->markVoteAsKnown(v->getHash());
-      }
+    dev::RLPStream s(vote_count_to_send);
+    for (uint32_t i = index; i < index + vote_count_to_send; i++) {
+      const auto &next_vote = send_next_votes_bundle[i];
+      s.appendRaw(next_vote->rlp(true));
+      LOG(log_dg_) << "Send out next vote " << next_vote->getHash() << " to peer " << peer_id;
+    }
+
+    if (sealAndSend(peer_id, SubprotocolPacketType::VotesSyncPacket, std::move(s))) {
+      LOG(log_nf_) << "Send out size of " << vote_count_to_send << " PBFT next votes to " << peer_id;
+    }
+
+    index += vote_count_to_send;
+  }
+  if (auto peer = peers_state_->getPeer(peer_id)) {
+    for (auto const &v : send_next_votes_bundle) {
+      peer->markVoteAsKnown(v->getHash());
     }
   }
 }

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
@@ -10,19 +10,17 @@
 
 namespace taraxa::network::tarcap {
 
-PbftSyncPacketHandler::PbftSyncPacketHandler(std::shared_ptr<PeersState> peers_state,
-                                             std::shared_ptr<PacketsStats> packets_stats,
-                                             std::shared_ptr<PbftSyncingState> pbft_syncing_state,
-                                             std::shared_ptr<PbftChain> pbft_chain,
-                                             std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<DagManager> dag_mgr,
-                                             std::shared_ptr<DagBlockManager> dag_blk_mgr,
-                                             std::shared_ptr<DbStorage> db, size_t network_sync_level_size,
-                                             const addr_t &node_addr)
+PbftSyncPacketHandler::PbftSyncPacketHandler(
+    std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
+    std::shared_ptr<PbftSyncingState> pbft_syncing_state, std::shared_ptr<PbftChain> pbft_chain,
+    std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<DagManager> dag_mgr,
+    std::shared_ptr<DagBlockManager> dag_blk_mgr, std::shared_ptr<util::ThreadPool> periodic_events_tp,
+    std::shared_ptr<DbStorage> db, size_t network_sync_level_size, const addr_t &node_addr)
     : ExtSyncingPacketHandler(std::move(peers_state), std::move(packets_stats), std::move(pbft_syncing_state),
                               std::move(pbft_chain), std::move(pbft_mgr), std::move(dag_mgr), std::move(dag_blk_mgr),
                               std::move(db), node_addr, "PBFT_SYNC_PH"),
-      network_sync_level_size_(network_sync_level_size),
-      delayed_sync_events_tp_(1, true) {}
+      periodic_events_tp_(periodic_events_tp),
+      network_sync_level_size_(network_sync_level_size) {}
 
 void PbftSyncPacketHandler::validatePacketRlpFormat(const PacketData &packet_data) const {
   if (constexpr size_t required_size = 3; packet_data.rlp_.itemCount() != required_size) {
@@ -148,7 +146,8 @@ void PbftSyncPacketHandler::process(const PacketData &packet_data, const std::sh
       if (pbft_sync_period > pbft_chain_->getPbftChainSize() + (10 * network_sync_level_size_)) {
         LOG(log_tr_) << "Syncing pbft blocks too fast than processing. Has synced period " << pbft_sync_period
                      << ", PBFT chain size " << pbft_chain_->getPbftChainSize();
-        delayed_sync_events_tp_.post(1000, [this] { delayedPbftSync(1); });
+        if (auto periodic_events_tp = periodic_events_tp_.lock())
+          periodic_events_tp->post(1000, [this] { delayedPbftSync(1); });
       } else {
         if (!syncPeerPbft(pbft_sync_period + 1)) {
           return restartSyncingPbft(true);
@@ -162,7 +161,8 @@ void PbftSyncPacketHandler::pbftSyncComplete() {
   if (pbft_mgr_->syncBlockQueueSize()) {
     LOG(log_tr_) << "Syncing pbft blocks faster than processing. Remaining sync size "
                  << pbft_mgr_->syncBlockQueueSize();
-    delayed_sync_events_tp_.post(1000, [this] { pbftSyncComplete(); });
+    if (auto periodic_events_tp = periodic_events_tp_.lock())
+      periodic_events_tp->post(1000, [this] { pbftSyncComplete(); });
   } else {
     LOG(log_dg_) << "Syncing PBFT is completed";
     // We are pbft synced with the node we are connected to but
@@ -190,7 +190,8 @@ void PbftSyncPacketHandler::delayedPbftSync(int counter) {
     if (pbft_sync_period > pbft_chain_->getPbftChainSize() + (10 * network_sync_level_size_)) {
       LOG(log_tr_) << "Syncing pbft blocks faster than processing " << pbft_sync_period << " "
                    << pbft_chain_->getPbftChainSize();
-      delayed_sync_events_tp_.post(1000, [this, counter] { delayedPbftSync(counter + 1); });
+      if (auto periodic_events_tp = periodic_events_tp_.lock())
+        periodic_events_tp->post(1000, [this, counter] { delayedPbftSync(counter + 1); });
     } else {
       if (!syncPeerPbft(pbft_sync_period + 1)) {
         return restartSyncingPbft(true);

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
@@ -23,8 +23,8 @@ void VotesSyncPacketHandler::validatePacketRlpFormat([[maybe_unused]] const Pack
 
 void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::shared_ptr<TaraxaPeer> &peer) {
   const auto next_votes_count = packet_data.rlp_.itemCount();
-  if (next_votes_count == 0) {
-    LOG(log_er_) << "Receive 0 next votes from peer " << packet_data.from_node_id_
+  if (next_votes_count == 0 || next_votes_count > kMaxVotesInPacket) {
+    LOG(log_er_) << "Receive " << next_votes_count << " next votes from peer " << packet_data.from_node_id_
                  << ". The peer may be a malicious player, will be disconnected";
     disconnect(packet_data.from_node_id_, dev::p2p::UserReason);
     return;

--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -40,7 +40,7 @@ TaraxaCapability::TaraxaCapability(std::weak_ptr<dev::p2p::Host> host, const dev
       node_stats_(nullptr),
       packets_handlers_(std::make_shared<PacketsHandler>()),
       thread_pool_(std::make_shared<TarcapThreadPool>(conf.network_packets_processing_threads, node_addr)),
-      periodic_events_tp_(1, false) {
+      periodic_events_tp_(std::make_shared<util::ThreadPool>(kPeriodicEventsThreadCount, false)) {
   LOG_OBJECTS_CREATE("TARCAP");
 
   assert(host.lock());
@@ -108,30 +108,30 @@ void TaraxaCapability::initPeriodicEvents(const NetworkConfig &conf, const std::
   const auto &tx_handler = packets_handlers_->getSpecificHandler(SubprotocolPacketType::TransactionPacket);
   auto tx_packet_handler = std::static_pointer_cast<TransactionPacketHandler>(tx_handler);
   if (trx_mgr /* just because of tests */ && conf.network_transaction_interval > 0) {
-    periodic_events_tp_.post_loop({conf.network_transaction_interval},
-                                  [tx_packet_handler = std::move(tx_packet_handler), trx_mgr = std::move(trx_mgr)] {
-                                    tx_packet_handler->periodicSendTransactions(trx_mgr->packTrxs());
-                                  });
+    periodic_events_tp_->post_loop({conf.network_transaction_interval},
+                                   [tx_packet_handler = std::move(tx_packet_handler), trx_mgr = std::move(trx_mgr)] {
+                                     tx_packet_handler->periodicSendTransactions(trx_mgr->packTrxs());
+                                   });
   }
 
   // Send status periodic event
   const auto &status_handler = packets_handlers_->getSpecificHandler(SubprotocolPacketType::StatusPacket);
   auto status_packet_handler = std::static_pointer_cast<StatusPacketHandler>(status_handler);
   const auto send_status_interval = 6 * lambda_ms_min;
-  periodic_events_tp_.post_loop({send_status_interval}, [status_packet_handler = std::move(status_packet_handler)] {
+  periodic_events_tp_->post_loop({send_status_interval}, [status_packet_handler = std::move(status_packet_handler)] {
     status_packet_handler->sendStatusToPeers();
   });
 
   // Logs packets stats periodic event
   if (conf.network_performance_log_interval > 0) {
-    periodic_events_tp_.post_loop({conf.network_performance_log_interval},
-                                  [packets_stats = std::move(packets_stats)] { packets_stats->logAndUpdateStats(); });
+    periodic_events_tp_->post_loop({conf.network_performance_log_interval},
+                                   [packets_stats = std::move(packets_stats)] { packets_stats->logAndUpdateStats(); });
   }
 
   // SUMMARY log periodic event
   const auto node_stats_log_interval = 5 * 6 * lambda_ms_min;
-  periodic_events_tp_.post_loop({node_stats_log_interval},
-                                [node_stats = node_stats_]() mutable { node_stats->logNodeStats(); });
+  periodic_events_tp_->post_loop({node_stats_log_interval},
+                                 [node_stats = node_stats_]() mutable { node_stats->logNodeStats(); });
 
   // Boot nodes checkup periodic event
   if (!boot_nodes_.empty()) {
@@ -145,7 +145,7 @@ void TaraxaCapability::initPeriodicEvents(const NetworkConfig &conf, const std::
     }
 
     // Every 30 seconds check if connected to another node and refresh boot nodes
-    periodic_events_tp_.post_loop({30000}, [this] {
+    periodic_events_tp_->post_loop({30000}, [this] {
       auto host = peers_state_->host_.lock();
       if (!host) {
         LOG(log_er_) << "Unable to obtain host in periodic boot nodes checkup!";
@@ -223,9 +223,9 @@ void TaraxaCapability::registerPacketHandlers(
       std::make_shared<GetPbftSyncPacketHandler>(peers_state_, packets_stats, pbft_syncing_state_, pbft_chain, db,
                                                  conf.network_sync_level_size, node_addr));
 
-  const auto pbft_handler =
-      std::make_shared<PbftSyncPacketHandler>(peers_state_, packets_stats, pbft_syncing_state_, pbft_chain, pbft_mgr,
-                                              dag_mgr, dag_blk_mgr, db, conf.network_sync_level_size, node_addr);
+  const auto pbft_handler = std::make_shared<PbftSyncPacketHandler>(
+      peers_state_, packets_stats, pbft_syncing_state_, pbft_chain, pbft_mgr, dag_mgr, dag_blk_mgr, periodic_events_tp_,
+      db, conf.network_sync_level_size, node_addr);
   packets_handlers_->registerHandler(SubprotocolPacketType::PbftSyncPacket, pbft_handler);
 
   thread_pool_->setPacketsHandlers(packets_handlers_);
@@ -338,12 +338,12 @@ inline bool TaraxaCapability::filterSyncIrrelevantPackets(SubprotocolPacketType 
 
 void TaraxaCapability::start() {
   thread_pool_->startProcessing();
-  periodic_events_tp_.start();
+  periodic_events_tp_->start();
 }
 
 void TaraxaCapability::stop() {
   thread_pool_->stopProcessing();
-  periodic_events_tp_.stop();
+  periodic_events_tp_->stop();
 }
 
 const std::shared_ptr<PeersState> &TaraxaCapability::getPeersState() { return peers_state_; }


### PR DESCRIPTION
Limit number of votes in a single packet and throttle votes packets not to send too many votes at once. The same is already done for transactions.