### PR TITLE
chore: remove dag transaction limit and refactor dag block gas limit

### DIFF
--- a/libraries/cli/include/cli/config_jsons/default.json
+++ b/libraries/cli/include/cli/config_jsons/default.json
@@ -240,8 +240,7 @@
     },
     "dag": {
       "block_proposer": {
-        "shard": 1,
-        "transaction_limit": 250
+        "shard": 1
       },
       "gas_limit": "0x989680"
     },

--- a/libraries/cli/include/cli/config_jsons/devnet.json
+++ b/libraries/cli/include/cli/config_jsons/devnet.json
@@ -415,8 +415,7 @@
     },
     "dag": {
       "block_proposer": {
-        "shard": 1,
-        "transaction_limit": 250
+        "shard": 1
       },
       "gas_limit": "0x989680"
     },

--- a/libraries/cli/include/cli/config_jsons/mainnet.json
+++ b/libraries/cli/include/cli/config_jsons/mainnet.json
@@ -345,8 +345,7 @@
     },
     "dag": {
       "block_proposer": {
-        "shard": 1,
-        "transaction_limit": 250
+        "shard": 1
       },
       "gas_limit": "0x989680"
     },

--- a/libraries/cli/include/cli/config_jsons/testnet.json
+++ b/libraries/cli/include/cli/config_jsons/testnet.json
@@ -300,8 +300,7 @@
     },
     "dag": {
       "block_proposer": {
-        "shard": 1,
-        "transaction_limit": 250
+        "shard": 1
       },
       "gas_limit": "0x989680"
     },

