### PR TITLE
docs: Add gh-actions to build and publish docs on gh-pages

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,26 @@
+name: Build and Deploy Docs
+on:
+  push:
+    branches:
+      - develop
+permissions:
+  contents: write
+jobs:
+  build-and-deploy:
+    concurrency: ci-${{ github.ref }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+
+      - name: Install deps 🔧
+        run: sudo apt-get install -y doxygen graphviz
+
+      - name: Build docs 🔧
+        run: doxygen
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: doxygen_docs/html


### PR DESCRIPTION
## Purpose
Make doxygen docs available on gh-pages

We still need to enable github pages in settings.

## Changes made
created a github action