### PR TITLE
chore: low nonce and insufficient balance transactions handling

### DIFF
--- a/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
+++ b/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
@@ -10,6 +10,8 @@
 
 namespace taraxa {
 
+enum class TransactionStatus { Verified = 0, Invalid, LowNonce, InsufficentBalance };
+
 class DagBlock;
 class DagManager;
 class FullNode;
@@ -46,13 +48,20 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
   std::pair<bool, std::string> insertTransaction(const std::shared_ptr<Transaction> &trx);
 
   /**
+   * @brief Invoked when block finalized in final chain
+   *
+   * @param block_number block number finalized
+   */
+  void blockFinalized(uint64_t block_number);
+
+  /**
    * @brief Inserts batch of verified transactions to transaction pool
    *
    * @note Some of the transactions might be already processed -> they are not processed and inserted again
    * @param txs transactions to be processed
    * @return number of successfully inserted unseen transactions
    */
-  uint32_t insertValidatedTransactions(SharedTransactions &&txs);
+  uint32_t insertValidatedTransactions(std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> &&txs);
 
   /**
    * @brief Marks transaction as known (was successfully verified and pushed into the tx pool)
@@ -127,7 +136,7 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
   std::shared_ptr<Transaction> getNonFinalizedTransaction(trx_hash_t const &hash) const;
   unsigned long getTransactionCount() const;
   void recoverNonfinalizedTransactions();
-  std::pair<bool, std::string> verifyTransaction(const std::shared_ptr<Transaction> &trx) const;
+  std::pair<TransactionStatus, std::string> verifyTransaction(const std::shared_ptr<Transaction> &trx) const;
 
  private:
   /**

--- a/libraries/core_libs/consensus/include/transaction/transaction_queue.hpp
+++ b/libraries/core_libs/consensus/include/transaction/transaction_queue.hpp
@@ -3,6 +3,7 @@
 #include "transaction/transaction.hpp"
 
 namespace taraxa {
+enum class TransactionStatus;
 /**
  * @brief this is NOT thread safe class. It is proteced only by transactions_mutex_ in the transaction mamanger !!!
  *
@@ -15,10 +16,11 @@ class TransactionQueue {
    * @brief insert a transaction into the queue, sorted by priority
    *
    * @param transaction
+   * @param last_block_number
    * @return true
    * @return false
    */
-  bool insert(std::shared_ptr<Transaction>&& transaction);
+  bool insert(std::pair<std::shared_ptr<Transaction>, TransactionStatus>&& transaction, uint64_t last_block_number = 0);
 
   /**
    * @brief remove transaction from queue
@@ -61,12 +63,28 @@ class TransactionQueue {
    */
   size_t size() const;
 
+  /**
+   * @brief Invoked when block finalized in final chain
+   *
+   * @param block_number block number finalized
+   */
+  void blockFinalized(uint64_t block_number);
+
  private:
   typedef std::function<bool(const std::shared_ptr<Transaction>&, const std::shared_ptr<Transaction>&)> ComperType;
   // It has to be multiset as two trx could have same value (nonce and gas price)
   using PriorityQueue = std::multiset<std::shared_ptr<Transaction>, ComperType>;
   PriorityQueue priority_queue_;
   std::unordered_map<trx_hash_t, PriorityQueue::iterator> hash_queue_;
+  // Low nonce and insufficient balance transactions which should not be included in proposed dag blocks but it is
+  // possible because of dag reordering that some dag block might arrive requiring these transactions.
+  std::unordered_map<trx_hash_t, std::pair<uint64_t, std::shared_ptr<Transaction>>> non_proposable_transactions_;
+
+  // Limit when non proposable transactions expire
+  const uint64_t kNonProposableTransactionsPeriodExpiryLimit = 10;
+
+  // Maximum number of save transactions
+  const uint64_t kNonProposableTransactionsLimit = 1000;
 };
 
 }  // namespace taraxa