--- a/libraries/config/include/config/dag_config.hpp
+++ b/libraries/config/include/config/dag_config.hpp
@@ -8,7 +8,6 @@ namespace taraxa {
 
 struct BlockProposerConfig {
   uint16_t shard = 1;
-  uint16_t transaction_limit = 250;
 
   bytes rlp() const;
 };

--- a/libraries/config/src/dag_config.cpp
+++ b/libraries/config/src/dag_config.cpp
@@ -7,10 +7,8 @@ namespace taraxa {
 
 bytes BlockProposerConfig::rlp() const {
   dev::RLPStream s;
-  s.appendList(2);
-
+  s.appendList(1);
   s << shard;
-  s << transaction_limit;
 
   return s.out();
 }
@@ -18,13 +16,9 @@ bytes BlockProposerConfig::rlp() const {
 Json::Value enc_json(const BlockProposerConfig& obj) {
   Json::Value ret(Json::objectValue);
   ret["shard"] = dev::toJS(obj.shard);
-  ret["transaction_limit"] = dev::toJS(obj.transaction_limit);
   return ret;
 }
-void dec_json(const Json::Value& json, BlockProposerConfig& obj) {
-  obj.shard = dev::getUInt(json["shard"]);
-  obj.transaction_limit = dev::getUInt(json["transaction_limit"]);
-}
+void dec_json(const Json::Value& json, BlockProposerConfig& obj) { obj.shard = dev::getUInt(json["shard"]); }
 
 bytes DagConfig::rlp() const {
   dev::RLPStream s;

--- a/libraries/core_libs/consensus/include/dag/block_proposer.hpp
+++ b/libraries/core_libs/consensus/include/dag/block_proposer.hpp
@@ -136,18 +136,20 @@ class BlockProposer : public std::enable_shared_from_this<BlockProposer> {
    * @brief Creates/proposes a new block with provided data
    * @param frontier frontier to use for pivot and tips of the new block
    * @param level level of the new block
-   * @param proposal_period proposal period
    * @param trxs transactions to be included in the block
+   * @param estimations transactions gas estimation
    * @param vdf vdf with correct difficulty calculation
    */
-  void proposeBlock(DagFrontier&& frontier, level_t level, uint64_t proposal_period, SharedTransactions&& trxs,
-                    VdfSortition&& vdf);
+  void proposeBlock(DagFrontier&& frontier, level_t level, SharedTransactions&& trxs,
+                    std::vector<uint64_t>&& estimations, VdfSortition&& vdf);
 
   /**
    * @brief Gets transactions to include in the block - sharding not supported yet
-   * @return transactions
+   * @param proposal_period proposal period
+   * @param weight_limit weight limit
+   * @return transactions and weight estimations
    */
-  SharedTransactions getShardedTrxs();
+  std::pair<SharedTransactions, std::vector<uint64_t>> getShardedTrxs(uint64_t proposal_period, uint64_t weight_limit);
 
   /**
    * @brief Gets current propose level for provided pivot and tips

--- a/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
+++ b/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
@@ -52,10 +52,20 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
 
   uint64_t estimateTransactionGas(std::shared_ptr<Transaction> trx, std::optional<uint64_t> proposal_period) const;
   uint64_t estimateTransactionGasByHash(const trx_hash_t &hash, std::optional<uint64_t> proposal_period) const;
+
   /**
-   * Retrieves transactions to be included in a proposed pbft block
+   * @brief Gets transactions from pool to include in the block with specified weight limit
+   * @param proposal_period proposal period
+   * @param weight_limit weight limit
+   * @return transactions and weight estimations
    */
-  SharedTransactions packTrxs(uint16_t max_trx_to_pack = 0);
+  std::pair<SharedTransactions, std::vector<uint64_t>> packTrxs(uint64_t proposal_period, uint64_t weight_limit);
+
+  /**
+   * @brief Gets all transactions from pool
+   * @return transactions
+   */
+  SharedTransactions getAllPoolTrxs();
 
   /**
    * Saves transactions from dag block which was added to the DAG. Removes transactions from memory pool

--- a/libraries/core_libs/consensus/include/transaction/transaction_queue.hpp
+++ b/libraries/core_libs/consensus/include/transaction/transaction_queue.hpp
@@ -62,6 +62,20 @@ class TransactionQueue {
   std::vector<std::shared_ptr<Transaction>> get(uint64_t count = 0) const;
 
   /**
+   * @brief resets internal iterator for getNextTransaction
+   *
+   */
+  void resetGetNextTransactionIterator();
+
+  /**
+   * @brief returns next transaction sorted by priority or null ptr if no transactions left
+   *
+   * @param count
+   * @return std::shared_ptr<Transaction>
+   */
+  std::shared_ptr<Transaction> getNextTransaction();
+
+  /**
    * @brief returns true/false if the transaction is in the queue
    *
    * @param hash
@@ -99,6 +113,9 @@ class TransactionQueue {
 
   // Maximum number of save transactions
   const uint64_t kNonProposableTransactionsLimit = 1000;
+
+  // Priority queue iterator
+  PriorityQueue::iterator priority_queue_it_;
 };
 
 /** @}*/

--- a/libraries/core_libs/consensus/src/transaction/transaction_queue.cpp
+++ b/libraries/core_libs/consensus/src/transaction/transaction_queue.cpp
@@ -51,6 +51,15 @@ std::vector<std::shared_ptr<Transaction>> TransactionQueue::get(uint64_t count) 
   return ret;
 }
 
+void TransactionQueue::resetGetNextTransactionIterator() { priority_queue_it_ = priority_queue_.begin(); }
+
+std::shared_ptr<Transaction> TransactionQueue::getNextTransaction() {
+  if (priority_queue_it_ == priority_queue_.end()) return nullptr;
+  auto res = *priority_queue_it_;
+  priority_queue_it_++;
+  return res;
+}
+
 bool TransactionQueue::erase(const trx_hash_t &hash) {
   // Find the hash
   const auto it = hash_queue_.find(hash);

--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -125,7 +125,7 @@ void TaraxaCapability::initPeriodicEvents(const NetworkConfig &conf, const std::
   if (trx_mgr /* just because of tests */ && conf.network_transaction_interval > 0) {
     periodic_events_tp_->post_loop({conf.network_transaction_interval},
                                    [tx_packet_handler = std::move(tx_packet_handler), trx_mgr = std::move(trx_mgr)] {
-                                     tx_packet_handler->periodicSendTransactions(trx_mgr->packTrxs());
+                                     tx_packet_handler->periodicSendTransactions(trx_mgr->getAllPoolTrxs());
                                    });
   }
 

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -1491,8 +1491,7 @@ TEST_F(FullNodeTest, chain_config_json) {
   },
   "dag": {
     "block_proposer": {
-      "shard": "0x1",
-      "transaction_limit": "0xfa"
+      "shard": "0x1"
     },
     "gas_limit": "0x989680"
   },

--- a/tests/transaction_test.cpp
+++ b/tests/transaction_test.cpp
@@ -152,13 +152,9 @@ TEST_F(TransactionTest, transaction_limit) {
   }
   t.join();
   thisThreadSleepForMilliSeconds(100);
-  SharedTransactions verified_trxs1, verified_trxs2, verified_trxs3;
-  verified_trxs1 = trx_mgr.packTrxs(10);
-  verified_trxs2 = trx_mgr.packTrxs(20);
-  verified_trxs3 = trx_mgr.packTrxs(0);
-  EXPECT_EQ(verified_trxs1.size(), 10);
-  EXPECT_EQ(verified_trxs2.size(), 20);
-  EXPECT_EQ(verified_trxs3.size(), g_signed_trx_samples->size());
+  SharedTransactions verified_trxs;
+  verified_trxs = trx_mgr.getAllPoolTrxs();
+  EXPECT_EQ(verified_trxs.size(), g_signed_trx_samples->size());
 }
 
 TEST_F(TransactionTest, prepare_signed_trx_for_propose) {
@@ -179,7 +175,7 @@ TEST_F(TransactionTest, prepare_signed_trx_for_propose) {
   auto batch = db->createWriteBatch();
 
   do {
-    packed_trxs = trx_mgr.packTrxs();
+    packed_trxs = trx_mgr.getAllPoolTrxs();
     total_packed_trxs.insert(total_packed_trxs.end(), packed_trxs.begin(), packed_trxs.end());
     trx_mgr.saveTransactionsFromDagBlock(packed_trxs);
     thisThreadSleepForMicroSeconds(100);
@@ -290,7 +286,7 @@ TEST_F(TransactionTest, transaction_concurrency) {
 
   // Verify all transactions are in correct state in pool, db and finalized
   std::set<trx_hash_t> pool_trx_hashes;
-  for (auto const& t : trx_mgr.packTrxs()) {
+  for (auto const& t : trx_mgr.getAllPoolTrxs()) {
     pool_trx_hashes.insert(t->getHash());
   }
 


### PR DESCRIPTION
Hard transaction limit of 250 transactions in a DAG block is removed since dag gas limit is the mechanism used to limit DAG blocks size

Gas limit for dag block was refactored to fix an existing bug and make it more efficienct