### PR TITLE
feat: enable mappings between vrf and eth keys

### DIFF
--- a/for_devs/local-net
+++ b/for_devs/local-net
@@ -65,10 +65,10 @@ def config(binary, boot_nodes, rpc_nodes):
         worker_name = f'boot-node-{i}'
         wallet_path = f'wallet-boot-node-{i}.json'
 
-        (private_key, public_key, public_address) = generate_node_wallet(binary, wallet_path)
+        (private_key, public_key, public_address, vrf_key) = generate_node_wallet(binary, wallet_path)
 
         private_keys[worker_name] = private_key
-        boot_nodes_public_addresses[worker_name] = public_address
+        boot_nodes_public_addresses[worker_name] = {public_address, vrf_key}
 
         boot_nodes_flags.append(
             f'127.0.0.1:10{i+1}02/{public_key}')
@@ -125,7 +125,7 @@ def config(binary, boot_nodes, rpc_nodes):
             cmd += f'--boot-nodes {boot_nodes_flags} '
 
             if type == "boot":
-                # cmd += '--boot-node ' // TODO: we should replace this with bootnode binary? 
+                # cmd += '--boot-node ' // TODO: we should replace this with bootnode binary?
                 cmd += f'--node-secret {private_keys[worker_name]} '
 
             if type == "boot":
@@ -149,10 +149,12 @@ def config(binary, boot_nodes, rpc_nodes):
             else:
                 default_validator = config['chain_config']['final_chain']['state']['dpos']['initial_validators'][0]
                 config['chain_config']['final_chain']['state']['dpos']['initial_validators'] = []
-                for key in boot_nodes_public_addresses:
-                    address = boot_nodes_public_addresses[key]
+                print("boot_nodes_public_addresses: ",boot_nodes_public_addresses)
+                for key, in boot_nodes_public_addresses:
+                    address, vrf_key = boot_nodes_public_addresses[key]
                     default_validator["address"] = address
                     default_validator["owner"] = address
+                    default_validator["vrf_key"] = vrf_key
                     config['chain_config']['final_chain']['state']['dpos']['initial_validators'].append(default_validator.copy())
 
                 genesis_balances = config['chain_config']['final_chain']['state']['genesis_balances']
@@ -184,7 +186,7 @@ def generate_node_wallet(binary, wallet_path):
             wallet_data = json.load(json_file)
             wallet.update(wallet_data)
 
-        return (wallet['node_secret'], wallet['node_public'], wallet['node_address'])
+        return (wallet['node_secret'], wallet['node_public'], wallet['node_address'], wallet['vrf_public'])
     else:
         return generate_wallet(binary)
 
@@ -205,7 +207,7 @@ def generate_faucet_wallet(binary):
         faucet_private_key = wallet['faucet_private_key']
         faucet_public_address = wallet['faucet_public_address']
     else:
-        (faucet_private_key, _, faucet_public_address) = generate_wallet(binary)
+        (faucet_private_key, _, faucet_public_address, _) = generate_wallet(binary)
         chain_id = randint(500, 1000)
 
         wallet = {
@@ -224,8 +226,10 @@ def generate_wallet(binary):
         f'{binary} --command account {private_key} | grep node_public | cut -d\  -f3- | tr -d \\"', shell=True).strip().decode('utf-8')
     public_address = subprocess.check_output(
         f'{binary} --command account {private_key} | grep node_address| cut -d\  -f3- | tr -d \\"', shell=True).strip().decode('utf-8')
+    vrf_key = subprocess.check_output(
+        f'{binary} --command account {private_key} | grep vrf_public| cut -d\  -f3- | tr -d \\"', shell=True).strip().decode('utf-8')
 
-    return (private_key, public_key, public_address)
+    return (private_key, public_key, public_address, vrf_key)
 
 
 def start_workers(binary, boot_nodes, rpc_nodes, tps):

--- a/for_devs/local-net
+++ b/for_devs/local-net
@@ -61,14 +61,16 @@ def config(binary, boot_nodes, rpc_nodes):
 
     boot_nodes_flags = []
     private_keys = {}
+    vrf_secrets = {}
     for i in range(boot_nodes):
         worker_name = f'boot-node-{i}'
         wallet_path = f'wallet-boot-node-{i}.json'
 
-        (private_key, public_key, public_address, vrf_key) = generate_node_wallet(binary, wallet_path)
+        (private_key, public_key, public_address, vrf_secret, vrf_public) = generate_node_wallet(binary, wallet_path)
 
         private_keys[worker_name] = private_key
-        boot_nodes_public_addresses[worker_name] = {public_address, vrf_key}
+        vrf_secrets[worker_name] = vrf_secret
+        boot_nodes_public_addresses[worker_name] = {public_address, vrf_public}
 
         boot_nodes_flags.append(
             f'127.0.0.1:10{i+1}02/{public_key}')
@@ -127,6 +129,7 @@ def config(binary, boot_nodes, rpc_nodes):
             if type == "boot":
                 # cmd += '--boot-node ' // TODO: we should replace this with bootnode binary?
                 cmd += f'--node-secret {private_keys[worker_name]} '
+                cmd += f'--vrf-secret {vrf_secrets[worker_name]} '
 
             if type == "boot":
                 port_prefix = '0'
@@ -150,7 +153,7 @@ def config(binary, boot_nodes, rpc_nodes):
                 default_validator = config['chain_config']['final_chain']['state']['dpos']['initial_validators'][0]
                 config['chain_config']['final_chain']['state']['dpos']['initial_validators'] = []
                 print("boot_nodes_public_addresses: ",boot_nodes_public_addresses)
-                for key, in boot_nodes_public_addresses:
+                for key in boot_nodes_public_addresses:
                     address, vrf_key = boot_nodes_public_addresses[key]
                     default_validator["address"] = address
                     default_validator["owner"] = address
@@ -185,8 +188,7 @@ def generate_node_wallet(binary, wallet_path):
         with open(wallet_path) as json_file:
             wallet_data = json.load(json_file)
             wallet.update(wallet_data)
-
-        return (wallet['node_secret'], wallet['node_public'], wallet['node_address'], wallet['vrf_public'])
+        return (wallet['node_secret'], wallet['node_public'], wallet['node_address'], wallet['vrf_secret'], wallet['vrf_public'])
     else:
         return generate_wallet(binary)
 
@@ -207,7 +209,7 @@ def generate_faucet_wallet(binary):
         faucet_private_key = wallet['faucet_private_key']
         faucet_public_address = wallet['faucet_public_address']
     else:
-        (faucet_private_key, _, faucet_public_address, _) = generate_wallet(binary)
+        (faucet_private_key, _, faucet_public_address, _, _) = generate_wallet(binary)
         chain_id = randint(500, 1000)
 
         wallet = {
@@ -226,10 +228,12 @@ def generate_wallet(binary):
         f'{binary} --command account {private_key} | grep node_public | cut -d\  -f3- | tr -d \\"', shell=True).strip().decode('utf-8')
     public_address = subprocess.check_output(
         f'{binary} --command account {private_key} | grep node_address| cut -d\  -f3- | tr -d \\"', shell=True).strip().decode('utf-8')
+    vrf_secret = subprocess.check_output(
+        f'{binary} --command vrf | grep vrf_secret | cut -d\  -f3- | tr -d \\"', shell=True).strip().decode('utf-8')
     vrf_key = subprocess.check_output(
-        f'{binary} --command account {private_key} | grep vrf_public| cut -d\  -f3- | tr -d \\"', shell=True).strip().decode('utf-8')
+        f'{binary} --command vrf {vrf_secret} | grep vrf_public| cut -d\  -f3- | tr -d \\"', shell=True).strip().decode('utf-8')
 
-    return (private_key, public_key, public_address, vrf_key)
+    return (private_key, public_key, public_address, vrf_secret, vrf_key)
 
 
 def start_workers(binary, boot_nodes, rpc_nodes, tps):

--- a/libraries/cli/include/cli/config_jsons/devnet.json
+++ b/libraries/cli/include/cli/config_jsons/devnet.json
@@ -383,16 +383,6 @@
                 "0x7e4aa664f71de4e9d0b4a6473d796372639bdcde": "0x84595161401484a000000"
               },
               "vrf_key": "37bf145ac98e7de7db6e5b933e72737fbf190fd4fb1d193b15cf8b00db30ba30"
-            },
-            {
-              "address": "0x2b95aeed70a4e21fcb8665b1a1e16eb114a1caf3",
-              "owner": "0x2b95aeed70a4e21fcb8665b1a1e16eb114a1caf3",
-              "commission": 0,
-              "endpoint": "",
-              "description": "Taraxa devnet validator 19",
-              "delegations": {
-                "0x7e4aa664f71de4e9d0b4a6473d796372639bdcde": "0x84595161401484a000000"
-              }
             }
           ]
         },

--- a/libraries/cli/include/cli/config_jsons/devnet.json
+++ b/libraries/cli/include/cli/config_jsons/devnet.json
@@ -9,9 +9,9 @@
   "network_max_peer_count": 30,
   "network_sync_level_size": 25,
   "network_packets_processing_threads": 14,
