### PR TITLE
clear_period_data test fix

### DIFF
--- a/libraries/core_libs/network/src/tarcap/packets_handlers/dag_block_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/dag_block_packet_handler.cpp
@@ -144,7 +144,7 @@ void DagBlockPacketHandler::onNewBlockReceived(DagBlock &&block, const std::shar
       case DagBlockManager::InsertAndVerifyBlockReturnType::AheadBlock:
       case DagBlockManager::InsertAndVerifyBlockReturnType::FutureBlock:
         if (peer->peer_dag_synced_) {
-          LOG(log_wr_) << "DagBlock" << block_hash << " is an ahead/future block. Peer " << peer->getId()
+          LOG(log_er_) << "DagBlock" << block_hash << " is an ahead/future block. Peer " << peer->getId()
                        << " will be disconnected";
           disconnect(peer->getId(), dev::p2p::UserReason);
         }

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/status_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/status_packet_handler.cpp
@@ -67,7 +67,7 @@ void StatusPacketHandler::process(const PacketData& packet_data, const std::shar
       selected_peer->peer_light_node = true;
       selected_peer->peer_light_node_history = node_history;
       if (pbft_synced_period + node_history < peer_pbft_chain_size) {
-        LOG(log_nf_) << "Light node is not able to serve our syncing request. " << packet_data.from_node_id_.abridged()
+        LOG(log_er_) << "Light node is not able to serve our syncing request. " << packet_data.from_node_id_.abridged()
                      << " peer will be disconnected";
         disconnect(packet_data.from_node_id_, dev::p2p::UserReason);
         return;


### PR DESCRIPTION
This test was intermittently failing because of very small values of max_levels_per_period and light_node_history which were set to these low levels so that the test can be performed quickly but it could cause one of these issues:
1. One node would get ahead the second one with dag blocks and would send ahead/future block which would cause the disconnect
2. One node would get ahead the second one with pbft chain and light node would delete old blocks so the other nodes could not sync from the light node

Fix is only sending a new transaction to a node if both nodes have same pbft chain size. Setting as light node, node that is not eligible to propose dag blocks not to allow the proposer to create dag blocks faster than other blocks process them.

Besides the test fix, I have also changed the log level for these two cases so that we always pick up when a node disconnect for one of these two reasons.