### PR TITLE
chore: reward votes gossip improvement

### DIFF
--- a/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_block_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_block_packet_handler.cpp
@@ -76,9 +76,10 @@ void PbftBlockPacketHandler::onNewPbftBlock(const std::shared_ptr<PbftBlock> &pb
     }
   }
 
+  vote_mgr_->sendRewardVotes(pbft_block_hash);
+
   LOG(log_dg_) << "sendPbftBlock " << pbft_block_hash << " to " << peers_to_log;
   for (auto const &peer : peers_to_send) {
-    vote_mgr_->sendRewardVotes(pbft_block_hash);
     sendPbftBlock(peer->getId(), pbft_block, my_chain_size);
     peer->markPbftBlockAsKnown(pbft_block_hash);
   }


### PR DESCRIPTION
Sending reward votes was under a loop for no reason which created two issues:
1. Calling it unnecessary multiple times
2. Not sending votes at all if pbft block is known to other connected nodes