### PR TITLE
chore: increase number of peer slots on devnet machines

### DIFF
--- a/libraries/cli/include/cli/devnet_config.hpp
+++ b/libraries/cli/include/cli/devnet_config.hpp
@@ -15,8 +15,8 @@ constexpr std::string_view devnet_json = R"foo({
   "network_simulated_delay": 0,
   "network_transaction_interval": 100,
   "network_bandwidth": 40,
-  "network_ideal_peer_count": 5,
-  "network_max_peer_count": 15,
+  "network_ideal_peer_count": 15,
+  "network_max_peer_count": 30,
   "network_sync_level_size": 25,
   "network_packets_processing_threads": 14,
   "network_peer_blacklist_timeout" : 600,
@@ -154,7 +154,7 @@ constexpr std::string_view devnet_json = R"foo({
             "max_size": 1000000000
           }
         ]
-      }, 
+      },
       {
         "name": "debug",
         "on": false,


### PR DESCRIPTION
## Purpose
Increase number of slots on devnet as nodes failed to connect to each because of this `Disconnect (reason: Peer had too many connections.)`

## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
