### PR TITLE
chore: fix handling of rewards votes for in special edge case

### DIFF
--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -200,6 +200,12 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   size_t periodDataQueueSize() const;
 
   /**
+   * @brief Returns true if queue is really empty
+   * @return
+   */
+  bool periodDataQueueEmpty() const;
+
+  /**
    * @brief Push synced period data in syncing queue
    * @param block synced period data from peer
    * @param current_block_cert_votes cert votes for PeriodData pbft block period
@@ -293,6 +299,13 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   uint64_t getFinalizedDPOSPeriod() const { return dpos_period_; }
 
   blk_hash_t getLastPbftBlockHash();
+
+  /**
+   * @brief Get only include reward votes that are list in PBFT block
+   * @param reward_votes_hashes reward votes hashes are list in PBFT block
+   * @return reward votes that are list in PBFT block
+   */
+  std::vector<std::shared_ptr<Vote>> getRewardVotesInBlock(const std::vector<vote_hash_t> &reward_votes_hashes);
 
  private:
   // DPOS
@@ -556,13 +569,6 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
    * @return PBFT block
    */
   std::shared_ptr<PbftBlock> getUnfinalizedBlock_(blk_hash_t const &block_hash);
-
-  /**
-   * @brief Get only include reward votes that are list in PBFT block
-   * @param reward_votes_hashes reward votes hashes are list in PBFT block
-   * @return reward votes that are list in PBFT block
-   */
-  std::vector<std::shared_ptr<Vote>> getRewardVotesInBlock(const std::vector<vote_hash_t> &reward_votes_hashes);
 
   std::atomic<bool> stopped_ = true;
 

--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -200,7 +200,7 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   size_t periodDataQueueSize() const;
 
   /**
-   * @brief Returns true if queue is really empty
+   * @brief Returns true if queue is empty
    * @return
    */
   bool periodDataQueueEmpty() const;

