### PR TITLE
bugfix: covering special case that happened on devnet

### DIFF
--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1941,6 +1941,15 @@ std::optional<std::pair<PeriodData, std::vector<std::shared_ptr<Vote>>>> PbftMan
     return std::nullopt;
   }
 
+  // Special case when previous block was already in chain so we hit condition
+  // pbft_chain_->findPbftBlockInChain(pbft_block_hash) and it's cert votes were not verified here, they are part of
+  // vote_manager so we need to replace them as they are not verified period_data structure
+  if (period_data.previous_block_cert_votes.size() && !period_data.previous_block_cert_votes.front()->getWeight()) {
+    if (auto votes = getRewardVotesInBlock(period_data.pbft_blk->getRewardVotes()); votes.size()) {
+      period_data.previous_block_cert_votes = std::move(votes);
+    }
+  }
+
   // Check cert votes validation
   try {
     period_data.hasEnoughValidCertVotes(

--- a/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
+++ b/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
@@ -603,6 +603,7 @@ void VoteManager::replaceRewardVotes(std::vector<std::shared_ptr<Vote>>&& cert_v
   reward_votes_ = {};
   reward_votes_pbft_block_hash_ = cert_votes[0]->getBlockHash();
   for (auto& v : cert_votes) {
+    assert(v->getWeight());
     reward_votes_.insert({v->getHash(), std::move(v)});
   }
 }


### PR DESCRIPTION
## Purpose
We have a special case, when reward votes in `period_data` not verified.
Scenario:

1. Node was out of sync 2 block (blocks N and N+1)
2. node receive 2 sync blocks (blocks N and N+1)
3. meanwhile it also receive pbft block  N "normal" way not via syncing
4. then when it runs `processPeriodData` it will hit condition `pbft_chain_->findPbftBlockInChain(pbft_block_hash)` and that means that `cert_votes` structure (cert_votes for N == previous_block_cert_votes N+1) is not verified, so also not `previous_block_cert_votes` for block N+1


## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
