### PR TITLE
chore: transaction thread safety

### DIFF
--- a/libraries/core_libs/consensus/include/final_chain/data.hpp
+++ b/libraries/core_libs/consensus/include/final_chain/data.hpp
@@ -95,7 +95,7 @@ struct NewBlock {
 
 struct FinalizationResult : NewBlock {
   std::shared_ptr<BlockHeader const> final_chain_blk;
-  Transactions trxs;
+  SharedTransactions trxs;
   TransactionReceipts trx_receipts;
 };
 

--- a/libraries/core_libs/consensus/include/final_chain/final_chain.hpp
+++ b/libraries/core_libs/consensus/include/final_chain/final_chain.hpp
@@ -58,7 +58,7 @@ class FinalChain {
 
   virtual void update_state_config(const state_api::Config& new_config) const = 0;
   virtual std::shared_ptr<TransactionHashes> transaction_hashes(std::optional<EthBlockNumber> n = {}) const = 0;
-  virtual Transactions transactions(std::optional<EthBlockNumber> n = {}) const = 0;
+  virtual SharedTransactions transactions(std::optional<EthBlockNumber> n = {}) const = 0;
   virtual std::optional<TransactionLocation> transaction_location(h256 const& trx_hash) const = 0;
   virtual std::optional<TransactionReceipt> transaction_receipt(h256 const& _transactionHash) const = 0;
   virtual uint64_t transactionCount(std::optional<EthBlockNumber> n = {}) const = 0;

--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -94,10 +94,9 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   void setMaxWaitForSoftVotedBlock_ms(uint64_t wait_ms);
   void setMaxWaitForNextVotedBlock_ms(uint64_t wait_ms);
 
-  static blk_hash_t calculateOrderHash(std::vector<blk_hash_t> const &dag_block_hashes,
-                                       std::vector<trx_hash_t> const &trx_hashes);
-  static blk_hash_t calculateOrderHash(std::vector<DagBlock> const &dag_blocks,
-                                       std::vector<Transaction> const &transactions);
+  static blk_hash_t calculateOrderHash(const std::vector<blk_hash_t> &dag_block_hashes,
+                                       const std::vector<trx_hash_t> &trx_hashes);
+  static blk_hash_t calculateOrderHash(const std::vector<DagBlock> &dag_blocks, const SharedTransactions &transactions);
 
  private:
   // DPOS

--- a/libraries/core_libs/consensus/include/transaction/gas_pricer.hpp
+++ b/libraries/core_libs/consensus/include/transaction/gas_pricer.hpp
@@ -33,7 +33,7 @@ class GasPricer {
    *
    * @param trxs from latest block
    */
-  void update(const Transactions &trxs);
+  void update(const SharedTransactions &trxs);
 
  private:
   /**

--- a/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
+++ b/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
@@ -41,7 +41,7 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
    * @param trx transaction to be processed
    * @return std::pair<bool, std::string> -> pair<OK status, ERR message>
    */
-  std::pair<bool, std::string> insertTransaction(Transaction const &trx);
+  std::pair<bool, std::string> insertTransaction(const std::shared_ptr<Transaction> &trx);
 
   /**
    * @brief Inserts batch of verified transactions to transaction pool

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1130,8 +1130,8 @@ size_t PbftManager::placeVote_(taraxa::blk_hash_t const &blockhash, PbftVoteType
   return weight;
 }
 
-blk_hash_t PbftManager::calculateOrderHash(std::vector<blk_hash_t> const &dag_block_hashes,
-                                           std::vector<trx_hash_t> const &trx_hashes) {
+blk_hash_t PbftManager::calculateOrderHash(const std::vector<blk_hash_t> &dag_block_hashes,
+                                           const std::vector<trx_hash_t> &trx_hashes) {
   if (dag_block_hashes.empty()) {
     return NULL_BLOCK_HASH;
   }
@@ -1147,8 +1147,7 @@ blk_hash_t PbftManager::calculateOrderHash(std::vector<blk_hash_t> const &dag_bl
   return dev::sha3(order_stream.out());
 }
 
-blk_hash_t PbftManager::calculateOrderHash(std::vector<DagBlock> const &dag_blocks,
-                                           std::vector<Transaction> const &trxs) {
+blk_hash_t PbftManager::calculateOrderHash(const std::vector<DagBlock> &dag_blocks, const SharedTransactions &trxs) {
   if (dag_blocks.empty()) {
     return NULL_BLOCK_HASH;
   }
@@ -1159,7 +1158,7 @@ blk_hash_t PbftManager::calculateOrderHash(std::vector<DagBlock> const &dag_bloc
   }
   order_stream.appendList(trxs.size());
   for (auto const &trx : trxs) {
-    order_stream << trx.getHash();
+    order_stream << trx->getHash();
   }
   return dev::sha3(order_stream.out());
 }
@@ -1464,7 +1463,7 @@ std::pair<vec_blk_t, bool> PbftManager::comparePbftBlockScheduleWithDAGblocks_(s
   cert_sync_block_.transactions.reserve(transactions.size());
   for (const auto &trx : transactions) {
     non_finalized_transactions.push_back(trx->getHash());
-    cert_sync_block_.transactions.push_back(*trx);
+    cert_sync_block_.transactions.push_back(trx);
   }
 
   auto calculated_order_hash = calculateOrderHash(dag_blocks_order, non_finalized_transactions);

--- a/libraries/core_libs/consensus/src/transaction/gas_pricer.cpp
+++ b/libraries/core_libs/consensus/src/transaction/gas_pricer.cpp
@@ -45,9 +45,9 @@ void GasPricer::init(const std::shared_ptr<DbStorage>& db) {
 
     if (const auto min_trx =
             *std::min_element(trxs->begin(), trxs->end(),
-                              [](const auto& t1, const auto& t2) { return t1.getGasPrice() < t2.getGasPrice(); });
-        min_trx.getGasPrice()) {
-      price_list_.push_front(min_trx.getGasPrice());
+                              [](const auto& t1, const auto& t2) { return t1->getGasPrice() < t2->getGasPrice(); });
+        min_trx->getGasPrice()) {
+      price_list_.push_front(min_trx->getGasPrice());
     }
   }
 
@@ -63,15 +63,16 @@ void GasPricer::init(const std::shared_ptr<DbStorage>& db) {
   }
 }
 
-void GasPricer::update(const Transactions& trxs) {
+void GasPricer::update(const SharedTransactions& trxs) {
   if (trxs.empty()) return;
 
-  if (const auto min_trx = *std::min_element(
-          trxs.begin(), trxs.end(), [](const auto& t1, const auto& t2) { return t1.getGasPrice() < t2.getGasPrice(); });
-      min_trx.getGasPrice()) {
+  if (const auto min_trx =
+          *std::min_element(trxs.begin(), trxs.end(),
+                            [](const auto& t1, const auto& t2) { return t1->getGasPrice() < t2->getGasPrice(); });
+      min_trx->getGasPrice()) {
     std::unique_lock lock(mutex_);
 
-    price_list_.push_back(min_trx.getGasPrice());
+    price_list_.push_back(min_trx->getGasPrice());
 
     std::vector<u256> sorted_prices;
     sorted_prices.reserve(price_list_.size());

--- a/libraries/core_libs/network/include/network/tarcap/shared_states/test_state.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/shared_states/test_state.hpp
@@ -11,8 +11,8 @@ namespace taraxa::network::tarcap {
 class TestState {
  public:
   bool hasTransaction(const trx_hash_t& tx_hash) const;
-  void insertTransaction(const Transaction& tx);
-  const Transaction& getTransaction(const trx_hash_t& tx_hash) const;
+  void insertTransaction(const std::shared_ptr<Transaction>& tx);
+  const std::shared_ptr<Transaction> getTransaction(const trx_hash_t& tx_hash) const;
   size_t getTransactionsSize() const;
 
   bool hasBlock(const blk_hash_t& block_hash) const;
@@ -20,11 +20,11 @@ class TestState {
   const DagBlock& getBlock(const blk_hash_t& block_hash) const;
   size_t getBlocksSize() const;
 
-  std::unordered_map<trx_hash_t, Transaction> getTransactions();
+  std::unordered_map<trx_hash_t, std::shared_ptr<Transaction>> getTransactions();
   std::unordered_map<blk_hash_t, DagBlock> getBlocks();
 
  private:
-  std::unordered_map<trx_hash_t, Transaction> test_transactions_;
+  std::unordered_map<trx_hash_t, std::shared_ptr<Transaction>> test_transactions_;
   mutable std::shared_mutex transactions_mutex_;
 
   std::unordered_map<blk_hash_t, DagBlock> test_blocks_;

--- a/libraries/core_libs/network/rpc/Test.cpp
+++ b/libraries/core_libs/network/rpc/Test.cpp
@@ -122,12 +122,12 @@ Json::Value Test::send_coin_transaction(const Json::Value &param1) {
       bytes data;
       // get trx receiving time stamp
       auto now = getCurrentTimeMilliSeconds();
-      taraxa::Transaction trx(nonce, value, gas_price, gas, data, sk, receiver);
-      LOG(log_time) << "Transaction " << trx.getHash() << " received at: " << now;
+      auto trx = std::make_shared<Transaction>(nonce, value, gas_price, gas, data, sk, receiver);
+      LOG(log_time) << "Transaction " << trx->getHash() << " received at: " << now;
       if (auto [ok, err_msg] = node->getTransactionManager()->insertTransaction(trx); !ok) {
         res["status"] = err_msg;
       } else {
-        res = toHex(trx.rlp());
+        res = toHex(trx->rlp());
       }
     }
   } catch (std::exception &e) {

--- a/libraries/core_libs/network/rpc/eth/Eth.cpp
+++ b/libraries/core_libs/network/rpc/eth/Eth.cpp
@@ -83,17 +83,17 @@ class EthImpl : public Eth, EthParams {
   string eth_sendTransaction(Json::Value const& _json) override {
     auto t = toTransactionSkeleton(_json);
     set_transaction_defaults(t, final_chain->last_block_number());
-    Transaction trx(t.nonce.value_or(0), t.value, t.gas_price.value_or(0), t.gas.value_or(0), t.data, secret,
-                    t.to ? optional(t.to) : nullopt, chain_id);
+    auto trx = std::make_shared<Transaction>(t.nonce.value_or(0), t.value, t.gas_price.value_or(0), t.gas.value_or(0),
+                                             t.data, secret, t.to ? optional(t.to) : nullopt, chain_id);
     send_trx(trx);
-    trx.rlp();
-    return toJS(trx.getHash());
+    trx->rlp();
+    return toJS(trx->getHash());
   }
 
   string eth_sendRawTransaction(string const& _rlp) override {
-    Transaction trx(jsToBytes(_rlp, OnFailed::Throw), true);
+    auto trx = std::make_shared<Transaction>(jsToBytes(_rlp, OnFailed::Throw), true);
     send_trx(trx);
-    return toJS(trx.getHash());
+    return toJS(trx->getHash());
   }
 
   Json::Value eth_getBlockByHash(string const& _blockHash, bool _includeTransactions) override {
@@ -167,12 +167,12 @@ class EthImpl : public Eth, EthParams {
 
   Json::Value eth_chainId() override { return chain_id ? Json::Value(toJS(chain_id)) : Json::Value(); }
 
-  void note_block_executed(BlockHeader const& blk_header, Transactions const& trxs,
+  void note_block_executed(BlockHeader const& blk_header, SharedTransactions const& trxs,
                            TransactionReceipts const& receipts) override {
     watches_.new_blocks_.process_update(blk_header.hash);
     ExtendedTransactionLocation trx_loc{{{blk_header.number}, blk_header.hash}};
     for (; trx_loc.index < trxs.size(); ++trx_loc.index) {
-      trx_loc.trx_hash = trxs[trx_loc.index].getHash();
+      trx_loc.trx_hash = trxs[trx_loc.index]->getHash();
       using LogsInput = typename decltype(watches_.logs_)::InputType;
       watches_.logs_.process_update(LogsInput(trx_loc, receipts[trx_loc.index]));
     }
@@ -192,7 +192,7 @@ class EthImpl : public Eth, EthParams {
       loc.blk_n = blk_header->number;
       loc.blk_h = blk_header->hash;
       for (auto const& t : final_chain->transactions(blk_n)) {
-        trxs_json.append(toJson(t, loc));
+        trxs_json.append(toJson(*t, loc));
         ++loc.index;
       }
     } else {
@@ -211,7 +211,7 @@ class EthImpl : public Eth, EthParams {
     }
     auto loc = final_chain->transaction_location(h);
     return LocalisedTransaction{
-        move(*trx),
+        trx,
         TransactionLocationWithBlockHash{
             *loc,
             *final_chain->block_hash(loc->blk_n),
@@ -225,7 +225,7 @@ class EthImpl : public Eth, EthParams {
       return {};
     }
     return LocalisedTransaction{
-        *get_trx(hashes->get(trx_pos)),
+        get_trx(hashes->get(trx_pos)),
         TransactionLocationWithBlockHash{
             {blk_n, trx_pos},
             *final_chain->block_hash(blk_n),
@@ -248,8 +248,8 @@ class EthImpl : public Eth, EthParams {
     return LocalisedTransactionReceipt{
         *r,
         ExtendedTransactionLocation{*loc_trx->trx_loc, trx_h},
-        trx.getSender(),
-        trx.getReceiver(),
+        trx->getSender(),
+        trx->getReceiver(),
     };
   }
 
@@ -419,7 +419,7 @@ class EthImpl : public Eth, EthParams {
     return res;
   }
 
-  static Json::Value toJson(LocalisedTransaction const& lt) { return toJson(lt.trx, lt.trx_loc); }
+  static Json::Value toJson(const LocalisedTransaction& lt) { return toJson(*lt.trx, lt.trx_loc); }
 
   static Json::Value toJson(BlockHeader const& obj) {
     Json::Value res(Json::objectValue);

--- a/libraries/core_libs/network/rpc/eth/Eth.h
+++ b/libraries/core_libs/network/rpc/eth/Eth.h
@@ -12,7 +12,7 @@ struct EthParams {
   uint64_t chain_id = 0;
   std::shared_ptr<FinalChain> final_chain;
   std::function<std::shared_ptr<Transaction>(h256 const&)> get_trx;
-  std::function<void(Transaction const& trx)> send_trx;
+  std::function<void(std::shared_ptr<Transaction> const& trx)> send_trx;
   std::function<u256()> gas_pricer = [] { return u256(0); };
   std::function<std::optional<SyncStatus>()> syncing_probe = [] { return std::nullopt; };
   WatchesConfig watches_cfg;
@@ -29,7 +29,7 @@ struct Eth : virtual ::taraxa::net::EthFace {
     ::taraxa::net::EthFace::operator=(std::move(rhs));
     return *this;
   }
-  virtual void note_block_executed(final_chain::BlockHeader const&, Transactions const&,
+  virtual void note_block_executed(final_chain::BlockHeader const&, SharedTransactions const&,
                                    final_chain::TransactionReceipts const&) = 0;
   virtual void note_pending_transaction(h256 const& trx_hash) = 0;
 };

--- a/libraries/core_libs/network/rpc/eth/data.hpp
+++ b/libraries/core_libs/network/rpc/eth/data.hpp
@@ -15,7 +15,7 @@ struct TransactionLocationWithBlockHash : TransactionLocation {
 };
 
 struct LocalisedTransaction {
-  Transaction trx{};
+  std::shared_ptr<Transaction> trx;
   std::optional<TransactionLocationWithBlockHash> trx_loc{};
 };
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
@@ -112,7 +112,7 @@ void PbftSyncPacketHandler::process(const PacketData &packet_data, const std::sh
       std::vector<blk_hash_t> blk_order;
       blk_order.reserve(sync_block.dag_blocks.size());
       for (auto t : sync_block.transactions) {
-        trx_order.push_back(t.getHash());
+        trx_order.push_back(t->getHash());
       }
       for (auto b : sync_block.dag_blocks) {
         blk_order.push_back(b.getHash());

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/transaction_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/transaction_packet_handler.cpp
@@ -74,7 +74,7 @@ void TransactionPacketHandler::onNewTransactions(SharedTransactions &&transactio
   for (auto const &trx : transactions) {
     auto trx_hash = trx->getHash();
     if (!test_state_->hasTransaction(trx_hash)) {
-      test_state_->insertTransaction(*trx);
+      test_state_->insertTransaction(trx);
       LOG(log_tr_) << "Received New Transaction " << trx_hash;
     } else {
       LOG(log_tr_) << "Received New Transaction" << trx_hash << "that is already known";

--- a/libraries/core_libs/network/src/tarcap/shared_states/test_state.cpp
+++ b/libraries/core_libs/network/src/tarcap/shared_states/test_state.cpp
@@ -7,12 +7,12 @@ bool TestState::hasTransaction(const trx_hash_t& tx_hash) const {
   return test_transactions_.count(tx_hash);
 }
 
-void TestState::insertTransaction(const Transaction& tx) {
+void TestState::insertTransaction(const std::shared_ptr<Transaction>& tx) {
   std::unique_lock lock(transactions_mutex_);
-  test_transactions_.emplace(tx.getHash(), tx);
+  test_transactions_.emplace(tx->getHash(), tx);
 }
 
-const Transaction& TestState::getTransaction(const trx_hash_t& tx_hash) const {
+const std::shared_ptr<Transaction> TestState::getTransaction(const trx_hash_t& tx_hash) const {
   std::shared_lock lock(transactions_mutex_);
   assert(test_transactions_.count(tx_hash));
 
@@ -46,7 +46,7 @@ size_t TestState::getBlocksSize() const {
   return test_blocks_.size();
 }
 
-std::unordered_map<trx_hash_t, Transaction> TestState::getTransactions() {
+std::unordered_map<trx_hash_t, std::shared_ptr<Transaction>> TestState::getTransactions() {
   std::shared_lock lock(transactions_mutex_);
   return test_transactions_;
 }

--- a/libraries/core_libs/node/src/node.cpp
+++ b/libraries/core_libs/node/src/node.cpp
@@ -137,7 +137,7 @@ void FullNode::start() {
             std::runtime_error(fmt("Transaction is rejected.\n"
                                    "RLP: %s\n"
                                    "Reason: %s",
-                                   dev::toJS(trx.rlp()), err_msg)));
+                                   dev::toJS(trx->rlp()), err_msg)));
       }
     };
     eth_rpc_params.syncing_probe = [network = network_, pbft_chain = pbft_chain_, pbft_mgr = pbft_mgr_] {

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -187,7 +187,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   dev::bytes getPeriodDataRaw(uint64_t period) const;
   std::optional<PbftBlock> getPbftBlock(uint64_t period) const;
   blk_hash_t getPeriodBlockHash(uint64_t period) const;
-  std::optional<std::vector<Transaction>> getPeriodTransactions(uint64_t period) const;
+  std::optional<SharedTransactions> getPeriodTransactions(uint64_t period) const;
 
   // DAG
   void saveDagBlock(DagBlock const& blk, Batch* write_batch_p = nullptr);

--- a/libraries/types/pbft_block/include/pbft/sync_block.hpp
+++ b/libraries/types/pbft_block/include/pbft/sync_block.hpp
@@ -6,12 +6,12 @@
 #include <vector>
 
 #include "common/types.hpp"
+#include "transaction/transaction.hpp"
 
 namespace taraxa {
 
 class Vote;
 class PbftBlock;
-struct Transaction;
 class DagBlock;
 
 class SyncBlock {
@@ -24,7 +24,7 @@ class SyncBlock {
   std::shared_ptr<PbftBlock> pbft_blk;
   std::vector<std::shared_ptr<Vote>> cert_votes;
   std::vector<DagBlock> dag_blocks;
-  std::vector<Transaction> transactions;
+  SharedTransactions transactions;
   bytes rlp() const;
   void clear();
   void hasEnoughValidCertVotes(size_t valid_sortition_players, size_t sortition_threshold, size_t pbft_2t_plus_1,

--- a/libraries/types/pbft_block/src/sync_block.cpp
+++ b/libraries/types/pbft_block/src/sync_block.cpp
@@ -26,7 +26,7 @@ SyncBlock::SyncBlock(dev::RLP&& rlp) {
   }
 
   for (auto const trx_rlp : *it) {
-    transactions.emplace_back(trx_rlp);
+    transactions.emplace_back(std::make_shared<Transaction>(trx_rlp));
   }
 }
 
@@ -45,7 +45,7 @@ bytes SyncBlock::rlp() const {
   }
   s.appendList(transactions.size());
   for (auto const& t : transactions) {
-    s.appendRaw(t.rlp());
+    s.appendRaw(t->rlp());
   }
   return s.invalidate();
 }

--- a/libraries/types/transaction/include/transaction/transaction.hpp
+++ b/libraries/types/transaction/include/transaction/transaction.hpp
@@ -24,15 +24,16 @@ struct Transaction {
   uint64_t chain_id_ = 0;
   dev::SignatureStruct vrs_;
   mutable trx_hash_t hash_;
-  mutable bool hash_initialized_ = false;
+  mutable std::atomic_bool hash_initialized_ = false;
   bool is_zero_ = false;
-  mutable util::DefaultConstructCopyableMovable<std::mutex> hash_mu_;
-  mutable bool sender_initialized_ = false;
+  mutable std::mutex hash_mu_;
+  mutable std::atomic_bool sender_initialized_ = false;
   mutable bool sender_valid_ = false;
   mutable addr_t sender_;
-  mutable util::DefaultConstructCopyableMovable<std::mutex> sender_mu_;
+  mutable std::mutex sender_mu_;
+  mutable std::atomic_bool cached_rlp_set_ = false;
   mutable bytes cached_rlp_;
-  mutable util::DefaultConstructCopyableMovable<std::mutex> cached_rlp_mu_;
+  mutable std::mutex cached_rlp_mu_;
 
   template <bool for_signature>
   void streamRLP(dev::RLPStream &s) const;

--- a/tests/gas_pricer_test.cpp
+++ b/tests/gas_pricer_test.cpp
@@ -26,19 +26,19 @@ TEST_F(GasPricerTest, basic_test) {
   GasPricer gp;
   EXPECT_EQ(gp.bid(), 1);
 
-  gp.update({Transaction(0, 0, 1 /*gas_price*/, 0, bytes(), secret)});
+  gp.update({std::make_shared<Transaction>(0, 0, 1 /*gas_price*/, 0, bytes(), secret)});
   EXPECT_EQ(gp.bid(), 1);
 