-  "network_peer_blacklist_timeout" : 600,
-  "is_light_node" : false,
-  "deep_syncing_threshold" : 10,
+  "network_peer_blacklist_timeout": 600,
+  "is_light_node": false,
+  "deep_syncing_threshold": 10,
   "network_boot_nodes": [
     {
       "id": "fdcf4c860d9bb1f17608cbf2dd10ac3ae8d0ba41aa20b3e43fb85a72617a356f8609475d68b44e25dd508a0e5b36da75e7ae9aaf93360f4f002464d1d75fd353",
@@ -179,13 +179,13 @@
           "delegation_locking_period": "0x5",
           "eligibility_balance_threshold": "0xd3c21bcecceda1000000",
           "vote_eligibility_balance_step": "0x152d02c7e14af6800000",
-          "validator_maximum_stake":"0x84595161401484A000000",
-          "minimum_deposit":"0x0",
+          "validator_maximum_stake": "0x84595161401484A000000",
+          "minimum_deposit": "0x0",
           "max_block_author_reward": "0xa",
-          "commission_change_delta":"0x0",
-          "commission_change_frequency":"0x0",
-          "yield_percentage":"0x14",
-           "initial_validators": [
+          "commission_change_delta": "0x0",
+          "commission_change_frequency": "0x0",
+          "yield_percentage": "0x14",
+          "initial_validators": [
             {
               "address": "0x780fe8b2226cf212c55635de399ee4c2a860810c",
               "owner": "0x780fe8b2226cf212c55635de399ee4c2a860810c",
@@ -194,7 +194,8 @@
               "description": "Taraxa devnet validator 1",
               "delegations": {
                 "0x7e4aa664f71de4e9d0b4a6473d796372639bdcde": "0x84595161401484a000000"
-              }
+              },
+              "vrf_key": "05fe580fd2d461ee5f762a33bbe669403bb04a851f2e9ed8d2579a9c9b77c3ec"
             },
             {
               "address": "0x56e0de6933d9d0453d0363caf42b136eb5854e4e",
@@ -204,7 +205,8 @@
               "description": "Taraxa devnet validator 2",
               "delegations": {
                 "0x7e4aa664f71de4e9d0b4a6473d796372639bdcde": "0x84595161401484a000000"
-              }
+              },
+              "vrf_key": "70d34c86787e5f7bd0f266cad291cb521e23176fa37c6efc034858a1620ac69e"
             },
             {
               "address": "0x71bdcbec7e3642782447b0fbf31eed068dfbdbb1",
@@ -214,164 +216,180 @@
               "description": "Taraxa devnet validator 3",
               "delegations": {
                 "0x7e4aa664f71de4e9d0b4a6473d796372639bdcde": "0x84595161401484a000000"
-              }
+              },
+              "vrf_key": "f8d5c00ce9fa3058341e051b36a1e6ccf69df81fb865568b2bf1507d085691e2"
             },
             {
               "address": "0xac24bc60a491bd0c29414e5f34aa6bbd8d4aa499",
               "owner": "0xac24bc60a491bd0c29414e5f34aa6bbd8d4aa499",
               "commission": 0,
               "endpoint": "",
-              "description": "Taraxa devnet validator 5",
+              "description": "Taraxa devnet validator 4",
               "delegations": {
                 "0x7e4aa664f71de4e9d0b4a6473d796372639bdcde": "0x84595161401484a000000"
-              }
+              },
+              "vrf_key": "aa12507d00c992b95e65d80b21fd2db5b48c4f7ff4393064828d1adc930710b4"
             },
             {
               "address": "0x635d3831ad5d1252a2a07f09b8d3539b3af34df8",
               "owner": "0x635d3831ad5d1252a2a07f09b8d3539b3af34df8",
               "commission": 0,
               "endpoint": "",
-              "description": "Taraxa devnet validator 6",
+              "description": "Taraxa devnet validator 5",
               "delegations": {
                 "0x7e4aa664f71de4e9d0b4a6473d796372639bdcde": "0x84595161401484a000000"
-              }
+              },
+              "vrf_key": "bd34898ae0080187c408b5724f05682855c4425fda61d332f5f9d746d4eb753a"
             },
             {
               "address": "0x43af71034ed7fd0b54496a30ba4a5889a94e7088",
               "owner": "0x43af71034ed7fd0b54496a30ba4a5889a94e7088",
               "commission": 0,
               "endpoint": "",
-              "description": "Taraxa devnet validator 7",
+              "description": "Taraxa devnet validator 6",
               "delegations": {
                 "0x7e4aa664f71de4e9d0b4a6473d796372639bdcde": "0x84595161401484a000000"
-              }
+              },
+              "vrf_key": "25d35fed93989c40b4e8685d9d7ee02213230221ea9efcbe8cfccfc788670dba"
             },
             {
               "address": "0x4546f088bf636ed4652d1635c98ef5422805dfa3",
               "owner": "0x4546f088bf636ed4652d1635c98ef5422805dfa3",
               "commission": 0,
               "endpoint": "",
-              "description": "Taraxa devnet validator 8",
+              "description": "Taraxa devnet validator 7",
               "delegations": {
                 "0x7e4aa664f71de4e9d0b4a6473d796372639bdcde": "0x84595161401484a000000"
-              }
+              },
+              "vrf_key": "55c0bd1af84fb793a5dd7b960e330248d8a0acde566922b3e210f43592700dad"
             },
             {
               "address": "0x8ca042649a263272442bee8b7209fa19426e54c4",
               "owner": "0x8ca042649a263272442bee8b7209fa19426e54c4",
               "commission": 0,
               "endpoint": "",
-              "description": "Taraxa devnet validator 9",
+              "description": "Taraxa devnet validator 8",
               "delegations": {
                 "0x7e4aa664f71de4e9d0b4a6473d796372639bdcde": "0x84595161401484a000000"
-              }
+              },
+              "vrf_key": "33131367e7279ee51c0f26c6f9b6627848f822d134abef21a88be467dfbaae7b"
             },
             {
               "address": "0x7d7319df8950546850a01a0d793ee602f6eb390f",
               "owner": "0x7d7319df8950546850a01a0d793ee602f6eb390f",
               "commission": 0,
               "endpoint": "",
-              "description": "Taraxa devnet validator 10",
+              "description": "Taraxa devnet validator 9",
               "delegations": {
                 "0x7e4aa664f71de4e9d0b4a6473d796372639bdcde": "0x84595161401484a000000"
-              }
+              },
+              "vrf_key": "da63de37c69a59cb3ebbcfb79ef8d561b18b448b544a14438c62cd56bc0a29f5"
             },
             {
               "address": "0x64c171b9845c15c4555f7a4489895f0e687c496c",
               "owner": "0x64c171b9845c15c4555f7a4489895f0e687c496c",
               "commission": 0,
               "endpoint": "",
-              "description": "Taraxa devnet validator 11",
+              "description": "Taraxa devnet validator 10",
               "delegations": {
                 "0x7e4aa664f71de4e9d0b4a6473d796372639bdcde": "0x84595161401484a000000"
-              }
+              },
+              "vrf_key": "337178752602a5ca38928bf0d8d434ec653505c92b280b0edab6c39d5e79f4fd"
             },
             {
               "address": "0x614c85fad6f17f03949f735e05b1a24c5155b726",
               "owner": "0x614c85fad6f17f03949f735e05b1a24c5155b726",
               "commission": 0,
               "endpoint": "",
-              "description": "Taraxa devnet validator 12",
+              "description": "Taraxa devnet validator 11",
               "delegations": {
                 "0x7e4aa664f71de4e9d0b4a6473d796372639bdcde": "0x84595161401484a000000"
-              }
+              },
+              "vrf_key": "ac08e4ca5f1bcdd61dbefa7551ab839bdd4545e59ee8a4ab5d3aabb71104ab73"
             },
             {
               "address": "0xeff3dd2b0a6c29146c46ca01764aae0691ee1744",
               "owner": "0xeff3dd2b0a6c29146c46ca01764aae0691ee1744",
               "commission": 0,
               "endpoint": "",
-              "description": "Taraxa devnet validator 13",
+              "description": "Taraxa devnet validator 12",
               "delegations": {
                 "0x7e4aa664f71de4e9d0b4a6473d796372639bdcde": "0x84595161401484a000000"
-              }
+              },
+              "vrf_key": "189b05cca0a816a36f977f0541ef7585218b2087f04b23444ab58d0c755adecc"
             },
             {
               "address": "0xe543a20db4fa1820cc9f00144fc402bb1f31aa29",
               "owner": "0xe543a20db4fa1820cc9f00144fc402bb1f31aa29",
               "commission": 0,
               "endpoint": "",
-              "description": "Taraxa devnet validator 14",
+              "description": "Taraxa devnet validator 13",
               "delegations": {
                 "0x7e4aa664f71de4e9d0b4a6473d796372639bdcde": "0x84595161401484a000000"
-              }
+              },
+              "vrf_key": "8e95172f90b68ee753132bf6342ee00b398e2417312f610d58c34729ab0608ee"
             },
             {
               "address": "0x211a5ec33fec843b14319bcd62ab30c2a064745e",
               "owner": "0x211a5ec33fec843b14319bcd62ab30c2a064745e",
               "commission": 0,
               "endpoint": "",
-              "description": "Taraxa devnet validator 15",
+              "description": "Taraxa devnet validator 14",
               "delegations": {
                 "0x7e4aa664f71de4e9d0b4a6473d796372639bdcde": "0x84595161401484a000000"
-              }
+              },
+              "vrf_key": "959551740ff948d9714f15a2bfb2183c4ead897dd79775a0a18488aa8936e2ba"
             },
             {
               "address": "0x5354adf587cad5fe74e4912d4b6c1f754538891d",
               "owner": "0x5354adf587cad5fe74e4912d4b6c1f754538891d",
               "commission": 0,
               "endpoint": "",
-              "description": "Taraxa devnet validator 16",
+              "description": "Taraxa devnet validator 15",
               "delegations": {
                 "0x7e4aa664f71de4e9d0b4a6473d796372639bdcde": "0x84595161401484a000000"
-              }
+              },
+              "vrf_key": "56b7831cb3e35c1d6d1e3f661de2068d6feeaa54074b3e02709a87d7f0d6c72a"
             },
             {
               "address": "0x1473a6c154655fdc1f19d98e5823d3bb3f09a895",
               "owner": "0x1473a6c154655fdc1f19d98e5823d3bb3f09a895",
               "commission": 0,
               "endpoint": "",
-              "description": "Taraxa devnet validator 17",
+              "description": "Taraxa devnet validator 16",
               "delegations": {
                 "0x7e4aa664f71de4e9d0b4a6473d796372639bdcde": "0x84595161401484a000000"
-              }
+              },
+              "vrf_key": "e774c519814cbc04008aa958932e7adb82ebbbd6ca69089c0a1458ea34fb4299"
             },
             {
               "address": "0x9588f6457d67792f141424983a93978f44331054",
               "owner": "0x9588f6457d67792f141424983a93978f44331054",
               "commission": 0,
               "endpoint": "",
-              "description": "Taraxa devnet validator 18",
+              "description": "Taraxa devnet validator 17",
               "delegations": {
                 "0x7e4aa664f71de4e9d0b4a6473d796372639bdcde": "0x84595161401484a000000"
-              }
+              },
+              "vrf_key": "1b15b7bef6a1dbe9aeb2792f2e38d6222d31f8c6c15cff1152f258013d70d933"
             },
             {
               "address": "0xb48da366e19f141f5647dcdb0960eb88719e1c8d",
               "owner": "0xb48da366e19f141f5647dcdb0960eb88719e1c8d",
               "commission": 0,
               "endpoint": "",
-              "description": "Taraxa devnet validator 19",
+              "description": "Taraxa devnet validator 18",
               "delegations": {
                 "0x7e4aa664f71de4e9d0b4a6473d796372639bdcde": "0x84595161401484a000000"
-              }
+              },
+              "vrf_key": "37bf145ac98e7de7db6e5b933e72737fbf190fd4fb1d193b15cf8b00db30ba30"
             },
             {
               "address": "0x2b95aeed70a4e21fcb8665b1a1e16eb114a1caf3",
               "owner": "0x2b95aeed70a4e21fcb8665b1a1e16eb114a1caf3",
               "commission": 0,
               "endpoint": "",
-              "description": "Taraxa devnet validator 20",
+              "description": "Taraxa devnet validator 19",
               "delegations": {
                 "0x7e4aa664f71de4e9d0b4a6473d796372639bdcde": "0x84595161401484a000000"
               }
@@ -401,9 +419,9 @@
         }
       }
     },
