### PR TITLE
chore: optimize transactions processing

### DIFF
--- a/libraries/common/include/common/constants.hpp
+++ b/libraries/common/include/common/constants.hpp
@@ -24,6 +24,8 @@ const uint32_t kMaxTransactionsInPacket{1000};
 
 const uint32_t kPeriodicEventsThreadCount{2};
 
+const uint64_t kMinTxGas{21000};
+
 // The various denominations; here for ease of use where needed within code.
 static const u256 kOneTara = dev::exp10<18>();
 // static const u256 kFinney = exp10<15>();

--- a/libraries/core_libs/consensus/include/transaction/transaction_queue.hpp
+++ b/libraries/core_libs/consensus/include/transaction/transaction_queue.hpp
@@ -62,20 +62,6 @@ class TransactionQueue {
   std::vector<std::shared_ptr<Transaction>> get(uint64_t count = 0) const;
 
   /**
-   * @brief resets internal iterator for getNextTransaction
-   *
-   */
-  void resetGetNextTransactionIterator();
-
-  /**
-   * @brief returns next transaction sorted by priority or null ptr if no transactions left
-   *
-   * @param count
-   * @return std::shared_ptr<Transaction>
-   */
-  std::shared_ptr<Transaction> getNextTransaction();
-
-  /**
    * @brief returns true/false if the transaction is in the queue
    *
    * @param hash
@@ -113,9 +99,6 @@ class TransactionQueue {
 
   // Maximum number of save transactions
   const uint64_t kNonProposableTransactionsLimit = 1000;
-
-  // Priority queue iterator
-  PriorityQueue::iterator priority_queue_it_;
 };
 
 /** @}*/

--- a/libraries/core_libs/consensus/src/transaction/transaction_queue.cpp
+++ b/libraries/core_libs/consensus/src/transaction/transaction_queue.cpp
@@ -51,15 +51,6 @@ std::vector<std::shared_ptr<Transaction>> TransactionQueue::get(uint64_t count) 
   return ret;
 }
 
-void TransactionQueue::resetGetNextTransactionIterator() { priority_queue_it_ = priority_queue_.begin(); }
-
-std::shared_ptr<Transaction> TransactionQueue::getNextTransaction() {
-  if (priority_queue_it_ == priority_queue_.end()) return nullptr;
-  auto res = *priority_queue_it_;
-  priority_queue_it_++;
-  return res;
-}
-
 bool TransactionQueue::erase(const trx_hash_t &hash) {
   // Find the hash
   const auto it = hash_queue_.find(hash);


### PR DESCRIPTION
Anything running under transaction_mutex in transaction_manager can be a major bottleneck for high TPS load.

transaction_accepted_.emit is moved out mutex since there was no need to run it under mutex.

Estimating transaction gas done under transaction mutex was a major bottleneck for transactions processing since estimation takes time. To avoid that batch of transactions from memory pool is retrieved and estimation is now done outside of mutex. I made an assumption that dag block gas limit divided by 21000 is max number of transaction we can fit under a single DAG block. I am not sure if this is a valid assumption. Is it possible to have transaction that does not take at least 21000 gas?

With these changes I am able to get  over 20k TPS processed in a single node