-  gp.update({Transaction(0, 0, 2 /*gas_price*/, 0, bytes(), secret)});
+  gp.update({std::make_shared<Transaction>(0, 0, 2 /*gas_price*/, 0, bytes(), secret)});
   EXPECT_EQ(gp.bid(), 1);
 
-  gp.update({Transaction(0, 0, 3 /*gas_price*/, 0, bytes(), secret)});
+  gp.update({std::make_shared<Transaction>(0, 0, 3 /*gas_price*/, 0, bytes(), secret)});
   EXPECT_EQ(gp.bid(), 2);
 
-  gp.update({Transaction(0, 0, 4 /*gas_price*/, 0, bytes(), secret)});
+  gp.update({std::make_shared<Transaction>(0, 0, 4 /*gas_price*/, 0, bytes(), secret)});
   EXPECT_EQ(gp.bid(), 2);
 
-  gp.update({Transaction(0, 0, 5 /*gas_price*/, 0, bytes(), secret)});
+  gp.update({std::make_shared<Transaction>(0, 0, 5 /*gas_price*/, 0, bytes(), secret)});
   EXPECT_EQ(gp.bid(), 3);
 }
 
@@ -54,7 +54,7 @@ TEST_F(GasPricerTest, random_test) {
 
   for (size_t i = 0; i < number_of_blocks; ++i) {
     const size_t gas_price = 1 + std::rand() % 1000;
-    gp.update({Transaction(0, 0, gas_price, 0, bytes(), secret)});
+    gp.update({std::make_shared<Transaction>(0, 0, gas_price, 0, bytes(), secret)});
     prices.push_back(gas_price);
   }
 

--- a/tests/hardfork_test.cpp
+++ b/tests/hardfork_test.cpp
@@ -87,7 +87,7 @@ TEST_F(HardforkTest, fix_genesis_fork_block_is_zero) {
   cfg.state.hardforks.fix_genesis_fork_block = 0;
   auto node = launch_nodes({node_cfg}).front();
 
-  Transaction dummy_trx(1, 0, 0, 0, bytes(), node->getSecretKey(), node->getAddress());
+  auto dummy_trx = std::make_shared<Transaction>(1, 0, 0, 0, bytes(), node->getSecretKey(), node->getAddress());
   // broadcast dummy transaction
   node->getTransactionManager()->insertTransaction(dummy_trx);
   wait({100s, 500ms}, [&](auto &ctx) {
@@ -123,7 +123,7 @@ TEST_F(HardforkTest, hardfork) {
   auto node = launch_nodes({node_cfg}).front();
   auto nonce = 0;
   auto dummy_trx = [&nonce, node]() {
-    Transaction dummy_trx(nonce++, 0, 0, 0, bytes(), node->getSecretKey(), node->getAddress());
+    auto dummy_trx = std::make_shared<Transaction>(nonce++, 0, 0, 0, bytes(), node->getSecretKey(), node->getAddress());
     // broadcast dummy transaction
     node->getTransactionManager()->insertTransaction(dummy_trx);
   };

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -226,7 +226,7 @@ TEST_F(NetworkTest, sync_large_pbft_block) {
         ctx.fail_if(trx_pool_size > 0);
       });
     }
-    nodes[0]->getTransactionManager()->insertTransaction(*signed_trxs[i]);
+    nodes[0]->getTransactionManager()->insertTransaction(signed_trxs[i]);
   }
 
   const auto node1_pbft_chain = nodes[0]->getPbftChain();
@@ -508,8 +508,8 @@ TEST_F(NetworkTest, node_pbft_sync) {
 
   SyncBlock sync_block1(std::make_shared<PbftBlock>(pbft_block1), votes_for_pbft_blk1);
   sync_block1.dag_blocks.push_back(blk1);
-  sync_block1.transactions.push_back(*g_signed_trx_samples[0]);
-  sync_block1.transactions.push_back(*g_signed_trx_samples[1]);
+  sync_block1.transactions.push_back(g_signed_trx_samples[0]);
+  sync_block1.transactions.push_back(g_signed_trx_samples[1]);
 
   db1->savePeriodData(sync_block1, batch);
   // Update period_pbft_block in DB
@@ -566,8 +566,8 @@ TEST_F(NetworkTest, node_pbft_sync) {
 
   SyncBlock sync_block2(std::make_shared<PbftBlock>(pbft_block2), votes_for_pbft_blk2);
   sync_block2.dag_blocks.push_back(blk2);
-  sync_block2.transactions.push_back(*g_signed_trx_samples[2]);
-  sync_block2.transactions.push_back(*g_signed_trx_samples[3]);
+  sync_block2.transactions.push_back(g_signed_trx_samples[2]);
+  sync_block2.transactions.push_back(g_signed_trx_samples[3]);
 
   db1->savePeriodData(sync_block2, batch);
 
@@ -669,8 +669,8 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
 
   SyncBlock sync_block1(std::make_shared<PbftBlock>(pbft_block1), votes_for_pbft_blk1);
   sync_block1.dag_blocks.push_back(blk1);
-  sync_block1.transactions.push_back(*g_signed_trx_samples[0]);
-  sync_block1.transactions.push_back(*g_signed_trx_samples[1]);
+  sync_block1.transactions.push_back(g_signed_trx_samples[0]);
+  sync_block1.transactions.push_back(g_signed_trx_samples[1]);
 
   db1->savePeriodData(sync_block1, batch);
   // Update pbft chain
@@ -713,8 +713,8 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
 
   SyncBlock sync_block2(std::make_shared<PbftBlock>(pbft_block2), votes_for_pbft_blk1);
   sync_block2.dag_blocks.push_back(blk1);
-  sync_block2.transactions.push_back(*g_signed_trx_samples[2]);
-  sync_block2.transactions.push_back(*g_signed_trx_samples[3]);
+  sync_block2.transactions.push_back(g_signed_trx_samples[2]);
+  sync_block2.transactions.push_back(g_signed_trx_samples[3]);
 
   db1->savePeriodData(sync_block2, batch);
   // Update pbft chain
@@ -1274,8 +1274,8 @@ TEST_F(NetworkTest, node_full_sync) {
   // When last level have more than 1 DAG blocks, send a dummy transaction to converge DAG
   if (!dag_synced) {
     std::cout << "Send dummy trx" << std::endl;
-    Transaction dummy_trx(num_of_trxs++, 0, 2, TEST_TX_GAS_LIMIT, bytes(), nodes[0]->getSecretKey(),
-                          nodes[0]->getAddress());
+    auto dummy_trx = std::make_shared<Transaction>(num_of_trxs++, 0, 2, TEST_TX_GAS_LIMIT, bytes(),
+                                                   nodes[0]->getSecretKey(), nodes[0]->getAddress());
     // broadcast dummy transaction
     nodes[0]->getTransactionManager()->insertTransaction(dummy_trx);
 
@@ -1329,8 +1329,8 @@ TEST_F(NetworkTest, node_full_sync) {
   // When last level have more than 1 DAG blocks, send a dummy transaction to converge DAG
   if (!dag_synced) {
     std::cout << "Send dummy trx" << std::endl;
-    Transaction dummy_trx(num_of_trxs++, 0, 2, TEST_TX_GAS_LIMIT, bytes(), nodes[0]->getSecretKey(),
-                          nodes[0]->getAddress());
+    auto dummy_trx = std::make_shared<Transaction>(num_of_trxs++, 0, 2, TEST_TX_GAS_LIMIT, bytes(),
+                                                   nodes[0]->getSecretKey(), nodes[0]->getAddress());
     // broadcast dummy transaction
     nodes[0]->getTransactionManager()->insertTransaction(dummy_trx);
 

--- a/tests/p2p_test.cpp
+++ b/tests/p2p_test.cpp
@@ -159,8 +159,8 @@ TEST_F(P2PTest, capability_send_block) {
   }
   EXPECT_EQ(rtransactions.size(), 2);
   if (rtransactions.size() == 2) {
-    EXPECT_EQ(Transaction(*transactions[0]), rtransactions[g_signed_trx_samples[0]->getHash()]);
-    EXPECT_EQ(Transaction(*transactions[1]), rtransactions[g_signed_trx_samples[1]->getHash()]);
+    EXPECT_EQ(*transactions[0], *rtransactions[g_signed_trx_samples[0]->getHash()]);
+    EXPECT_EQ(*transactions[1], *rtransactions[g_signed_trx_samples[1]->getHash()]);
   }
 }
 
@@ -288,8 +288,8 @@ TEST_F(P2PTest, block_propagate) {
     auto rtransactions = vCapabilities[i]->test_state_->getTransactions();
     EXPECT_EQ(rtransactions.size(), 2);
     if (rtransactions.size() == 2) {
-      EXPECT_EQ(Transaction(*transactions[0]), rtransactions[g_signed_trx_samples[0]->getHash()]);
-      EXPECT_EQ(Transaction(*transactions[1]), rtransactions[g_signed_trx_samples[1]->getHash()]);
+      EXPECT_EQ(*transactions[0], *rtransactions[g_signed_trx_samples[0]->getHash()]);
+      EXPECT_EQ(*transactions[1], *rtransactions[g_signed_trx_samples[1]->getHash()]);
     }
   }
   EXPECT_EQ(blocks1.size(), 1);

--- a/tests/pbft_manager_test.cpp
+++ b/tests/pbft_manager_test.cpp
@@ -62,7 +62,7 @@ void check_2tPlus1_validVotingPlayers_activePlayers_threshold(size_t committee_s
     trxs_count++;
     EXPECT_HAPPENS({120s, 1s}, [&](auto &ctx) {
       for (auto &node : nodes) {
-        if (ctx.fail_if(!node->getFinalChain()->transaction_location(trx.getHash()))) {
+        if (ctx.fail_if(!node->getFinalChain()->transaction_location(trx->getHash()))) {
           return;
         }
       }
@@ -71,8 +71,8 @@ void check_2tPlus1_validVotingPlayers_activePlayers_threshold(size_t committee_s
 
   auto init_bal = node_1_expected_bal / nodes.size();
   for (size_t i(1); i < nodes.size(); ++i) {
-    Transaction master_boot_node_send_coins(nonce++, init_bal, gas_price, TEST_TX_GAS_LIMIT, bytes(),
-                                            nodes[0]->getSecretKey(), nodes[i]->getAddress());
+    auto master_boot_node_send_coins = std::make_shared<Transaction>(
+        nonce++, init_bal, gas_price, TEST_TX_GAS_LIMIT, bytes(), nodes[0]->getSecretKey(), nodes[i]->getAddress());
     node_1_expected_bal -= init_bal;
     // broadcast trx and insert
     nodes[0]->getTransactionManager()->insertTransaction(master_boot_node_send_coins);
@@ -85,8 +85,8 @@ void check_2tPlus1_validVotingPlayers_activePlayers_threshold(size_t committee_s
       if (nodes[i]->getDB()->getNumTransactionExecuted() != trxs_count) {
         std::cout << "node" << i << " executed " << nodes[i]->getDB()->getNumTransactionExecuted()
                   << " transactions, expected " << trxs_count << std::endl;
-        Transaction dummy_trx(nonce++, 0, 2, TEST_TX_GAS_LIMIT, bytes(), nodes[0]->getSecretKey(),
-                              nodes[0]->getAddress());
+        auto dummy_trx = std::make_shared<Transaction>(nonce++, 0, 2, TEST_TX_GAS_LIMIT, bytes(),
+                                                       nodes[0]->getSecretKey(), nodes[0]->getAddress());
         // broadcast dummy transaction
         nodes[0]->getTransactionManager()->insertTransaction(dummy_trx);
         trxs_count++;
@@ -128,8 +128,9 @@ void check_2tPlus1_validVotingPlayers_activePlayers_threshold(size_t committee_s
     // Sending coins in Robin Cycle in order to make all nodes to be active
     // players, but not guarantee
     auto receiver_index = (i + 1) % nodes.size();
-    Transaction send_coins_in_robin_cycle(nonce++, send_coins, gas_price, TEST_TX_GAS_LIMIT, bytes(),
-                                          nodes[i]->getSecretKey(), nodes[receiver_index]->getAddress());
+    auto send_coins_in_robin_cycle =
+        std::make_shared<Transaction>(nonce++, send_coins, gas_price, TEST_TX_GAS_LIMIT, bytes(),
+                                      nodes[i]->getSecretKey(), nodes[receiver_index]->getAddress());
     // broadcast trx and insert
     nodes[i]->getTransactionManager()->insertTransaction(send_coins_in_robin_cycle);
     trxs_count++;
@@ -141,8 +142,8 @@ void check_2tPlus1_validVotingPlayers_activePlayers_threshold(size_t committee_s
       if (nodes[i]->getDB()->getNumTransactionExecuted() != trxs_count) {
         std::cout << "node" << i << " executed " << nodes[i]->getDB()->getNumTransactionExecuted()
                   << " transactions. Expected " << trxs_count << std::endl;
-        Transaction dummy_trx(nonce++, 0, 2, TEST_TX_GAS_LIMIT, bytes(), nodes[0]->getSecretKey(),
-                              nodes[0]->getAddress());
+        auto dummy_trx = std::make_shared<Transaction>(nonce++, 0, 2, TEST_TX_GAS_LIMIT, bytes(),
+                                                       nodes[0]->getSecretKey(), nodes[0]->getAddress());
         // broadcast dummy transaction
         nodes[0]->getTransactionManager()->insertTransaction(dummy_trx);
         trxs_count++;
@@ -411,7 +412,7 @@ TEST_F(PbftManagerTest, check_get_eligible_vote_count) {
     trxs_count++;
     EXPECT_HAPPENS({120s, 1s}, [&](auto &ctx) {
       for (auto &node : nodes) {
-        if (ctx.fail_if(!node->getFinalChain()->transaction_location(trx.getHash()))) {
+        if (ctx.fail_if(!node->getFinalChain()->transaction_location(trx->getHash()))) {
           return;
         }
       }
@@ -420,8 +421,8 @@ TEST_F(PbftManagerTest, check_get_eligible_vote_count) {
 
   auto init_bal = node_1_expected_bal / nodes.size() / 2;
   for (size_t i(1); i < nodes.size(); ++i) {
-    Transaction master_boot_node_send_coins(nonce++, init_bal, gas_price, TEST_TX_GAS_LIMIT, bytes(),
-                                            nodes[0]->getSecretKey(), nodes[i]->getAddress());
+    auto master_boot_node_send_coins = std::make_shared<Transaction>(
+        nonce++, init_bal, gas_price, TEST_TX_GAS_LIMIT, bytes(), nodes[0]->getSecretKey(), nodes[i]->getAddress());
     node_1_expected_bal -= init_bal;
     // broadcast trx and insert
     nodes[0]->getTransactionManager()->insertTransaction(master_boot_node_send_coins);
@@ -434,8 +435,8 @@ TEST_F(PbftManagerTest, check_get_eligible_vote_count) {
       if (nodes[i]->getDB()->getNumTransactionExecuted() != trxs_count) {
         std::cout << "node" << i << " executed " << nodes[i]->getDB()->getNumTransactionExecuted()
                   << " transactions, expected " << trxs_count << std::endl;
-        Transaction dummy_trx(nonce++, 0, 2, TEST_TX_GAS_LIMIT, bytes(), nodes[0]->getSecretKey(),
-                              nodes[0]->getAddress());
+        auto dummy_trx = std::make_shared<Transaction>(nonce++, 0, 2, TEST_TX_GAS_LIMIT, bytes(),
+                                                       nodes[0]->getSecretKey(), nodes[0]->getAddress());
         // broadcast dummy transaction
         nodes[0]->getTransactionManager()->insertTransaction(dummy_trx);
         trxs_count++;
@@ -462,8 +463,9 @@ TEST_F(PbftManagerTest, check_get_eligible_vote_count) {
     // Sending coins in Robin Cycle in order to make all nodes to be active
     // players, but not guarantee
     auto receiver_index = (i + 1) % nodes.size();
-    Transaction send_coins_in_robin_cycle(nonce++, send_coins, gas_price, TEST_TX_GAS_LIMIT, bytes(),
-                                          nodes[i]->getSecretKey(), nodes[receiver_index]->getAddress());
+    auto send_coins_in_robin_cycle =
+        std::make_shared<Transaction>(nonce++, send_coins, gas_price, TEST_TX_GAS_LIMIT, bytes(),
+                                      nodes[i]->getSecretKey(), nodes[receiver_index]->getAddress());
     // broadcast trx and insert
     nodes[i]->getTransactionManager()->insertTransaction(send_coins_in_robin_cycle);
     trxs_count++;
@@ -475,8 +477,8 @@ TEST_F(PbftManagerTest, check_get_eligible_vote_count) {
       if (nodes[i]->getDB()->getNumTransactionExecuted() != trxs_count) {
         std::cout << "node" << i << " executed " << nodes[i]->getDB()->getNumTransactionExecuted()
                   << " transactions. Expected " << trxs_count << std::endl;
-        Transaction dummy_trx(nonce++, 0, 2, TEST_TX_GAS_LIMIT, bytes(), nodes[0]->getSecretKey(),
-                              nodes[0]->getAddress());
+        auto dummy_trx = std::make_shared<Transaction>(nonce++, 0, 2, TEST_TX_GAS_LIMIT, bytes(),
+                                                       nodes[0]->getSecretKey(), nodes[0]->getAddress());
         // broadcast dummy transaction
         nodes[0]->getTransactionManager()->insertTransaction(dummy_trx);
         trxs_count++;
@@ -538,8 +540,8 @@ TEST_F(PbftManagerTest, pbft_manager_run_single_node) {
   auto coins_value = val_t(100);
   auto gas_price = val_t(2);
   auto data = bytes();
-  Transaction trx_master_boot_node_to_receiver(0, coins_value, gas_price, TEST_TX_GAS_LIMIT, data, node->getSecretKey(),
-                                               receiver);
+  auto trx_master_boot_node_to_receiver =
+      std::make_shared<Transaction>(0, coins_value, gas_price, TEST_TX_GAS_LIMIT, data, node->getSecretKey(), receiver);
   node->getTransactionManager()->insertTransaction(trx_master_boot_node_to_receiver);
 
   // Check there is proposing DAG blocks
@@ -565,8 +567,8 @@ TEST_F(PbftManagerTest, pbft_manager_run_multi_nodes) {
 
   // create a transaction transfer coins from node1 to node2
   const auto gas_price = val_t(2);
-  Transaction trx_master_boot_node_to_node2(1, val_t(100), gas_price, TEST_TX_GAS_LIMIT, bytes(),
-                                            nodes[0]->getSecretKey(), node2_addr);
+  auto trx_master_boot_node_to_node2 = std::make_shared<Transaction>(1, val_t(100), gas_price, TEST_TX_GAS_LIMIT,
+                                                                     bytes(), nodes[0]->getSecretKey(), node2_addr);
   // broadcast trx and insert
   nodes[0]->getTransactionManager()->insertTransaction(trx_master_boot_node_to_node2);
 
@@ -580,8 +582,8 @@ TEST_F(PbftManagerTest, pbft_manager_run_multi_nodes) {
   wait_for_balances(nodes, expected_balances1, {100s, 500ms});
 
   // create a transaction transfer coins from node1 to node3
-  Transaction trx_master_boot_node_to_node3(2, val_t(1000), gas_price, TEST_TX_GAS_LIMIT, bytes(),
-                                            nodes[0]->getSecretKey(), node3_addr);
+  auto trx_master_boot_node_to_node3 = std::make_shared<Transaction>(2, val_t(1000), gas_price, TEST_TX_GAS_LIMIT,
+                                                                     bytes(), nodes[0]->getSecretKey(), node3_addr);
   // broadcast trx and insert
   nodes[0]->getTransactionManager()->insertTransaction(trx_master_boot_node_to_node3);
 

--- a/tests/sortition_test.cpp
+++ b/tests/sortition_test.cpp
@@ -29,7 +29,7 @@ SyncBlock createBlock(uint64_t period, uint16_t efficiency, size_t dag_blocks_co
   auto trx_per_block = effective_transactions / dag_blocks_count;
 
   for (uint32_t i = 0; i < trx_hashes.size(); ++i) {
-    b.transactions.push_back(Transaction());
+    b.transactions.push_back(std::make_shared<Transaction>());
   }
 
   for (size_t i = 0; i < dag_blocks_count; ++i) {

--- a/tests/util_test/samples.hpp
+++ b/tests/util_test/samples.hpp
@@ -26,10 +26,11 @@ class TxGenerator {
 
   auto getSerialTrxWithSameSender(uint trx_num, uint64_t const &start_nonce, val_t const &value,
                                   addr_t const &receiver = addr_t::random()) const {
-    std::vector<Transaction> trxs;
+    SharedTransactions trxs;
     for (auto i = start_nonce; i < start_nonce + trx_num; ++i) {
-      trxs.emplace_back(Transaction(i, value, 0, TEST_TX_GAS_LIMIT, str2bytes("00FEDCBA9876543210000000"),
-                                    getRandomUniqueSenderSecret(), receiver));
+      trxs.emplace_back(std::make_shared<Transaction>(i, value, 0, TEST_TX_GAS_LIMIT,
+                                                      str2bytes("00FEDCBA9876543210000000"),
+                                                      getRandomUniqueSenderSecret(), receiver));
     }
     return trxs;
   }
@@ -110,17 +111,17 @@ inline std::map<int, TestAccount> createTestAccountTable(std::string const &file
   return acc_table;
 }
 
-inline std::vector<Transaction> createMockTrxSamples(unsigned start, unsigned num) {
+inline SharedTransactions createMockTrxSamples(unsigned start, unsigned num) {
   assert(start + num < std::numeric_limits<unsigned>::max());
-  std::vector<Transaction> trxs;
+  SharedTransactions trxs;
   for (auto i = start; i < num; ++i) {
-    Transaction trx(i,                                      // nonce
-                    3,                                      // value
-                    4,                                      // gas_price
-                    5,                                      // gas
-                    str2bytes("00FEDCBA9876543210000000"),  // data
-                    secret_t::random(),                     // secret
-                    addr_t(i * 1000)                        // receiver
+    auto trx = std::make_shared<Transaction>(i,                                      // nonce
+                                             3,                                      // value
+                                             4,                                      // gas_price
+                                             5,                                      // gas
+                                             str2bytes("00FEDCBA9876543210000000"),  // data
+                                             secret_t::random(),                     // secret
+                                             addr_t(i * 1000)                        // receiver
     );
     trxs.emplace_back(trx);
   }


### PR DESCRIPTION
This change includes a fix for Transaction thread safety. Some transaction get methods like rlp() or getSender() were not thread safe which is not fixed. As part of this fix the default copy constructor in Transaction class is deleted. This is also done to prevent any unneeded copy of transaction object.