--- a/libraries/core_libs/network/include/network/network.hpp
+++ b/libraries/core_libs/network/include/network/network.hpp
@@ -51,7 +51,7 @@ class Network {
   Json::Value getPacketsStats();
   std::vector<dev::p2p::NodeID> getAllPeersIDs() const;
   void onNewBlockVerified(DagBlock &&blk, bool proposed, SharedTransactions &&trxs);
-  void onNewTransactions(SharedTransactions &&transactions);
+  void onNewTransactions(std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> &&transactions);
   void restartSyncingPbft(bool force = false);
   void onNewPbftBlock(std::shared_ptr<PbftBlock> const &pbft_block);
   bool pbft_syncing();

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/transaction_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/transaction_packet_handler.hpp
@@ -7,6 +7,7 @@
 namespace taraxa {
 class DagBlockManager;
 class TransactionManager;
+enum class TransactionStatus;
 }  // namespace taraxa
 
 namespace taraxa::network::tarcap {
@@ -19,7 +20,7 @@ class TransactionPacketHandler final : public PacketHandler {
                            std::shared_ptr<TransactionManager> trx_mgr, std::shared_ptr<DagBlockManager> dag_blk_mgr,
                            std::shared_ptr<TestState> test_state, const addr_t& node_addr);
 
-  void onNewTransactions(SharedTransactions&& transactions);
+  void onNewTransactions(std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>>&& transactions);
   void sendTransactions(dev::p2p::NodeID const& peer_id, std::vector<taraxa::bytes> const& transactions);
 
   /**

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
@@ -24,6 +24,7 @@ class NextVotesManager;
 class DagManager;
 class DagBlockManager;
 class TransactionManager;
+enum class TransactionStatus;
 }  // namespace taraxa
 
 namespace taraxa::network::tarcap {
@@ -77,7 +78,7 @@ class TaraxaCapability : public dev::p2p::CapabilityFace {
   void restartSyncingPbft(bool force = false);
   bool pbft_syncing() const;
   void onNewBlockVerified(DagBlock &&blk, bool proposed, SharedTransactions &&trxs);
-  void onNewTransactions(SharedTransactions &&transactions);
+  void onNewTransactions(std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> &&transactions);
   void onNewPbftBlock(std::shared_ptr<PbftBlock> const &pbft_block);
   void onNewPbftVote(std::shared_ptr<Vote> &&vote);
   void broadcastPreviousRoundNextVotesBundle();

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
@@ -65,6 +65,24 @@ class TaraxaPeer : public boost::noncopyable {
 
   const dev::p2p::NodeID &getId() const { return id_; }
 
+  /**
+   * @brief Reports suspicious pacet
+   *
+   * @return true in case suspicious packet count within current minute is greater than kMaxSuspiciousPacketPerMinute
+   */
+  bool reportSuspiciousPacket() {
+    uint64_t now =
+        std::chrono::duration_cast<std::chrono::minutes>(std::chrono::system_clock::now().time_since_epoch()).count();
+    // Reset counter if no suspicious packet sent for over a minute
+    if (now > timestamp_suspicious_packet_) {
+      suspicious_packet_count_ = 1;
+      timestamp_suspicious_packet_ = now;
+    } else {
+      suspicious_packet_count_++;
+    }
+    return suspicious_packet_count_ > kMaxSuspiciousPacketPerMinute;
+  }
+
   std::atomic<bool> syncing_ = false;
   std::atomic<uint64_t> dag_level_ = 0;
   std::atomic<uint64_t> pbft_chain_size_ = 0;
@@ -88,6 +106,10 @@ class TaraxaPeer : public boost::noncopyable {
   // PBFT
   ExpirationCache<blk_hash_t> known_pbft_blocks_;
   ExpirationCache<vote_hash_t> known_votes_;  // for peers
+
+  std::atomic<uint64_t> timestamp_suspicious_packet_ = 0;
+  std::atomic<uint64_t> suspicious_packet_count_ = 0;
+  const uint64_t kMaxSuspiciousPacketPerMinute = 1000;
 };
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/src/network.cpp
+++ b/libraries/core_libs/network/src/network.cpp
@@ -6,6 +6,8 @@
 
 #include <boost/tokenizer.hpp>
 
+#include "transaction/transaction_manager.hpp"
+
 namespace taraxa {
 
 Network::Network(NetworkConfig const &config, std::filesystem::path const &network_file_path, dev::KeyPair const &key,
@@ -88,7 +90,8 @@ void Network::onNewBlockVerified(DagBlock &&blk, bool proposed, SharedTransactio
   taraxa_capability_->onNewBlockVerified(std::move(blk), proposed, std::move(trxs));
 }
 
-void Network::onNewTransactions(SharedTransactions &&transactions) {
+void Network::onNewTransactions(
+    std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> &&transactions) {
   LOG(log_tr_) << "On new transactions" << transactions.size();
   taraxa_capability_->onNewTransactions(std::move(transactions));
 }

--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -346,7 +346,8 @@ void TaraxaCapability::onNewBlockVerified(DagBlock &&blk, bool proposed, SharedT
                                                                                      std::move(trxs));
 }
 
-void TaraxaCapability::onNewTransactions(SharedTransactions &&transactions) {
+void TaraxaCapability::onNewTransactions(
+    std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> &&transactions) {
   packets_handlers_->getSpecificHandler<TransactionPacketHandler>()->onNewTransactions(std::move(transactions));
 }
 

--- a/libraries/core_libs/node/src/node.cpp
+++ b/libraries/core_libs/node/src/node.cpp
@@ -220,6 +220,14 @@ void FullNode::start() {
       },
       subscription_pool_);
 
+  final_chain_->block_finalized_.subscribe(
+      [trx_manager = as_weak(trx_mgr_)](auto const &res) {
+        if (auto trx_mgr = trx_manager.lock()) {
+          trx_mgr->blockFinalized(res->final_chain_blk->number);
+        }
+      },
+      subscription_pool_);
+
   // Subscription to process hardforks
   final_chain_->block_applying_.subscribe([&](uint64_t block_num) {
     // TODO: should have only common hardfork code calling hardfork executor

--- a/tests/p2p_test.cpp
+++ b/tests/p2p_test.cpp
@@ -142,8 +142,9 @@ TEST_F(P2PTest, capability_send_block) {
                {g_signed_trx_samples[0]->getHash(), g_signed_trx_samples[1]->getHash()}, sig_t(7777), blk_hash_t(888),
                addr_t(999));
 
-  SharedTransactions transactions{g_signed_trx_samples[0], g_signed_trx_samples[1]};
-  thc2->onNewTransactions(SharedTransactions(transactions));
+  std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> transactions{
+      {g_signed_trx_samples[0], TransactionStatus::Verified}, {g_signed_trx_samples[1], TransactionStatus::Verified}};
+  thc2->onNewTransactions(std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>>(transactions));
   std::vector<taraxa::bytes> transactions_raw;
   transactions_raw.push_back(g_signed_trx_samples[0]->rlp());
   transactions_raw.push_back(g_signed_trx_samples[1]->rlp());
@@ -159,8 +160,8 @@ TEST_F(P2PTest, capability_send_block) {
   }
   EXPECT_EQ(rtransactions.size(), 2);
   if (rtransactions.size() == 2) {
-    EXPECT_EQ(*transactions[0], *rtransactions[g_signed_trx_samples[0]->getHash()]);
-    EXPECT_EQ(*transactions[1], *rtransactions[g_signed_trx_samples[1]->getHash()]);
+    EXPECT_EQ(*transactions[0].first, *rtransactions[g_signed_trx_samples[0]->getHash()]);
+    EXPECT_EQ(*transactions[1].first, *rtransactions[g_signed_trx_samples[1]->getHash()]);
   }
 }
 
@@ -257,9 +258,10 @@ TEST_F(P2PTest, block_propagate) {
                {g_signed_trx_samples[0]->getHash(), g_signed_trx_samples[1]->getHash()}, sig_t(7777), blk_hash_t(0),
                addr_t(999));
 
-  SharedTransactions transactions{g_signed_trx_samples[0], g_signed_trx_samples[1]};
-  thc1->onNewTransactions(SharedTransactions(transactions));
-  SharedTransactions transactions2;
+  std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> transactions{
+      {g_signed_trx_samples[0], TransactionStatus::Verified}, {g_signed_trx_samples[1], TransactionStatus::Verified}};
+  thc1->onNewTransactions(std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>>(transactions));
+  std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> transactions2;
   thc1->onNewTransactions(std::move(transactions2));
   thc1->onNewBlockReceived(DagBlock(blk));
 
@@ -288,8 +290,8 @@ TEST_F(P2PTest, block_propagate) {
     auto rtransactions = vCapabilities[i]->test_state_->getTransactions();
     EXPECT_EQ(rtransactions.size(), 2);
     if (rtransactions.size() == 2) {
-      EXPECT_EQ(*transactions[0], *rtransactions[g_signed_trx_samples[0]->getHash()]);
-      EXPECT_EQ(*transactions[1], *rtransactions[g_signed_trx_samples[1]->getHash()]);
+      EXPECT_EQ(*transactions[0].first, *rtransactions[g_signed_trx_samples[0]->getHash()]);
+      EXPECT_EQ(*transactions[1].first, *rtransactions[g_signed_trx_samples[1]->getHash()]);
     }
   }
   EXPECT_EQ(blocks1.size(), 1);

--- a/tests/transaction_test.cpp
+++ b/tests/transaction_test.cpp
@@ -7,6 +7,8 @@
 #include <vector>
 
 #include "common/static_init.hpp"
+#include "config/chain_config.hpp"
+#include "final_chain/trie_common.hpp"
 #include "logger/logger.hpp"
 #include "transaction/transaction_manager.hpp"
 #include "transaction/transaction_queue.hpp"
@@ -116,34 +118,39 @@ TEST_F(TransactionTest, sig) {
 }
 
 TEST_F(TransactionTest, verifiers) {
-  TransactionManager trx_mgr(FullNodeConfig(), std::make_shared<DbStorage>(data_dir), nullptr, addr_t());
+  taraxa::final_chain::Config cfg = ChainConfig::predefined("test").final_chain;
+  auto db = std::make_shared<DbStorage>(data_dir);
+  auto final_chain = NewFinalChain(db, cfg);
+  TransactionManager trx_mgr(FullNodeConfig(), db, final_chain, addr_t());
   // insert trx
   std::thread t([&trx_mgr]() {
-    for (auto const& t : *g_trx_samples) {
+    for (auto const& t : *g_signed_trx_samples) {
       trx_mgr.insertTransaction(t);
     }
   });
 
   // insert trx again, should not duplicated
-  for (auto const& t : *g_trx_samples) {
+  for (auto const& t : *g_signed_trx_samples) {
     trx_mgr.insertTransaction(t);
   }
   t.join();
   thisThreadSleepForMilliSeconds(100);
-  EXPECT_EQ(trx_mgr.getTransactionPoolSize(), g_trx_samples->size());
+  EXPECT_EQ(trx_mgr.getTransactionPoolSize(), g_signed_trx_samples->size());
 }
 
 TEST_F(TransactionTest, transaction_limit) {
-  TransactionManager trx_mgr(FullNodeConfig(), std::make_shared<DbStorage>(data_dir), nullptr, addr_t());
+  auto db = std::make_shared<DbStorage>(data_dir);
+  TransactionManager trx_mgr(FullNodeConfig(), db, NewFinalChain(db, ChainConfig::predefined("test").final_chain),
+                             addr_t());
   // insert trx
   std::thread t([&trx_mgr]() {
-    for (auto const& t : *g_trx_samples) {
+    for (auto const& t : *g_signed_trx_samples) {
       trx_mgr.insertTransaction(t);
     }
   });
 
   // insert trx again, should not duplicated
-  for (auto const& t : *g_trx_samples) {
+  for (auto const& t : *g_signed_trx_samples) {
     trx_mgr.insertTransaction(t);
   }
   t.join();
@@ -154,12 +161,13 @@ TEST_F(TransactionTest, transaction_limit) {
   verified_trxs3 = trx_mgr.packTrxs(0);
   EXPECT_EQ(verified_trxs1.size(), 10);
   EXPECT_EQ(verified_trxs2.size(), 20);
-  EXPECT_EQ(verified_trxs3.size(), g_trx_samples->size());
+  EXPECT_EQ(verified_trxs3.size(), g_signed_trx_samples->size());
 }
 
 TEST_F(TransactionTest, prepare_signed_trx_for_propose) {
   auto db = std::make_shared<DbStorage>(data_dir);
-  TransactionManager trx_mgr(FullNodeConfig(), db, nullptr, addr_t());
+  TransactionManager trx_mgr(FullNodeConfig(), db, NewFinalChain(db, ChainConfig::predefined("test").final_chain),
+                             addr_t());
   std::thread insertTrx([&trx_mgr]() {
     for (auto const& t : *g_signed_trx_samples) {
       trx_mgr.insertTransaction(t);
@@ -184,9 +192,76 @@ TEST_F(TransactionTest, prepare_signed_trx_for_propose) {
   EXPECT_EQ(total_packed_trxs.size(), NUM_TRX) << " Packed Trx: " << ::testing::PrintToString(total_packed_trxs);
 }
 
+TEST_F(TransactionTest, transaction_low_nonce) {
+  auto db = std::make_shared<DbStorage>(data_dir);
+  taraxa::final_chain::Config cfg = ChainConfig::predefined("test").final_chain;
+  cfg.state.execution_options.enable_nonce_skipping = true;
+  auto final_chain = NewFinalChain(db, cfg);
+  TransactionManager trx_mgr(FullNodeConfig(), db, final_chain, addr_t());
+  const auto& trx_nonce_2 = g_signed_trx_samples[1];
+  const auto& trx_low_nonce = g_signed_trx_samples[0];
+  auto trx_samples = samples::createSignedTrxSamples(1, 2, dev::KeyPair::create().secret());
+  const auto& trx_insufficient_balance = trx_samples[0];
+
+  // Insert and execute transaction with nonce 2
+  EXPECT_TRUE(trx_mgr.insertTransaction(trx_nonce_2).first);
+  std::vector<trx_hash_t> trx_hashes;
+  trx_hashes.emplace_back(trx_nonce_2->getHash());
+  DagBlock dag_blk({}, {}, {}, trx_hashes, secret_t::random());
+  db->saveDagBlock(dag_blk);
+  auto pbft_block = std::make_shared<PbftBlock>(blk_hash_t(), blk_hash_t(), blk_hash_t(), 1, addr_t::random(),
+                                                dev::KeyPair::create().secret());
+  SyncBlock sync_block(pbft_block, {});
+  sync_block.dag_blocks.push_back(dag_blk);
+  SharedTransactions trxs{trx_nonce_2};
+  sync_block.transactions = trxs;
+  auto batch = db->createWriteBatch();
+  db->saveTransactionPeriod(trx_nonce_2->getHash(), 1, 0);
+  db->savePeriodData(sync_block, batch);
+  db->commitWriteBatch(batch);
+  final_chain->finalize(std::move(sync_block), {dag_blk.getHash()}).get();
+
+  // Verify low nonce transaction is detected in verification
+  auto result = trx_mgr.verifyTransaction(trx_low_nonce);
+  EXPECT_EQ(result.first, TransactionStatus::LowNonce);
+  EXPECT_FALSE(trx_mgr.insertTransaction(trx_low_nonce).first);
+
+  // Verify insufficient balance transaction is detected in verification
+  result = trx_mgr.verifyTransaction(trx_insufficient_balance);
+  EXPECT_EQ(result.first, TransactionStatus::InsufficentBalance);
+  EXPECT_FALSE(trx_mgr.insertTransaction(trx_insufficient_balance).first);
+
+  std::vector<trx_hash_t> trx_hashes_low_nonce;
+  trx_hashes_low_nonce.push_back(trx_low_nonce->getHash());
+  DagBlock dag_blk_with_low_nonce_transaction({}, {}, {}, trx_hashes_low_nonce, secret_t::random());
+
+  std::vector<trx_hash_t> trx_hashes_insufficient_balance;
+  trx_hashes_insufficient_balance.push_back(trx_insufficient_balance->getHash());
+  DagBlock dag_blk_with_insufficient_balance_transaction({}, {}, {}, trx_hashes_insufficient_balance,
+                                                         secret_t::random());
+
+  // Verify dag blocks will pass verification if contain low nonce or insufficient balance transactions
+  EXPECT_FALSE(trx_mgr.checkBlockTransactions(dag_blk_with_low_nonce_transaction));
+  trx_mgr.insertValidatedTransactions({{trx_low_nonce, TransactionStatus::LowNonce}});
+  EXPECT_TRUE(trx_mgr.checkBlockTransactions(dag_blk_with_low_nonce_transaction));
+  EXPECT_FALSE(trx_mgr.checkBlockTransactions(dag_blk_with_insufficient_balance_transaction));
+  trx_mgr.insertValidatedTransactions({{trx_insufficient_balance, TransactionStatus::InsufficentBalance}});
+  EXPECT_TRUE(trx_mgr.checkBlockTransactions(dag_blk_with_insufficient_balance_transaction));
+
+  trx_mgr.blockFinalized(11);
+  EXPECT_TRUE(trx_mgr.checkBlockTransactions(dag_blk_with_low_nonce_transaction));
+  EXPECT_TRUE(trx_mgr.checkBlockTransactions(dag_blk_with_insufficient_balance_transaction));
+
+  // Verify that after 10 executed blocks transactions expire
+  trx_mgr.blockFinalized(12);
+  EXPECT_FALSE(trx_mgr.checkBlockTransactions(dag_blk_with_low_nonce_transaction));
+  EXPECT_FALSE(trx_mgr.checkBlockTransactions(dag_blk_with_insufficient_balance_transaction));
+}
+
 TEST_F(TransactionTest, transaction_concurrency) {
   auto db = std::make_shared<DbStorage>(data_dir);
-  TransactionManager trx_mgr(FullNodeConfig(), db, nullptr, addr_t());
+  TransactionManager trx_mgr(FullNodeConfig(), db, NewFinalChain(db, ChainConfig::predefined("test").final_chain),
+                             addr_t());
   bool stopped = false;
   // Insert transactions to memory pool and keep trying to insert them again on separate thread, it should always fail
   std::thread insertTrx([&trx_mgr, &stopped]() {
@@ -253,8 +328,8 @@ TEST_F(TransactionTest, priority_queue) {
     auto trx2 = std::make_shared<Transaction>(nonce, 1, 1, 100, str2bytes("00FEDCBA9876543210000000"), g_secret,
                                               addr_t::random());
     const auto trx_hash = trx->getHash();
-    priority_queue.insert(std::move(trx2));
-    priority_queue.insert(std::move(trx));
+    priority_queue.insert({trx2, TransactionStatus::Verified}, 1);
+    priority_queue.insert({trx, TransactionStatus::Verified}, 1);
     EXPECT_EQ(priority_queue.get(1)[0]->getHash(), trx_hash);
     EXPECT_EQ(priority_queue.size(), 2);
   }
@@ -266,8 +341,8 @@ TEST_F(TransactionTest, priority_queue) {
     auto trx = std::make_shared<Transaction>(nonce, 1, 1, 100, str2bytes("00FEDCBA9876543210000000"), g_secret,
                                              addr_t::random());
     auto trx2 = trx;
-    EXPECT_TRUE(priority_queue.insert(std::move(trx)));
-    EXPECT_FALSE(priority_queue.insert(std::move(trx2)));
+    EXPECT_TRUE(priority_queue.insert({trx, TransactionStatus::Verified}, 1));
+    EXPECT_FALSE(priority_queue.insert({trx2, TransactionStatus::Verified}, 1));
     EXPECT_EQ(priority_queue.size(), 1);
   }
 
@@ -280,8 +355,8 @@ TEST_F(TransactionTest, priority_queue) {
     auto trx2 = std::make_shared<Transaction>(nonce, 1, 1, 100, str2bytes("00FEDCBA9876543210000000"), g_secret,
                                               addr_t::random());
     auto trx_hash = trx->getHash();
-    priority_queue.insert(std::move(trx2));
-    priority_queue.insert(std::move(trx));
+    priority_queue.insert({trx2, TransactionStatus::Verified}, 1);
+    priority_queue.insert({trx, TransactionStatus::Verified}, 1);
     EXPECT_EQ(priority_queue.get(1)[0]->getHash(), trx_hash);
     EXPECT_EQ(priority_queue.size(), 2);
   }
@@ -306,9 +381,9 @@ TEST_F(TransactionTest, priority_queue) {
     auto trxa2_hash = trxa2->getHash();
     auto trxb1_hash = trxb1->getHash();
 
-    priority_queue.insert(std::move(trxb1));
-    priority_queue.insert(std::move(trxa2));
-    priority_queue.insert(std::move(trxa1));
+    priority_queue.insert({trxb1, TransactionStatus::Verified}, 1);
+    priority_queue.insert({trxa2, TransactionStatus::Verified}, 1);
+    priority_queue.insert({trxa1, TransactionStatus::Verified}, 1);
     EXPECT_EQ(priority_queue.size(), 3);
     EXPECT_EQ(priority_queue.get(3)[0]->getHash(), trxa1_hash);
     EXPECT_EQ(priority_queue.get(3)[1]->getHash(), trxa2_hash);


### PR DESCRIPTION
Transactions with low nonce and insufficient balance should not be placed into transactions pool to propose dag blocks from but at the same time there are scenarios when such transactions might be needed by incoming dag blocks.

My proposed solution is keeping these transactions in a separate memory map. Once a dag block arrives if it is missing a transaction it will check in these low nonce and insufficient balance transactions as well.

These transactions will expire if no dag blocks arrive after a certain number of periods are executed.

Insufficient balance transactions have different handling than low nonce because there is a chance that such transactions will have sufficient balance after a new block is executed so on block execution they might be moved to regular transactions pool if this is the case