-    "gas_price" : {
-      "blocks" : 200,
-      "percentile" : 60
+    "gas_price": {
+      "blocks": 200,
+      "percentile": 60
     },
     "pbft": {
       "committee_size": "0x3e8",
@@ -424,7 +442,10 @@
     },
     "sortition": {
       "changes_count_for_average": 10,
-      "dag_efficiency_targets": [6900, 7100],
+      "dag_efficiency_targets": [
+        6900,
+        7100
+      ],
       "changing_interval": 200,
       "computation_interval": 50,
       "vrf": {

--- a/libraries/cli/include/cli/config_jsons/testnet.json
+++ b/libraries/cli/include/cli/config_jsons/testnet.json
@@ -9,9 +9,9 @@
   "network_max_peer_count": 50,
   "network_sync_level_size": 10,
   "network_packets_processing_threads": 14,
-  "network_peer_blacklist_timeout" : 600,
-  "is_light_node" : false,
-  "deep_syncing_threshold" : 10,
+  "network_peer_blacklist_timeout": 600,
+  "is_light_node": false,
+  "deep_syncing_threshold": 10,
   "network_boot_nodes": [
     {
       "id": "f36f467529fe91a750dfdc8086fd0d2f30bad9f55a5800b6b4aa603c7787501db78dc4ac1bf3cf16e42af7c2ebb53648653013c3da1987494960d751871d598a",
@@ -194,12 +194,12 @@
           "delegation_locking_period": "0x5",
           "eligibility_balance_threshold": "0xd3c21bcecceda1000000",
           "vote_eligibility_balance_step": "0x152d02c7e14af6800000",
-          "validator_maximum_stake":"0x84595161401484A000000",
-          "minimum_deposit":"0x0",
+          "validator_maximum_stake": "0x84595161401484A000000",
+          "minimum_deposit": "0x0",
           "max_block_author_reward": "0xa",
-          "commission_change_delta":"0x0",
-          "commission_change_frequency":"0x0",
-          "yield_percentage":"0x14",
+          "commission_change_delta": "0x0",
+          "commission_change_frequency": "0x0",
+          "yield_percentage": "0x14",
           "initial_validators": [
             {
               "address": "0x18551e353aa65bc0ffbdf9d93b7ad4a8fe29cf95",
@@ -209,7 +209,8 @@
               "description": "Taraxa testnet validator 1",
               "delegations": {
                 "0x76870407332398322576505f3c5423d0a71af296": "0x84595161401484a000000"
-              }
+              },
+              "vrf_key": "3cebcfdc7a076352e7b55c5a277a63769ff7baf62d44bd9a8d9add904ab11b7b"
             },
             {
               "address": "0xc578bb5fc3dac3e96a8c4cb126c71d2dc9082817",
@@ -219,7 +220,8 @@
               "description": "Taraxa testnet validator 2",
               "delegations": {
                 "0x76870407332398322576505f3c5423d0a71af296": "0x84595161401484a000000"
-              }
+              },
+              "vrf_key": "48c633fe14f3c5e13ffb62816fa3111d3a09739bd9be7b6ab05c3f03ed6a879c"
             },
             {
               "address": "0x5c9afb23fba3967ca6102fb60c9949f6a38cd9e8",
@@ -229,7 +231,8 @@
               "description": "Taraxa testnet validator 3",
               "delegations": {
                 "0x76870407332398322576505f3c5423d0a71af296": "0x84595161401484a000000"
-              }
+              },
+              "vrf_key": "f8bbb0c73c74997498796b845458e1cca5a0ef83b3489fca084badd9fba968c6"
             },
             {
               "address": "0x403480c2b2ade0851c62bd1ff7a594c416aff7ce",
@@ -239,7 +242,8 @@
               "description": "Taraxa testnet validator 4",
               "delegations": {
                 "0x76870407332398322576505f3c5423d0a71af296": "0x84595161401484a000000"
-              }
+              },
+              "vrf_key": "c3912a8c849032ebdc071397c5ae4178a5e67f3399315b30fd6277fca8e1b64f"
             },
             {
               "address": "0x5042fa2711fe547e46c2f64852fdaa5982c80697",
@@ -249,7 +253,8 @@
               "description": "Taraxa testnet validator 5",
               "delegations": {
                 "0x76870407332398322576505f3c5423d0a71af296": "0x84595161401484a000000"
-              }
+              },
+              "vrf_key": "7c6dab1852f34ebdf3ad73b60ad70b95b2a6a457d88693823f356c3f8ccc74c6"
             },
             {
               "address": "0x6258d8f51ea17e873f69a2a978fe311fd95743dd",
@@ -259,7 +264,8 @@
               "description": "Taraxa testnet validator 6",
               "delegations": {
                 "0x76870407332398322576505f3c5423d0a71af296": "0x84595161401484a000000"
-              }
+              },
+              "vrf_key": "f5f88dcc7fbfa50a576359ae05ace6ca28352fbc40b4ebbc99605e04c6f42883"
             }
           ]
         },
@@ -286,9 +292,9 @@
         }
       }
     },
