### PR TITLE
fix: change of genesis hash because of unordered_map reordering

### DIFF
--- a/libraries/config/include/config/state_api_config.hpp
+++ b/libraries/config/include/config/state_api_config.hpp
@@ -25,7 +25,7 @@ struct ETHChainConfig {
 Json::Value enc_json(const ETHChainConfig& obj);
 void dec_json(const Json::Value& json, ETHChainConfig& obj);
 
-using BalanceMap = std::unordered_map<addr_t, u256>;
+using BalanceMap = std::map<addr_t, u256>;
 Json::Value enc_json(const BalanceMap& obj);
 void dec_json(const Json::Value& json, BalanceMap& obj);
 


### PR DESCRIPTION
#1836 
This is happening because unordered_map doesn't guarantee elements order. So sometimes it is different