--- a/libraries/core_libs/consensus/include/pbft/period_data_queue.hpp
+++ b/libraries/core_libs/consensus/include/pbft/period_data_queue.hpp
@@ -50,6 +50,12 @@ class PeriodDataQueue {
   size_t size() const;
 
   /**
+   * @brief Return true if the queue is empty
+   * @return
+   */
+  bool empty() const;
+
+  /**
    * @brief Get period number of the last synced block in queue
    * @return period number of the last synced block in queue. If syncing queue is empty, return 0
    */

--- a/libraries/core_libs/consensus/include/pbft/period_data_queue.hpp
+++ b/libraries/core_libs/consensus/include/pbft/period_data_queue.hpp
@@ -59,7 +59,7 @@ class PeriodDataQueue {
    * @brief Get last pbft block from queue
    * @return last block or nullptr if queue empty
    */
-  std::shared_ptr<PbftBlock> lastPbftBlock();
+  std::shared_ptr<PbftBlock> lastPbftBlock() const;
 
  private:
   std::deque<std::pair<PeriodData, dev::p2p::NodeID>> queue_;

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1952,7 +1952,7 @@ blk_hash_t PbftManager::lastPbftBlockHashFromQueueOrChain() {
   return pbft_chain_->getLastPbftBlockHash();
 }
 
-bool PbftManager::periodDataQueueEmpty() const { return sync_queue_.lastPbftBlock() == nullptr; }
+bool PbftManager::periodDataQueueEmpty() const { return sync_queue_.empty(); }
 
 void PbftManager::periodDataQueuePush(PeriodData &&period_data, dev::p2p::NodeID const &node_id,
                                       std::vector<std::shared_ptr<Vote>> &&current_block_cert_votes) {

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1952,10 +1952,11 @@ blk_hash_t PbftManager::lastPbftBlockHashFromQueueOrChain() {
   return pbft_chain_->getLastPbftBlockHash();
 }
 
+bool PbftManager::periodDataQueueEmpty() const { return sync_queue_.lastPbftBlock() == nullptr; }
+
 void PbftManager::periodDataQueuePush(PeriodData &&period_data, dev::p2p::NodeID const &node_id,
                                       std::vector<std::shared_ptr<Vote>> &&current_block_cert_votes) {
   const auto period = period_data.pbft_blk->getPeriod();
-
   if (!sync_queue_.push(std::move(period_data), node_id, pbft_chain_->getPbftChainSize(),
                         std::move(current_block_cert_votes))) {
     LOG(log_er_) << "Trying to push period data with " << period << " period, but current period is "

--- a/libraries/core_libs/consensus/src/pbft/period_data_queue.cpp
+++ b/libraries/core_libs/consensus/src/pbft/period_data_queue.cpp
@@ -53,7 +53,7 @@ std::tuple<PeriodData, std::vector<std::shared_ptr<Vote>>, dev::p2p::NodeID> Per
     return {block.first, last_block_cert_votes_, block.second};
 }
 
-std::shared_ptr<PbftBlock> PeriodDataQueue::lastPbftBlock() {
+std::shared_ptr<PbftBlock> PeriodDataQueue::lastPbftBlock() const {
   std::shared_lock lock(queue_access_);
   if (queue_.size() > 0) {
     return queue_.back().first.pbft_blk;

--- a/libraries/core_libs/consensus/src/pbft/period_data_queue.cpp
+++ b/libraries/core_libs/consensus/src/pbft/period_data_queue.cpp
@@ -21,6 +21,11 @@ size_t PeriodDataQueue::size() const {
     return queue_.size() - 1;
 }
 
+bool PeriodDataQueue::empty() const {
+  std::shared_lock lock(queue_access_);
+  return queue_.empty();
+}
+
 void PeriodDataQueue::clear() {
   std::unique_lock lock(queue_access_);
   period_ = 0;

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/pbft_sync_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/pbft_sync_packet_handler.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "network/tarcap/packets_handlers/common/ext_syncing_packet_handler.hpp"
+#include "vote_manager/vote_manager.hpp"
 
 namespace taraxa::network::tarcap {
 
@@ -9,7 +10,7 @@ class PbftSyncPacketHandler final : public ExtSyncingPacketHandler {
   PbftSyncPacketHandler(std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
                         std::shared_ptr<PbftSyncingState> pbft_syncing_state, std::shared_ptr<PbftChain> pbft_chain,
                         std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<DagManager> dag_mgr,
-                        std::shared_ptr<DagBlockManager> dag_blk_mgr,
+                        std::shared_ptr<DagBlockManager> dag_blk_mgr, std::shared_ptr<VoteManager> vote_mgr,
                         std::shared_ptr<util::ThreadPool> periodic_events_tp, std::shared_ptr<DbStorage> db,
                         size_t network_sync_level_size, const addr_t& node_addr);
 
@@ -24,6 +25,8 @@ class PbftSyncPacketHandler final : public ExtSyncingPacketHandler {
 
   void pbftSyncComplete();
   void delayedPbftSync(int counter);
+
+  std::shared_ptr<VoteManager> vote_mgr_;
 
   std::weak_ptr<util::ThreadPool> periodic_events_tp_;
 

--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -226,8 +226,8 @@ void TaraxaCapability::registerPacketHandlers(
                                                                pbft_chain, db, conf.network_sync_level_size, node_addr);
 
   packets_handlers_->registerHandler<PbftSyncPacketHandler>(
-      peers_state_, packets_stats, pbft_syncing_state_, pbft_chain, pbft_mgr, dag_mgr, dag_blk_mgr, periodic_events_tp_,
-      db, conf.network_sync_level_size, node_addr);
+      peers_state_, packets_stats, pbft_syncing_state_, pbft_chain, pbft_mgr, dag_mgr, dag_blk_mgr, vote_mgr,
+      periodic_events_tp_, db, conf.network_sync_level_size, node_addr);
 
   thread_pool_->setPacketsHandlers(packets_handlers_);
 }


### PR DESCRIPTION
## Purpose
Currently we have a bug and for the first synced PBFT block we do not validate rewards votes. This PR should handle this case


## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
