### PR TITLE
Cleanup pointer casts in network and tarcap classes

### DIFF
--- a/libraries/core_libs/consensus/src/dag/dag.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag.cpp
@@ -13,6 +13,7 @@
 
 #include "dag/dag.hpp"
 #include "network/network.hpp"
+#include "network/tarcap/packets_handlers/dag_block_packet_handler.hpp"
 #include "transaction/transaction_manager.hpp"
 
 #define NULL_BLOCK_HASH blk_hash_t(0)
@@ -449,7 +450,8 @@ bool DagManager::addDagBlock(DagBlock &&blk, SharedTransactions &&trxs, bool pro
     if (save) {
       block_verified_.emit(blk);
       if (auto net = network_.lock()) {
-        net->onNewBlockVerified(std::move(blk), proposed, std::move(trxs));
+        net->getSpecificHandler<network::tarcap::DagBlockPacketHandler>()->onNewBlockVerified(std::move(blk), proposed,
+                                                                                              std::move(trxs));
       }
     }
   }

--- a/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
+++ b/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
@@ -6,6 +6,7 @@
 #include <optional>
 
 #include "network/network.hpp"
+#include "network/tarcap/packets_handlers/vote_packet_handler.hpp"
 #include "pbft/pbft_manager.hpp"
 
 constexpr size_t EXTENDED_PARTITION_STEPS = 1000;
