### PR TITLE
fix: pbft_next_votes_sync_in_behind_round seg fault

### DIFF
--- a/libraries/core_libs/consensus/src/dag/dag.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag.cpp
@@ -317,7 +317,6 @@ void DagManager::stop() {
     return;
   }
   std::unique_lock lock(mutex_);
-  trx_mgr_ = nullptr;
   block_worker_.join();
 }
 


### PR DESCRIPTION
In test pbft_next_votes_sync_in_behind_round there was a segfault caused by DagManager calling trx_mgr after it was set to nullptr. Fix is not to set trx_mgr to nullptr. I am not sure what was the reason this was ever set to nullptr. It was actually done by a commit by me 2 years ago when the code base was different.