-    "gas_price" : {
-      "blocks" : 200,
-      "percentile" : 60
+    "gas_price": {
+      "blocks": 200,
+      "percentile": 60
     },
     "pbft": {
       "committee_size": "0x3e8",
@@ -309,7 +315,10 @@
     },
     "sortition": {
       "changes_count_for_average": 10,
-      "dag_efficiency_targets": [6900, 7100],
+      "dag_efficiency_targets": [
+        6900,
+        7100
+      ],
       "changing_interval": 200,
       "computation_interval": 50,
       "vrf": {

--- a/libraries/common/include/common/vrf_wrapper.hpp
+++ b/libraries/common/include/common/vrf_wrapper.hpp
@@ -28,24 +28,22 @@ class VrfSortitionBase {
  public:
   VrfSortitionBase() = default;
 
-  VrfSortitionBase(vrf_sk_t const &sk, bytes const &msg) : pk_(vrf_wrapper::getVrfPublicKey(sk)) {
-    assert(isValidVrfPublicKey(pk_));
+  VrfSortitionBase(vrf_sk_t const &sk, bytes const &msg) {
+    const auto pk(vrf_wrapper::getVrfPublicKey(sk));
+    assert(isValidVrfPublicKey(pk));
     proof_ = vrf_wrapper::getVrfProof(sk, msg).value();
-    output_ = vrf_wrapper::getVrfOutput(pk_, proof_, msg).value();
+    output_ = vrf_wrapper::getVrfOutput(pk, proof_, msg).value();
     thresholdFromOutput();
   }
 
   static dev::bytes makeVrfInput(taraxa::level_t level, const dev::h256 &period_hash);
 
-  bool verify(bytes const &msg) const;
+  bool verify(const vrf_pk_t &pk, const bytes &msg) const;
 
-  bool operator==(VrfSortitionBase const &other) const {
-    return pk_ == other.pk_ && proof_ == other.proof_ && output_ == other.output_;
-  }
+  bool operator==(VrfSortitionBase const &other) const { return proof_ == other.proof_ && output_ == other.output_; }
 
   virtual std::ostream &print(std::ostream &strm) const {
     strm << "\n[VRF SortitionBase] " << std::endl;
-    strm << "  pk: " << pk_ << std::endl;
     strm << "  proof: " << proof_ << std::endl;
     strm << "  output: " << output_ << std::endl;
     return strm;
@@ -59,7 +57,6 @@ class VrfSortitionBase {
   void thresholdFromOutput() const { threshold_ = (((uint16_t)output_[1] << 8) | output_[0]); }
 
  public:
-  vrf_pk_t pk_;
   vrf_proof_t proof_;
   mutable vrf_output_t output_;
   mutable uint16_t threshold_;

--- a/libraries/common/src/vrf_wrapper.cpp
+++ b/libraries/common/src/vrf_wrapper.cpp
@@ -44,11 +44,11 @@ dev::bytes VrfSortitionBase::makeVrfInput(taraxa::level_t level, const dev::h256
   return s.invalidate();
 }
 
-bool VrfSortitionBase::verify(bytes const &msg) const {
-  if (!isValidVrfPublicKey(pk_)) {
+bool VrfSortitionBase::verify(const vrf_pk_t &pk, const bytes &msg) const {
+  if (!isValidVrfPublicKey(pk)) {
     return false;
   }
-  auto res = vrf_wrapper::getVrfOutput(pk_, proof_, msg);
+  auto res = vrf_wrapper::getVrfOutput(pk, proof_, msg);
   if (res != std::nullopt) {
     output_ = res.value();
     thresholdFromOutput();

--- a/libraries/config/include/config/state_api_config.hpp
+++ b/libraries/config/include/config/state_api_config.hpp
@@ -5,6 +5,7 @@
 
 #include "common/encoding_rlp.hpp"
 #include "common/types.hpp"
+#include "common/vrf_wrapper.hpp"
 #include "config/hardfork.hpp"
 
 namespace taraxa::state_api {
@@ -32,6 +33,7 @@ void dec_json(const Json::Value& json, BalanceMap& obj);
 struct ValidatorInfo {
   addr_t address;
   addr_t owner;
+  vrf_wrapper::vrf_pk_t vrf_key;
   uint16_t commission = 0;
   std::string endpoint;
   std::string description;

--- a/libraries/config/src/state_api_config.cpp
+++ b/libraries/config/src/state_api_config.cpp
@@ -4,6 +4,8 @@
 
 #include <sstream>
 
+#include "common/vrf_wrapper.hpp"
+
 namespace taraxa::state_api {
 
 Json::Value enc_json(const ETHChainConfig& obj) {
@@ -71,6 +73,7 @@ Json::Value enc_json(const ValidatorInfo& obj) {
 
   json["address"] = dev::toJS(obj.address);
   json["owner"] = dev::toJS(obj.owner);
+  json["vrf_key"] = dev::toJS(obj.vrf_key);
   json["commission"] = dev::toJS(obj.commission);
   json["endpoint"] = obj.endpoint;
   json["description"] = obj.description;
@@ -81,6 +84,7 @@ Json::Value enc_json(const ValidatorInfo& obj) {
 void dec_json(const Json::Value& json, ValidatorInfo& obj) {
   obj.address = addr_t(json["address"].asString());
   obj.owner = addr_t(json["owner"].asString());
+  obj.vrf_key = vrf_wrapper::vrf_pk_t(json["vrf_key"].asString());
   obj.commission = dev::getUInt(json["commission"]);
   obj.endpoint = json["endpoint"].asString();
   obj.description = json["description"].asString();
@@ -160,7 +164,7 @@ RLP_FIELDS_DEFINE(ExecutionOptions, disable_nonce_check, enable_nonce_skipping)
 RLP_FIELDS_DEFINE(BlockRewardsOptions, disable_block_rewards, disable_contract_distribution)
 RLP_FIELDS_DEFINE(ETHChainConfig, homestead_block, dao_fork_block, eip_150_block, eip_158_block, byzantium_block,
                   constantinople_block, petersburg_block)
-RLP_FIELDS_DEFINE(ValidatorInfo, address, owner, commission, endpoint, description, delegations)
+RLP_FIELDS_DEFINE(ValidatorInfo, address, owner, vrf_key, commission, endpoint, description, delegations)
 RLP_FIELDS_DEFINE(DPOSConfig, eligibility_balance_threshold, vote_eligibility_balance_step, validator_maximum_stake,
                   minimum_deposit, max_block_author_reward, commission_change_delta, commission_change_frequency,
                   delegation_delay, delegation_locking_period, blocks_per_year, yield_percentage, initial_validators)

--- a/libraries/core_libs/consensus/include/dag/dag.hpp
+++ b/libraries/core_libs/consensus/include/dag/dag.hpp
@@ -149,8 +149,8 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
   explicit DagManager(blk_hash_t const &dag_genesis_block_hash, addr_t node_addr,
                       std::shared_ptr<TransactionManager> trx_mgr, std::shared_ptr<PbftChain> pbft_chain,
                       std::shared_ptr<DagBlockManager> dag_blk_mgr, std::shared_ptr<DbStorage> db,
-                      bool is_light_node = false, uint64_t light_node_history = 0,
-                      uint32_t max_levels_per_period = kMaxLevelsPerPeriod,
+                      std::shared_ptr<KeyManager> key_manager, bool is_light_node = false,
+                      uint64_t light_node_history = 0, uint32_t max_levels_per_period = kMaxLevelsPerPeriod,
                       uint32_t dag_expiry_limit = kDagExpiryLevelLimit);
   virtual ~DagManager() { stop(); }
 
@@ -310,6 +310,7 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
   std::shared_ptr<DagBlockManager> dag_blk_mgr_;
   std::weak_ptr<Network> network_;
   std::shared_ptr<DbStorage> db_;
+  std::shared_ptr<KeyManager> key_manager_;
   blk_hash_t anchor_;      // anchor of the last period
   blk_hash_t old_anchor_;  // anchor of the second to last period
   uint64_t period_;        // last period

--- a/libraries/core_libs/consensus/include/dag/dag_block_manager.hpp
+++ b/libraries/core_libs/consensus/include/dag/dag_block_manager.hpp
@@ -4,6 +4,7 @@
 #include "dag/dag_block.hpp"
 #include "dag/sortition_params_manager.hpp"
 #include "final_chain/final_chain.hpp"
+#include "key_manager/key_manager.hpp"
 #include "pbft/pbft_chain.hpp"
 #include "transaction/transaction_manager.hpp"
 #include "vdf/sortition.hpp"
@@ -50,7 +51,8 @@ class DagBlockManager {
   DagBlockManager(addr_t node_addr, const SortitionConfig &sortition_config, const DagConfig &dag_config,
                   std::shared_ptr<DbStorage> db, std::shared_ptr<TransactionManager> trx_mgr,
                   std::shared_ptr<FinalChain> final_chain, std::shared_ptr<PbftChain> pbft_chain,
-                  uint32_t queue_limit = 0, uint32_t max_levels_per_period = kMaxLevelsPerPeriod);
+                  std::shared_ptr<KeyManager> key_manager, uint32_t queue_limit = 0,
+                  uint32_t max_levels_per_period = kMaxLevelsPerPeriod);
   ~DagBlockManager();
 
   DagBlockManager(const DagBlockManager &) = delete;
@@ -151,6 +153,7 @@ class DagBlockManager {
   std::shared_ptr<TransactionManager> trx_mgr_;
   std::shared_ptr<FinalChain> final_chain_;
   std::shared_ptr<PbftChain> pbft_chain_;
+  std::shared_ptr<KeyManager> key_manager_;
 
   ExpirationCache<blk_hash_t> invalid_blocks_;
   ExpirationCacheMap<blk_hash_t, DagBlock> seen_blocks_;

--- a/libraries/core_libs/consensus/include/final_chain/final_chain.hpp
+++ b/libraries/core_libs/consensus/include/final_chain/final_chain.hpp
@@ -169,6 +169,14 @@ class FinalChain {
   virtual u256 get_staking_balance(addr_t const& addr, std::optional<EthBlockNumber> blk_n = {}) const = 0;
 
   /**
+   * @brief Get the vrf key object from DPOS state
+   * @param addr account address
+   * @param blk_n number of block we are getting state from
+   * @return vrf_wrapper::vrf_pk_t
+   */
+  virtual vrf_wrapper::vrf_pk_t get_vrf_key(const addr_t& addr, std::optional<EthBlockNumber> blk_n = {}) const = 0;
+
+  /**
    * @brief Returns the value from a storage position at a given address.
    * @param addr account address
    * @param key position in the storage

--- a/libraries/core_libs/consensus/include/final_chain/state_api.hpp
+++ b/libraries/core_libs/consensus/include/final_chain/state_api.hpp
@@ -55,6 +55,7 @@ class StateAPI {
 
   bool dpos_is_eligible(EthBlockNumber blk_num, addr_t const& addr) const;
   u256 get_staking_balance(EthBlockNumber blk_num, const addr_t& addr) const;
+  vrf_wrapper::vrf_pk_t get_vrf_key(EthBlockNumber blk_num, const addr_t& addr) const;
   static addr_t const& dpos_contract_addr();
 };
 /** @} */

--- a/libraries/core_libs/consensus/include/key_manager/key_manager.hpp
+++ b/libraries/core_libs/consensus/include/key_manager/key_manager.hpp
@@ -18,7 +18,7 @@ class KeyManager {
   std::shared_ptr<vrf_wrapper::vrf_pk_t> get(const addr_t &addr);
 
  private:
-  mutable std::shared_mutex mutex_;
+  std::shared_mutex mutex_;
   std::unordered_map<addr_t, std::shared_ptr<vrf_wrapper::vrf_pk_t>> key_map_;
 
   std::shared_ptr<FinalChain> final_chain_;

--- a/libraries/core_libs/consensus/include/key_manager/key_manager.hpp
+++ b/libraries/core_libs/consensus/include/key_manager/key_manager.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+
+#include "common/vrf_wrapper.hpp"
+#include "final_chain/final_chain.hpp"
+
+namespace taraxa {
+class KeyManager {
+ public:
+  KeyManager(std::shared_ptr<FinalChain> final_chain);
+  KeyManager(const KeyManager &) = delete;
+  KeyManager(KeyManager &&) = delete;
+  KeyManager &operator=(const KeyManager &) = delete;
+  KeyManager &operator=(KeyManager &&) = delete;
+
+  std::shared_ptr<vrf_wrapper::vrf_pk_t> get(const addr_t &addr);
+
+ private:
+  mutable std::shared_mutex mutex_;
+  std::unordered_map<addr_t, std::shared_ptr<vrf_wrapper::vrf_pk_t>> key_map_;
+
+  std::shared_ptr<FinalChain> final_chain_;
+};
+}  // namespace taraxa

--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -6,6 +6,7 @@
 #include "common/types.hpp"
 #include "common/vrf_wrapper.hpp"
 #include "config/config.hpp"
+#include "key_manager/key_manager.hpp"
 #include "logger/logger.hpp"
 #include "network/network.hpp"
 #include "network/tarcap/taraxa_capability.hpp"
@@ -72,8 +73,9 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
               std::shared_ptr<DbStorage> db, std::shared_ptr<PbftChain> pbft_chain,
               std::shared_ptr<VoteManager> vote_mgr, std::shared_ptr<NextVotesManager> next_votes_mgr,
               std::shared_ptr<DagManager> dag_mgr, std::shared_ptr<DagBlockManager> dag_blk_mgr,
-              std::shared_ptr<TransactionManager> trx_mgr, std::shared_ptr<FinalChain> final_chain, secret_t node_sk,
-              vrf_sk_t vrf_sk, uint32_t max_levels_per_period = kMaxLevelsPerPeriod);
+              std::shared_ptr<TransactionManager> trx_mgr, std::shared_ptr<FinalChain> final_chain,
+              std::shared_ptr<KeyManager> key_manager, secret_t node_sk, vrf_sk_t vrf_sk,
+              uint32_t max_levels_per_period = kMaxLevelsPerPeriod);
   ~PbftManager();
   PbftManager(const PbftManager &) = delete;
   PbftManager(PbftManager &&) = delete;
@@ -585,6 +587,7 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   std::shared_ptr<DagBlockManager> dag_blk_mgr_;
   std::shared_ptr<TransactionManager> trx_mgr_;
   std::shared_ptr<FinalChain> final_chain_;
+  std::shared_ptr<KeyManager> key_manager_;
 
   addr_t node_addr_;
   secret_t node_sk_;

--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -2,6 +2,7 @@
 
 #include "common/util.hpp"
 #include "final_chain/final_chain.hpp"
+#include "key_manager/key_manager.hpp"
 #include "pbft/pbft_chain.hpp"
 #include "vote/vote.hpp"
 
@@ -22,7 +23,8 @@ class Network;
  */
 class NextVotesManager {
  public:
-  NextVotesManager(addr_t node_addr, std::shared_ptr<DbStorage> db, std::shared_ptr<FinalChain> final_chain);
+  NextVotesManager(addr_t node_addr, std::shared_ptr<DbStorage> db, std::shared_ptr<FinalChain> final_chain,
+                   std::shared_ptr<KeyManager> key_manager);
 
   /**
    * @brief Clear previous PBFT round next voting type votes
@@ -117,6 +119,7 @@ class NextVotesManager {
 
   std::shared_ptr<DbStorage> db_;
   std::shared_ptr<FinalChain> final_chain_;
+  std::shared_ptr<KeyManager> key_manager_;
 
   bool enough_votes_for_null_block_hash_;
   blk_hash_t voted_value_;  // For value is not null block hash
@@ -136,7 +139,7 @@ class VoteManager {
  public:
   VoteManager(size_t pbft_committee_size, const addr_t& node_addr, std::shared_ptr<DbStorage> db,
               std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<FinalChain> final_chain,
-              std::shared_ptr<NextVotesManager> next_votes_mgr);
+              std::shared_ptr<NextVotesManager> next_votes_mgr, std::shared_ptr<KeyManager> key_manager);
   ~VoteManager();
   VoteManager(const VoteManager&) = delete;
   VoteManager(VoteManager&&) = delete;
@@ -358,6 +361,7 @@ class VoteManager {
   std::shared_ptr<PbftChain> pbft_chain_;
   std::shared_ptr<FinalChain> final_chain_;
   std::shared_ptr<NextVotesManager> next_votes_manager_;
+  std::shared_ptr<KeyManager> key_manager_;
   std::weak_ptr<Network> network_;
 
   blk_hash_t reward_votes_pbft_block_hash_;

--- a/libraries/core_libs/consensus/src/dag/dag_block_manager.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_block_manager.cpp
@@ -197,7 +197,7 @@ DagBlockManager::InsertAndVerifyBlockReturnType DagBlockManager::verifyBlock(con
   }
 
   const auto &dag_block_sender = blk.getSender();
-  // Get vrf publick key
+  // Get vrf public key
   const auto pk = key_manager_->get(dag_block_sender);
   if (!pk) {
     LOG(log_er_) << "DAG block " << block_hash << " with " << blk.getLevel() << " level no VRF key for sender"

--- a/libraries/core_libs/consensus/src/dag/dag_block_manager.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_block_manager.cpp
@@ -1,17 +1,20 @@
 #include "dag/dag_block_manager.hpp"
 
 #include "dag/dag.hpp"
+#include "key_manager/key_manager.hpp"
 
 namespace taraxa {
 
 DagBlockManager::DagBlockManager(addr_t node_addr, const SortitionConfig &sortition_config, const DagConfig &dag_config,
                                  std::shared_ptr<DbStorage> db, std::shared_ptr<TransactionManager> trx_mgr,
                                  std::shared_ptr<FinalChain> final_chain, std::shared_ptr<PbftChain> pbft_chain,
-                                 uint32_t queue_limit, uint32_t max_levels_per_period)
-    : db_(db),
-      trx_mgr_(trx_mgr),
-      final_chain_(final_chain),
-      pbft_chain_(pbft_chain),
+                                 std::shared_ptr<KeyManager> key_manager, uint32_t queue_limit,
+                                 uint32_t max_levels_per_period)
+    : db_(std::move(db)),
+      trx_mgr_(std::move(trx_mgr)),
+      final_chain_(std::move(final_chain)),
+      pbft_chain_(std::move(pbft_chain)),
+      key_manager_(std::move(key_manager)),
       invalid_blocks_(cache_max_size_, cache_delete_step_),
       seen_blocks_(cache_max_size_, cache_delete_step_),
       queue_limit_(queue_limit),
@@ -193,10 +196,20 @@ DagBlockManager::InsertAndVerifyBlockReturnType DagBlockManager::verifyBlock(con
     return InsertAndVerifyBlockReturnType::ExpiredBlock;
   }
 
+  const auto &dag_block_sender = blk.getSender();
+  // Get vrf publick key
+  const auto pk = key_manager_->get(dag_block_sender);
+  if (!pk) {
+    LOG(log_er_) << "DAG block " << block_hash << " with " << blk.getLevel() << " level no VRF key for sender"
+                 << dag_block_sender;
+    markBlockInvalid(block_hash);
+    return InsertAndVerifyBlockReturnType::FailedVdfVerification;
+  }
+
   // Verify VDF solution
   const auto proposal_period_hash = db_->getPeriodBlockHash(*propose_period);
   try {
-    blk.verifyVdf(sortition_params_manager_.getSortitionParams(*propose_period), proposal_period_hash);
+    blk.verifyVdf(sortition_params_manager_.getSortitionParams(*propose_period), proposal_period_hash, *pk);
   } catch (vdf_sortition::VdfSortition::InvalidVdfSortition const &e) {
     LOG(log_er_) << "DAG block " << block_hash << " with " << blk.getLevel()
                  << " level failed on VDF verification with pivot hash " << blk.getPivot() << " reason " << e.what();
@@ -205,7 +218,6 @@ DagBlockManager::InsertAndVerifyBlockReturnType DagBlockManager::verifyBlock(con
     return InsertAndVerifyBlockReturnType::FailedVdfVerification;
   }
 
-  auto dag_block_sender = blk.getSender();
   bool dpos_qualified;
   try {
     dpos_qualified = final_chain_->dpos_is_eligible(*propose_period, dag_block_sender);

--- a/libraries/core_libs/consensus/src/final_chain/final_chain.cpp
+++ b/libraries/core_libs/consensus/src/final_chain/final_chain.cpp
@@ -341,6 +341,10 @@ class FinalChainImpl final : public FinalChain {
     return state_api_.get_staking_balance(last_if_absent(blk_n), addr);
   }
 
+  vrf_wrapper::vrf_pk_t get_vrf_key(addr_t const& addr, std::optional<EthBlockNumber> blk_n = {}) const override {
+    return state_api_.get_vrf_key(last_if_absent(blk_n), addr);
+  }
+
   void update_state_config(const state_api::Config& new_config) override {
     delegation_delay_ = new_config.dpos->delegation_delay;
     state_api_.update_state_config(new_config);

--- a/libraries/core_libs/consensus/src/final_chain/state_api.cpp
+++ b/libraries/core_libs/consensus/src/final_chain/state_api.cpp
@@ -234,6 +234,11 @@ u256 StateAPI::get_staking_balance(EthBlockNumber blk_num, const addr_t& addr) c
   return c_method_args_rlp<u256, to_u256, taraxa_evm_state_api_dpos_get_staking_balance>(this_c_, blk_num, addr);
 }
 
+vrf_wrapper::vrf_pk_t StateAPI::get_vrf_key(EthBlockNumber blk_num, const addr_t& addr) const {
+  return vrf_wrapper::vrf_pk_t(
+      c_method_args_rlp<bytes, to_bytes, taraxa_evm_state_api_dpos_get_vrf_key>(this_c_, blk_num, addr));
+}
+
 addr_t const& StateAPI::dpos_contract_addr() {
   static auto const ret = [] {
     auto ret_c = taraxa_evm_state_api_dpos_contract_addr();

--- a/libraries/core_libs/consensus/src/key_manager/key_manager.cpp
+++ b/libraries/core_libs/consensus/src/key_manager/key_manager.cpp
@@ -16,7 +16,7 @@ std::shared_ptr<vrf_wrapper::vrf_pk_t> KeyManager::get(const addr_t& addr) {
   {
     std::unique_lock lock(mutex_);
     if (auto key = final_chain_->get_vrf_key(addr); key != kEmptyVrfKey) {
-      key_map_[addr] = std::make_shared<vrf_wrapper::vrf_pk_t>(key);
+      key_map_[addr] = std::make_shared<vrf_wrapper::vrf_pk_t>(std::move(key));
       return key_map_.at(addr);
     } else {
       return nullptr;

--- a/libraries/core_libs/consensus/src/key_manager/key_manager.cpp
+++ b/libraries/core_libs/consensus/src/key_manager/key_manager.cpp
@@ -1,0 +1,26 @@
+#include "key_manager/key_manager.hpp"
+
+namespace taraxa {
+
+static const vrf_wrapper::vrf_pk_t kEmptyVrfKey;
+
+KeyManager::KeyManager(std::shared_ptr<FinalChain> final_chain) : final_chain_(std::move(final_chain)) {}
+
+std::shared_ptr<vrf_wrapper::vrf_pk_t> KeyManager::get(const addr_t& addr) {
+  {
+    std::shared_lock lock(mutex_);
+    if (key_map_.contains(addr)) {
+      return key_map_.at(addr);
+    }
+  }
+  {
+    std::unique_lock lock(mutex_);
+    if (auto key = final_chain_->get_vrf_key(addr); key != kEmptyVrfKey) {
+      key_map_[addr] = std::make_shared<vrf_wrapper::vrf_pk_t>(key);
+      return key_map_.at(addr);
+    } else {
+      return nullptr;
+    }
+  }
+}
+}  // namespace taraxa

--- a/libraries/core_libs/consensus/src/key_manager/key_manager.cpp
+++ b/libraries/core_libs/consensus/src/key_manager/key_manager.cpp
@@ -9,18 +9,17 @@ KeyManager::KeyManager(std::shared_ptr<FinalChain> final_chain) : final_chain_(s
 std::shared_ptr<vrf_wrapper::vrf_pk_t> KeyManager::get(const addr_t& addr) {
   {
     std::shared_lock lock(mutex_);
-    if (key_map_.contains(addr)) {
-      return key_map_.at(addr);
+    if (const auto it = key_map_.find(addr); it != key_map_.end()) {
+      return it->second;
     }
   }
   {
     std::unique_lock lock(mutex_);
     if (auto key = final_chain_->get_vrf_key(addr); key != kEmptyVrfKey) {
-      key_map_[addr] = std::make_shared<vrf_wrapper::vrf_pk_t>(std::move(key));
-      return key_map_.at(addr);
-    } else {
-      return nullptr;
+      const auto [it, _] = key_map_.insert_or_assign(addr, std::make_shared<vrf_wrapper::vrf_pk_t>(std::move(key)));
+      return it->second;
     }
+    return nullptr;
   }
 }
 }  // namespace taraxa

--- a/libraries/core_libs/node/include/node/node.hpp
+++ b/libraries/core_libs/node/include/node/node.hpp
@@ -41,6 +41,7 @@ class TransactionManager;
 class GasPricer;
 class PbftManager;
 struct NetworkConfig;
+class KeyManager;
 
 class FullNode : public std::enable_shared_from_this<FullNode> {
   using shared_ptr_t = std::shared_ptr<FullNode>;
@@ -77,6 +78,7 @@ class FullNode : public std::enable_shared_from_this<FullNode> {
   std::shared_ptr<NextVotesManager> next_votes_mgr_;
   std::shared_ptr<PbftManager> pbft_mgr_;
   std::shared_ptr<PbftChain> pbft_chain_;
+  std::shared_ptr<KeyManager> key_manager_;
   std::shared_ptr<FinalChain> final_chain_;
   std::shared_ptr<net::RpcServer> jsonrpc_http_;
   std::shared_ptr<net::WSServer> jsonrpc_ws_;

--- a/libraries/types/dag_block/include/dag/dag_block.hpp
+++ b/libraries/types/dag_block/include/dag/dag_block.hpp
@@ -90,7 +90,8 @@ class DagBlock {
   std::string getJsonStr() const;
 
   bool verifySig() const;
-  void verifyVdf(const SortitionParams &vdf_config, const h256 &proposal_period_hash) const;
+  void verifyVdf(const SortitionParams &vdf_config, const h256 &proposal_period_hash,
+                 const vrf_wrapper::vrf_pk_t &pk) const;
   bytes rlp(bool include_sig) const;
 
   /**

--- a/libraries/types/dag_block/src/dag_block.cpp
+++ b/libraries/types/dag_block/src/dag_block.cpp
@@ -118,8 +118,10 @@ bool DagBlock::verifySig() const {
   return !pk.isZero();
 }
 
-void DagBlock::verifyVdf(const SortitionParams &vdf_config, const h256 &proposal_period_hash) const {
-  vdf_.verifyVdf(vdf_config, VrfSortitionBase::makeVrfInput(getLevel(), proposal_period_hash), getPivot().asBytes());
+void DagBlock::verifyVdf(const SortitionParams &vdf_config, const h256 &proposal_period_hash,
+                         const vrf_wrapper::vrf_pk_t &pk) const {
+  vdf_.verifyVdf(vdf_config, VrfSortitionBase::makeVrfInput(getLevel(), proposal_period_hash), pk,
+                 getPivot().asBytes());
 }
 
 blk_hash_t const &DagBlock::getHash() const {

--- a/libraries/types/pbft_block/include/pbft/period_data.hpp
+++ b/libraries/types/pbft_block/include/pbft/period_data.hpp
@@ -54,9 +54,10 @@ class PeriodData {
    * @param pbft_2t_plus_1 PBFT 2t+1
    * @param dpos_eligible_vote_count function of getting voter DPOS eligible votes count
    */
-  void hasEnoughValidCertVotes(const std::vector<std::shared_ptr<Vote>>& votes, size_t valid_sortition_players,
-                               size_t sortition_threshold, size_t pbft_2t_plus_1,
-                               std::function<size_t(addr_t const&)> const& dpos_eligible_vote_count) const;
+  void hasEnoughValidCertVotes(
+      const std::vector<std::shared_ptr<Vote>>& votes, size_t valid_sortition_players, size_t sortition_threshold,
+      size_t pbft_2t_plus_1, std::function<size_t(addr_t const&)> const& dpos_eligible_vote_count,
+      std::function<std::shared_ptr<vrf_wrapper::vrf_pk_t>(addr_t const&)> const& get_vrf_key) const;
 };
 std::ostream& operator<<(std::ostream& strm, PeriodData const& b);
 

--- a/libraries/types/vote/include/vote/vote.hpp
+++ b/libraries/types/vote/include/vote/vote.hpp
@@ -31,7 +31,8 @@ class Vote {
    * @param sortition_threshold PBFT sortition threshold that is minimum of between PBFT committee size and total DPOS
    * votes count
    */
-  void validate(uint64_t stake, double dpos_total_votes_count, double sortition_threshold) const;
+  void validate(uint64_t stake, double dpos_total_votes_count, double sortition_threshold,
+                const vrf_wrapper::vrf_pk_t& pk) const;
 
   /**
    * @brief Get vote hash
@@ -61,7 +62,7 @@ class Vote {
    * @brief Verify VRF sortition
    * @return true if passed
    */
-  bool verifyVrfSortition() const { return vrf_sortition_.verify(); }
+  bool verifyVrfSortition(const vrf_pk_t& pk) const { return vrf_sortition_.verify(pk); }
 
   /**
    * @brief Get VRF sortition

--- a/libraries/types/vote/include/vote/vrf_sortition.hpp
+++ b/libraries/types/vote/include/vote/vrf_sortition.hpp
@@ -95,7 +95,7 @@ class VrfPbftSortition : public vrf_wrapper::VrfSortitionBase {
    * @brief Verify VRF sortition
    * @return true if passed
    */
-  bool verify() const { return VrfSortitionBase::verify(pbft_msg_.getRlpBytes()); }
+  bool verify(const vrf_pk_t& pk) const { return VrfSortitionBase::verify(pk, pbft_msg_.getRlpBytes()); }
 
   bool operator==(VrfPbftSortition const& other) const {
     return pbft_msg_ == other.pbft_msg_ && vrf_wrapper::VrfSortitionBase::operator==(other);
@@ -128,7 +128,6 @@ class VrfPbftSortition : public vrf_wrapper::VrfSortitionBase {
 
   friend std::ostream& operator<<(std::ostream& strm, const VrfPbftSortition& vrf_sortition) {
     strm << "[VRF sortition] " << std::endl;
-    strm << "  pk: " << vrf_sortition.pk_ << std::endl;
     strm << "  proof: " << vrf_sortition.proof_ << std::endl;
     strm << "  output: " << vrf_sortition.output_ << std::endl;
     strm << vrf_sortition.pbft_msg_ << std::endl;

--- a/libraries/types/vote/src/vote.cpp
+++ b/libraries/types/vote/src/vote.cpp
@@ -34,15 +34,15 @@ void Vote::validate(uint64_t stake, double dpos_total_votes_count, double sortit
     throw std::logic_error(err.str());
   }
 
-  if (!verifyVrfSortition()) {
-    std::stringstream err;
-    err << "Invalid vrf proof. " << *this;
-    throw std::logic_error(err.str());
-  }
-
   if (!verifyVote()) {
     std::stringstream err;
     err << "Invalid vote signature. " << dev::toHex(rlp(false)) << "  " << *this;
+    throw std::logic_error(err.str());
+  }
+
+  if (!verifyVrfSortition()) {
+    std::stringstream err;
+    err << "Invalid vrf proof. " << *this;
     throw std::logic_error(err.str());
   }
 

--- a/libraries/types/vote/src/vote.cpp
+++ b/libraries/types/vote/src/vote.cpp
@@ -25,7 +25,8 @@ Vote::Vote(secret_t const& node_sk, VrfPbftSortition vrf_sortition, blk_hash_t c
   cached_voter_ = dev::toPublic(node_sk);
 }
 
-void Vote::validate(uint64_t stake, double dpos_total_votes_count, double sortition_threshold) const {
+void Vote::validate(uint64_t stake, double dpos_total_votes_count, double sortition_threshold,
+                    const vrf_wrapper::vrf_pk_t& pk) const {
   if (!stake) {
     // After deep syncing, node could receive votes but still behind, may don't have vote sender state in table
     // If in PBFT blocks syncing for cert votes, that's malicious blocks
@@ -40,7 +41,7 @@ void Vote::validate(uint64_t stake, double dpos_total_votes_count, double sortit
     throw std::logic_error(err.str());
   }
 
-  if (!verifyVrfSortition()) {
+  if (!verifyVrfSortition(pk)) {
     std::stringstream err;
     err << "Invalid vrf proof. " << *this;
     throw std::logic_error(err.str());

--- a/libraries/types/vote/src/vrf_sortition.cpp
+++ b/libraries/types/vote/src/vrf_sortition.cpp
@@ -11,15 +11,14 @@ VrfPbftSortition::VrfPbftSortition(bytes const& b) {
   dev::RLP const rlp(b);
 
   uint8_t pbft_msg_type = 0;
-  util::rlp_tuple(util::RLPDecoderRef(rlp, true), pk_, pbft_msg_type, pbft_msg_.round, pbft_msg_.step, proof_);
+  util::rlp_tuple(util::RLPDecoderRef(rlp, true), pbft_msg_type, pbft_msg_.round, pbft_msg_.step, proof_);
   pbft_msg_.type = static_cast<PbftVoteTypes>(pbft_msg_type);
 }
 
 bytes VrfPbftSortition::getRlpBytes() const {
   dev::RLPStream s;
 
-  s.appendList(5);
-  s << pk_;
+  s.appendList(4);
   s << static_cast<uint8_t>(pbft_msg_.type);
   s << pbft_msg_.round;
   s << pbft_msg_.step;

--- a/libraries/vdf/include/vdf/sortition.hpp
+++ b/libraries/vdf/include/vdf/sortition.hpp
@@ -29,7 +29,8 @@ class VdfSortition : public vrf_wrapper::VrfSortitionBase {
 
   void computeVdfSolution(const SortitionParams& config, const bytes& msg, const std::atomic_bool& cancelled);
 
-  void verifyVdf(SortitionParams const& config, bytes const& vrf_input, bytes const& vdf_input) const;
+  void verifyVdf(SortitionParams const& config, bytes const& vrf_input, const vrf_pk_t& pk,
+                 bytes const& vdf_input) const;
 
   bytes rlp() const;
   bool operator==(VdfSortition const& other) const {
@@ -61,7 +62,7 @@ class VdfSortition : public vrf_wrapper::VrfSortitionBase {
       "9aee2a207e5173a7ee8f90ee9ab9b6a745d27c6e850e7ca7332388dfef7e5bbe6267d1f7"
       "9f9330e44715b3f2066f903081836c1c83ca29126f8fdc5f5922bf3f9ddb4540171691ac"
       "cc1ef6a34b2a804a18159c89c39b16edee2ede35");
-  bool verifyVrf(bytes const& vrf_input) const;
+  bool verifyVrf(const vrf_pk_t& pk, const bytes& vrf_input) const;
 
   std::pair<bytes, bytes> vdf_sol_;
   unsigned long vdf_computation_time_ = 0;

--- a/tests/crypto_test.cpp
+++ b/tests/crypto_test.cpp
@@ -103,7 +103,7 @@ TEST_F(CryptoTest, vrf_sortition) {
   EXPECT_TRUE(sortition.calculateWeight(1, 1, 1, dev::FixedHash<64>::random()));
   auto b = sortition.getRlpBytes();
   VrfPbftSortition sortition3(b);
-  sortition3.verify();
+  sortition3.verify(getVrfPublicKey(sk));
   EXPECT_EQ(sortition, sortition2);
   EXPECT_EQ(sortition, sortition3);
 }
@@ -121,7 +121,7 @@ TEST_F(CryptoTest, vdf_sortition) {
   vdf2.computeVdfSolution(sortition_params, vdf_input.asBytes(), false);
   auto b = vdf.rlp();
   VdfSortition vdf3(b);
-  EXPECT_NO_THROW(vdf3.verifyVdf(sortition_params, getRlpBytes(level), vdf_input.asBytes()));
+  EXPECT_NO_THROW(vdf3.verifyVdf(sortition_params, getRlpBytes(level), getVrfPublicKey(sk), vdf_input.asBytes()));
   EXPECT_EQ(vdf, vdf2);
   EXPECT_EQ(vdf, vdf3);
 
@@ -170,11 +170,11 @@ TEST_F(CryptoTest, vdf_proof_verify) {
   level_t level = 1;
   VdfSortition vdf(sortition_params, sk, getRlpBytes(level));
   blk_hash_t vdf_input = blk_hash_t(200);
-
+  const auto pk = getVrfPublicKey(sk);
   vdf.computeVdfSolution(sortition_params, vdf_input.asBytes(), false);
-  EXPECT_NO_THROW(vdf.verifyVdf(sortition_params, getRlpBytes(level), vdf_input.asBytes()));
+  EXPECT_NO_THROW(vdf.verifyVdf(sortition_params, getRlpBytes(level), pk, vdf_input.asBytes()));
   VdfSortition vdf2(sortition_params, sk, getRlpBytes(level));
-  EXPECT_THROW(vdf2.verifyVdf(sortition_params, getRlpBytes(level), vdf_input.asBytes()),
+  EXPECT_THROW(vdf2.verifyVdf(sortition_params, getRlpBytes(level), pk, vdf_input.asBytes()),
                VdfSortition::InvalidVdfSortition);
 }
 

--- a/tests/dag_test.cpp
+++ b/tests/dag_test.cpp
@@ -141,8 +141,8 @@ TEST_F(DagTest, compute_epoch) {
   auto mgr = std::make_shared<DagManager>(
       GENESIS, addr_t(), trx_mgr, pbft_chain,
       std::make_shared<DagBlockManager>(addr_t(), node_cfgs[0].chain.sortition, node_cfgs[0].chain.dag, db_ptr, nullptr,
-                                        nullptr, pbft_chain),
-      db_ptr);
+                                        nullptr, pbft_chain, nullptr),
+      db_ptr, nullptr);
   DagBlock blkA(blk_hash_t(1), 0, {}, {trx_hash_t(2)}, sig_t(1), blk_hash_t(2), addr_t(1));
   DagBlock blkB(blk_hash_t(1), 0, {}, {trx_hash_t(3), trx_hash_t(4)}, sig_t(1), blk_hash_t(3), addr_t(1));
   DagBlock blkC(blk_hash_t(2), 1, {blk_hash_t(3)}, {}, sig_t(1), blk_hash_t(4), addr_t(1));
@@ -233,9 +233,9 @@ TEST_F(DagTest, dag_expiry) {
   auto trx_mgr = std::make_shared<TransactionManager>(FullNodeConfig(), db_ptr, nullptr, addr_t());
   auto pbft_chain = std::make_shared<PbftChain>(addr_t(), db_ptr);
   auto dag_blk_mgr = std::make_shared<DagBlockManager>(addr_t(), node_cfgs[0].chain.sortition, node_cfgs[0].chain.dag,
-                                                       db_ptr, nullptr, nullptr, pbft_chain);
-  auto mgr = std::make_shared<DagManager>(GENESIS, addr_t(), trx_mgr, pbft_chain, dag_blk_mgr, db_ptr, false, 0, 3,
-                                          EXPIRY_LIMIT);
+                                                       db_ptr, nullptr, nullptr, pbft_chain, nullptr);
+  auto mgr = std::make_shared<DagManager>(GENESIS, addr_t(), trx_mgr, pbft_chain, dag_blk_mgr, db_ptr, nullptr, false,
+                                          0, 3, EXPIRY_LIMIT);
   DagBlock blkA(blk_hash_t(1), 0, {}, {trx_hash_t(2)}, sig_t(1), blk_hash_t(2), addr_t(1));
   DagBlock blkB(blk_hash_t(1), 0, {}, {trx_hash_t(3), trx_hash_t(4)}, sig_t(1), blk_hash_t(3), addr_t(1));
   DagBlock blkC(blk_hash_t(2), 1, {blk_hash_t(3)}, {}, sig_t(1), blk_hash_t(4), addr_t(1));
@@ -311,8 +311,8 @@ TEST_F(DagTest, receive_block_in_order) {
   auto mgr = std::make_shared<DagManager>(
       GENESIS, addr_t(), trx_mgr, pbft_chain,
       std::make_shared<DagBlockManager>(addr_t(), node_cfgs[0].chain.sortition, node_cfgs[0].chain.dag, db_ptr, nullptr,
-                                        nullptr, pbft_chain),
-      db_ptr);
+                                        nullptr, pbft_chain, nullptr),
+      db_ptr, nullptr);
   DagBlock genesis_block(blk_hash_t(0), 0, {}, {}, sig_t(777), blk_hash_t(10), addr_t(15));
   DagBlock blk1(blk_hash_t(10), 0, {}, {}, sig_t(777), blk_hash_t(1), addr_t(15));
   DagBlock blk2(blk_hash_t(1), 0, {}, {}, sig_t(777), blk_hash_t(2), addr_t(15));
@@ -346,8 +346,8 @@ TEST_F(DagTest, compute_epoch_2) {
   auto mgr = std::make_shared<DagManager>(
       GENESIS, addr_t(), trx_mgr, pbft_chain,
       std::make_shared<DagBlockManager>(addr_t(), node_cfgs[0].chain.sortition, node_cfgs[0].chain.dag, db_ptr, nullptr,
-                                        nullptr, pbft_chain),
-      db_ptr);
+                                        nullptr, pbft_chain, nullptr),
+      db_ptr, nullptr);
   DagBlock blkA(blk_hash_t(1), 0, {}, {trx_hash_t(2)}, sig_t(1), blk_hash_t(2), addr_t(1));
   DagBlock blkB(blk_hash_t(1), 0, {}, {trx_hash_t(3), trx_hash_t(4)}, sig_t(1), blk_hash_t(3), addr_t(1));
   DagBlock blkC(blk_hash_t(2), 1, {blk_hash_t(3)}, {}, sig_t(1), blk_hash_t(4), addr_t(1));
@@ -430,8 +430,8 @@ TEST_F(DagTest, get_latest_pivot_tips) {
   auto mgr = std::make_shared<DagManager>(
       GENESIS, addr_t(), trx_mgr, pbft_chain,
       std::make_shared<DagBlockManager>(addr_t(), node_cfgs[0].chain.sortition, node_cfgs[0].chain.dag, db_ptr, nullptr,
-                                        nullptr, pbft_chain),
-      db_ptr);
+                                        nullptr, pbft_chain, nullptr),
+      db_ptr, nullptr);
   DagBlock blk1(blk_hash_t(0), 0, {}, {}, sig_t(0), blk_hash_t(1), addr_t(15));
   DagBlock blk2(blk_hash_t(1), 0, {}, {}, sig_t(1), blk_hash_t(2), addr_t(15));
   DagBlock blk3(blk_hash_t(2), 0, {}, {}, sig_t(1), blk_hash_t(3), addr_t(15));

--- a/tests/final_chain_test.cpp
+++ b/tests/final_chain_test.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "common/constants.hpp"
+#include "common/vrf_wrapper.hpp"
 #include "config/chain_config.hpp"
 #include "final_chain/trie_common.hpp"
 #include "util_test/gtest.hpp"
@@ -294,7 +295,8 @@ TEST_F(FinalChainTest, initial_validators) {
   fillConfigForGenesisTests(key.address());
 
   for (const auto& vk : validator_keys) {
-    state_api::ValidatorInfo validator{vk.address(), key.address(), 0, "", "", {}};
+    const auto [vrf_key, _] = taraxa::vrf_wrapper::getVrfKeyPair();
+    state_api::ValidatorInfo validator{vk.address(), key.address(), vrf_key, 0, "", "", {}};
     validator.delegations.emplace(key.address(), cfg.final_chain.state.dpos->validator_maximum_stake);
     cfg.final_chain.state.dpos->initial_validators.emplace_back(validator);
   }
@@ -313,9 +315,10 @@ TEST_F(FinalChainTest, initial_validators) {
 TEST_F(FinalChainTest, initial_validator_exceed_maximum_stake) {
   const dev::KeyPair key = dev::KeyPair::create();
   const dev::KeyPair validator_key = dev::KeyPair::create();
+  const auto [vrf_key, _] = taraxa::vrf_wrapper::getVrfKeyPair();
   fillConfigForGenesisTests(key.address());
 
-  state_api::ValidatorInfo validator{validator_key.address(), key.address(), 0, "", "", {}};
+  state_api::ValidatorInfo validator{validator_key.address(), key.address(), vrf_key, 0, "", "", {}};
   validator.delegations.emplace(key.address(), cfg.final_chain.state.dpos->validator_maximum_stake);
   validator.delegations.emplace(validator_key.address(), cfg.final_chain.state.dpos->minimum_deposit);
   cfg.final_chain.state.dpos->initial_validators.emplace_back(validator);

--- a/tests/py/common/node/node.py
+++ b/tests/py/common/node/node.py
@@ -69,9 +69,6 @@ class Node:
                 cfg["chain_config"]["final_chain"]["state"]["genesis_balances"]["4fae949ac2b72960fbe857b56532e2d3c8418d5e"] = "0x1ffffffffffffff"
                 cfg["chain_config"]["final_chain"]["state"]["genesis_balances"]["415cf514eb6a5a8bd4d325d4874eae8cf26bcfe0"] = "0x1ffffffffffffff"
                 cfg["chain_config"]["final_chain"]["state"]["genesis_balances"]["b770f7a99d0b7ad9adf6520be77ca20ee99b0858"] = "0x1ffffffffffffff"
-                cfg["chain_config"]["final_chain"]["state"]["dpos"]["genesis_state"] = {}
-                cfg["chain_config"]["final_chain"]["state"]["dpos"]["genesis_state"]["0xde2b1203d72d3549ee2f733b00b2789414c7cea5"] = {}
-                cfg["chain_config"]["final_chain"]["state"]["dpos"]["genesis_state"]["0xde2b1203d72d3549ee2f733b00b2789414c7cea5"]["0xde2b1203d72d3549ee2f733b00b2789414c7cea5"] = "0x3b9aca00"
                 cfg["chain_config"]["final_chain"]["state"]["execution_options"] = {}
                 cfg["chain_config"]["final_chain"]["state"]["execution_options"]["disable_nonce_check"] = True
             with open(datadir_cfg_file_path, mode="w") as f:

--- a/tests/vote_test.cpp
+++ b/tests/vote_test.cpp
@@ -183,9 +183,10 @@ TEST_F(VoteTest, add_cleanup_get_votes) {
   size_t valid_sortition_players = 1;
   pbft_mgr->setSortitionThreshold(valid_sortition_players);
   uint64_t pbft_round = 2;
-  vote_mgr->verifyVotes(pbft_round, [&pbft_mgr, valid_sortition_players](auto const &v) {
+  const auto pk = vrf_wrapper::getVrfPublicKey(node->getVrfSecretKey());
+  vote_mgr->verifyVotes(pbft_round, [&pbft_mgr, valid_sortition_players, &pk](auto const &v) {
     try {
-      v->validate(1, valid_sortition_players, pbft_mgr->getSortitionThreshold());
+      v->validate(1, valid_sortition_players, pbft_mgr->getSortitionThreshold(), pk);
     } catch (const std::logic_error &e) {
       return false;
     }


### PR DESCRIPTION
## Purpose
Fixes: #1847 
EVM PR: https://github.com/Taraxa-project/taraxa-evm/pull/93

With this PR we introduce mappings between eth public key and vrf. Current implementation is pretty simplified, but in future there will be new feature that will enable updating those keys. 


## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