@@ -39,7 +40,7 @@ void VoteManager::retreieveVotes_() {
     if (v->getStep() >= FIRST_FINISH_STEP && pbft_step > EXTENDED_PARTITION_STEPS) {
       std::vector<std::shared_ptr<Vote>> votes = {v};
       if (auto net = network_.lock()) {
-        net->onNewPbftVotes(std::move(votes));
+        net->getSpecificHandler<network::tarcap::VotePacketHandler>()->onNewPbftVotes(std::move(votes));
       }
     }
 

--- a/libraries/core_libs/network/include/network/network.hpp
+++ b/libraries/core_libs/network/include/network/network.hpp
@@ -51,35 +51,20 @@ class Network {
   unsigned getNodeCount();
   Json::Value getStatus();
   Json::Value getPacketsStats();
-  void onNewBlockVerified(DagBlock &&blk, bool proposed, SharedTransactions &&trxs);
-  void onNewTransactions(std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> &&transactions);
   void restartSyncingPbft(bool force = false);
-  void onNewPbftBlock(std::shared_ptr<PbftBlock> const &pbft_block);
   bool pbft_syncing();
   uint64_t syncTimeSeconds() const;
   void setSyncStatePeriod(uint64_t period);
-
-  void handleMaliciousSyncPeer(dev::p2p::NodeID const &id);
-
-  void onNewPbftVotes(std::vector<std::shared_ptr<Vote>> &&votes);
-  void broadcastPreviousRoundNextVotesBundle();
 
   template <typename PacketHandlerType>
   std::shared_ptr<PacketHandlerType> getSpecificHandler() const;
 
   // METHODS USED IN TESTS ONLY
-  void sendBlock(dev::p2p::NodeID const &id, DagBlock const &blk, const SharedTransactions &trxs);
-  void sendBlocks(const dev::p2p::NodeID &id, std::vector<std::shared_ptr<DagBlock>> &&blocks,
-                  SharedTransactions &&transactions, uint64_t request_period, uint64_t period);
-  void sendTransactions(dev::p2p::NodeID const &_id, std::vector<taraxa::bytes> const &transactions);
   void setPendingPeersToReady();
   dev::p2p::NodeID getNodeId() const;
   int getReceivedBlocksCount() const;
   int getReceivedTransactionsCount() const;
   std::shared_ptr<network::tarcap::TaraxaPeer> getPeer(dev::p2p::NodeID const &id) const;
-
-  // PBFT
-  void sendPbftBlock(const dev::p2p::NodeID &id, const PbftBlock &pbft_block, uint64_t pbft_chain_size);
   // END METHODS USED IN TESTS ONLY
 
  private:

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/pbft_block_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/pbft_block_packet_handler.hpp
@@ -17,8 +17,9 @@ class PbftBlockPacketHandler final : public PacketHandler {
                          std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<PbftManager> pbft_mgr,
                          const addr_t& node_addr);
 
-  void onNewPbftBlock(PbftBlock const& pbft_block);
-  void sendPbftBlock(const dev::p2p::NodeID& peer_id, const PbftBlock& pbft_block, uint64_t pbft_chain_size);
+  void onNewPbftBlock(const std::shared_ptr<PbftBlock>& pbft_block);
+  void sendPbftBlock(const dev::p2p::NodeID& peer_id, const std::shared_ptr<PbftBlock>& pbft_block,
+                     uint64_t pbft_chain_size);
 
   // Packet type that is processed by this handler
   static constexpr SubprotocolPacketType kPacketType_ = SubprotocolPacketType::PbftBlockPacket;

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
@@ -79,29 +79,12 @@ class TaraxaCapability : public dev::p2p::CapabilityFace {
   const std::shared_ptr<PeersState> &getPeersState();
   const std::shared_ptr<NodeStats> &getNodeStats();
 
-  void restartSyncingPbft(bool force = false);
   bool pbft_syncing() const;
-  void onNewBlockVerified(DagBlock &&blk, bool proposed, SharedTransactions &&trxs);
-  void onNewTransactions(std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> &&transactions);
-  void onNewPbftBlock(std::shared_ptr<PbftBlock> const &pbft_block);
-  void onNewPbftVotes(std::vector<std::shared_ptr<Vote>> &&votes);
-  void broadcastPreviousRoundNextVotesBundle();
-  void sendTransactions(dev::p2p::NodeID const &id, std::vector<taraxa::bytes> const &transactions);
-  void handleMaliciousSyncPeer(dev::p2p::NodeID const &id);
   void setSyncStatePeriod(uint64_t period);
 
   // METHODS USED IN TESTS ONLY
-  void sendBlock(dev::p2p::NodeID const &id, DagBlock const &blk, const SharedTransactions &trxs);
-  void sendBlocks(const dev::p2p::NodeID &id, std::vector<std::shared_ptr<DagBlock>> &&blocks,
-                  SharedTransactions &&transactions, uint64_t request_period, uint64_t period);
   size_t getReceivedBlocksCount() const;
   size_t getReceivedTransactionsCount() const;
-
-  void onNewBlockReceived(DagBlock &&block);
-
-  // PBFT
-  void sendPbftBlock(const dev::p2p::NodeID &id, const PbftBlock &pbft_block, uint64_t pbft_chain_size);
-
   // END METHODS USED IN TESTS ONLY
 
  private:

--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -251,7 +251,7 @@ void TaraxaCapability::onDisconnect(dev::p2p::NodeID const &_nodeID) {
   if (pbft_syncing_state_->isPbftSyncing() && pbft_syncing_state_->syncingPeer() == _nodeID) {
     if (peers_state_->getPeersCount() > 0) {
       LOG(log_dg_) << "Restart PBFT/DAG syncing due to syncing peer disconnect.";
-      restartSyncingPbft(true);
+      packets_handlers_->getSpecificHandler<PbftSyncPacketHandler>()->restartSyncingPbft(true);
     } else {
       LOG(log_dg_) << "Stop PBFT/DAG syncing due to syncing peer disconnect and no other peers available.";
       pbft_syncing_state_->setPbftSyncing(false);
@@ -332,68 +332,14 @@ const std::shared_ptr<PeersState> &TaraxaCapability::getPeersState() { return pe
 
 const std::shared_ptr<NodeStats> &TaraxaCapability::getNodeStats() { return node_stats_; }
 
-void TaraxaCapability::restartSyncingPbft(bool force) {
-  packets_handlers_->getSpecificHandler<PbftSyncPacketHandler>()->restartSyncingPbft(force);
-}
-
 bool TaraxaCapability::pbft_syncing() const { return pbft_syncing_state_->isPbftSyncing(); }
-
-void TaraxaCapability::handleMaliciousSyncPeer(dev::p2p::NodeID const &id) {
-  packets_handlers_->getSpecificHandler<PbftSyncPacketHandler>()->handleMaliciousSyncPeer(id);
-}
-
-void TaraxaCapability::onNewBlockVerified(DagBlock &&blk, bool proposed, SharedTransactions &&trxs) {
-  packets_handlers_->getSpecificHandler<DagBlockPacketHandler>()->onNewBlockVerified(std::move(blk), proposed,
-                                                                                     std::move(trxs));
-}
-
-void TaraxaCapability::onNewTransactions(
-    std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> &&transactions) {
-  packets_handlers_->getSpecificHandler<TransactionPacketHandler>()->onNewTransactions(std::move(transactions));
-}
-
-void TaraxaCapability::onNewBlockReceived(DagBlock &&block) {
-  packets_handlers_->getSpecificHandler<DagBlockPacketHandler>()->onNewBlockReceived(std::move(block));
-}
-
-void TaraxaCapability::onNewPbftBlock(std::shared_ptr<PbftBlock> const &pbft_block) {
-  packets_handlers_->getSpecificHandler<PbftBlockPacketHandler>()->onNewPbftBlock(*pbft_block);
-}
-
-void TaraxaCapability::onNewPbftVotes(std::vector<std::shared_ptr<Vote>> &&votes) {
-  packets_handlers_->getSpecificHandler<VotePacketHandler>()->onNewPbftVotes(std::move(votes));
-}
-
-void TaraxaCapability::broadcastPreviousRoundNextVotesBundle() {
-  packets_handlers_->getSpecificHandler<VotesSyncPacketHandler>()->broadcastPreviousRoundNextVotesBundle();
-}
-
-void TaraxaCapability::sendTransactions(dev::p2p::NodeID const &id, std::vector<taraxa::bytes> const &transactions) {
-  packets_handlers_->getSpecificHandler<TransactionPacketHandler>()->sendTransactions(id, transactions);
-}
 
 void TaraxaCapability::setSyncStatePeriod(uint64_t period) { pbft_syncing_state_->setSyncStatePeriod(period); }
 
 // METHODS USED IN TESTS ONLY
-void TaraxaCapability::sendBlock(dev::p2p::NodeID const &id, DagBlock const &blk, const SharedTransactions &trxs) {
-  packets_handlers_->getSpecificHandler<DagBlockPacketHandler>()->sendBlock(id, blk, trxs);
-}
-
-void TaraxaCapability::sendBlocks(const dev::p2p::NodeID &id, std::vector<std::shared_ptr<DagBlock>> &&blocks,
-                                  SharedTransactions &&transactions, uint64_t request_period, uint64_t period) {
-  packets_handlers_->getSpecificHandler<GetDagSyncPacketHandler>()->sendBlocks(
-      id, std::move(blocks), std::move(transactions), request_period, period);
-}
-
 size_t TaraxaCapability::getReceivedBlocksCount() const { return test_state_->getBlocksSize(); }
 
 size_t TaraxaCapability::getReceivedTransactionsCount() const { return test_state_->getTransactionsSize(); }
-
-// PBFT
-void TaraxaCapability::sendPbftBlock(const dev::p2p::NodeID &id, const PbftBlock &pbft_block,
-                                     uint64_t pbft_chain_size) {
-  packets_handlers_->getSpecificHandler<PbftBlockPacketHandler>()->sendPbftBlock(id, pbft_block, pbft_chain_size);
-}
-
 // END METHODS USED IN TESTS ONLY
+
 }  // namespace taraxa::network::tarcap

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -199,16 +199,16 @@ TEST_F(FullNodeTest, db_test) {
   auto pbft_block3 = make_simple_pbft_block(blk_hash_t(3), 3);
   auto pbft_block4 = make_simple_pbft_block(blk_hash_t(4), 4);
   EXPECT_EQ(db.getPbftCertVotedBlock(blk_hash_t(1)), nullptr);
-  db.savePbftCertVotedBlock(pbft_block1);
-  EXPECT_EQ(db.getPbftCertVotedBlock(pbft_block1.getBlockHash())->rlp(false), pbft_block1.rlp(false));
+  db.savePbftCertVotedBlock(*pbft_block1);
+  EXPECT_EQ(db.getPbftCertVotedBlock(pbft_block1->getBlockHash())->rlp(false), pbft_block1->rlp(false));
   batch = db.createWriteBatch();
-  db.addPbftCertVotedBlockToBatch(pbft_block2, batch);
-  db.addPbftCertVotedBlockToBatch(pbft_block3, batch);
-  db.addPbftCertVotedBlockToBatch(pbft_block4, batch);
+  db.addPbftCertVotedBlockToBatch(*pbft_block2, batch);
+  db.addPbftCertVotedBlockToBatch(*pbft_block3, batch);
+  db.addPbftCertVotedBlockToBatch(*pbft_block4, batch);
   db.commitWriteBatch(batch);
-  EXPECT_EQ(db.getPbftCertVotedBlock(pbft_block2.getBlockHash())->rlp(false), pbft_block2.rlp(false));
-  EXPECT_EQ(db.getPbftCertVotedBlock(pbft_block3.getBlockHash())->rlp(false), pbft_block3.rlp(false));
-  EXPECT_EQ(db.getPbftCertVotedBlock(pbft_block4.getBlockHash())->rlp(false), pbft_block4.rlp(false));
+  EXPECT_EQ(db.getPbftCertVotedBlock(pbft_block2->getBlockHash())->rlp(false), pbft_block2->rlp(false));
+  EXPECT_EQ(db.getPbftCertVotedBlock(pbft_block3->getBlockHash())->rlp(false), pbft_block3->rlp(false));
+  EXPECT_EQ(db.getPbftCertVotedBlock(pbft_block4->getBlockHash())->rlp(false), pbft_block4->rlp(false));
 
   // pbft_blocks and cert votes
   EXPECT_FALSE(db.pbftBlockInDb(blk_hash_t(0)));
@@ -233,10 +233,10 @@ TEST_F(FullNodeTest, db_test) {
   batch = db.createWriteBatch();
   std::vector<std::shared_ptr<Vote>> votes;
 
-  SyncBlock sync_block1(std::make_shared<PbftBlock>(pbft_block1), cert_votes);
-  SyncBlock sync_block2(std::make_shared<PbftBlock>(pbft_block2), votes);
-  SyncBlock sync_block3(std::make_shared<PbftBlock>(pbft_block3), votes);
-  SyncBlock sync_block4(std::make_shared<PbftBlock>(pbft_block4), votes);
+  SyncBlock sync_block1(pbft_block1, cert_votes);
+  SyncBlock sync_block2(pbft_block2, votes);
+  SyncBlock sync_block3(pbft_block3, votes);
+  SyncBlock sync_block4(pbft_block4, votes);
 
   db.savePeriodData(sync_block1, batch);
   db.savePeriodData(sync_block2, batch);
@@ -244,18 +244,18 @@ TEST_F(FullNodeTest, db_test) {
   db.savePeriodData(sync_block4, batch);
 
   db.commitWriteBatch(batch);
-  EXPECT_TRUE(db.pbftBlockInDb(pbft_block1.getBlockHash()));
-  EXPECT_TRUE(db.pbftBlockInDb(pbft_block2.getBlockHash()));
-  EXPECT_TRUE(db.pbftBlockInDb(pbft_block3.getBlockHash()));
-  EXPECT_TRUE(db.pbftBlockInDb(pbft_block4.getBlockHash()));
-  EXPECT_EQ(db.getPbftBlock(pbft_block1.getBlockHash())->rlp(false), pbft_block1.rlp(false));
-  EXPECT_EQ(db.getPbftBlock(pbft_block2.getBlockHash())->rlp(false), pbft_block2.rlp(false));
-  EXPECT_EQ(db.getPbftBlock(pbft_block3.getBlockHash())->rlp(false), pbft_block3.rlp(false));
-  EXPECT_EQ(db.getPbftBlock(pbft_block4.getBlockHash())->rlp(false), pbft_block4.rlp(false));
+  EXPECT_TRUE(db.pbftBlockInDb(pbft_block1->getBlockHash()));
+  EXPECT_TRUE(db.pbftBlockInDb(pbft_block2->getBlockHash()));
+  EXPECT_TRUE(db.pbftBlockInDb(pbft_block3->getBlockHash()));
+  EXPECT_TRUE(db.pbftBlockInDb(pbft_block4->getBlockHash()));
+  EXPECT_EQ(db.getPbftBlock(pbft_block1->getBlockHash())->rlp(false), pbft_block1->rlp(false));
+  EXPECT_EQ(db.getPbftBlock(pbft_block2->getBlockHash())->rlp(false), pbft_block2->rlp(false));
+  EXPECT_EQ(db.getPbftBlock(pbft_block3->getBlockHash())->rlp(false), pbft_block3->rlp(false));
+  EXPECT_EQ(db.getPbftBlock(pbft_block4->getBlockHash())->rlp(false), pbft_block4->rlp(false));
 
-  SyncBlock pbft_block_cert_votes(std::make_shared<PbftBlock>(pbft_block1), cert_votes);
-  auto cert_votes_from_db = db.getCertVotes(pbft_block1.getPeriod());
-  SyncBlock pbft_block_cert_votes_from_db(std::make_shared<PbftBlock>(pbft_block1), cert_votes_from_db);
+  SyncBlock pbft_block_cert_votes(pbft_block1, cert_votes);
+  auto cert_votes_from_db = db.getCertVotes(pbft_block1->getPeriod());
+  SyncBlock pbft_block_cert_votes_from_db(pbft_block1, cert_votes_from_db);
   EXPECT_EQ(pbft_block_cert_votes.rlp(), pbft_block_cert_votes_from_db.rlp());
 
   // pbft_blocks (head)

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -11,6 +11,11 @@
 #include "dag/block_proposer.hpp"
 #include "dag/dag.hpp"
 #include "logger/logger.hpp"
+#include "network/tarcap/packets_handlers/dag_block_packet_handler.hpp"
+#include "network/tarcap/packets_handlers/get_dag_sync_packet_handler.hpp"
+#include "network/tarcap/packets_handlers/pbft_block_packet_handler.hpp"
+#include "network/tarcap/packets_handlers/transaction_packet_handler.hpp"
+#include "network/tarcap/packets_handlers/votes_sync_packet_handler.hpp"
 #include "pbft/pbft_manager.hpp"
 #include "util_test/samples.hpp"
 #include "util_test/util.hpp"
@@ -40,8 +45,7 @@ auto g_conf3 = Lazy([] { return three_default_configs[2]; });
 
 struct NetworkTest : BaseTest {};
 
-// Test creates two Network setup and verifies sending block
-// between is successfull
+// Test creates two Network setup and verifies sending block between is successfull
 TEST_F(NetworkTest, transfer_block) {
   std::unique_ptr<Network> nw1 = std::make_unique<taraxa::Network>(g_conf1);
   std::unique_ptr<Network> nw2 = std::make_unique<taraxa::Network>(g_conf2);
@@ -54,7 +58,7 @@ TEST_F(NetworkTest, transfer_block) {
 
   std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> transactions{
       {g_signed_trx_samples[0], TransactionStatus::Verified}, {g_signed_trx_samples[1], TransactionStatus::Verified}};
-  nw2->onNewTransactions(std::move(transactions));
+  nw2->getSpecificHandler<network::tarcap::TransactionPacketHandler>()->onNewTransactions(std::move(transactions));
 
   EXPECT_HAPPENS({10s, 200ms}, [&](auto& ctx) {
     nw1->setPendingPeersToReady();
@@ -63,7 +67,7 @@ TEST_F(NetworkTest, transfer_block) {
     WAIT_EXPECT_EQ(ctx, nw2->getPeerCount(), 1)
   });
 
-  nw2->sendBlock(nw1->getNodeId(), blk, {});
+  nw2->getSpecificHandler<network::tarcap::DagBlockPacketHandler>()->sendBlock(nw1->getNodeId(), blk, {});
 
   std::cout << "Waiting packages for 10 seconds ..." << std::endl;
 
@@ -128,7 +132,8 @@ TEST_F(NetworkTest, DISABLED_transfer_lot_of_blocks) {
     dag_blocks.emplace_back(std::make_shared<DagBlock>(blk));
   }
 
-  nw1->onNewTransactions(std::move(verified_transactions));
+  nw1->getSpecificHandler<network::tarcap::TransactionPacketHandler>()->onNewTransactions(
+      std::move(verified_transactions));
   for (auto block : dag_blocks) {
     dag_blk_mgr1->insertAndVerifyBlock(DagBlock(*block));
   }
@@ -138,7 +143,8 @@ TEST_F(NetworkTest, DISABLED_transfer_lot_of_blocks) {
   const auto node1_period = node1->getPbftChain()->getPbftChainSize();
   const auto node2_period = node2->getPbftChain()->getPbftChainSize();
   std::cout << "node1 period " << node1_period << ", node2 period " << node2_period << std::endl;
-  nw1->sendBlocks(nw2->getNodeId(), std::move(dag_blocks), {}, node2_period, node1_period);
+  nw1->getSpecificHandler<network::tarcap::GetDagSyncPacketHandler>()->sendBlocks(
+      nw2->getNodeId(), std::move(dag_blocks), {}, node2_period, node1_period);
 
   std::cout << "Waiting Sync ..." << std::endl;
   wait({30s, 200ms}, [&](auto& ctx) { WAIT_EXPECT_NE(ctx, dag_blk_mgr2->getDagBlock(block_hash), nullptr) });
@@ -153,7 +159,8 @@ TEST_F(NetworkTest, send_pbft_block) {
   auto pbft_block = make_simple_pbft_block(blk_hash_t(1), 2, node_cfgs[0].chain.dag_genesis_block.getHash());
   uint64_t chain_size = 111;
 
-  nw2->sendPbftBlock(nw1->getNodeId(), pbft_block, chain_size);
+  nw2->getSpecificHandler<network::tarcap::PbftBlockPacketHandler>()->sendPbftBlock(nw1->getNodeId(), pbft_block,
+                                                                                    chain_size);
 
   auto node2_id = nw2->getNodeId();
   EXPECT_HAPPENS({10s, 200ms},
@@ -313,7 +320,7 @@ TEST_F(NetworkTest, transfer_transaction) {
   transactions.push_back(g_signed_trx_samples[1]->rlp());
   transactions.push_back(g_signed_trx_samples[2]->rlp());
 
-  nw2->sendTransactions(nw1_nodeid, transactions);
+  nw2->getSpecificHandler<network::tarcap::TransactionPacketHandler>()->sendTransactions(nw1_nodeid, transactions);
 
   EXPECT_HAPPENS({2s, 200ms}, [&](auto& ctx) { WAIT_EXPECT_EQ(ctx, nw1->getReceivedTransactionsCount(), 3) });
 }
@@ -943,7 +950,7 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_2) {
   std::shared_ptr<Network> nw2 = node2->getNetwork();
 
   // Node1 broadcast next votes1 to node2
-  nw1->broadcastPreviousRoundNextVotesBundle();
+  nw1->getSpecificHandler<network::tarcap::VotesSyncPacketHandler>()->broadcastPreviousRoundNextVotesBundle();
 
   auto node2_expect_size = next_votes1.size() + next_votes2.size();
   EXPECT_HAPPENS({5s, 100ms},
@@ -962,7 +969,7 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_2) {
   node1_db->commitWriteBatch(batch);
 
   // Node2 broadcast updated next votes to node1
-  nw2->broadcastPreviousRoundNextVotesBundle();
+  nw2->getSpecificHandler<network::tarcap::VotesSyncPacketHandler>()->broadcastPreviousRoundNextVotesBundle();
 
   auto node1_expect_size = next_votes1.size() + next_votes2.size();
   EXPECT_HAPPENS({5s, 100ms},

--- a/tests/pbft_chain_test.cpp
+++ b/tests/pbft_chain_test.cpp
@@ -9,6 +9,7 @@
 #include "common/static_init.hpp"
 #include "logger/logger.hpp"
 #include "network/network.hpp"
+#include "network/tarcap/packets_handlers/pbft_block_packet_handler.hpp"
 #include "pbft/pbft_manager.hpp"
 #include "util_test/samples.hpp"
 #include "util_test/util.hpp"
@@ -146,7 +147,7 @@ TEST_F(PbftChainTest, proposal_block_broadcast) {
   bool find_erased_block = pbft_chain1->findUnverifiedPbftBlock(pbft_block->getBlockHash());
   ASSERT_FALSE(find_erased_block);
 
-  nw1->onNewPbftBlock(pbft_block);
+  nw1->getSpecificHandler<network::tarcap::PbftBlockPacketHandler>()->onNewPbftBlock(pbft_block);
 
   // Check node2 and node3 receive the PBFT block
   EXPECT_HAPPENS({20s, 200ms}, [&](auto &ctx) {

--- a/tests/util_test/util.hpp
+++ b/tests/util_test/util.hpp
@@ -318,7 +318,7 @@ inline auto own_effective_genesis_bal(FullNodeConfig const& cfg) {
 }
 
 inline auto make_simple_pbft_block(h256 const& hash, uint64_t period, h256 const& anchor_hash = blk_hash_t(0)) {
-  return PbftBlock(hash, anchor_hash, blk_hash_t(), period, addr_t(0), secret_t::random());
+  return std::make_shared<PbftBlock>(hash, anchor_hash, blk_hash_t(), period, addr_t(0), secret_t::random());
 }
 
 inline std::vector<blk_hash_t> getOrderedDagBlocks(std::shared_ptr<DbStorage> const& db) {

--- a/tests/vote_test.cpp
+++ b/tests/vote_test.cpp
@@ -311,7 +311,7 @@ TEST_F(VoteTest, vote_broadcast) {
   size_t step = 1002;
   auto vote = pbft_mgr1->generateVote(propose_block_hash, type, period, step);
 
-  node1->getNetwork()->onNewPbftVotes(std::vector{vote});
+  node1->getNetwork()->getSpecificHandler<network::tarcap::VotePacketHandler>()->onNewPbftVotes(std::vector{vote});
 
   auto vote_mgr1 = node1->getVoteManager();
   auto vote_mgr2 = node2->getVoteManager();


### PR DESCRIPTION
Use templated getSpecificHandler method to get rid of those pointer casts in network and tarcap classes

Fixed https://github.com/Taraxa-project/taraxa-node/issues/1722