### PR TITLE
Votes ddos protection

### DIFF
--- a/libraries/config/include/config/state_api_config.hpp
+++ b/libraries/config/include/config/state_api_config.hpp
@@ -91,6 +91,7 @@ struct Config {
   ExecutionOptions execution_options;
   BlockRewardsOptions block_rewards_options;
   BalanceMap genesis_balances;
+  // TODO[1899]: dpos confing should not be optional
   std::optional<DPOSConfig> dpos;
   // Hardforks hardforks;
 

--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -311,13 +311,6 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   blk_hash_t getLastPbftBlockHash();
 
   /**
-   * @brief Get only include reward votes that are list in PBFT block
-   * @param reward_votes_hashes reward votes hashes are list in PBFT block
-   * @return reward votes that are list in PBFT block
-   */
-  std::vector<std::shared_ptr<Vote>> getRewardVotesInBlock(const std::vector<vote_hash_t> &reward_votes_hashes);
-
-  /**
    * @brief Validates vote
    *
    * @param vote to be validated

--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -312,12 +312,12 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   std::vector<std::shared_ptr<Vote>> getRewardVotesInBlock(const std::vector<vote_hash_t> &reward_votes_hashes);
 
   /**
-   * @brief Validates vote against dpos contract
+   * @brief Validates vote
    *
    * @param vote to be validated
    * @return <true, ""> vote validation passed, otherwise <false, "err msg">
    */
-  std::pair<bool, std::string> dposValidateVote(const std::shared_ptr<Vote> &vote);
+  std::pair<bool, std::string> validateVote(const std::shared_ptr<Vote> &vote) const;
 
  private:
   // DPOS

--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -127,6 +127,12 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   uint64_t getPbftRound() const;
 
   /**
+   * @brief Get PBFT round & period number
+   * @return <PBFT round, PBFT period>
+   */
+  std::pair<uint64_t, uint64_t> getPbftRoundAndPeriod() const;
+
+  /**
    * @brief Get PBFT step number
    * @return PBFT step
    */
@@ -162,10 +168,10 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
    * @param prev_blk_hash previous PBFT block hash
    * @param anchor_hash proposed DAG pivot block hash for finalization
    * @param order_hash the hash of all DAG blocks include in the PBFT block
-   * @return PBFT block hash
+   * @return PBFT block
    */
-  blk_hash_t generatePbftBlock(const blk_hash_t &prev_blk_hash, const blk_hash_t &anchor_hash,
-                               const blk_hash_t &order_hash);
+  std::shared_ptr<PbftBlock> generatePbftBlock(const blk_hash_t &prev_blk_hash, const blk_hash_t &anchor_hash,
+                                               const blk_hash_t &order_hash);
 
   /**
    * @brief Generate a vote
@@ -453,17 +459,18 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
 
   /**
    * @brief Propose a new PBFT block
-   * @param propose_period PBFT propose period
-   * @return proposed PBFT block hash
+   * @return proposed PBFT block
    */
-  blk_hash_t proposePbftBlock_(uint64_t propose_period);
+  std::shared_ptr<PbftBlock> proposePbftBlock_();
 
   /**
    * @brief Identify a leader block from all received proposed PBFT blocks for the current round by using minimum
    * Verifiable Random Function (VRF) output. In filter state, don’t need check vote value correction.
+   * @param round current pbft round
+   * @param previous_round_period previous pbft round period
    * @return optional(pair<PBFT leader block hash, PBFT leader period>)
    */
-  std::optional<std::pair<blk_hash_t, uint64_t>> identifyLeaderBlock_();
+  std::optional<std::pair<blk_hash_t, uint64_t>> identifyLeaderBlock_(uint64_t round, uint64_t previous_round_period);
 
   /**
    * @brief Calculate the lowest hash of a vote by vote weight
@@ -574,10 +581,9 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   void checkPreviousRoundNextVotedValueChange_();
 
   /**
-   * @brief Update soft voting PBFT block if there are enough soft voting votes
-   * @return true if soft voting PBFT block updated
+   * @return soft voted PBFT block if there is enough (2t+1) soft votes + it's period, otherwise returns empty optional
    */
-  bool updateSoftVotedBlockForThisRound_();
+  std::optional<std::pair<blk_hash_t, uint64_t>> getSoftVotedBlockForThisRound_();
 
   /**
    * @brief Process synced PBFT blocks if PBFT syncing queue is not empty
@@ -595,7 +601,7 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   std::atomic<bool> stopped_ = true;
 
   // Ensures that only one PBFT block per period can be proposed
-  blk_hash_t proposed_block_hash_ = NULL_BLOCK_HASH;
+  std::shared_ptr<PbftBlock> proposed_block_ = nullptr;
 
   std::unique_ptr<std::thread> daemon_;
   std::shared_ptr<DbStorage> db_;
@@ -628,11 +634,15 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   PbftStates state_ = value_proposal_state;
 
   std::atomic<uint64_t> round_ = 1;
+  std::atomic<uint64_t> previous_round_period_ = 1;
   size_t step_ = 1;
   size_t startingStepInRound_ = 1;
 
-  blk_hash_t own_starting_value_for_round_ = NULL_BLOCK_HASH;
-  blk_hash_t soft_voted_block_for_this_round_ = NULL_BLOCK_HASH;
+  std::pair<blk_hash_t, uint64_t /* period */> own_starting_value_for_round_{NULL_BLOCK_HASH, 1};
+  std::optional<std::pair<blk_hash_t, uint64_t /* period */>> soft_voted_block_for_round_{};
+
+  // TODO: was blk_hash_t last_cert_voted_value_ = NULL_BLOCK_HASH; and it was set to NULL_BLOCK_HASH in pushBlock
+  std::optional<std::pair<blk_hash_t, uint64_t /* period */>> cert_voted_block_for_round_{};
 
   // Period data for pbft block that is being currently cert voted for
   PeriodData period_data_;
@@ -646,7 +656,6 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   bool previous_round_next_voted_null_block_hash_ = false;
 
   blk_hash_t last_soft_voted_value_ = NULL_BLOCK_HASH;
-  blk_hash_t last_cert_voted_value_ = NULL_BLOCK_HASH;
 
   std::chrono::duration<double> duration_;
   u_long next_step_time_ms_ = 0;

--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -618,6 +618,9 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
 
   std::default_random_engine random_engine_{std::random_device{}()};
 
+  // Flag that says if node is in sync after it enters new round
+  bool new_round_in_sync_ = false;
+
   const size_t COMMITTEE_SIZE;
   const size_t NUMBER_OF_PROPOSERS;
   const size_t DAG_BLOCKS_SIZE;

--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -324,6 +324,7 @@ class VoteManager {
   blk_hash_t reward_votes_pbft_block_hash_;
   uint64_t last_pbft_block_cert_round_;
   std::unordered_map<vote_hash_t, std::shared_ptr<Vote>> reward_votes_;
+  std::unordered_map<addr_t, vote_hash_t> reward_votes_unique_authors_;
   mutable std::shared_mutex reward_votes_mutex_;
 
   // <PBFT round, <PBFT step, <voter address, pair<vote 1, vote 2>>>>

--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -137,7 +137,7 @@ class NextVotesManager {
  */
 class VoteManager {
  public:
-  VoteManager(size_t pbft_committee_size, const addr_t& node_addr, std::shared_ptr<DbStorage> db,
+  VoteManager(const addr_t& node_addr, std::shared_ptr<DbStorage> db,
               std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<FinalChain> final_chain,
               std::shared_ptr<NextVotesManager> next_votes_mgr, std::shared_ptr<KeyManager> key_manager);
   ~VoteManager();
@@ -202,8 +202,10 @@ class VoteManager {
   /**
    * @brief Add a vote to the verified votes map
    * @param vote vote
+   *
+   * @return true if vote was successfully added, otherwise false
    */
-  void addVerifiedVote(std::shared_ptr<Vote> const& vote);
+  bool addVerifiedVote(std::shared_ptr<Vote> const& vote);
 
   /**
    * @brief Check if the vote has been in the verified votes map
@@ -276,12 +278,17 @@ class VoteManager {
 
   /**
    * @brief Add last period cert vote to reward_votes_ after the cert vote voted block finalized
-   *
    * @param cert vote voted to last period PBFT block
    *
-   * @return true if add successful
+   * @return true if vote was successfully added, otherwise false
    */
   bool addRewardVote(const std::shared_ptr<Vote>& vote);
+
+  /**
+   * @param vote_hash
+   * @return true if vote_hash is already in rewards_votes, otheriwse false
+   */
+  bool isKnownRewardVote(const vote_hash_t& vote_hash);
 
   /**
    * @brief Check reward_votes_ if including all reward votes for the PBFT block
@@ -378,9 +385,6 @@ class VoteManager {
   mutable boost::shared_mutex unverified_votes_access_;
   mutable boost::shared_mutex verified_votes_access_;
 
-  const size_t pbft_committee_size_;
-  const addr_t node_addr_;
-
   std::shared_ptr<DbStorage> db_;
   std::shared_ptr<PbftChain> pbft_chain_;
   std::shared_ptr<FinalChain> final_chain_;
@@ -388,6 +392,7 @@ class VoteManager {
   std::shared_ptr<KeyManager> key_manager_;
   std::weak_ptr<Network> network_;
 
+  // TODO: this seems like something we dont we dont need
   blk_hash_t reward_votes_pbft_block_hash_;
   uint64_t last_pbft_block_cert_round_;
   std::unordered_map<vote_hash_t, std::shared_ptr<Vote>> reward_votes_;

--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -137,9 +137,9 @@ class NextVotesManager {
  */
 class VoteManager {
  public:
-  VoteManager(const addr_t& node_addr, std::shared_ptr<DbStorage> db,
-              std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<FinalChain> final_chain,
-              std::shared_ptr<NextVotesManager> next_votes_mgr, std::shared_ptr<KeyManager> key_manager);
+  VoteManager(const addr_t& node_addr, std::shared_ptr<DbStorage> db, std::shared_ptr<PbftChain> pbft_chain,
+              std::shared_ptr<FinalChain> final_chain, std::shared_ptr<NextVotesManager> next_votes_mgr,
+              std::shared_ptr<KeyManager> key_manager);
   ~VoteManager();
   VoteManager(const VoteManager&) = delete;
   VoteManager(VoteManager&&) = delete;

--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -212,9 +212,9 @@ class VoteManager {
 
   // reward votes
   /**
-   * @return current rewards votes pbft block hash
+   * @return current rewards votes <pbft block hash, pbft block period>
    */
-  blk_hash_t getCurrentRewardsVotesBlock() const;
+  std::pair<blk_hash_t, uint64_t> getCurrentRewardsVotesBlock() const;
 
   /**
    * @brief Add last period cert vote to reward_votes_ after the cert vote voted block finalized
@@ -275,25 +275,6 @@ class VoteManager {
    */
   void sendRewardVotes(const blk_hash_t& pbft_block_hash);
 
-  /**
-   * @brief Verify reward vote
-   *
-   * @param cert vote voted to last period PBFT block
-   *
-   * @return true if pass vote verification
-   */
-  bool verifyRewardVote(const std::shared_ptr<Vote>& vote);
-
-  /**
-   * @brief Verify reward vote
-   *
-   * @param cert vote voted to last period PBFT block
-   * @param period period
-   *
-   * @return true if pass vote verification
-   */
-  bool verifyRewardVoteForPeriod(const std::shared_ptr<Vote>& vote, uint64_t period);
-
  private:
   /**
    * @brief Retrieve all verified votes from DB to the verified votes map. And broadcast all next voting type votes to
@@ -332,10 +313,9 @@ class VoteManager {
   // TODO[1907]: end of VerifiedVotes class
 
   // TODO[1907]: this will be part of RewardVotes class
-  blk_hash_t reward_votes_pbft_block_hash_;
+  std::pair<blk_hash_t, uint64_t /* period */> reward_votes_pbft_block_;
   uint64_t last_pbft_block_cert_round_;
   std::unordered_map<vote_hash_t, std::shared_ptr<Vote>> reward_votes_;
-  std::unordered_map<addr_t, vote_hash_t> reward_votes_unique_authors_;
   mutable std::shared_mutex reward_votes_mutex_;
   // TODO[1907]: end of RewardVotes class
 

--- a/libraries/core_libs/consensus/src/final_chain/rewards_stats.cpp
+++ b/libraries/core_libs/consensus/src/final_chain/rewards_stats.cpp
@@ -96,7 +96,7 @@ std::vector<addr_t> RewardsStats::processStats(const PeriodData& block, uint64_t
     auto tx_validator = getTransactionValidator(tx->getHash());
     assert(tx_validator.has_value());
 
-    txs_validators.push_back(tx_validator.value());
+    txs_validators.push_back(*tx_validator);
   }
 
   return txs_validators;

--- a/libraries/core_libs/consensus/src/pbft/pbft_chain.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_chain.cpp
@@ -65,7 +65,7 @@ PbftBlock PbftChain::getPbftBlockInChain(const taraxa::blk_hash_t& pbft_block_ha
     LOG(log_er_) << "Cannot find PBFT block hash " << pbft_block_hash << " in DB";
     assert(false);
   }
-  return pbft_block.value();
+  return *pbft_block;
 }
 
 std::shared_ptr<PbftBlock> PbftChain::getUnverifiedPbftBlock(const taraxa::blk_hash_t& pbft_block_hash) {

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -414,7 +414,6 @@ bool PbftManager::resetRound_() {
   vote_mgr_->cleanupVotes(consensus_pbft_round);
 
   if (executed_pbft_block_) {
-    vote_mgr_->removeVerifiedVotes();
     updateDposState_();
     // reset sortition_threshold and TWO_T_PLUS_ONE
     updateTwoTPlusOneAndThreshold_();
@@ -1695,7 +1694,6 @@ void PbftManager::pushSyncedPbftBlocksIntoChain() {
       net->setSyncStatePeriod(period);
 
       if (executed_pbft_block_) {
-        vote_mgr_->removeVerifiedVotes();
         updateDposState_();
         // update sortition_threshold and TWO_T_PLUS_ONE
         updateTwoTPlusOneAndThreshold_();
@@ -1918,13 +1916,10 @@ void PbftManager::countVotes_() const {
   auto round = getPbftRound();
   while (!monitor_stop_) {
     auto verified_votes = vote_mgr_->getVerifiedVotes();
-    auto unverified_votes = vote_mgr_->copyUnverifiedVotes();
     std::vector<std::shared_ptr<Vote>> votes;
-    votes.reserve(verified_votes.size() + unverified_votes.size());
+    votes.reserve(verified_votes.size());
     votes.insert(votes.end(), std::make_move_iterator(verified_votes.begin()),
                  std::make_move_iterator(verified_votes.end()));
-    votes.insert(votes.end(), std::make_move_iterator(unverified_votes.begin()),
-                 std::make_move_iterator(unverified_votes.end()));
 
     size_t last_step_votes = 0;
     size_t current_step_votes = 0;

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -266,6 +266,8 @@ std::pair<bool, uint64_t> PbftManager::getDagBlockPeriod(blk_hash_t const &hash)
 
 uint64_t PbftManager::getPbftRound() const { return round_; }
 
+std::pair<uint64_t, uint64_t> PbftManager::getPbftRoundAndPeriod() const { return {round_, previous_round_period_}; }
+
 uint64_t PbftManager::getPbftStep() const { return step_; }
 
 void PbftManager::setPbftRound(uint64_t const round) {
@@ -346,25 +348,31 @@ void PbftManager::resetStep_() {
 }
 
 bool PbftManager::resetRound_() {
-  // Jump to round
-  auto consensus_pbft_round = vote_mgr_->roundDeterminedFromVotes(TWO_T_PLUS_ONE);
-  // current round
-  auto round = getPbftRound();
-
-  if (consensus_pbft_round <= round) {
+  auto determined_round_and_period = vote_mgr_->determineRoundAndPeriodFromVotes(TWO_T_PLUS_ONE);
+  if (!determined_round_and_period.has_value()) {
     return false;
   }
 
-  LOG(log_nf_) << "Determined round from votes: " << consensus_pbft_round;
+  auto [determined_round, determined_previous_round_period] = determined_round_and_period.value();
+
+  // current round
+  auto round = getPbftRound();
+  if (determined_round <= round) {
+    return false;
+  }
+
+  LOG(log_nf_) << "Round & period reset to: " << determined_round << ", " << determined_previous_round_period;
   round_clock_initial_datetime_ = now_;
   // Update current round and reset step to 1
-  round_ = consensus_pbft_round;
+  round_ = determined_round;
+  previous_round_period_ = determined_previous_round_period;
   resetStep_();
   state_ = value_proposal_state;
 
-  LOG(log_dg_) << "Advancing clock to pbft round " << consensus_pbft_round << ", step 1, and resetting clock.";
+  LOG(log_dg_) << "Advancing clock to pbft round " << determined_round << ", period "
+               << determined_previous_round_period << ", step 1, and resetting clock.";
 
-  const auto previoud_round = consensus_pbft_round - 1;
+  const auto previous_round = determined_round - 1;
 
   auto next_votes = next_votes_manager_->getNextVotes();
 
@@ -372,13 +380,14 @@ bool PbftManager::resetRound_() {
   auto batch = db_->createWriteBatch();
 
   // Update PBFT round and reset step to 1
-  db_->addPbftMgrFieldToBatch(PbftMgrRoundStep::PbftRound, consensus_pbft_round, batch);
+  db_->addPbftMgrFieldToBatch(PbftMgrRoundStep::PbftRound, determined_round, batch);
+  db_->addPbftMgrFieldToBatch(PbftMgrRoundStep::PreviousRoundPbftPeriod, determined_previous_round_period, batch);
   db_->addPbftMgrFieldToBatch(PbftMgrRoundStep::PbftStep, 1, batch);
 
-  db_->addPbft2TPlus1ToBatch(previoud_round, TWO_T_PLUS_ONE, batch);
-  db_->addNextVotesToBatch(previoud_round, next_votes, batch);
+  db_->addPbft2TPlus1ToBatch(previous_round, TWO_T_PLUS_ONE, batch);
+  db_->addNextVotesToBatch(previous_round, next_votes, batch);
   if (round > 1) {
-    // Cleanup old previoud round next votes
+    // Cleanup old previous round next votes
     db_->removeNextVotesToBatch(round - 1, batch);
   }
 
@@ -388,11 +397,15 @@ bool PbftManager::resetRound_() {
   db_->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposTotalVotesCount,
                                      getDposTotalVotesCount(), batch);
   db_->addPbftMgrStatusToBatch(PbftMgrStatus::ExecutedInRound, false, batch);
-  db_->addPbftMgrVotedValueToBatch(PbftMgrVotedValue::OwnStartingValueInRound, NULL_BLOCK_HASH, batch);
+  db_->addPbftMgrVotedValueToBatch(PbftMgrVotedValue::OwnStartingValueInRound,
+                                   {NULL_BLOCK_HASH, determined_previous_round_period}, batch);
   db_->addPbftMgrStatusToBatch(PbftMgrStatus::NextVotedNullBlockHash, false, batch);
   db_->addPbftMgrStatusToBatch(PbftMgrStatus::NextVotedSoftValue, false, batch);
-  db_->addPbftMgrVotedValueToBatch(PbftMgrVotedValue::SoftVotedBlockHashInRound, NULL_BLOCK_HASH, batch);
-  if (soft_voted_block_for_this_round_) {
+
+  db_->removePbftMgrVotedValueToBatch(PbftMgrVotedValue::SoftVotedBlockInRound, batch);
+  db_->removePbftMgrVotedValueToBatch(PbftMgrVotedValue::CertVotedBlockInRound, batch);
+
+  if (soft_voted_block_for_round_) {
     // Cleanup soft votes for previous round
     db_->removeSoftVotesToBatch(round, batch);
   }
@@ -401,17 +414,18 @@ bool PbftManager::resetRound_() {
   have_executed_this_round_ = false;
   should_have_cert_voted_in_this_round_ = false;
   // reset starting value to NULL_BLOCK_HASH
-  own_starting_value_for_round_ = NULL_BLOCK_HASH;
+  own_starting_value_for_round_ = {NULL_BLOCK_HASH, determined_previous_round_period};
   // reset next voted value since start a new round
   next_voted_null_block_hash_ = false;
   next_voted_soft_value_ = false;
   polling_state_print_log_ = true;
 
-  // Reset soft voting leader value in the new upcoming round
-  soft_voted_block_for_this_round_ = NULL_BLOCK_HASH;
+  // Reset soft voting leader & cert voted block values in the new upcoming round
+  soft_voted_block_for_round_.reset();
+  cert_voted_block_for_round_.reset();
 
   // Move to a new round, cleanup previous round votes
-  vote_mgr_->cleanupVotes(consensus_pbft_round);
+  vote_mgr_->cleanupVotes(determined_round);
 
   if (executed_pbft_block_) {
     updateDposState_();
@@ -454,6 +468,7 @@ void PbftManager::initialState() {
   max_wait_for_next_voted_block_steps_ms_ = MAX_WAIT_FOR_NEXT_VOTED_BLOCK_STEPS * 2 * LAMBDA_ms;
 
   auto round = db_->getPbftMgrField(PbftMgrRoundStep::PbftRound);
+  auto previous_round_period = db_->getPbftMgrField(PbftMgrRoundStep::PreviousRoundPbftPeriod);
   auto step = db_->getPbftMgrField(PbftMgrRoundStep::PbftStep);
   if (round == 1 && step == 1) {
     // Node start from scratch
@@ -475,7 +490,8 @@ void PbftManager::initialState() {
   // This is used to offset endtime for second finishing step...
   startingStepInRound_ = step;
   setPbftStep(step);
-  setPbftRound(round);
+  round_ = round;
+  previous_round_period_ = previous_round_period;
 
   if (round > 1) {
     // Get next votes for previous round from DB
@@ -497,7 +513,7 @@ void PbftManager::initialState() {
   previous_round_next_voted_value_ = next_votes_manager_->getVotedValue();
   previous_round_next_voted_null_block_hash_ = next_votes_manager_->haveEnoughVotesForNullBlockHash();
 
-  LOG(log_nf_) << "Node initialize at round " << round << " step " << step
+  LOG(log_nf_) << "Node initialize at round " << round << ", r-1 period " << previous_round_period << ", step " << step
                << ". Previous round has enough next votes for NULL_BLOCK_HASH: " << std::boolalpha
                << next_votes_manager_->haveEnoughVotesForNullBlockHash() << ", voted value "
                << previous_round_next_voted_value_ << ", next votes size in previous round is "
@@ -508,39 +524,40 @@ void PbftManager::initialState() {
   pbft_step_last_requested_sync_ = 0;
 
   auto own_starting_value = db_->getPbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound);
-  if (own_starting_value) {
+  if (own_starting_value.has_value()) {
     // From DB
-    own_starting_value_for_round_ = *own_starting_value;
+    own_starting_value_for_round_ = own_starting_value.value();
   } else {
     // Default value
-    own_starting_value_for_round_ = NULL_BLOCK_HASH;
+    assert(previous_round_period == 1);
+    own_starting_value_for_round_ = {NULL_BLOCK_HASH, 1};
   }
 
-  auto soft_voted_block_hash = db_->getPbftMgrVotedValue(PbftMgrVotedValue::SoftVotedBlockHashInRound);
-  if (soft_voted_block_hash) {
+  auto soft_voted_block = db_->getPbftMgrVotedValue(PbftMgrVotedValue::SoftVotedBlockInRound);
+  if (soft_voted_block.has_value()) {
     // From DB
-    soft_voted_block_for_this_round_ = *soft_voted_block_hash;
+    soft_voted_block_for_round_ = soft_voted_block;
     for (const auto &vote : db_->getSoftVotes(round)) {
-      if (vote->getBlockHash() != *soft_voted_block_hash) {
-        LOG(log_er_) << "The soft vote should have voting value " << *soft_voted_block_hash << ". Vote" << vote;
+      if (vote->getBlockHash() != soft_voted_block->first) {
+        LOG(log_er_) << "The soft vote should have voting value " << soft_voted_block->first << ". Vote" << vote;
         continue;
       }
       vote_mgr_->addVerifiedVote(vote);
     }
   } else {
     // Default value
-    soft_voted_block_for_this_round_ = NULL_BLOCK_HASH;
+    soft_voted_block_for_round_.reset();
   }
 
   // Used for detecting timeout due to malicious node
   // failing to gossip PBFT block or DAG blocks
-  // Requires that soft_voted_block_for_this_round_ already be initialized from db
+  // Requires that soft_voted_block_for_round_ already be initialized from db
   initializeVotedValueTimeouts_();
 
-  auto last_cert_voted_value = db_->getPbftMgrVotedValue(PbftMgrVotedValue::LastCertVotedValue);
-  if (last_cert_voted_value) {
-    last_cert_voted_value_ = *last_cert_voted_value;
-    LOG(log_nf_) << "Initialize last cert voted value " << last_cert_voted_value_;
+  if (auto cert_voted_block = db_->getPbftMgrVotedValue(PbftMgrVotedValue::CertVotedBlockInRound);
+      cert_voted_block.has_value()) {
+    cert_voted_block_for_round_ = cert_voted_block.value();
+    LOG(log_nf_) << "Initialize last cert voted value " << cert_voted_block_for_round_->first;
   }
 
   executed_pbft_block_ = db_->getPbftMgrStatus(PbftMgrStatus::ExecutedBlock);
@@ -635,11 +652,11 @@ void PbftManager::setFinishPollingState_() {
 void PbftManager::loopBackFinishState_() {
   auto round = getPbftRound();
   LOG(log_dg_) << "CONSENSUS debug round " << round << " , step " << step_
-               << " | next_voted_soft_value_ = " << next_voted_soft_value_
-               << " soft block = " << soft_voted_block_for_this_round_
+               << " | next_voted_soft_value_ = " << next_voted_soft_value_ << " soft_voted_value_for_round = "
+               << (soft_voted_block_for_round_.has_value() ? soft_voted_block_for_round_->first.abridged() : "no value")
                << " next_voted_null_block_hash_ = " << next_voted_null_block_hash_
-               << " last_soft_voted_value_ = " << last_soft_voted_value_
-               << " last_cert_voted_value_ = " << last_cert_voted_value_
+               << " last_soft_voted_value_ = " << last_soft_voted_value_ << " cert_voted_value_for_round = "
+               << (cert_voted_block_for_round_.has_value() ? cert_voted_block_for_round_->first.abridged() : "no value")
                << " previous_round_next_voted_value_ = " << previous_round_next_voted_value_;
   state_ = finish_state;
   setPbftStep(step_ + 1);
@@ -665,8 +682,34 @@ bool PbftManager::stateOperations_() {
   duration_ = now_ - round_clock_initial_datetime_;
   elapsed_time_in_round_ms_ = std::chrono::duration_cast<std::chrono::milliseconds>(duration_).count();
 
-  auto round = getPbftRound();
-  LOG(log_tr_) << "PBFT current round is " << round << ", step is " << step_;
+  auto [round, previous_round_period] = getPbftRoundAndPeriod();
+  LOG(log_dg_) << "PBFT current round(r): " << round << ", r-1 period: " << previous_round_period << ", step " << step_;
+
+  static bool is_new_round = false;
+  if (is_new_round) {
+    // Checks if node is in sync with determined pbft period from votes, if not - do not allow node to place votes
+    // This check is done only at the beginning of new round by purpose as chain size might change after cert vote step
+    // when new cert voted block is pushed into the chain
+    // TODO: think about this properly - should we allow next voting even if node is out of sync ?
+    const auto chain_size = pbft_chain_->getPbftChainSize();
+    if (chain_size < previous_round_period - 1) {
+      LOG(log_wr_) << "Period determined from next votes: " << previous_round_period
+                   << " < chain size + 1: " << chain_size + 1 << ". Wait to get in sync.";
+      // TODO: use some normal sleep time
+      using namespace std::chrono_literals;
+      std::this_thread::sleep_for(50ms);
+      return true;
+    }
+
+    if (chain_size > previous_round_period) {
+      // It should never happen that node has bigger chain size than period determined from the latest next votes,
+      // something is probably seriously wrong in such case
+      assert(true);
+    }
+
+    // Node is in sync
+    is_new_round = false;
+  }
 
   // Remove old votes
   vote_mgr_->cleanupVotes(round);
@@ -675,60 +718,72 @@ bool PbftManager::stateOperations_() {
   // ROUND.  IF WE HAVE THEN WE EXECUTE THE BLOCK
   // ONLY CHECK IF HAVE *NOT* YET EXECUTED THIS ROUND...
   if (state_ == certify_state && !have_executed_this_round_) {
-    auto voted_block_hash_with_cert_votes = vote_mgr_->getVotesBundleByRoundAndStep(round, 3, TWO_T_PLUS_ONE);
-    if (voted_block_hash_with_cert_votes) {
-      LOG(log_dg_) << "PBFT block " << voted_block_hash_with_cert_votes->voted_block_hash << " has enough certed votes";
+    if (auto certified_block = vote_mgr_->getVotesBundle(round, previous_round_period, 3, TWO_T_PLUS_ONE);
+        certified_block.has_value()) {
+      LOG(log_dg_) << "PBFT block " << certified_block->voted_block_hash << " has enough cert votes";
       // put pbft block into chain
-      const auto vote_size = voted_block_hash_with_cert_votes->votes.size();
-      if (pushCertVotedPbftBlockIntoChain_(voted_block_hash_with_cert_votes->voted_block_hash,
-                                           std::move(voted_block_hash_with_cert_votes->votes))) {
+      if (pushCertVotedPbftBlockIntoChain_(certified_block->voted_block_hash, std::move(certified_block->votes))) {
         db_->savePbftMgrStatus(PbftMgrStatus::ExecutedInRound, true);
         have_executed_this_round_ = true;
-        LOG(log_nf_) << "Write " << vote_size << " cert votes ... in round " << round;
+        LOG(log_nf_) << "Write " << certified_block->votes.size() << " cert votes ... in round " << round;
 
         duration_ = std::chrono::system_clock::now() - now_;
         auto execute_trxs_in_ms = std::chrono::duration_cast<std::chrono::milliseconds>(duration_).count();
-        LOG(log_dg_) << "Pushing PBFT block and Execution spent " << execute_trxs_in_ms << " ms. in round " << round;
+        LOG(log_dg_) << "PBFT block " << certified_block->voted_block_hash
+                     << " certified and pushed into chain in round " << round << ". Execution time "
+                     << execute_trxs_in_ms << " [ms]";
         // Restart while loop
         return true;
+      } else {
+        LOG(log_er_) << "PBFT block " << certified_block->voted_block_hash
+                     << " certified but not pushed into chain in round " << round;
       }
     }
   }
 
-  return resetRound_();
-}
-
-bool PbftManager::updateSoftVotedBlockForThisRound_() {
-  if (soft_voted_block_for_this_round_) {
-    // Have enough soft votes for current round already
-    return true;
-  }
-
-  auto round = getPbftRound();
-  const auto voted_block_hash_with_soft_votes = vote_mgr_->getVotesBundleByRoundAndStep(round, 2, TWO_T_PLUS_ONE);
-  if (voted_block_hash_with_soft_votes) {
-    // Have enough soft votes for a voted value
-    auto batch = db_->createWriteBatch();
-    db_->addPbftMgrVotedValueToBatch(PbftMgrVotedValue::SoftVotedBlockHashInRound,
-                                     voted_block_hash_with_soft_votes->voted_block_hash, batch);
-    db_->addSoftVotesToBatch(round, voted_block_hash_with_soft_votes->votes, batch);
-    db_->commitWriteBatch(batch);
-
-    soft_voted_block_for_this_round_ = voted_block_hash_with_soft_votes->voted_block_hash;
-
+  if (resetRound_()) {
+    is_new_round = true;
     return true;
   }
 
   return false;
 }
 
+std::optional<std::pair<blk_hash_t, uint64_t>> PbftManager::getSoftVotedBlockForThisRound_() {
+  // Check current round cache
+  if (soft_voted_block_for_round_.has_value()) {
+    // Have enough soft votes for current round already
+    return soft_voted_block_for_round_;
+  }
+
+  auto [round, previous_round_period] = getPbftRoundAndPeriod();
+
+  const auto voted_block_hash_with_soft_votes =
+      vote_mgr_->getVotesBundle(round, previous_round_period, 2, TWO_T_PLUS_ONE);
+  if (voted_block_hash_with_soft_votes.has_value()) {
+    // Have enough soft votes for a voted value
+    auto batch = db_->createWriteBatch();
+    soft_voted_block_for_round_ = {std::make_pair(voted_block_hash_with_soft_votes->voted_block_hash,
+                                                  voted_block_hash_with_soft_votes->votes_period)};
+
+    db_->addPbftMgrVotedValueToBatch(PbftMgrVotedValue::SoftVotedBlockInRound, soft_voted_block_for_round_.value(),
+                                     batch);
+    db_->addSoftVotesToBatch(round, voted_block_hash_with_soft_votes->votes, batch);
+    db_->commitWriteBatch(batch);
+
+    return soft_voted_block_for_round_;
+  }
+
+  return {};
+}
+
 void PbftManager::initializeVotedValueTimeouts_() {
   time_began_waiting_next_voted_block_ = std::chrono::system_clock::now();
   time_began_waiting_soft_voted_block_ = std::chrono::system_clock::now();
 
-  // Concern: Requires that soft_voted_block_for_this_round_ already be initialized from db
-  if (soft_voted_block_for_this_round_) {
-    last_soft_voted_value_ = soft_voted_block_for_this_round_;
+  // Concern: Requires that soft_voted_block_for_round_ already be initialized from db
+  if (soft_voted_block_for_round_.has_value()) {
+    last_soft_voted_value_ = soft_voted_block_for_round_->first;
   }
 }
 
@@ -757,14 +812,15 @@ void PbftManager::checkPreviousRoundNextVotedValueChange_() {
 
 void PbftManager::proposeBlock_() {
   // Value Proposal
-  auto round = getPbftRound();
+  auto [round, previous_round_period] = getPbftRoundAndPeriod();
+  LOG(log_dg_) << "PBFT value proposal state in round(r): " << round << ", r-1 period: " << previous_round_period;
+
   if (round == 1) {
     // Round 1 cannot propose block. Everyone has to next vote NULL_BLOCK_HASH in round 1 to make consensus go to next
     // round
     return;
   }
 
-  LOG(log_tr_) << "PBFT value proposal state in round " << round;
   // Round greater than 1
   if (next_votes_manager_->haveEnoughVotesForNullBlockHash()) {
     LOG(log_nf_) << "Previous round " << round - 1 << " next voted block is NULL_BLOCK_HASH";
@@ -775,93 +831,120 @@ void PbftManager::proposeBlock_() {
     assert(false);
   }
 
+  // Propose new block
   if (giveUpNextVotedBlock_()) {
-    const auto propose_period = pbft_chain_->getPbftChainSize() + 1;
-
     // PBFT block only be able to propose once in each period
-    if (!proposed_block_hash_) {
-      proposed_block_hash_ = proposePbftBlock_(propose_period);
+    if (!proposed_block_) {
+      proposed_block_ = proposePbftBlock_();
     }
-    if (proposed_block_hash_) {
-      db_->savePbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound, proposed_block_hash_);
-      own_starting_value_for_round_ = proposed_block_hash_;
 
-      auto place_votes = placeVote_(own_starting_value_for_round_, propose_vote_type, propose_period, round, step_);
-      if (place_votes) {
-        LOG(log_nf_) << "Proposing " << place_votes << " own starting value " << own_starting_value_for_round_
-                     << " for round " << round;
+    if (proposed_block_) {
+      own_starting_value_for_round_ = {proposed_block_->getBlockHash(), proposed_block_->getPeriod()};
+      db_->savePbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound, own_starting_value_for_round_);
+
+      if (auto vote_weight = placeVote_(proposed_block_->getBlockHash(), propose_vote_type,
+                                        proposed_block_->getPeriod(), round, step_);
+          vote_weight) {
+        LOG(log_nf_) << "Placed propose vote for new block " << proposed_block_->getBlockHash() << ", vote weight "
+                     << vote_weight << ", round " << round << ", period " << proposed_block_->getPeriod() << ", step "
+                     << step_;
       }
     }
-  } else if (previous_round_next_voted_value_) {
-    db_->savePbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound, previous_round_next_voted_value_);
-    own_starting_value_for_round_ = previous_round_next_voted_value_;
+    return;
+  }
 
-    auto pbft_block = pbft_chain_->getUnverifiedPbftBlock(own_starting_value_for_round_);
+  // Re-propose block from previous round
+  if (!previous_round_next_voted_value_) {
+    // There is no block from previous round, return
+    return;
+  }
+
+  own_starting_value_for_round_ = {previous_round_next_voted_value_, previous_round_period};
+  db_->savePbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound, own_starting_value_for_round_);
+
+  auto pbft_block = pbft_chain_->getUnverifiedPbftBlock(own_starting_value_for_round_.first);
+  if (!pbft_block) {
+    LOG(log_dg_) << "Unable to find proposal block " << own_starting_value_for_round_.first
+                 << " from previous round in unverified queue";
+    pbft_block = db_->getPbftCertVotedBlock(own_starting_value_for_round_.first);
     if (!pbft_block) {
-      LOG(log_dg_) << "Can't get proposal block " << own_starting_value_for_round_ << " in unverified queue";
-      pbft_block = db_->getPbftCertVotedBlock(own_starting_value_for_round_);
-      if (!pbft_block) {
-        LOG(log_dg_) << "Can't get proposal block " << own_starting_value_for_round_ << " in database";
-      }
+      LOG(log_dg_) << "Unable to find proposal block " << own_starting_value_for_round_.first
+                   << " from previous round in database";
+      return;
     }
-    if (pbft_block) {
-      // place vote
-      auto place_votes =
-          placeVote_(own_starting_value_for_round_, propose_vote_type, pbft_block->getPeriod(), round, step_);
-      if (place_votes) {
-        LOG(log_nf_) << "Rebroadcast next voted block " << own_starting_value_for_round_ << ", and propose "
-                     << place_votes << " votes "
-                     << " from previous round. In round " << round;
-        // broadcast pbft block
-        if (auto net = network_.lock()) {
-          net->getSpecificHandler<network::tarcap::PbftBlockPacketHandler>()->onNewPbftBlock(pbft_block);
-        }
-      }
+  }
+
+  if (pbft_block->getPeriod() != previous_round_period) {
+    LOG(log_er_) << "Previous round next voted block: " << pbft_block->getBlockHash()
+                 << " period: " << pbft_block->getPeriod()
+                 << " != previous round next votes pbft period: " << previous_round_period;
+    return;
+  }
+
+  // place vote
+  if (auto vote_weight =
+          placeVote_(pbft_block->getBlockHash(), propose_vote_type, pbft_block->getPeriod(), round, step_);
+      vote_weight) {
+    LOG(log_nf_) << "Placed propose vote for previous round block " << pbft_block->getBlockHash() << ", vote weight "
+                 << vote_weight << ", round " << round << ", period " << pbft_block->getPeriod() << ", step " << step_;
+
+    // broadcast pbft block
+    if (auto net = network_.lock()) {
+      net->getSpecificHandler<network::tarcap::PbftBlockPacketHandler>()->onNewPbftBlock(pbft_block);
     }
   }
 }
 
 void PbftManager::identifyBlock_() {
   // The Filtering Step
-  auto round = getPbftRound();
-  LOG(log_tr_) << "PBFT filtering state in round " << round;
+  auto [round, previous_round_period] = getPbftRoundAndPeriod();
+  LOG(log_dg_) << "PBFT filtering state in round(r): " << round << ", r-1 period: " << previous_round_period;
 
   if (giveUpNextVotedBlock_()) {
     // Identity leader
-    if (auto leader_block = identifyLeaderBlock_(); leader_block.has_value()) {
-      db_->savePbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound, leader_block->first);
-      own_starting_value_for_round_ = leader_block->first;
-      LOG(log_dg_) << "Identify leader block " << leader_block->first << " at round " << round;
+    if (auto leader_block = identifyLeaderBlock_(round, previous_round_period); leader_block.has_value()) {
+      auto [leader_block_hash, leader_block_period] = leader_block.value();
+      own_starting_value_for_round_ = {leader_block_hash, leader_block_period};
+      db_->savePbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound, own_starting_value_for_round_);
+      LOG(log_dg_) << "Leader block identified " << leader_block_hash << ", round " << round << ", period "
+                   << leader_block_period;
 
-      if (auto place_votes = placeVote_(leader_block->first, soft_vote_type, leader_block->second, round, step_);
-          place_votes) {
-        LOG(log_nf_) << "Soft votes " << place_votes << " voting block " << leader_block->first << " at round "
-                     << round;
+      if (auto vote_weight = placeVote_(leader_block_hash, soft_vote_type, leader_block_period, round, step_);
+          vote_weight) {
+        LOG(log_nf_) << "Placed soft vote for " << leader_block_hash << ", vote weight " << vote_weight << ", round "
+                     << round << ", period " << leader_block_period << ", step " << step_;
       }
 
       updateLastSoftVotedValue_(leader_block->first);
     }
-  } else if (previous_round_next_voted_value_) {
-    // TODO: what period to send here ???
-    const auto voting_period = pbft_chain_->getPbftChainSize() + 1;
-    auto place_votes = placeVote_(previous_round_next_voted_value_, soft_vote_type, voting_period, round, step_);
 
-    // Generally this value will either be the same as last soft voted value from previous round
-    // but a node could have observed a previous round next voted value that differs from what they
-    // soft voted.
-    updateLastSoftVotedValue_(previous_round_next_voted_value_);
-
-    if (place_votes) {
-      LOG(log_nf_) << "Soft votes " << place_votes << " voting block " << previous_round_next_voted_value_
-                   << " from previous round. In round " << round;
-    }
+    return;
   }
+
+  // Soft vote for block from previous round
+  if (!previous_round_next_voted_value_) {
+    // There is no block from previous round, return
+    return;
+  }
+
+  if (auto vote_weight =
+          placeVote_(previous_round_next_voted_value_, soft_vote_type, previous_round_period, round, step_);
+      vote_weight) {
+    LOG(log_nf_) << "Placed soft vote for block from previous round " << previous_round_next_voted_value_
+                 << ", vote weight " << vote_weight << ", round " << round << ", period " << previous_round_period
+                 << ", step " << step_;
+  }
+
+  // Generally this value will either be the same as last soft voted value from previous round
+  // but a node could have observed a previous round next voted value that differs from what they
+  // soft voted.
+  updateLastSoftVotedValue_(previous_round_next_voted_value_);
 }
 
 void PbftManager::certifyBlock_() {
   // The Certifying Step
-  auto round = getPbftRound();
-  LOG(log_tr_) << "PBFT certifying state in round " << round;
+  auto [round, previous_round_period] = getPbftRoundAndPeriod();
+  LOG(log_dg_) << "PBFT certifying state in round(r): " << round << ", r-1 period: " << previous_round_period;
 
   go_finish_state_ = elapsed_time_in_round_ms_ > 4 * LAMBDA_ms - POLLING_INTERVAL_ms;
 
@@ -877,84 +960,107 @@ void PbftManager::certifyBlock_() {
     return;
   }
 
-  if (!should_have_cert_voted_in_this_round_) {
-    LOG(log_tr_) << "In step 3";
+  // Already sent (or should have) cert voted in this round
+  if (should_have_cert_voted_in_this_round_) {
+    LOG(log_dg_) << "Already did (or should have) cert vote in this round " << round;
+    return;
+  }
 
-    // TODO: we are not checking if new certe voted block previous block hash exists
-    if (updateSoftVotedBlockForThisRound_() && compareBlocksAndRewardVotes_(soft_voted_block_for_this_round_)) {
-      LOG(log_tr_) << "Finished compareBlocksAndRewardVotes_";
+  // Get soft voted bock with 2t+1 soft votes
+  const auto soft_voted_block = getSoftVotedBlockForThisRound_();
+  if (soft_voted_block.has_value() == false) {
+    LOG(log_dg_) << "Certify: Not enough soft votes for current round yet. Round " << round << ", r-1 period "
+                 << previous_round_period;
+    return;
+  }
+  const auto [current_round_soft_voted_block, current_round_soft_votes_period] = soft_voted_block.value();
 
-      // NOTE: If we have already executed this round then block won't be found in unverified queue...
-      bool executed_soft_voted_block_for_this_round = false;
-      if (have_executed_this_round_) {
-        LOG(log_tr_) << "Have already executed before certifying in step 3 in round " << round;
-        auto last_pbft_block_hash = pbft_chain_->getLastPbftBlockHash();
-        if (last_pbft_block_hash == soft_voted_block_for_this_round_) {
-          LOG(log_tr_) << "Having executed, last block in chain is the soft voted block in round " << round;
-          executed_soft_voted_block_for_this_round = true;
-        }
+  if (!compareBlocksAndRewardVotes_(current_round_soft_voted_block)) {
+    LOG(log_dg_) << "Incomplete or invalid soft voted block " << current_round_soft_voted_block << ", round " << round
+                 << ", r-1 period " << previous_round_period;
+    return;
+  }
+
+  // TODO: we are not checking if new cert voted block previous block hash exists ?
+
+  LOG(log_tr_) << "Finished compareBlocksAndRewardVotes_";
+
+  // NOTE: If we have already executed this round then block won't be found in unverified queue...
+  bool executed_soft_voted_block_for_this_round = false;
+  if (have_executed_this_round_) {
+    LOG(log_tr_) << "Have already executed before certifying in step 3 in round " << round;
+    auto last_pbft_block_hash = pbft_chain_->getLastPbftBlockHash();
+    if (last_pbft_block_hash == current_round_soft_voted_block) {
+      LOG(log_tr_) << "Having executed, last block in chain is the soft voted block in round " << round;
+      executed_soft_voted_block_for_this_round = true;
+    }
+  }
+
+  bool unverified_soft_vote_block_for_this_round_is_valid = false;
+  if (!executed_soft_voted_block_for_this_round) {
+    auto block = pbft_chain_->getUnverifiedPbftBlock(current_round_soft_voted_block);
+    if (block && pbft_chain_->checkPbftBlockValidation(*block)) {
+      unverified_soft_vote_block_for_this_round_is_valid = true;
+    } else {
+      if (!block) {
+        LOG(log_er_) << "Cannot find the unverified pbft block " << current_round_soft_voted_block << " in round "
+                     << round << ", step 3";
       }
+      syncPbftChainFromPeers_(invalid_soft_voted_block, current_round_soft_voted_block);
+    }
+  }
 
-      bool unverified_soft_vote_block_for_this_round_is_valid = false;
-      if (!executed_soft_voted_block_for_this_round) {
-        auto block = pbft_chain_->getUnverifiedPbftBlock(soft_voted_block_for_this_round_);
-        if (block && pbft_chain_->checkPbftBlockValidation(*block)) {
-          unverified_soft_vote_block_for_this_round_is_valid = true;
-        } else {
-          if (!block) {
-            LOG(log_er_) << "Cannot find the unverified pbft block " << soft_voted_block_for_this_round_ << " in round "
-                         << round << " step 3";
-          }
-          syncPbftChainFromPeers_(invalid_soft_voted_block, soft_voted_block_for_this_round_);
-        }
-      }
+  if (executed_soft_voted_block_for_this_round || unverified_soft_vote_block_for_this_round_is_valid) {
+    // compareBlocksAndRewardVotes_ has checked the cert voted block exist
+    auto cert_voted_block = getUnfinalizedBlock_(current_round_soft_voted_block);
+    assert(cert_voted_block != nullptr);
 
-      if (executed_soft_voted_block_for_this_round || unverified_soft_vote_block_for_this_round_is_valid) {
-        // compareBlocksAndRewardVotes_ has checked the cert voted block exist
-        auto cert_voted_block = getUnfinalizedBlock_(soft_voted_block_for_this_round_);
-        assert(cert_voted_block != nullptr);
+    if (cert_voted_block->getPeriod() != current_round_soft_votes_period) {
+      LOG(log_er_) << "CertifyBlock: Soft voted block period " << cert_voted_block->getPeriod()
+                   << " != 2t+1 soft votes period " << current_round_soft_votes_period << ", round " << round;
+      return;
+    }
 
-        last_cert_voted_value_ = soft_voted_block_for_this_round_;
+    cert_voted_block_for_round_ = {cert_voted_block->getBlockHash(), cert_voted_block->getPeriod()};
 
-        auto batch = db_->createWriteBatch();
-        db_->addPbftMgrVotedValueToBatch(PbftMgrVotedValue::LastCertVotedValue, last_cert_voted_value_, batch);
-        db_->addPbftCertVotedBlockToBatch(*cert_voted_block, batch);
-        db_->commitWriteBatch(batch);
+    auto batch = db_->createWriteBatch();
+    db_->addPbftMgrVotedValueToBatch(PbftMgrVotedValue::CertVotedBlockInRound, cert_voted_block_for_round_.value(),
+                                     batch);
+    db_->addPbftCertVotedBlockToBatch(*cert_voted_block, batch);
+    db_->commitWriteBatch(batch);
 
-        should_have_cert_voted_in_this_round_ = true;
+    should_have_cert_voted_in_this_round_ = true;
 
-        // generate cert vote
-        if (auto place_votes = placeVote_(soft_voted_block_for_this_round_, cert_vote_type,
-                                          cert_voted_block->getPeriod(), round, step_);
-            place_votes) {
-          LOG(log_nf_) << "Cert votes " << place_votes << " voting " << soft_voted_block_for_this_round_ << " in round "
-                       << round;
-        }
-      }
+    // generate cert vote
+    if (auto vote_weight =
+            placeVote_(cert_voted_block->getBlockHash(), cert_vote_type, cert_voted_block->getPeriod(), round, step_);
+        vote_weight) {
+      LOG(log_nf_) << "Placed cert vote " << cert_voted_block->getBlockHash() << ", vote weight " << vote_weight
+                   << ", round " << round << ", period " << cert_voted_block->getPeriod() << ", step " << step_;
     }
   }
 }
 
 void PbftManager::firstFinish_() {
   // Even number steps from 4 are in first finish
+  auto [round, previous_round_period] = getPbftRoundAndPeriod();
+  LOG(log_dg_) << "PBFT first finishing state in round(r): " << round << ", r-1 period: " << previous_round_period;
 
-  auto round = getPbftRound();
-  LOG(log_tr_) << "PBFT first finishing state at step " << step_ << " in round " << round;
-
-  if (last_cert_voted_value_ != NULL_BLOCK_HASH) {
-    auto last_cert_voted_block = getUnfinalizedBlock_(last_cert_voted_value_);
+  if (cert_voted_block_for_round_.has_value()) {
+    auto last_cert_voted_block = getUnfinalizedBlock_(cert_voted_block_for_round_->first);
     assert(last_cert_voted_block != nullptr);
 
-    if (auto place_votes =
-            placeVote_(last_cert_voted_value_, next_vote_type, last_cert_voted_block->getPeriod(), round, step_);
-        place_votes) {
-      LOG(log_nf_) << "Next votes " << place_votes << " voting cert voted value " << last_cert_voted_value_
-                   << " for round " << round << " , step " << step_;
+    if (auto vote_weight = placeVote_(last_cert_voted_block->getBlockHash(), next_vote_type,
+                                      last_cert_voted_block->getPeriod(), round, step_);
+        vote_weight) {
+      LOG(log_nf_) << "Placed first finish next vote for " << last_cert_voted_block->getBlockHash() << ", vote weight "
+                   << vote_weight << ", round " << round << ", period " << last_cert_voted_block->getPeriod()
+                   << ", step " << step_;
     }
 
     // Re-broadcast pbft block in case some nodes do not have it
     if (step_ % 20 == 0) {
-      auto pbft_block = db_->getPbftCertVotedBlock(last_cert_voted_value_);
+      auto pbft_block = db_->getPbftCertVotedBlock(cert_voted_block_for_round_->first);
       assert(pbft_block);
       if (auto net = network_.lock()) {
         LOG(log_nf_) << "Rebroadcasting PBFT block: " << pbft_block->getBlockHash() << " and reward votes "
@@ -967,54 +1073,51 @@ void PbftManager::firstFinish_() {
     // 1) haven't cert voted it
     // 2) we are looking at value that was next voted in previous round
     // 3) we don't have the block or if have block it can't be cert voted (yet)
-    bool giveUpSoftVotedBlockInFirstFinish = last_cert_voted_value_ == NULL_BLOCK_HASH &&
-                                             own_starting_value_for_round_ == previous_round_next_voted_value_ &&
+    bool giveUpSoftVotedBlockInFirstFinish = !cert_voted_block_for_round_.has_value() &&
+                                             own_starting_value_for_round_.first == previous_round_next_voted_value_ &&
                                              giveUpSoftVotedBlock_() &&
-                                             !compareBlocksAndRewardVotes_(own_starting_value_for_round_);
+                                             !compareBlocksAndRewardVotes_(own_starting_value_for_round_.first);
 
     if (round >= 2 && (giveUpNextVotedBlock_() || giveUpSoftVotedBlockInFirstFinish)) {
-      // last_cert_voted_value_ == NULL_BLOCK_HASH, which means the block was successfully pushed into the chain and we
-      // can use pbft chain size + 1 as period
-      const auto voting_period = pbft_chain_->getPbftChainSize() + 1;
-      auto place_votes = placeVote_(NULL_BLOCK_HASH, next_vote_type, voting_period, round, step_);
-      if (place_votes) {
-        LOG(log_nf_) << "Next votes " << place_votes << " voting NULL BLOCK for round " << round << ", at step "
-                     << step_;
+      if (auto vote_weight = placeVote_(NULL_BLOCK_HASH, next_vote_type, previous_round_period, round, step_);
+          vote_weight) {
+        LOG(log_nf_) << "Placed first finish next vote for " << NULL_BLOCK_HASH << ", vote weight " << vote_weight
+                     << ", round " << round << ", period " << previous_round_period << ", step " << step_;
       }
     } else {
-      if (own_starting_value_for_round_ != previous_round_next_voted_value_ &&
+      if (own_starting_value_for_round_.first != previous_round_next_voted_value_ &&
           previous_round_next_voted_value_ != NULL_BLOCK_HASH &&
           !pbft_chain_->findPbftBlockInChain(previous_round_next_voted_value_)) {
-        if (own_starting_value_for_round_ == NULL_BLOCK_HASH) {
-          db_->savePbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound, previous_round_next_voted_value_);
-          own_starting_value_for_round_ = previous_round_next_voted_value_;
+        if (own_starting_value_for_round_.first == NULL_BLOCK_HASH) {
+          own_starting_value_for_round_ = {previous_round_next_voted_value_, previous_round_period};
+          db_->savePbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound, own_starting_value_for_round_);
           LOG(log_dg_) << "Updating own starting value of NULL BLOCK HASH to previous round next voted value of "
                        << previous_round_next_voted_value_;
         } else if (compareBlocksAndRewardVotes_(previous_round_next_voted_value_)) {
           // Check if we have received the previous round next voted value and its a viable value...
           // IF it is viable then reset own starting value to it...
-          db_->savePbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound, previous_round_next_voted_value_);
+          own_starting_value_for_round_ = {previous_round_next_voted_value_, previous_round_period};
+          db_->savePbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound, own_starting_value_for_round_);
           LOG(log_dg_) << "Updating own starting value of " << own_starting_value_for_round_
                        << " to previous round next voted value of " << previous_round_next_voted_value_;
-          own_starting_value_for_round_ = previous_round_next_voted_value_;
         }
       }
 
-      // TODO: what period to send here ???
-      // this period could be probably saved when saving own_starting_value_for_round_
-      const auto voting_period = pbft_chain_->getPbftChainSize() + 1;
-      auto place_votes = placeVote_(own_starting_value_for_round_, next_vote_type, voting_period, round, step_);
-      if (place_votes) {
-        LOG(log_nf_) << "Next votes " << place_votes << " voting nodes own starting value "
-                     << own_starting_value_for_round_ << " for round " << round << ", at step " << step_;
+      if (auto vote_weight = placeVote_(own_starting_value_for_round_.first, next_vote_type,
+                                        own_starting_value_for_round_.second, round, step_);
+          vote_weight) {
+        LOG(log_nf_) << "Placed first finish next vote for " << own_starting_value_for_round_.first << ", vote weight "
+                     << vote_weight << ", round " << round << ", period " << own_starting_value_for_round_.second
+                     << ", step " << step_;
+
         // Re-broadcast pbft block in case some nodes do not have it
-      }
-      if (step_ % 20 == 0) {
-        auto pbft_block = getUnfinalizedBlock_(own_starting_value_for_round_);
-        if (auto net = network_.lock(); net && pbft_block) {
+        if (step_ % 20 == 0) {
+          auto pbft_block = getUnfinalizedBlock_(own_starting_value_for_round_.first);
+          if (auto net = network_.lock(); net && pbft_block) {
           LOG(log_nf_) << "Rebroadcasting PBFT block: " << pbft_block->getBlockHash() << " and reward votes "
                        << pbft_block->getRewardVotes();
-          net->getSpecificHandler<network::tarcap::PbftBlockPacketHandler>()->onNewPbftBlock(pbft_block);
+            net->getSpecificHandler<network::tarcap::PbftBlockPacketHandler>()->onNewPbftBlock(pbft_block);
+          }
         }
       }
     }
@@ -1023,59 +1126,67 @@ void PbftManager::firstFinish_() {
 
 void PbftManager::secondFinish_() {
   // Odd number steps from 5 are in second finish
-  auto round = getPbftRound();
-  LOG(log_tr_) << "PBFT second finishing state at step " << step_ << " in round " << round;
+  auto [round, previous_round_period] = getPbftRoundAndPeriod();
+  LOG(log_dg_) << "PBFT second finishing state in round(r): " << round << ", r-1 period: " << previous_round_period;
+
   assert(step_ >= startingStepInRound_);
   auto end_time_for_step = (2 + step_ - startingStepInRound_) * LAMBDA_ms - POLLING_INTERVAL_ms;
   LOG(log_tr_) << "Step " << step_ << " end time " << end_time_for_step;
-
-  updateSoftVotedBlockForThisRound_();
-  if (soft_voted_block_for_this_round_) {
-    auto voted_block_hash_with_soft_votes = vote_mgr_->getVotesBundleByRoundAndStep(round, 2, TWO_T_PLUS_ONE);
-    if (voted_block_hash_with_soft_votes) {
-      // Have enough soft votes for a voting value
-      auto net = network_.lock();
-      assert(net);  // Should never happen
-      net->getSpecificHandler<network::tarcap::VotePacketHandler>()->onNewPbftVotes(
-          std::move(voted_block_hash_with_soft_votes->votes));
-      vote_mgr_->sendRewardVotes(getLastPbftBlockHash());
-      LOG(log_dg_) << "Node has seen enough soft votes voted at " << voted_block_hash_with_soft_votes->voted_block_hash
-                   << ", regossip soft votes. In round " << round << " step " << step_;
-    }
-  }
 
   // We only want to give up soft voted value IF:
   // 1) haven't cert voted it
   // 2) we are looking at value that was next voted in previous round
   // 3) we don't have the block or if have block it can't be cert voted (yet)
-  bool giveUpSoftVotedBlockInSecondFinish =
-      last_cert_voted_value_ == NULL_BLOCK_HASH && last_soft_voted_value_ == previous_round_next_voted_value_ &&
-      giveUpSoftVotedBlock_() && !compareBlocksAndRewardVotes_(soft_voted_block_for_this_round_);
+  bool giveUpSoftVotedBlockInSecondFinish = false;
 
-  if (!next_voted_soft_value_ && soft_voted_block_for_this_round_ && !giveUpSoftVotedBlockInSecondFinish) {
-    // TODO: what period to send here ???
-    const auto voting_period = pbft_chain_->getPbftChainSize() + 1;
+  if (const auto soft_voted_block = getSoftVotedBlockForThisRound_(); soft_voted_block.has_value()) {
+    const auto [current_round_soft_voted_block, current_round_soft_votes_period] = soft_voted_block.value();
 
-    LOG(log_dg_) << "1 Place vote, round: " << round << ", step: " << step_
-                 << ", voter: " << dev::toAddress(dev::toPublic(node_sk_))
-                 << ", block: " << soft_voted_block_for_this_round_.abridged();
-
-    auto place_votes = placeVote_(soft_voted_block_for_this_round_, next_vote_type, voting_period, round, step_);
-    if (place_votes) {
-      LOG(log_nf_) << "Next votes " << place_votes << " voting " << soft_voted_block_for_this_round_ << " for round "
-                   << round << ", at step " << step_;
-
-      db_->savePbftMgrStatus(PbftMgrStatus::NextVotedSoftValue, true);
-      next_voted_soft_value_ = true;
+    auto soft_voted_block_votes = vote_mgr_->getVotesBundle(round, current_round_soft_votes_period, 2, TWO_T_PLUS_ONE);
+    if (soft_voted_block_votes.has_value()) {
+      // Have enough soft votes for a voting value
+      auto net = network_.lock();
+      assert(net);  // Should never happen
+      net->getSpecificHandler<network::tarcap::VotePacketHandler>()->onNewPbftVotes(
+          std::move(soft_voted_block_votes->votes));
+      vote_mgr_->sendRewardVotes(getLastPbftBlockHash());
+      LOG(log_dg_) << "Node has seen enough soft votes voted at " << soft_voted_block_votes->voted_block_hash
+                   << ", regossip soft votes. In round " << round << ", period " << soft_voted_block_votes->votes_period
+                   << " step " << step_;
     }
+
+    // we did not cert vote
+    giveUpSoftVotedBlockInSecondFinish =
+        !cert_voted_block_for_round_.has_value() && last_soft_voted_value_ == previous_round_next_voted_value_ &&
+        giveUpSoftVotedBlock_() && !compareBlocksAndRewardVotes_(current_round_soft_voted_block);
+
+    if (!next_voted_soft_value_ && !giveUpSoftVotedBlockInSecondFinish) {
+      if (auto vote_weight =
+              placeVote_(current_round_soft_voted_block, next_vote_type, current_round_soft_votes_period, round, step_);
+          vote_weight) {
+        LOG(log_nf_) << "Placed second finish vote for " << current_round_soft_voted_block << ", vote weight "
+                     << vote_weight << ", round " << round << ", period " << current_round_soft_votes_period
+                     << ", step " << step_;
+
+        db_->savePbftMgrStatus(PbftMgrStatus::NextVotedSoftValue, true);
+        next_voted_soft_value_ = true;
+      }
+    }
+  } else {
+    LOG(log_dg_) << "Second finish: Not enough soft votes for current round yet. Round " << round << ", r-1 period "
+                 << previous_round_period;
+
+    // we did not cert vote
+    giveUpSoftVotedBlockInSecondFinish = !cert_voted_block_for_round_.has_value() &&
+                                         last_soft_voted_value_ == previous_round_next_voted_value_ &&
+                                         giveUpSoftVotedBlock_();
   }
 
   if (!next_voted_null_block_hash_ && round >= 2 && (giveUpSoftVotedBlockInSecondFinish || giveUpNextVotedBlock_())) {
-    // TODO: what period to send here ???
-    const auto voting_period = pbft_chain_->getPbftChainSize() + 1;
-    auto place_votes = placeVote_(NULL_BLOCK_HASH, next_vote_type, voting_period, round, step_);
-    if (place_votes) {
-      LOG(log_nf_) << "Next votes " << place_votes << " voting NULL BLOCK for round " << round << ", at step " << step_;
+    if (auto vote_weight = placeVote_(NULL_BLOCK_HASH, next_vote_type, previous_round_period, round, step_);
+        vote_weight) {
+      LOG(log_nf_) << "Placed second finish vote for " << NULL_BLOCK_HASH << ", vote weight " << vote_weight
+                   << ", round " << round << ", period " << previous_round_period << ", step " << step_;
 
       db_->savePbftMgrStatus(PbftMgrStatus::NextVotedNullBlockHash, true);
       next_voted_null_block_hash_ = true;
@@ -1099,8 +1210,8 @@ void PbftManager::secondFinish_() {
   loop_back_finish_state_ = elapsed_time_in_round_ms_ > end_time_for_step;
 }
 
-blk_hash_t PbftManager::generatePbftBlock(const blk_hash_t &prev_blk_hash, const blk_hash_t &anchor_hash,
-                                          const blk_hash_t &order_hash) {
+std::shared_ptr<PbftBlock> PbftManager::generatePbftBlock(const blk_hash_t &prev_blk_hash,
+                                                          const blk_hash_t &anchor_hash, const blk_hash_t &order_hash) {
   const auto propose_period = pbft_chain_->getPbftChainSize() + 1;
   // Reward votes should only include those reward votes with the same round as the round last pbft block was pushed
   // into chain
@@ -1119,10 +1230,10 @@ blk_hash_t PbftManager::generatePbftBlock(const blk_hash_t &prev_blk_hash, const
     net->getSpecificHandler<network::tarcap::PbftBlockPacketHandler>()->onNewPbftBlock(pbft_block);
   }
 
-  LOG(log_dg_) << node_addr_ << " propose PBFT block succussful! in round: " << round_ << " in step: " << step_
+  LOG(log_dg_) << node_addr_ << " propose PBFT block successful! in round: " << round_ << " in step: " << step_
                << " PBFT block: " << pbft_block->getBlockHash();
 
-  return pbft_block->getBlockHash();
+  return pbft_block;
 }
 
 std::shared_ptr<Vote> PbftManager::generateVote(blk_hash_t const &blockhash, PbftVoteTypes type, uint64_t period,
@@ -1181,6 +1292,8 @@ uint64_t PbftManager::getCurrentPbftSortitionThreshold(PbftVoteTypes vote_type) 
 }
 
 uint64_t PbftManager::getPbftSortitionThreshold(PbftVoteTypes vote_type, uint64_t pbft_period) const {
+  // TODO[1896]: final_chain_->dpos... ret values should be cached as it is heavily used and most of the time it
+  // returns the same value!
   const uint64_t total_dpos_votes_count = final_chain_->dpos_eligible_total_vote_count(pbft_period);
 
   switch (vote_type) {
@@ -1198,6 +1311,15 @@ size_t PbftManager::placeVote_(taraxa::blk_hash_t const &blockhash, PbftVoteType
                                uint64_t round, size_t step) {
   if (!weighted_votes_count_) {
     // No delegation
+    return 0;
+  }
+
+  // chain size must be => vote_period, it should be == for propose/soft/cert votes but it can be > for next votes
+  // as chain size might be incremented if block was certified during certify step
+  if (pbft_chain_->getPbftChainSize() < period - 1) {
+    LOG(log_dg_) << "Cannot place vote if out of sync. Chain size " << pbft_chain_->getPbftChainSize()
+                 << ", voted block " << blockhash << ", vote round " << round << ", vote period " << period
+                 << ", vote step " << step;
     return 0;
   }
 
@@ -1283,13 +1405,14 @@ std::optional<blk_hash_t> findClosestAnchor(const std::vector<blk_hash_t> &ghost
   return ghost[1];
 }
 
-blk_hash_t PbftManager::proposePbftBlock_(uint64_t propose_period) {
+std::shared_ptr<PbftBlock> PbftManager::proposePbftBlock_() {
   auto round = getPbftRound();
+  const auto propose_period = pbft_chain_->getPbftChainSize() + 1;
   VrfPbftSortition vrf_sortition(vrf_sk_, {propose_vote_type, propose_period, round, 1});
   if (weighted_votes_count_ == 0 ||
       !vrf_sortition.calculateWeight(getDposWeightedVotesCount(), getDposTotalVotesCount(),
                                      getCurrentPbftSortitionThreshold(propose_vote_type), dev::toPublic(node_sk_))) {
-    return NULL_BLOCK_HASH;
+    return nullptr;
   }
 
   LOG(log_dg_) << "Into propose PBFT block";
@@ -1298,6 +1421,13 @@ blk_hash_t PbftManager::proposePbftBlock_(uint64_t propose_period) {
   if (last_pbft_block_hash) {
     auto prev_block_hash = last_pbft_block_hash;
     auto prev_pbft_block = pbft_chain_->getPbftBlockInChain(prev_block_hash);
+
+    if (prev_pbft_block.getPeriod() != propose_period - 1) [[unlikely]] {
+      LOG(log_er_) << "Last pbft block " << prev_block_hash.abridged() << " period " << prev_pbft_block.getPeriod()
+                   << " differs from chain size " << propose_period << ". Possible reason - race condition";
+      return nullptr;
+    }
+
     last_period_dag_anchor_block_hash = prev_pbft_block.getPivotDagBlockHash();
     while (!last_period_dag_anchor_block_hash) {
       // The anchor is NULL BLOCK HASH
@@ -1450,12 +1580,12 @@ h256 PbftManager::getProposal(const std::shared_ptr<Vote> &vote) const {
   return lowest_hash;
 }
 
-std::optional<std::pair<blk_hash_t, uint64_t>> PbftManager::identifyLeaderBlock_() {
-  auto round = getPbftRound();
-  LOG(log_dg_) << "Into identify leader block, in round " << round;
+std::optional<std::pair<blk_hash_t, uint64_t>> PbftManager::identifyLeaderBlock_(uint64_t round,
+                                                                                 uint64_t previous_round_period) {
+  LOG(log_tr_) << "Identify leader block, in round(r): " << round << ", r-1 period: " << previous_round_period;
 
   // Get all proposal votes in the round
-  auto votes = vote_mgr_->getProposalVotes(round);
+  auto votes = vote_mgr_->getProposalVotes(round, previous_round_period);
 
   // Each leader candidate with <vote_signature_hash, vote>
   std::vector<std::pair<h256, std::shared_ptr<Vote>>> leader_candidates;
@@ -1463,6 +1593,14 @@ std::optional<std::pair<blk_hash_t, uint64_t>> PbftManager::identifyLeaderBlock_
   for (auto const &v : votes) {
     if (v->getRound() != round) {
       LOG(log_er_) << "Vote round is not same with current round " << round << ". Vote " << v;
+      continue;
+    }
+    // If previous round period determined from next votes is N, propose vote period can be:
+    // - either N (re-proposed block from previous round)
+    // - either N + 1 (proposed new block)
+    if (v->getPeriod() != previous_round_period && v->getPeriod() != previous_round_period + 1) {
+      LOG(log_er_) << "Vote period is not in required interval [" << previous_round_period << ", "
+                   << previous_round_period + 1 << "] based on previous round determined period";
       continue;
     }
     if (v->getStep() != 1) {
@@ -1766,9 +1904,9 @@ bool PbftManager::pushPbftBlock_(PeriodData &&period_data, std::vector<std::shar
   auto const &pbft_block_hash = period_data.pbft_blk->getBlockHash();
   if (db_->pbftBlockInDb(pbft_block_hash)) {
     LOG(log_nf_) << "PBFT block: " << pbft_block_hash << " in DB already.";
-    if (last_cert_voted_value_ == pbft_block_hash) {
-      LOG(log_er_) << "Last cert voted value should be NULL_BLOCK_HASH. Block hash " << last_cert_voted_value_
-                   << " has been pushed into chain already";
+    if (cert_voted_block_for_round_.has_value() && cert_voted_block_for_round_->first == pbft_block_hash) {
+      LOG(log_er_) << "Last cert voted value should be NULL_BLOCK_HASH. Block hash "
+                   << cert_voted_block_for_round_->first << " has been pushed into chain already";
       assert(false);
     }
     return false;
@@ -1797,9 +1935,6 @@ bool PbftManager::pushPbftBlock_(PeriodData &&period_data, std::vector<std::shar
   db_->savePeriodData(period_data, batch);
   db_->addLastBlockCertVotesToBatch(cert_votes, batch);
 
-  // Reset last cert voted value to NULL_BLOCK_HASH
-  db_->addPbftMgrVotedValueToBatch(PbftMgrVotedValue::LastCertVotedValue, NULL_BLOCK_HASH, batch);
-
   // pass pbft with dag blocks and transactions to adjust difficulty
   if (period_data.pbft_blk->getPivotDagBlockHash() != NULL_BLOCK_HASH) {
     dag_mgr_->sortitionParamsManager().pbftBlockPushed(period_data, batch,
@@ -1826,15 +1961,13 @@ bool PbftManager::pushPbftBlock_(PeriodData &&period_data, std::vector<std::shar
 
   vote_mgr_->replaceRewardVotes(std::move(cert_votes));
 
-  last_cert_voted_value_ = NULL_BLOCK_HASH;
-
   LOG(log_nf_) << "Pushed new PBFT block " << pbft_block_hash << " into chain. Period: " << pbft_period
                << ", round: " << getPbftRound();
 
   finalize_(std::move(period_data), std::move(dag_blocks_order));
 
   // Reset proposed PBFT block hash to NULL for next period PBFT block proposal
-  proposed_block_hash_ = NULL_BLOCK_HASH;
+  proposed_block_ = nullptr;
   db_->savePbftMgrStatus(PbftMgrStatus::ExecutedBlock, true);
   executed_pbft_block_ = true;
   return true;
@@ -1881,16 +2014,6 @@ bool PbftManager::giveUpSoftVotedBlock_() {
 
 bool PbftManager::giveUpNextVotedBlock_() {
   auto round = getPbftRound();
-
-  if (last_cert_voted_value_ != NULL_BLOCK_HASH) {
-    // Last cert voted value should equal to voted value
-    if (polling_state_print_log_) {
-      LOG(log_nf_) << "In round " << round << " step " << step_ << ", last cert voted value is "
-                   << last_cert_voted_value_;
-      polling_state_print_log_ = false;
-    }
-    return false;
-  }
 
   if (previous_round_next_voted_value_ == NULL_BLOCK_HASH) {
     // In round 1 also return here

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -683,7 +683,7 @@ bool PbftManager::stateOperations_() {
   elapsed_time_in_round_ms_ = std::chrono::duration_cast<std::chrono::milliseconds>(duration_).count();
 
   auto [round, previous_round_period] = getPbftRoundAndPeriod();
-  LOG(log_dg_) << "PBFT current round(r): " << round << ", r-1 period: " << previous_round_period << ", step " << step_;
+  LOG(log_tr_) << "PBFT current round(r): " << round << ", r-1 period: " << previous_round_period << ", step " << step_;
 
   static bool is_new_round = false;
   if (is_new_round) {
@@ -1300,15 +1300,6 @@ uint64_t PbftManager::getPbftSortitionThreshold(PbftVoteTypes vote_type, uint64_
 
 size_t PbftManager::placeVote_(taraxa::blk_hash_t const &blockhash, PbftVoteTypes vote_type, uint64_t period,
                                uint64_t round, size_t step) {
-  // chain size must be => vote_period, it should be == for propose/soft/cert votes but it can be > for next votes
-  // as chain size might be incremented if block was certified during certify step
-  if (pbft_chain_->getPbftChainSize() < period - 1) {
-    LOG(log_dg_) << "Cannot place vote if out of sync. Chain size " << pbft_chain_->getPbftChainSize()
-                 << ", voted block " << blockhash << ", vote round " << round << ", vote period " << period
-                 << ", vote step " << step;
-    return 0;
-  }
-
   uint64_t voter_dpos_votes_count = 0;
   uint64_t total_dpos_votes_count = 0;
   uint64_t pbft_sortition_threshold = 0;
@@ -1349,6 +1340,7 @@ size_t PbftManager::placeVote_(taraxa::blk_hash_t const &blockhash, PbftVoteType
       LOG(log_er_) << "Generated vote " << vote->getHash().abridged()
                    << " is not unique. Err: " << is_unique_vote.second;
       assert(false);
+      return 0;
     }
   }
 

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -685,8 +685,7 @@ bool PbftManager::stateOperations_() {
   auto [round, previous_round_period] = getPbftRoundAndPeriod();
   LOG(log_tr_) << "PBFT current round(r): " << round << ", r-1 period: " << previous_round_period << ", step " << step_;
 
-  static bool is_new_round = false;
-  if (is_new_round) {
+  if (!new_round_in_sync_) {
     // Checks if node is in sync with determined pbft period from votes, if not - do not allow node to place votes
     // This check is done only at the beginning of new round by purpose as chain size might change after cert vote step
     // when new cert voted block is pushed into the chain
@@ -700,7 +699,7 @@ bool PbftManager::stateOperations_() {
     }
 
     // Node is in sync
-    is_new_round = false;
+    new_round_in_sync_ = false;
   }
 
   // Remove old votes
@@ -734,7 +733,7 @@ bool PbftManager::stateOperations_() {
   }
 
   if (resetRound_()) {
-    is_new_round = true;
+    new_round_in_sync_ = false;
     return true;
   }
 

--- a/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
+++ b/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
@@ -94,7 +94,7 @@ uint64_t VoteManager::getVerifiedVotesSize() const {
 bool VoteManager::addVerifiedVote(std::shared_ptr<Vote> const& vote) {
   assert(vote->getWeight().has_value());
   const auto hash = vote->getHash();
-  const auto weight = vote->getWeight().value();
+  const auto weight = *vote->getWeight();
   if (!weight) {
     LOG(log_er_) << "Unable to add vote " << hash << " into the verified queue. Invalid vote weight";
     return false;
@@ -428,7 +428,7 @@ std::optional<VotesBundle> VoteManager::getVotesBundle(uint64_t round, uint64_t 
       for (const auto& v : voted_value.second.second) {
         assert(v.second->getWeight().has_value());
         votes_bundle.votes.emplace_back(v.second);
-        count += v.second->getWeight().value();
+        count += *v.second->getWeight();
 
         // For certify votes - collect all votes, for all other vote types, collect just 2t+1 votes
         if (step != certify_state && count >= two_t_plus_one) {

--- a/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
+++ b/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
@@ -15,7 +15,8 @@ constexpr size_t FIRST_FINISH_STEP = 4;
 
 namespace taraxa {
 VoteManager::VoteManager(const addr_t& node_addr, std::shared_ptr<DbStorage> db, std::shared_ptr<PbftChain> pbft_chain,
-                         std::shared_ptr<FinalChain> final_chain, std::shared_ptr<NextVotesManager> next_votes_mgr, std::shared_ptr<KeyManager> key_manager)
+                         std::shared_ptr<FinalChain> final_chain, std::shared_ptr<NextVotesManager> next_votes_mgr,
+                         std::shared_ptr<KeyManager> key_manager)
     : db_(std::move(db)),
       pbft_chain_(std::move(pbft_chain)),
       final_chain_(std::move(final_chain)),

--- a/libraries/core_libs/network/include/network/network.hpp
+++ b/libraries/core_libs/network/include/network/network.hpp
@@ -27,7 +27,7 @@ class PacketHandler;
 // TODO merge with TaraxaCapability, and then split the result in reasonable components
 class Network {
  public:
-  Network(FullNodeConfig const &config, const h256 &genesis_hash = {},
+  Network(const FullNodeConfig &config, const h256 &genesis_hash = {},
           dev::p2p::Host::CapabilitiesFactory construct_capabilities = {},
           std::filesystem::path const &network_file_path = {}, dev::KeyPair const &key = dev::KeyPair::create(),
           std::shared_ptr<DbStorage> db = {}, std::shared_ptr<PbftManager> pbft_mgr = {},
@@ -69,7 +69,6 @@ class Network {
   // END METHODS USED IN TESTS ONLY
 
  private:
-  FullNodeConfig kConf;
   util::ThreadPool tp_;
   std::shared_ptr<dev::p2p::Host> host_;
   std::shared_ptr<network::tarcap::TaraxaCapability> taraxa_capability_;

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_votes_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_votes_packet_handler.hpp
@@ -5,6 +5,7 @@
 namespace taraxa {
 class Vote;
 class PbftManager;
+class PbftChain;
 }  // namespace taraxa
 
 namespace taraxa::network::tarcap {
@@ -16,8 +17,8 @@ namespace taraxa::network::tarcap {
 class ExtVotesPacketHandler : public PacketHandler {
  public:
   ExtVotesPacketHandler(std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
-                        std::shared_ptr<PbftManager> pbft_mgr, const addr_t& node_addr,
-                        const std::string& log_channel_name);
+                        std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<PbftChain> pbft_chain,
+                        const addr_t& node_addr, const std::string& log_channel_name);
 
   virtual ~ExtVotesPacketHandler() = default;
   ExtVotesPacketHandler(const ExtVotesPacketHandler&) = default;
@@ -25,12 +26,29 @@ class ExtVotesPacketHandler : public PacketHandler {
   ExtVotesPacketHandler& operator=(const ExtVotesPacketHandler&) = default;
   ExtVotesPacketHandler& operator=(ExtVotesPacketHandler&&) = default;
 
+  /**
+   * @brief Validates standard vote
+   *
+   * @param vote to be validated
+   * @return <true, ""> vote validation passed, otherwise <false, "err msg">
+   */
+  std::pair<bool, std::string> validateStandardVote(const std::shared_ptr<Vote>& vote);
+
+  /**
+   * @brief Validates reward vote
+   *
+   * @param vote to be validated
+   * @return <true, ""> vote validation passed, otherwise <false, "err msg">
+   */
+  std::pair<bool, std::string> validateRewardVote(const std::shared_ptr<Vote>& vote);
+
   void onNewPbftVotes(std::vector<std::shared_ptr<Vote>>&& votes);
   void sendPbftVotes(const dev::p2p::NodeID& peer_id, std::vector<std::shared_ptr<Vote>>&& votes,
                      bool is_next_votes = false);
 
- private:
+ protected:
   std::shared_ptr<PbftManager> pbft_mgr_;
+  std::shared_ptr<PbftChain> pbft_chain_;
 };
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_votes_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_votes_packet_handler.hpp
@@ -42,6 +42,14 @@ class ExtVotesPacketHandler : public PacketHandler {
    */
   std::pair<bool, std::string> validateRewardVote(const std::shared_ptr<Vote>& vote);
 
+  /**
+   * @brief Validates next vote
+   *
+   * @param vote to be validated
+   * @return <true, ""> vote validation passed, otherwise <false, "err msg">
+   */
+  std::pair<bool, std::string> validateNextVote(const std::shared_ptr<Vote>& vote);
+
   void onNewPbftVotes(std::vector<std::shared_ptr<Vote>>&& votes);
   void sendPbftVotes(const dev::p2p::NodeID& peer_id, std::vector<std::shared_ptr<Vote>>&& votes,
                      bool is_next_votes = false);

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_votes_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_votes_packet_handler.hpp
@@ -6,6 +6,7 @@ namespace taraxa {
 class Vote;
 class PbftManager;
 class PbftChain;
+class VoteManager;
 }  // namespace taraxa
 
 namespace taraxa::network::tarcap {
@@ -18,13 +19,14 @@ class ExtVotesPacketHandler : public PacketHandler {
  public:
   ExtVotesPacketHandler(std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
                         std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<PbftChain> pbft_chain,
-                        const addr_t& node_addr, const std::string& log_channel_name);
+                        std::shared_ptr<VoteManager> vote_mgr, const uint32_t dpos_delay, const addr_t& node_addr,
+                        const std::string& log_channel_name);
 
   virtual ~ExtVotesPacketHandler() = default;
-  ExtVotesPacketHandler(const ExtVotesPacketHandler&) = default;
-  ExtVotesPacketHandler(ExtVotesPacketHandler&&) = default;
-  ExtVotesPacketHandler& operator=(const ExtVotesPacketHandler&) = default;
-  ExtVotesPacketHandler& operator=(ExtVotesPacketHandler&&) = default;
+  ExtVotesPacketHandler(const ExtVotesPacketHandler&) = delete;
+  ExtVotesPacketHandler(ExtVotesPacketHandler&&) = delete;
+  ExtVotesPacketHandler& operator=(const ExtVotesPacketHandler&) = delete;
+  ExtVotesPacketHandler& operator=(ExtVotesPacketHandler&&) = delete;
 
   /**
    * @brief Validates standard vote
@@ -32,7 +34,7 @@ class ExtVotesPacketHandler : public PacketHandler {
    * @param vote to be validated
    * @return <true, ""> vote validation passed, otherwise <false, "err msg">
    */
-  std::pair<bool, std::string> validateStandardVote(const std::shared_ptr<Vote>& vote);
+  std::pair<bool, std::string> validateStandardVote(const std::shared_ptr<Vote>& vote) const;
 
   /**
    * @brief Validates reward vote
@@ -40,7 +42,7 @@ class ExtVotesPacketHandler : public PacketHandler {
    * @param vote to be validated
    * @return <true, ""> vote validation passed, otherwise <false, "err msg">
    */
-  std::pair<bool, std::string> validateRewardVote(const std::shared_ptr<Vote>& vote);
+  std::pair<bool, std::string> validateRewardVote(const std::shared_ptr<Vote>& vote) const;
 
   /**
    * @brief Validates next vote
@@ -48,15 +50,47 @@ class ExtVotesPacketHandler : public PacketHandler {
    * @param vote to be validated
    * @return <true, ""> vote validation passed, otherwise <false, "err msg">
    */
-  std::pair<bool, std::string> validateNextVote(const std::shared_ptr<Vote>& vote);
+  std::pair<bool, std::string> validateNextSyncVote(const std::shared_ptr<Vote>& vote) const;
 
   void onNewPbftVotes(std::vector<std::shared_ptr<Vote>>&& votes);
   void sendPbftVotes(const dev::p2p::NodeID& peer_id, std::vector<std::shared_ptr<Vote>>&& votes,
                      bool is_next_votes = false);
 
  protected:
+  /**
+   * @brief Common validation for all types of votes
+   *
+   * @param vote to be validated
+   * @return <true, ""> vote validation passed, otherwise <false, "err msg">
+   */
+  std::pair<bool, std::string> validateVote(const std::shared_ptr<Vote>& vote) const;
+
+  /**
+   * @brief Sets voter max round
+   *
+   * @param voter
+   * @param round
+   */
+  void setVoterMaxRound(const addr_t& voter, uint64_t round);
+
+  /**
+   * @param voter
+   * @return voter max round based on received votes from him
+   */
+  uint64_t getVoterMaxRound(const addr_t& voter) const;
+
+ protected:
+  // Dpos contract delay - it is used to validate pbft period in votes -> does not make sense to accept vote
+  // with vote period > current pbft period + kDposDelay_ as the valiation will fail
+  const uint32_t kDposDelay_;
+
   std::shared_ptr<PbftManager> pbft_mgr_;
   std::shared_ptr<PbftChain> pbft_chain_;
+  std::shared_ptr<VoteManager> vote_mgr_;
+
+  // <vote addres, max received round>
+  std::unordered_map<addr_t, uint64_t> voters_max_rounds_;
+  mutable std::shared_mutex voters_max_rounds_mutex_;
 };
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_votes_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_votes_packet_handler.hpp
@@ -81,8 +81,8 @@ class ExtVotesPacketHandler : public PacketHandler {
 
  protected:
   // Dpos contract delay - it is used to validate pbft period in votes -> does not make sense to accept vote
-  // with vote period > current pbft period + kDposDelay_ as the valiation will fail
-  const uint32_t kDposDelay_;
+  // with vote period > current pbft period + kDposDelay as the valiation will fail
+  const uint32_t kDposDelay;
 
   std::shared_ptr<PbftManager> pbft_mgr_;
   std::shared_ptr<PbftChain> pbft_chain_;

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_votes_sync_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_votes_sync_packet_handler.hpp
@@ -12,8 +12,8 @@ namespace taraxa::network::tarcap {
 class GetVotesSyncPacketHandler final : public ExtVotesPacketHandler {
  public:
   GetVotesSyncPacketHandler(std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
-                            std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<NextVotesManager> next_votes_mgr,
-                            const addr_t& node_addr);
+                            std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<PbftChain> pbft_chain,
+                            std::shared_ptr<NextVotesManager> next_votes_mgr, const addr_t& node_addr);
 
   // Packet type that is processed by this handler
   static constexpr SubprotocolPacketType kPacketType_ = SubprotocolPacketType::GetVotesSyncPacket;
@@ -22,7 +22,6 @@ class GetVotesSyncPacketHandler final : public ExtVotesPacketHandler {
   void validatePacketRlpFormat(const PacketData& packet_data) const override;
   void process(const PacketData& packet_data, const std::shared_ptr<TaraxaPeer>& peer) override;
 
-  std::shared_ptr<PbftManager> pbft_mgr_;
   std::shared_ptr<NextVotesManager> next_votes_mgr_;
 };
 

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_votes_sync_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_votes_sync_packet_handler.hpp
@@ -4,6 +4,7 @@
 
 namespace taraxa {
 class PbftManager;
+class VoteManager;
 class NextVotesManager;
 }  // namespace taraxa
 
@@ -13,7 +14,8 @@ class GetVotesSyncPacketHandler final : public ExtVotesPacketHandler {
  public:
   GetVotesSyncPacketHandler(std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
                             std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<PbftChain> pbft_chain,
-                            std::shared_ptr<NextVotesManager> next_votes_mgr, const addr_t& node_addr);
+                            std::shared_ptr<VoteManager> vote_mgr, std::shared_ptr<NextVotesManager> next_votes_mgr,
+                            const uint32_t dpos_delay, const addr_t& node_addr);
 
   // Packet type that is processed by this handler
   static constexpr SubprotocolPacketType kPacketType_ = SubprotocolPacketType::GetVotesSyncPacket;

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/vote_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/vote_packet_handler.hpp
@@ -13,7 +13,7 @@ class VotePacketHandler final : public ExtVotesPacketHandler {
  public:
   VotePacketHandler(std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
                     std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<PbftChain> pbft_chain,
-                    std::shared_ptr<VoteManager> vote_mgr, const addr_t& node_addr);
+                    std::shared_ptr<VoteManager> vote_mgr, const uint32_t dpos_delay, const addr_t& node_addr);
 
   // Packet type that is processed by this handler
   static constexpr SubprotocolPacketType kPacketType_ = SubprotocolPacketType::VotePacket;
@@ -22,7 +22,6 @@ class VotePacketHandler final : public ExtVotesPacketHandler {
   void validatePacketRlpFormat(const PacketData& packet_data) const override;
   void process(const PacketData& packet_data, const std::shared_ptr<TaraxaPeer>& peer) override;
 
-  std::shared_ptr<VoteManager> vote_mgr_;
   ExpirationCache<vote_hash_t> seen_votes_;
 };
 

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/vote_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/vote_packet_handler.hpp
@@ -12,8 +12,8 @@ namespace taraxa::network::tarcap {
 class VotePacketHandler final : public ExtVotesPacketHandler {
  public:
   VotePacketHandler(std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
-                    std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<VoteManager> vote_mgr,
-                    const addr_t& node_addr);
+                    std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<PbftChain> pbft_chain,
+                    std::shared_ptr<VoteManager> vote_mgr, const addr_t& node_addr);
 
   // Packet type that is processed by this handler
   static constexpr SubprotocolPacketType kPacketType_ = SubprotocolPacketType::VotePacket;
@@ -22,7 +22,6 @@ class VotePacketHandler final : public ExtVotesPacketHandler {
   void validatePacketRlpFormat(const PacketData& packet_data) const override;
   void process(const PacketData& packet_data, const std::shared_ptr<TaraxaPeer>& peer) override;
 
-  std::shared_ptr<PbftManager> pbft_mgr_;
   std::shared_ptr<VoteManager> vote_mgr_;
   ExpirationCache<vote_hash_t> seen_votes_;
 };

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/votes_sync_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/votes_sync_packet_handler.hpp
@@ -16,7 +16,7 @@ class VotesSyncPacketHandler final : public ExtVotesPacketHandler {
   VotesSyncPacketHandler(std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
                          std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<PbftChain> pbft_chain,
                          std::shared_ptr<VoteManager> vote_mgr, std::shared_ptr<NextVotesManager> next_votes_mgr,
-                         std::shared_ptr<DbStorage> db, const addr_t& node_addr);
+                         std::shared_ptr<DbStorage> db, const uint32_t dpos_delay, const addr_t& node_addr);
 
   void broadcastPreviousRoundNextVotesBundle();
 
@@ -27,7 +27,6 @@ class VotesSyncPacketHandler final : public ExtVotesPacketHandler {
   void validatePacketRlpFormat(const PacketData& packet_data) const override;
   void process(const PacketData& packet_data, const std::shared_ptr<TaraxaPeer>& peer) override;
 
-  std::shared_ptr<VoteManager> vote_mgr_;
   std::shared_ptr<NextVotesManager> next_votes_mgr_;
   std::shared_ptr<DbStorage> db_;
 };

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/votes_sync_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/votes_sync_packet_handler.hpp
@@ -14,9 +14,9 @@ namespace taraxa::network::tarcap {
 class VotesSyncPacketHandler final : public ExtVotesPacketHandler {
  public:
   VotesSyncPacketHandler(std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
-                         std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<VoteManager> vote_mgr,
-                         std::shared_ptr<NextVotesManager> next_votes_mgr, std::shared_ptr<DbStorage> db,
-                         const addr_t& node_addr);
+                         std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<PbftChain> pbft_chain,
+                         std::shared_ptr<VoteManager> vote_mgr, std::shared_ptr<NextVotesManager> next_votes_mgr,
+                         std::shared_ptr<DbStorage> db, const addr_t& node_addr);
 
   void broadcastPreviousRoundNextVotesBundle();
 
@@ -27,7 +27,6 @@ class VotesSyncPacketHandler final : public ExtVotesPacketHandler {
   void validatePacketRlpFormat(const PacketData& packet_data) const override;
   void process(const PacketData& packet_data, const std::shared_ptr<TaraxaPeer>& peer) override;
 
-  std::shared_ptr<PbftManager> pbft_mgr_;
   std::shared_ptr<VoteManager> vote_mgr_;
   std::shared_ptr<NextVotesManager> next_votes_mgr_;
   std::shared_ptr<DbStorage> db_;

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
@@ -120,7 +120,7 @@ class TaraxaCapability : public dev::p2p::CapabilityFace {
   // Packets stats
   std::shared_ptr<PacketsStats> packets_stats_;
 
-  // Network config
+  // Node config
   const FullNodeConfig &kConf;
 
   // Peers state

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
@@ -93,15 +93,17 @@ class TaraxaCapability : public dev::p2p::CapabilityFace {
   // END METHODS USED IN TESTS ONLY
 
  protected:
-  virtual void initPeriodicEvents(const NetworkConfig &conf, const std::shared_ptr<PbftManager> &pbft_mgr,
+  virtual void initPeriodicEvents(const std::shared_ptr<PbftManager> &pbft_mgr,
                                   std::shared_ptr<TransactionManager> trx_mgr,
                                   std::shared_ptr<PacketsStats> packets_stats);
-  virtual void registerPacketHandlers(
-      const FullNodeConfig &conf, const h256 &genesis_hash, const std::shared_ptr<PacketsStats> &packets_stats,
-      const std::shared_ptr<DbStorage> &db, const std::shared_ptr<PbftManager> &pbft_mgr,
-      const std::shared_ptr<PbftChain> &pbft_chain, const std::shared_ptr<VoteManager> &vote_mgr,
-      const std::shared_ptr<NextVotesManager> &next_votes_mgr, const std::shared_ptr<DagManager> &dag_mgr,
-      const std::shared_ptr<TransactionManager> &trx_mgr, addr_t const &node_addr);
+  virtual void registerPacketHandlers(const h256 &genesis_hash, const std::shared_ptr<PacketsStats> &packets_stats,
+                                      const std::shared_ptr<DbStorage> &db,
+                                      const std::shared_ptr<PbftManager> &pbft_mgr,
+                                      const std::shared_ptr<PbftChain> &pbft_chain,
+                                      const std::shared_ptr<VoteManager> &vote_mgr,
+                                      const std::shared_ptr<NextVotesManager> &next_votes_mgr,
+                                      const std::shared_ptr<DagManager> &dag_mgr,
+                                      const std::shared_ptr<TransactionManager> &trx_mgr, addr_t const &node_addr);
 
  private:
   void initBootNodes(const std::vector<NodeConfig> &network_boot_nodes, const dev::KeyPair &key);

--- a/libraries/core_libs/network/src/network.cpp
+++ b/libraries/core_libs/network/src/network.cpp
@@ -19,27 +19,27 @@ Network::Network(const FullNodeConfig &config, const h256 &genesis_hash,
                  std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<PbftChain> pbft_chain,
                  std::shared_ptr<VoteManager> vote_mgr, std::shared_ptr<NextVotesManager> next_votes_mgr,
                  std::shared_ptr<DagManager> dag_mgr, std::shared_ptr<TransactionManager> trx_mgr)
-    : kConf(config), tp_(config.network.network_num_threads, false) {
+    : tp_(config.network.network_num_threads, false) {
   auto const &node_addr = key.address();
   LOG_OBJECTS_CREATE("NETWORK");
-  LOG(log_nf_) << "Read Network Config: " << std::endl << kConf.network << std::endl;
+  LOG(log_nf_) << "Read Network Config: " << std::endl << config.network << std::endl;
 
   // TODO make all these properties configurable
   dev::p2p::NetworkConfig net_conf;
-  net_conf.listenIPAddress = kConf.network.network_listen_ip;
-  net_conf.listenPort = kConf.network.network_tcp_port;
+  net_conf.listenIPAddress = config.network.network_listen_ip;
+  net_conf.listenPort = config.network.network_tcp_port;
   net_conf.discovery = true;
   net_conf.allowLocalDiscovery = true;
   net_conf.traverseNAT = false;
-  net_conf.publicIPAddress = kConf.network.network_public_ip;
+  net_conf.publicIPAddress = config.network.network_public_ip;
   net_conf.pin = false;
 
   dev::p2p::TaraxaNetworkConfig taraxa_net_conf;
-  taraxa_net_conf.ideal_peer_count = kConf.network.network_ideal_peer_count;
+  taraxa_net_conf.ideal_peer_count = config.network.network_ideal_peer_count;
 
-  // TODO kConf.network.network_max_peer_count -> kConf.network.peer_count_stretch
-  taraxa_net_conf.peer_stretch = kConf.network.network_max_peer_count / kConf.network.network_ideal_peer_count;
-  taraxa_net_conf.chain_id = kConf.chain_id;
+  // TODO config.network.network_max_peer_count -> config.network.peer_count_stretch
+  taraxa_net_conf.peer_stretch = config.network.network_max_peer_count / config.network.network_ideal_peer_count;
+  taraxa_net_conf.chain_id = config.chain_id;
   taraxa_net_conf.expected_parallelism = tp_.capacity();
 
   string net_version = "TaraxaNode";  // TODO maybe give a proper name?
@@ -48,7 +48,7 @@ Network::Network(const FullNodeConfig &config, const h256 &genesis_hash,
       assert(!host.expired());
 
       auto taraxa_capability =
-          network::tarcap::TaraxaCapability::make(host, key, kConf, genesis_hash, TARAXA_NET_VERSION, db, pbft_mgr,
+          network::tarcap::TaraxaCapability::make(host, key, config, genesis_hash, TARAXA_NET_VERSION, db, pbft_mgr,
                                                   pbft_chain, vote_mgr, next_votes_mgr, dag_mgr, trx_mgr);
       return dev::p2p::Host::CapabilityList{taraxa_capability};
     };
@@ -62,7 +62,7 @@ Network::Network(const FullNodeConfig &config, const h256 &genesis_hash,
     });
   }
 
-  LOG(log_nf_) << "Configured host. Listening on address: " << kConf.network.network_listen_ip << ":"
+  LOG(log_nf_) << "Configured host. Listening on address: " << config.network.network_listen_ip << ":"
                << config.network.network_tcp_port;
 }
 
@@ -74,9 +74,7 @@ Network::~Network() {
 void Network::start() {
   tp_.start();
   taraxa_capability_->start();
-  LOG(log_nf_) << "Started Network address: " << kConf.network.network_listen_ip << ":"
-               << kConf.network.network_tcp_port << std::endl;
-  LOG(log_nf_) << "Started Node id: " << host_->id();
+  LOG(log_nf_) << "Started Node id: " << host_->id() << ", listening on port " << host_->listenPort();
 }
 
 bool Network::isStarted() { return tp_.is_running(); }

--- a/libraries/core_libs/network/src/network.cpp
+++ b/libraries/core_libs/network/src/network.cpp
@@ -13,7 +13,7 @@
 
 namespace taraxa {
 
-Network::Network(FullNodeConfig const &config, const h256 &genesis_hash,
+Network::Network(const FullNodeConfig &config, const h256 &genesis_hash,
                  dev::p2p::Host::CapabilitiesFactory construct_capabilities,
                  std::filesystem::path const &network_file_path, dev::KeyPair const &key, std::shared_ptr<DbStorage> db,
                  std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<PbftChain> pbft_chain,
@@ -33,6 +33,7 @@ Network::Network(FullNodeConfig const &config, const h256 &genesis_hash,
   net_conf.traverseNAT = false;
   net_conf.publicIPAddress = kConf.network.network_public_ip;
   net_conf.pin = false;
+
   dev::p2p::TaraxaNetworkConfig taraxa_net_conf;
   taraxa_net_conf.ideal_peer_count = kConf.network.network_ideal_peer_count;
 
@@ -60,6 +61,9 @@ Network::Network(FullNodeConfig const &config, const h256 &genesis_hash,
         ;
     });
   }
+
+  LOG(log_nf_) << "Configured host. Listening on address: " << kConf.network.network_listen_ip << ":"
+               << config.network.network_tcp_port;
 }
 
 Network::~Network() {

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_votes_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_votes_packet_handler.cpp
@@ -25,7 +25,7 @@ std::pair<bool, std::string> ExtVotesPacketHandler::validateStandardVote(const s
   // Old vote or vote from too far in the future, can be dropped
   // TODO[1880]: should be vote->getPeriod() <= current_pbft_period - if <=, some tests are failing due to missing
   // reward votes -> whole rewards votes gossiping need to be checked...
-  if (vote->getPeriod() < current_pbft_period || vote->getPeriod() > current_pbft_period + kDposDelay) {
+  if (vote->getPeriod() < current_pbft_period || vote->getPeriod() - 1 > current_pbft_period + kDposDelay) {
     std::stringstream err;
     err << "Invalid period: Vote period: " << vote->getPeriod() << ", current pbft period: " << current_pbft_period;
     return {false, err.str()};
@@ -52,7 +52,7 @@ std::pair<bool, std::string> ExtVotesPacketHandler::validateNextSyncVote(const s
   const auto current_pbft_round = pbft_mgr_->getPbftRound();
 
   // Old vote or vote from too far in the future, can be dropped
-  if (vote->getPeriod() < current_pbft_period || vote->getPeriod() > current_pbft_period + kDposDelay) {
+  if (vote->getPeriod() < current_pbft_period || vote->getPeriod() - 1 > current_pbft_period + kDposDelay) {
     std::stringstream err;
     err << "Invalid period: Vote period: " << vote->getPeriod() << ", current pbft period: " << current_pbft_period;
     return {false, err.str()};

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_votes_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_votes_packet_handler.cpp
@@ -2,28 +2,30 @@
 
 #include "pbft/pbft_manager.hpp"
 #include "vote/vote.hpp"
+#include "vote_manager/vote_manager.hpp"
 
 namespace taraxa::network::tarcap {
 
 ExtVotesPacketHandler::ExtVotesPacketHandler(std::shared_ptr<PeersState> peers_state,
                                              std::shared_ptr<PacketsStats> packets_stats,
                                              std::shared_ptr<PbftManager> pbft_mgr,
-                                             std::shared_ptr<PbftChain> pbft_chain, const addr_t &node_addr,
-                                             const std::string &log_channel_name)
+                                             std::shared_ptr<PbftChain> pbft_chain,
+                                             std::shared_ptr<VoteManager> vote_mgr, const uint32_t dpos_delay,
+                                             const addr_t &node_addr, const std::string &log_channel_name)
     : PacketHandler(std::move(peers_state), std::move(packets_stats), node_addr, log_channel_name),
+      kDposDelay_(dpos_delay),
       pbft_mgr_(std::move(pbft_mgr)),
-      pbft_chain_(std::move(pbft_chain)) {}
+      pbft_chain_(std::move(pbft_chain)),
+      vote_mgr_(std::move(vote_mgr)) {}
 
-std::pair<bool, std::string> ExtVotesPacketHandler::validateStandardVote(const std::shared_ptr<Vote> &vote) {
-  // TODO: add checks related to the roud & period that could be too far ahead, etc... ?
-
+std::pair<bool, std::string> ExtVotesPacketHandler::validateStandardVote(const std::shared_ptr<Vote> &vote) const {
   const uint64_t current_pbft_period = pbft_chain_->getPbftChainSize();
   const auto current_pbft_round = pbft_mgr_->getPbftRound();
 
   // Old vote or vote from too far in the future, can be dropped
-  // TODO: current_pbft_period + 5 -> put 5 into some variable
-  // TODO: here should be vote->getPeriod() < current_pbft_period
-  if (vote->getPeriod() < current_pbft_period || vote->getPeriod() > current_pbft_period + 5) {
+  // TODO[1880]: should be vote->getPeriod() <= current_pbft_period - if <=, some tests are failing due to missing
+  // reward votes -> whole rewards votes gossiping need to be checked...
+  if (vote->getPeriod() < current_pbft_period || vote->getPeriod() > current_pbft_period + kDposDelay_) {
     std::stringstream err;
     err << "Invalid period: Vote period: " << vote->getPeriod() << ", current pbft period: " << current_pbft_period;
     return {false, err.str()};
@@ -35,26 +37,47 @@ std::pair<bool, std::string> ExtVotesPacketHandler::validateStandardVote(const s
     return {false, err.str()};
   }
 
-  return pbft_mgr_->dposValidateVote(vote);
+  if (auto voter_max_round = getVoterMaxRound(vote->getVoterAddr()); vote->getRound() + 1 < voter_max_round) {
+    std::stringstream err;
+    err << "Invalid round: Vote round: " << vote->getRound()
+        << ", voter current max received round: " << voter_max_round;
+    return {false, err.str()};
+  }
+
+  return validateVote(vote);
 }
 
-std::pair<bool, std::string> ExtVotesPacketHandler::validateNextVote(const std::shared_ptr<Vote> &vote) {
+std::pair<bool, std::string> ExtVotesPacketHandler::validateNextSyncVote(const std::shared_ptr<Vote> &vote) const {
+  const uint64_t current_pbft_period = pbft_chain_->getPbftChainSize();
+  const auto current_pbft_round = pbft_mgr_->getPbftRound();
+
+  // Old vote or vote from too far in the future, can be dropped
+  if (vote->getPeriod() < current_pbft_period || vote->getPeriod() > current_pbft_period + kDposDelay_) {
+    std::stringstream err;
+    err << "Invalid period: Vote period: " << vote->getPeriod() << ", current pbft period: " << current_pbft_period;
+    return {false, err.str()};
+  }
+
+  if (vote->getRound() < current_pbft_round - 1) {
+    std::stringstream err;
+    err << "Invalid round: Vote round: " << vote->getRound() << ", current pbft round: " << current_pbft_round;
+    return {false, err.str()};
+  }
+
   if (vote->getType() != next_vote_type) {
     std::stringstream err;
     err << "Invalid type: " << static_cast<uint64_t>(vote->getType());
     return {false, err.str()};
   }
 
-  return validateStandardVote(vote);
+  return validateVote(vote);
 }
 
-std::pair<bool, std::string> ExtVotesPacketHandler::validateRewardVote(const std::shared_ptr<Vote> &vote) {
+std::pair<bool, std::string> ExtVotesPacketHandler::validateRewardVote(const std::shared_ptr<Vote> &vote) const {
   const uint64_t current_pbft_period = pbft_chain_->getPbftChainSize();
   const auto current_pbft_round = pbft_mgr_->getPbftRound();
 
-  // TODO: think about this: should be reward vote period == current_pbft_period ???
-  // TODO: current_pbft_period + 5 -> put 5 into some variable
-  if (vote->getPeriod() < current_pbft_period || vote->getPeriod() > current_pbft_period + 5) {
+  if (vote->getPeriod() != current_pbft_period) {
     std::stringstream err;
     err << "Invalid period: Vote period: " << vote->getPeriod() << ", current pbft period: " << current_pbft_period;
     return {false, err.str()};
@@ -69,7 +92,6 @@ std::pair<bool, std::string> ExtVotesPacketHandler::validateRewardVote(const std
   if (vote->getType() != cert_vote_type) {
     std::stringstream err;
     err << "Invalid type: " << static_cast<uint64_t>(vote->getType());
-    // throw MaliciousPeerException(err.str());
     return {false, err.str()};
   }
 
@@ -79,19 +101,48 @@ std::pair<bool, std::string> ExtVotesPacketHandler::validateRewardVote(const std
     return {false, err.str()};
   }
 
-  if (pbft_chain_->getLastPbftBlockHash() != vote->getBlockHash()) {
-    // Should not happen, reward_votes_pbft_block_hash_ should always equal to last block hash in PBFT chain
+  if (vote_mgr_->getCurrentRewardsVotesBlock() != vote->getBlockHash()) {
     std::stringstream err;
     err << "Invalid PBFT block hash " << vote->getBlockHash().abridged() << " -> different from "
         << pbft_chain_->getLastPbftBlockHash().abridged();
-    // throw MaliciousPeerException(err.str());
     return {false, err.str()};
   }
 
-  return pbft_mgr_->dposValidateVote(vote);
+  return validateVote(vote);
+}
+
+std::pair<bool, std::string> ExtVotesPacketHandler::validateVote(const std::shared_ptr<Vote> &vote) const {
+  // Check is vote is unique per round & step & voter -> each address can generate just 1 vote per round & step
+  if (auto unique_vote_validation = vote_mgr_->isUniqueVote(vote); !unique_vote_validation.first) {
+    return unique_vote_validation;
+  }
+
+  return pbft_mgr_->validateVote(vote);
+}
+
+void ExtVotesPacketHandler::setVoterMaxRound(const addr_t &voter, uint64_t round) {
+  if (getVoterMaxRound(voter) >= round) {
+    return;
+  }
+
+  std::unique_lock lock(voters_max_rounds_mutex_);
+  if (auto inserted_value = voters_max_rounds_.insert({voter, round}); !inserted_value.second) {
+    if (round > inserted_value.first->second) {
+      inserted_value.first->second = round;
+    }
+  }
+}
+
+uint64_t ExtVotesPacketHandler::getVoterMaxRound(const addr_t &voter) const {
+  std::shared_lock lock(voters_max_rounds_mutex_);
+
+  auto voter_max_round = voters_max_rounds_.find(voter);
+  return voter_max_round == voters_max_rounds_.end() ? 0 : voter_max_round->second;
 }
 
 void ExtVotesPacketHandler::onNewPbftVotes(std::vector<std::shared_ptr<Vote>> &&votes) {
+  const auto rewards_votes_block = vote_mgr_->getCurrentRewardsVotesBlock();
+
   for (const auto &peer : peers_state_->getAllPeers()) {
     if (peer.second->syncing_) {
       continue;
@@ -101,8 +152,7 @@ void ExtVotesPacketHandler::onNewPbftVotes(std::vector<std::shared_ptr<Vote>> &&
     for (const auto &v : votes) {
       if (!peer.second->isVoteKnown(v->getHash()) &&
           (peer.second->pbft_round_ <= v->getRound() ||
-           (v->getType() == cert_vote_type &&
-            v->getBlockHash() == pbft_mgr_->getLastPbftBlockHash() /* reward vote */))) {
+           (v->getType() == cert_vote_type && v->getBlockHash() == rewards_votes_block /* reward vote */))) {
         send_votes.push_back(v);
       }
     }

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_votes_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_votes_packet_handler.cpp
@@ -155,7 +155,7 @@ void ExtVotesPacketHandler::sendPbftVotes(const dev::p2p::NodeID &peer_id, std::
       const auto &v = votes[i];
       // Withou sending also vote weight,
       // check_committeeSize_less_or_equal_to_activePlayers & check_committeeSize_greater_than_activePlayers tests fail
-      s.appendRaw(v->rlp(true, true));
+      s.appendRaw(v->rlp(true, false));
       LOG(log_dg_) << "Send out vote " << v->getHash() << " to peer " << peer_id;
     }
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_votes_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_votes_packet_handler.cpp
@@ -94,7 +94,12 @@ std::pair<bool, std::string> ExtVotesPacketHandler::validateVote(const std::shar
     return unique_vote_validation;
   }
 
-  return pbft_mgr_->validateVote(vote);
+  const auto vote_valid = pbft_mgr_->validateVote(vote);
+  if (!vote_valid.first) {
+    LOG(log_er_) << "Vote \"dpos\" validation failed: " << vote_valid.second;
+  }
+
+  return vote_valid;
 }
 
 void ExtVotesPacketHandler::setVoterMaxRound(const addr_t &voter, uint64_t round) {

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/get_votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/get_votes_sync_packet_handler.cpp
@@ -5,14 +5,12 @@
 
 namespace taraxa::network::tarcap {
 
-GetVotesSyncPacketHandler::GetVotesSyncPacketHandler(std::shared_ptr<PeersState> peers_state,
-                                                     std::shared_ptr<PacketsStats> packets_stats,
-                                                     std::shared_ptr<PbftManager> pbft_mgr,
-                                                     std::shared_ptr<PbftChain> pbft_chain,
-                                                     std::shared_ptr<NextVotesManager> next_votes_mgr,
-                                                     const addr_t &node_addr)
+GetVotesSyncPacketHandler::GetVotesSyncPacketHandler(
+    std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
+    std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<VoteManager> vote_mgr,
+    std::shared_ptr<NextVotesManager> next_votes_mgr, const uint32_t dpos_delay, const addr_t &node_addr)
     : ExtVotesPacketHandler(std::move(peers_state), std::move(packets_stats), std::move(pbft_mgr),
-                            std::move(pbft_chain), node_addr, "GET_VOTES_SYNC_PH"),
+                            std::move(pbft_chain), std::move(vote_mgr), dpos_delay, node_addr, "GET_VOTES_SYNC_PH"),
       next_votes_mgr_(std::move(next_votes_mgr)) {}
 
 void GetVotesSyncPacketHandler::validatePacketRlpFormat(const PacketData &packet_data) const {

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/get_votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/get_votes_sync_packet_handler.cpp
@@ -8,10 +8,11 @@ namespace taraxa::network::tarcap {
 GetVotesSyncPacketHandler::GetVotesSyncPacketHandler(std::shared_ptr<PeersState> peers_state,
                                                      std::shared_ptr<PacketsStats> packets_stats,
                                                      std::shared_ptr<PbftManager> pbft_mgr,
+                                                     std::shared_ptr<PbftChain> pbft_chain,
                                                      std::shared_ptr<NextVotesManager> next_votes_mgr,
                                                      const addr_t &node_addr)
-    : ExtVotesPacketHandler(std::move(peers_state), std::move(packets_stats), pbft_mgr, node_addr, "GET_VOTES_SYNC_PH"),
-      pbft_mgr_(std::move(pbft_mgr)),
+    : ExtVotesPacketHandler(std::move(peers_state), std::move(packets_stats), std::move(pbft_mgr),
+                            std::move(pbft_chain), node_addr, "GET_VOTES_SYNC_PH"),
       next_votes_mgr_(std::move(next_votes_mgr)) {}
 
 void GetVotesSyncPacketHandler::validatePacketRlpFormat(const PacketData &packet_data) const {

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
@@ -46,14 +46,9 @@ void VotePacketHandler::process(const PacketData &packet_data, const std::shared
       }
 
       if (auto vote_is_valid = validateRewardVote(vote); vote_is_valid.first == false) {
-        LOG(log_er_) << "Reward vote " << vote_hash.abridged() << " validation failed. Err: " << vote_is_valid.second
-                     << ", vote round " << vote->getRound() << ", current round: " << current_pbft_round
+        LOG(log_er_) << "Reward vote " << vote_hash.abridged() << " validation failed. Err: \"" << vote_is_valid.second
+                     << "\", vote round " << vote->getRound() << ", current round: " << current_pbft_round
                      << ", vote type: " << static_cast<uint64_t>(vote->getType());
-        continue;
-      }
-
-      if (!vote_mgr_->insertUniqueVote(vote)) {
-        LOG(log_dg_) << "Non unique reward vote " << vote_hash << " (race condition)";
         continue;
       }
 
@@ -68,11 +63,6 @@ void VotePacketHandler::process(const PacketData &packet_data, const std::shared
 
       if (auto vote_is_valid = validateStandardVote(vote); vote_is_valid.first == false) {
         LOG(log_er_) << "Vote " << vote_hash.abridged() << " validation failed. Err: " << vote_is_valid.second;
-        continue;
-      }
-
-      if (!vote_mgr_->insertUniqueVote(vote)) {
-        LOG(log_dg_) << "Non unique vote " << vote_hash << " (race condition)";
         continue;
       }
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
@@ -7,9 +7,10 @@ namespace taraxa::network::tarcap {
 
 VotePacketHandler::VotePacketHandler(std::shared_ptr<PeersState> peers_state,
                                      std::shared_ptr<PacketsStats> packets_stats, std::shared_ptr<PbftManager> pbft_mgr,
-                                     std::shared_ptr<VoteManager> vote_mgr, const addr_t &node_addr)
-    : ExtVotesPacketHandler(std::move(peers_state), std::move(packets_stats), pbft_mgr, node_addr, "PBFT_VOTE_PH"),
-      pbft_mgr_(std::move(pbft_mgr)),
+                                     std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<VoteManager> vote_mgr,
+                                     const addr_t &node_addr)
+    : ExtVotesPacketHandler(std::move(peers_state), std::move(packets_stats), std::move(pbft_mgr),
+                            std::move(pbft_chain), node_addr, "PBFT_VOTE_PH"),
       vote_mgr_(std::move(vote_mgr)),
       seen_votes_(1000000, 1000) {}
 
@@ -21,6 +22,8 @@ void VotePacketHandler::validatePacketRlpFormat([[maybe_unused]] const PacketDat
 }
 
 void VotePacketHandler::process(const PacketData &packet_data, const std::shared_ptr<TaraxaPeer> &peer) {
+  const uint64_t current_pbft_period = pbft_chain_->getPbftChainSize();
+
   std::vector<std::shared_ptr<Vote>> votes;
   const auto count = packet_data.rlp_.itemCount();
   for (size_t i = 0; i < count; i++) {
@@ -31,7 +34,16 @@ void VotePacketHandler::process(const PacketData &packet_data, const std::shared
     const auto vote_round = vote->getRound();
     const auto current_pbft_round = pbft_mgr_->getPbftRound();
 
+    // Old vote or vote from too far in the future, can be dropped
+    // TODO: current_pbft_period + 5 -> put 5 into some variable
+    if (vote->getPeriod() < current_pbft_period || vote->getPeriod() > current_pbft_period + 5) {
+      LOG(log_dg_) << "Dropping vote " << vote_hash << " due to period. Vote period: " << vote->getPeriod()
+                   << ", current pbft period: " << current_pbft_period;
+      continue;
+    }
+
     // Synchronization point in case multiple threads are processing the same vote at the same time
+    // TODO: we might not need this as such synchronization is done in queues already ?
     if (!seen_votes_.insert(vote_hash)) {
       LOG(log_dg_) << "Received vote " << vote_hash << " (from " << packet_data.from_node_id_.abridged()
                    << ") already seen.";
@@ -39,20 +51,44 @@ void VotePacketHandler::process(const PacketData &packet_data, const std::shared
     }
     peer->markVoteAsKnown(vote_hash);
 
-    // Check reward vote
-    if (vote_round < current_pbft_round) {
-      if (!vote_mgr_->addRewardVote(vote)) {
+    // TODO: I am so sure about this, why do we allow smaller round without any bound ?
+    // TODO: this is bad - we say vote is reward vote based on round, but it is not enough as some out of sync node
+    // might send us standard vote and we identify as reward vote - this way we cant really set peer as malicious if
+    // reward vote type != cert vote, etc...
+    if (vote_round < current_pbft_round) {  // reward vote
+      if (vote_mgr_->isKnownRewardVote(vote->getHash())) {
+        LOG(log_dg_) << "Reward vote " << vote_hash.abridged() << " already inserted in verified queue";
+      }
+
+      if (auto vote_is_valid = validateRewardVote(vote); vote_is_valid.first == false) {
+        LOG(log_er_) << "Reward vote " << vote_hash.abridged() << " validation failed. Err: " << vote_is_valid.second;
         continue;
       }
-    } else {
-      // Votes vote_round >= current_pbft_round
-      // Adds unverified vote into queue
-      if (vote_mgr_->voteInVerifiedMap(vote) || !vote_mgr_->addUnverifiedVote(vote)) {
-        LOG(log_dg_) << "Received PBFT vote " << vote_hash << " (from " << packet_data.from_node_id_.abridged()
-                     << ") already saved in (un)verified queues.";
+
+      if (!vote_mgr_->addRewardVote(vote)) {
+        LOG(log_dg_) << "Reward vote " << vote_hash.abridged() << " already inserted in verified queue(race condition)";
+        continue;
+      }
+    } else {  // standard vote -> vote_round >= current_pbft_round
+      if (vote_mgr_->voteInVerifiedMap(vote)) {
+        LOG(log_dg_) << "Vote " << vote_hash.abridged() << " already inserted in verified queue";
+      }
+
+      if (auto vote_is_valid = validateStandardVote(vote); vote_is_valid.first == false) {
+        LOG(log_er_) << "Vote " << vote_hash.abridged() << " validation failed. Err: " << vote_is_valid.second;
+        continue;
+      }
+
+      if (!vote_mgr_->addVerifiedVote(vote)) {
+        LOG(log_dg_) << "Vote " << vote_hash << " already inserted in verified queue(race condition)";
         continue;
       }
     }
+
+    // TODO: add protection so each voter can cast only 1 vote per round & step
+
+    // Do not mark it before, as peers have small caches of known votes. Only mark gossiping votes
+    peer->markVoteAsKnown(vote_hash);
     votes.push_back(std::move(vote));
   }
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
@@ -43,7 +43,7 @@ void VotePacketHandler::process(const PacketData &packet_data, const std::shared
     // we identify it as reward vote and use wrong validation....
     if (vote_round < current_pbft_round) {  // reward vote
       if (vote_mgr_->isInRewardsVotes(vote->getHash())) {
-        LOG(log_dg_) << "Reward vote " << vote_hash.abridged() << " already inserted in reeards votes";
+        LOG(log_dg_) << "Reward vote " << vote_hash.abridged() << " already inserted in rewards votes";
       }
 
       if (auto vote_is_valid = validateRewardVote(vote); vote_is_valid.first == false) {

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
@@ -22,8 +22,6 @@ void VotePacketHandler::validatePacketRlpFormat([[maybe_unused]] const PacketDat
 }
 
 void VotePacketHandler::process(const PacketData &packet_data, const std::shared_ptr<TaraxaPeer> &peer) {
-  const uint64_t current_pbft_period = pbft_chain_->getPbftChainSize();
-
   std::vector<std::shared_ptr<Vote>> votes;
   const auto count = packet_data.rlp_.itemCount();
   for (size_t i = 0; i < count; i++) {
@@ -33,14 +31,6 @@ void VotePacketHandler::process(const PacketData &packet_data, const std::shared
 
     const auto vote_round = vote->getRound();
     const auto current_pbft_round = pbft_mgr_->getPbftRound();
-
-    // Old vote or vote from too far in the future, can be dropped
-    // TODO: current_pbft_period + 5 -> put 5 into some variable
-    if (vote->getPeriod() < current_pbft_period || vote->getPeriod() > current_pbft_period + 5) {
-      LOG(log_dg_) << "Dropping vote " << vote_hash << " due to period. Vote period: " << vote->getPeriod()
-                   << ", current pbft period: " << current_pbft_period;
-      continue;
-    }
 
     // Synchronization point in case multiple threads are processing the same vote at the same time
     // TODO: we might not need this as such synchronization is done in queues already ?

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
@@ -46,7 +46,7 @@ void VotePacketHandler::process(const PacketData &packet_data, const std::shared
       }
 
       if (auto vote_is_valid = validateRewardVote(vote); vote_is_valid.first == false) {
-        LOG(log_er_) << "Reward vote " << vote_hash.abridged() << " validation failed. Err: \"" << vote_is_valid.second
+        LOG(log_wr_) << "Reward vote " << vote_hash.abridged() << " validation failed. Err: \"" << vote_is_valid.second
                      << "\", vote round " << vote->getRound() << ", current round: " << current_pbft_round
                      << ", vote type: " << static_cast<uint64_t>(vote->getType());
         continue;
@@ -62,7 +62,7 @@ void VotePacketHandler::process(const PacketData &packet_data, const std::shared
       }
 
       if (auto vote_is_valid = validateStandardVote(vote); vote_is_valid.first == false) {
-        LOG(log_er_) << "Vote " << vote_hash.abridged() << " validation failed. Err: " << vote_is_valid.second;
+        LOG(log_wr_) << "Vote " << vote_hash.abridged() << " validation failed. Err: " << vote_is_valid.second;
         continue;
       }
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
@@ -53,7 +53,7 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
       }
 
       if (auto vote_is_valid = validateStandardVote(next_vote); vote_is_valid.first == false) {
-        LOG(log_er_) << "Vote " << next_vote_hash.abridged() << " validation failed. Err: " << vote_is_valid.second;
+        LOG(log_wr_) << "Vote " << next_vote_hash.abridged() << " validation failed. Err: " << vote_is_valid.second;
         continue;
       }
 
@@ -65,7 +65,7 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
       setVoterMaxRound(vote->getVoterAddr(), vote->getRound());
     } else {  // pbft_current_round == peer_pbft_round
       if (auto vote_is_valid = validateNextSyncVote(next_vote); vote_is_valid.first == false) {
-        LOG(log_er_) << "Next vote " << next_vote_hash.abridged()
+        LOG(log_wr_) << "Next vote " << next_vote_hash.abridged()
                      << " validation failed. Err: " << vote_is_valid.second;
         continue;
       }

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
@@ -5,14 +5,12 @@
 
 namespace taraxa::network::tarcap {
 
-VotesSyncPacketHandler::VotesSyncPacketHandler(std::shared_ptr<PeersState> peers_state,
-                                               std::shared_ptr<PacketsStats> packets_stats,
-                                               std::shared_ptr<PbftManager> pbft_mgr,
-                                               std::shared_ptr<VoteManager> vote_mgr,
-                                               std::shared_ptr<NextVotesManager> next_votes_mgr,
-                                               std::shared_ptr<DbStorage> db, const addr_t &node_addr)
-    : ExtVotesPacketHandler(std::move(peers_state), std::move(packets_stats), pbft_mgr, node_addr, "VOTES_SYNC_PH"),
-      pbft_mgr_(std::move(pbft_mgr)),
+VotesSyncPacketHandler::VotesSyncPacketHandler(
+    std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
+    std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<VoteManager> vote_mgr,
+    std::shared_ptr<NextVotesManager> next_votes_mgr, std::shared_ptr<DbStorage> db, const addr_t &node_addr)
+    : ExtVotesPacketHandler(std::move(peers_state), std::move(packets_stats), std::move(pbft_mgr),
+                            std::move(pbft_chain), node_addr, "VOTES_SYNC_PH"),
       vote_mgr_(std::move(vote_mgr)),
       next_votes_mgr_(std::move(next_votes_mgr)),
       db_(std::move(db)) {}
@@ -28,21 +26,51 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
   auto vote = std::make_shared<Vote>(packet_data.rlp_[0].data().toBytes());
 
   const auto pbft_current_round = pbft_mgr_->getPbftRound();
+  const uint64_t pbft_current_period = pbft_chain_->getPbftChainSize();
   const auto peer_pbft_round = vote->getRound() + 1;
+
+  // Next votes are from too far ahead in the future
+  if (pbft_current_round > peer_pbft_round) {
+    LOG(log_dg_) << "Dropping votes sync packet due to round. Votes round: " << peer_pbft_round
+                 << ", current pbft round: " << pbft_current_round;
+    return;
+  }
 
   std::vector<std::shared_ptr<Vote>> next_votes;
   const auto next_votes_count = packet_data.rlp_.itemCount();
   for (size_t i = 0; i < next_votes_count; i++) {
     auto next_vote = std::make_shared<Vote>(packet_data.rlp_[i].data().toBytes());
+    const auto next_vote_hash = next_vote->getHash();
     if (next_vote->getRound() != peer_pbft_round - 1) {
       LOG(log_er_) << "Received next votes bundle with unmatched rounds from " << packet_data.from_node_id_
-                   << ". The peer may be a malicous player, will be disconnected";
+                   << ". The peer may be a malicious player, will be disconnected";
       disconnect(packet_data.from_node_id_, dev::p2p::UserReason);
       return;
     }
 
-    const auto next_vote_hash = next_vote->getHash();
-    LOG(log_nf_) << "Received PBFT next vote " << next_vote_hash;
+    // Old vote or vote from too far in the future, can be dropped
+    // TODO: current_pbft_period + 5 -> put 5 into some variable
+    if (next_vote->getPeriod() < pbft_current_period || next_vote->getPeriod() > pbft_current_period + 5) {
+      LOG(log_dg_) << "Dropping vote " << next_vote_hash << " due to period. Vote period: " << vote->getPeriod()
+                   << ", current pbft period: " << pbft_current_period;
+      continue;
+    }
+
+    if (auto vote_is_valid = validateStandardVote(vote); vote_is_valid.first == false) {
+      LOG(log_er_) << "Vote " << next_vote_hash << " validation failed. Err: " << vote_is_valid.second;
+      continue;
+    }
+
+    if (pbft_current_round < peer_pbft_round) {
+      // Check if vote is already in verified queue, if not - try to add it
+      if (vote_mgr_->voteInVerifiedMap(next_vote) || !vote_mgr_->addVerifiedVote(next_vote)) {
+        LOG(log_dg_) << "Received PBFT next vote " << next_vote_hash << " (from "
+                     << packet_data.from_node_id_.abridged() << ") already saved in verified queue.";
+        continue;
+      }
+    }
+
+    LOG(log_dg_) << "Received PBFT next vote " << next_vote_hash;
     peer->markVoteAsKnown(next_vote_hash);
     next_votes.push_back(std::move(next_vote));
   }
@@ -51,29 +79,6 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
                << " node current round " << pbft_current_round << ", peer pbft round " << peer_pbft_round;
 
   if (pbft_current_round < peer_pbft_round) {
-    // Add into votes unverified queue
-    for (auto it = next_votes.begin(); it != next_votes.end();) {
-      auto vote_hash = (*it)->getHash();
-      auto vote_round = (*it)->getRound();
-
-      if (vote_mgr_->voteInUnverifiedMap(vote_round, vote_hash) || vote_mgr_->voteInVerifiedMap(*it)) {
-        LOG(log_dg_) << "Received PBFT next vote " << vote_hash << " (from " << packet_data.from_node_id_.abridged()
-                     << ") already saved in queue.";
-        it = next_votes.erase(it);
-        continue;
-      }
-
-      // Synchronization point in case multiple threads are processing the same vote at the same time
-      // Adds unverified vote into local structure + database
-      if (!vote_mgr_->addUnverifiedVote(*it)) {
-        LOG(log_dg_) << "Received PBFT next vote " << vote_hash << " (from " << packet_data.from_node_id_.abridged()
-                     << ") already saved in unverified queue by a different thread(race condition).";
-        it = next_votes.erase(it);
-        continue;
-      }
-      ++it;
-    }
-
     onNewPbftVotes(std::move(next_votes));
 
   } else if (pbft_current_round == peer_pbft_round) {

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
@@ -57,11 +57,6 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
         continue;
       }
 
-      if (!vote_mgr_->insertUniqueVote(vote)) {
-        LOG(log_dg_) << "Non unique vote " << next_vote_hash.abridged() << " (race condition)";
-        continue;
-      }
-
       if (!vote_mgr_->addVerifiedVote(next_vote)) {
         LOG(log_dg_) << "Vote " << next_vote_hash.abridged() << " already inserted in verified queue(race condition)";
         continue;

--- a/libraries/core_libs/network/src/tarcap/stats/node_stats.cpp
+++ b/libraries/core_libs/network/src/tarcap/stats/node_stats.cpp
@@ -151,7 +151,6 @@ void NodeStats::logNodeStats() {
   LOG(log_nf_) << "Node elligible vote count:       " << local_weighted_votes;
 
   LOG(log_dg_) << "****** Memory structures sizes ******";
-  LOG(log_dg_) << "Unverified votes size:           " << vote_mgr_->getUnverifiedVotesSize();
   LOG(log_dg_) << "Verified votes size:             " << vote_mgr_->getVerifiedVotesSize();
 
   LOG(log_dg_) << "Non finalized txs size:          " << trx_mgr_->getNonfinalizedTrxSize();

--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -192,11 +192,12 @@ void TaraxaCapability::registerPacketHandlers(
   // Register all packet handlers
 
   // Consensus packets with high processing priority
-  packets_handlers_->registerHandler<VotePacketHandler>(peers_state_, packets_stats, pbft_mgr, vote_mgr, node_addr);
-  packets_handlers_->registerHandler<GetVotesSyncPacketHandler>(peers_state_, packets_stats, pbft_mgr, next_votes_mgr,
-                                                                node_addr);
-  packets_handlers_->registerHandler<VotesSyncPacketHandler>(peers_state_, packets_stats, pbft_mgr, vote_mgr,
-                                                             next_votes_mgr, db, node_addr);
+  packets_handlers_->registerHandler<VotePacketHandler>(peers_state_, packets_stats, pbft_mgr, pbft_chain, vote_mgr,
+                                                        node_addr);
+  packets_handlers_->registerHandler<GetVotesSyncPacketHandler>(peers_state_, packets_stats, pbft_mgr, pbft_chain,
+                                                                next_votes_mgr, node_addr);
+  packets_handlers_->registerHandler<VotesSyncPacketHandler>(peers_state_, packets_stats, pbft_mgr, pbft_chain,
+                                                             vote_mgr, next_votes_mgr, db, node_addr);
 
   // Standard packets with mid processing priority
   packets_handlers_->registerHandler<PbftBlockPacketHandler>(peers_state_, packets_stats, pbft_chain, pbft_mgr,

--- a/libraries/core_libs/network/src/tarcap/threadpool/packets_blocking_mask.cpp
+++ b/libraries/core_libs/network/src/tarcap/threadpool/packets_blocking_mask.cpp
@@ -83,7 +83,7 @@ void PacketsBlockingMask::setDagBlockLevelBeingProcessed(const PacketData& packe
   // are allowed
   if (const auto smallest_processing_dag_level = getSmallestDagLevelBeingProcessed();
       smallest_processing_dag_level.has_value()) {
-    assert(dag_level <= smallest_processing_dag_level.value());
+    assert(dag_level <= *smallest_processing_dag_level);
   }
 
   auto& processing_dag_level = processing_dag_levels_[dag_level];
@@ -129,7 +129,7 @@ bool PacketsBlockingMask::isDagBlockPacketBlockedByLevel(const PacketData& packe
   }
 
   const auto dag_level = DagBlock::extract_dag_level_from_rlp(packet_data.rlp_);
-  if (dag_level > smallest_processing_dag_level.value()) {
+  if (dag_level > *smallest_processing_dag_level) {
     return true;
   }
 

--- a/libraries/core_libs/network/src/tarcap/threadpool/tarcap_thread_pool.cpp
+++ b/libraries/core_libs/network/src/tarcap/threadpool/tarcap_thread_pool.cpp
@@ -104,7 +104,7 @@ void TarcapThreadPool::processPacket(size_t worker_id) {
     LOG(log_dg_) << "Worker (" << worker_id << ") process packet: " << packet->type_str_ << ", id(" << packet->id_
                  << ")";
 
-    queue_.updateDependenciesStart(packet.value());
+    queue_.updateDependenciesStart(*packet);
     lock.unlock();
 
     try {
@@ -112,7 +112,7 @@ void TarcapThreadPool::processPacket(size_t worker_id) {
       auto& handler = packets_handlers_->getSpecificHandler(packet->type_);
 
       // Process packet by specific packet type handler
-      handler->processPacket(packet.value());
+      handler->processPacket(*packet);
     } catch (const std::exception& e) {
       LOG(log_er_) << "Worker (" << worker_id << ") packet: " << packet->type_str_ << ", id(" << packet->id_
                    << ") processing exception caught: " << e.what();
@@ -122,7 +122,7 @@ void TarcapThreadPool::processPacket(size_t worker_id) {
     }
 
     // Once packet handler is done with processing, update priority queue dependencies
-    queue_.updateDependenciesFinish(packet.value(), queue_mutex_, cond_var_);
+    queue_.updateDependenciesFinish(*packet, queue_mutex_, cond_var_);
   }
 }
 

--- a/libraries/core_libs/node/src/node.cpp
+++ b/libraries/core_libs/node/src/node.cpp
@@ -98,13 +98,12 @@ void FullNode::init() {
   auto dag_genesis_block_hash = conf_.chain.dag_genesis_block.getHash();
 
   pbft_chain_ = std::make_shared<PbftChain>(node_addr, db_);
-  next_votes_mgr_ = std::make_shared<NextVotesManager>(node_addr, db_, final_chain_, key_manager_);
+  next_votes_mgr_ = std::make_shared<NextVotesManager>(node_addr, db_, final_chain_);
   dag_mgr_ =
       std::make_shared<DagManager>(dag_genesis_block_hash, node_addr, conf_.chain.sortition, conf_.chain.dag, trx_mgr_,
                                    pbft_chain_, final_chain_, db_, key_manager_, conf_.is_light_node,
                                    conf_.light_node_history, conf_.max_levels_per_period, conf_.dag_expiry_limit);
-  vote_mgr_ = std::make_shared<VoteManager>(node_addr, db_, pbft_chain_, final_chain_,
-                                            next_votes_mgr_, key_manager_);
+  vote_mgr_ = std::make_shared<VoteManager>(node_addr, db_, pbft_chain_, final_chain_, next_votes_mgr_);
   pbft_mgr_ = std::make_shared<PbftManager>(conf_.chain.pbft, dag_genesis_block_hash, node_addr, db_, pbft_chain_,
                                             vote_mgr_, next_votes_mgr_, dag_mgr_, trx_mgr_, final_chain_, key_manager_,
                                             kp_.secret(), conf_.vrf_secret, conf_.max_levels_per_period);

--- a/libraries/core_libs/node/src/node.cpp
+++ b/libraries/core_libs/node/src/node.cpp
@@ -103,7 +103,7 @@ void FullNode::init() {
       std::make_shared<DagManager>(dag_genesis_block_hash, node_addr, conf_.chain.sortition, conf_.chain.dag, trx_mgr_,
                                    pbft_chain_, final_chain_, db_, key_manager_, conf_.is_light_node,
                                    conf_.light_node_history, conf_.max_levels_per_period, conf_.dag_expiry_limit);
-  vote_mgr_ = std::make_shared<VoteManager>(conf_.chain.pbft.committee_size, node_addr, db_, pbft_chain_, final_chain_,
+  vote_mgr_ = std::make_shared<VoteManager>(node_addr, db_, pbft_chain_, final_chain_,
                                             next_votes_mgr_, key_manager_);
   pbft_mgr_ = std::make_shared<PbftManager>(conf_.chain.pbft, dag_genesis_block_hash, node_addr, db_, pbft_chain_,
                                             vote_mgr_, next_votes_mgr_, dag_mgr_, trx_mgr_, final_chain_, key_manager_,

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -37,7 +37,7 @@ enum PbftMgrPreviousRoundStatus : uint8_t {
   PreviousRoundDposTotalVotesCount
 };
 
-enum PbftMgrRoundStep : uint8_t { PbftRound = 0, PbftStep };
+enum PbftMgrRoundStep : uint8_t { PbftRound = 0, PreviousRoundPbftPeriod, PbftStep };
 
 enum PbftMgrStatus : uint8_t {
   ExecutedBlock = 0,
@@ -46,7 +46,7 @@ enum PbftMgrStatus : uint8_t {
   NextVotedNullBlockHash,
 };
 
-enum PbftMgrVotedValue : uint8_t { OwnStartingValueInRound = 0, SoftVotedBlockHashInRound, LastCertVotedValue };
+enum PbftMgrVotedValue : uint8_t { OwnStartingValueInRound = 0, SoftVotedBlockInRound, CertVotedBlockInRound };
 
 class DbException : public std::exception {
  public:
@@ -243,9 +243,11 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   void savePbftMgrStatus(PbftMgrStatus field, bool const& value);
   void addPbftMgrStatusToBatch(PbftMgrStatus field, bool const& value, Batch& write_batch);
 
-  std::shared_ptr<blk_hash_t> getPbftMgrVotedValue(PbftMgrVotedValue field);
-  void savePbftMgrVotedValue(PbftMgrVotedValue field, blk_hash_t const& value);
-  void addPbftMgrVotedValueToBatch(PbftMgrVotedValue field, blk_hash_t const& value, Batch& write_batch);
+  void savePbftMgrVotedValue(PbftMgrVotedValue field, const std::pair<blk_hash_t, uint64_t>& value);
+  void addPbftMgrVotedValueToBatch(PbftMgrVotedValue field, const std::pair<blk_hash_t, uint64_t>& value,
+                                   Batch& write_batch);
+  void removePbftMgrVotedValueToBatch(PbftMgrVotedValue field, Batch& write_batch);
+  std::optional<std::pair<blk_hash_t, uint64_t>> getPbftMgrVotedValue(PbftMgrVotedValue field);
 
   std::shared_ptr<PbftBlock> getPbftCertVotedBlock(blk_hash_t const& block_hash);
   void savePbftCertVotedBlock(PbftBlock const& pbft_block);

--- a/libraries/types/pbft_block/src/period_data.cpp
+++ b/libraries/types/pbft_block/src/period_data.cpp
@@ -110,7 +110,7 @@ void PeriodData::hasEnoughValidCertVotes(
     }
 
     assert(v->getWeight());
-    total_votes += v->getWeight().value();
+    total_votes += *v->getWeight();
   }
 
   if (total_votes < pbft_2t_plus_1) {

--- a/libraries/types/vote/include/vote/vote.hpp
+++ b/libraries/types/vote/include/vote/vote.hpp
@@ -101,6 +101,12 @@ class Vote {
   PbftVoteTypes getType() const { return vrf_sortition_.pbft_msg_.type; }
 
   /**
+   * @brief Get vote PBFT period
+   * @return vote PBFT period
+   */
+  uint64_t getPeriod() const { return vrf_sortition_.pbft_msg_.period; }
+
+  /**
    * @brief Get vote PBFT round
    * @return vote PBFT round
    */

--- a/libraries/types/vote/include/vote/vote.hpp
+++ b/libraries/types/vote/include/vote/vote.hpp
@@ -188,6 +188,7 @@ class Vote {
  */
 struct VotesBundle {
   blk_hash_t voted_block_hash;
+  uint64_t votes_period;
   std::vector<std::shared_ptr<Vote>> votes;  // Greater than 2t+1 votes
 
   VotesBundle() : voted_block_hash(blk_hash_t(0)) {}

--- a/libraries/types/vote/include/vote/vrf_sortition.hpp
+++ b/libraries/types/vote/include/vote/vrf_sortition.hpp
@@ -17,44 +17,35 @@ enum PbftVoteTypes : uint8_t { propose_vote_type = 0, soft_vote_type, cert_vote_
 /**
  * @brief VrfPbftMsg struct uses vote type, PBFT round, and PBFT step to generate a message for doing VRF sortition.
  */
-struct VrfPbftMsg {
+class VrfPbftMsg {
+ public:
   VrfPbftMsg() = default;
-  VrfPbftMsg(PbftVoteTypes type, uint64_t round, size_t step) : type(type), round(round), step(step) {}
+  VrfPbftMsg(PbftVoteTypes type, uint64_t period, uint64_t round, size_t step);
 
   /**
-   * @brief Combine vote type, PBFT round, and PBFT step to a string
-   * @return a string of vote type, PBFT round, and PBFT step
+   * @brief Combine vote type, PBFT period, round and step to a string
+   * @return a string of vote type, PBFT period, round and step
    */
-  std::string toString() const {
-    return std::to_string(type) + "_" + std::to_string(round) + "_" + std::to_string(step);
-  }
-
-  bool operator==(VrfPbftMsg const& other) const {
-    return type == other.type && round == other.round && step == other.step;
-  }
-
-  friend std::ostream& operator<<(std::ostream& strm, VrfPbftMsg const& pbft_msg) {
-    strm << "  [Vrf Pbft Msg] " << std::endl;
-    strm << "    type: " << static_cast<uint32_t>(pbft_msg.type) << std::endl;
-    strm << "    round: " << pbft_msg.round << std::endl;
-    strm << "    step: " << pbft_msg.step << std::endl;
-    return strm;
-  }
+  std::string toString() const;
 
   /**
    * @brief Get bytes of RLP stream
    * @return bytes of RLP stream
    */
-  bytes getRlpBytes() const {
-    dev::RLPStream s;
-    s.appendList(3);
-    s << static_cast<uint8_t>(type);
-    s << round;
-    s << step;
-    return s.invalidate();
+  bytes getRlpBytes() const;
+
+  bool operator==(VrfPbftMsg const& other) const;
+  friend std::ostream& operator<<(std::ostream& strm, VrfPbftMsg const& pbft_msg) {
+    strm << "  [Vrf Pbft Msg] " << std::endl;
+    strm << "    type: " << static_cast<uint32_t>(pbft_msg.type) << std::endl;
+    strm << "    period: " << pbft_msg.period << std::endl;
+    strm << "    round: " << pbft_msg.round << std::endl;
+    strm << "    step: " << pbft_msg.step << std::endl;
+    return strm;
   }
 
   PbftVoteTypes type;
+  uint64_t period;
   uint64_t round;
   size_t step;
 };

--- a/libraries/types/vote/include/vote/vrf_sortition.hpp
+++ b/libraries/types/vote/include/vote/vrf_sortition.hpp
@@ -17,7 +17,7 @@ enum PbftVoteTypes : uint8_t { propose_vote_type = 0, soft_vote_type, cert_vote_
 /**
  * @brief VrfPbftMsg struct uses vote type, PBFT round, and PBFT step to generate a message for doing VRF sortition.
  */
-class VrfPbftMsg {
+struct VrfPbftMsg {
  public:
   VrfPbftMsg() = default;
   VrfPbftMsg(PbftVoteTypes type, uint64_t period, uint64_t round, size_t step);

--- a/libraries/types/vote/src/vrf_sortition.cpp
+++ b/libraries/types/vote/src/vrf_sortition.cpp
@@ -7,19 +7,42 @@
 
 namespace taraxa {
 
+VrfPbftMsg::VrfPbftMsg(PbftVoteTypes type, uint64_t period, uint64_t round, size_t step)
+    : type(type), period(period), round(round), step(step) {}
+
+std::string VrfPbftMsg::toString() const {
+  return std::to_string(type) + "_" + std::to_string(period) + "_" + std::to_string(round) + "_" + std::to_string(step);
+}
+
+bool VrfPbftMsg::operator==(VrfPbftMsg const& other) const {
+  return type == other.type && period == other.period && round == other.round && step == other.step;
+}
+
+bytes VrfPbftMsg::getRlpBytes() const {
+  dev::RLPStream s;
+  s.appendList(4);
+  s << static_cast<uint8_t>(type);
+  s << period;
+  s << round;
+  s << step;
+  return s.invalidate();
+}
+
 VrfPbftSortition::VrfPbftSortition(bytes const& b) {
   dev::RLP const rlp(b);
 
   uint8_t pbft_msg_type = 0;
-  util::rlp_tuple(util::RLPDecoderRef(rlp, true), pbft_msg_type, pbft_msg_.round, pbft_msg_.step, proof_);
+  util::rlp_tuple(util::RLPDecoderRef(rlp, true), pbft_msg_type, pbft_msg_.period, pbft_msg_.round, pbft_msg_.step,
+                  proof_);
   pbft_msg_.type = static_cast<PbftVoteTypes>(pbft_msg_type);
 }
 
 bytes VrfPbftSortition::getRlpBytes() const {
   dev::RLPStream s;
 
-  s.appendList(4);
+  s.appendList(5);
   s << static_cast<uint8_t>(pbft_msg_.type);
+  s << pbft_msg_.period;
   s << pbft_msg_.round;
   s << pbft_msg_.step;
   s << proof_;

--- a/tests/crypto_test.cpp
+++ b/tests/crypto_test.cpp
@@ -95,7 +95,7 @@ TEST_F(CryptoTest, vrf_sortition) {
   vrf_sk_t sk(
       "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
       "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
-  VrfPbftMsg msg(PbftVoteTypes::cert_vote_type, 2, 3);
+  VrfPbftMsg msg(PbftVoteTypes::cert_vote_type, 2, 2, 3);
   VrfPbftSortition sortition(sk, msg);
   VrfPbftSortition sortition2(sk, msg);
 
@@ -296,18 +296,18 @@ TEST_F(CryptoTest, sortition_rate) {
   // Sortition rate THRESHOLD / PLAYERS = 5%
   size_t pbft_step = 3;
   for (int i = 0; i < round; i++) {
-    VrfPbftMsg msg(PbftVoteTypes::cert_vote_type, i, pbft_step);
+    VrfPbftMsg msg(PbftVoteTypes::cert_vote_type, i, i, pbft_step);
     VrfPbftSortition sortition(sk, msg);
     count += sortition.calculateWeight(1, valid_sortition_players, sortition_threshold, sk);
   }
-  EXPECT_EQ(count, 48);  // Test experience
+  EXPECT_EQ(count, 45);  // Test experience
 
   count = 0;
   sortition_threshold = valid_sortition_players;
   // Test for one player sign round messages to get sortition
   // Sortition rate THRESHOLD / PLAYERS = 100%
   for (int i = 0; i < round; i++) {
-    VrfPbftMsg msg(PbftVoteTypes::cert_vote_type, i, pbft_step);
+    VrfPbftMsg msg(PbftVoteTypes::cert_vote_type, i, i, pbft_step);
     VrfPbftSortition sortition(sk, msg);
     count += sortition.calculateWeight(1, valid_sortition_players, sortition_threshold, dev::FixedHash<64>::random());
   }
@@ -323,7 +323,7 @@ TEST_F(CryptoTest, sortition_rate) {
     dev::KeyPair key_pair = dev::KeyPair::create();
     for (int j = 0; j < round; j++) {
       auto [pk, sk] = getVrfKeyPair();
-      VrfPbftMsg msg(PbftVoteTypes::cert_vote_type, i, pbft_step);
+      VrfPbftMsg msg(PbftVoteTypes::cert_vote_type, i, i, pbft_step);
       VrfPbftSortition sortition(sk, msg);
       count += sortition.calculateWeight(1, valid_sortition_players, sortition_threshold, dev::FixedHash<64>::random());
     }
@@ -385,7 +385,7 @@ TEST_F(CryptoTest, leader_selection) {
   };
 
   for (uint64_t i = 0; i < rounds; i++) {
-    const VrfPbftMsg msg(propose_vote_type, i, 1);
+    const VrfPbftMsg msg(propose_vote_type, i, i, 1);
     std::unordered_map<uint64_t, dev::h256> outputs;
 
     selector(outputs, msg, high_stake_nodes, high_stake_nodes_power);

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -224,7 +224,7 @@ TEST_F(FullNodeTest, db_test) {
   // Certified votes
   std::vector<std::shared_ptr<Vote>> cert_votes;
   for (auto i = 0; i < 3; i++) {
-    VrfPbftMsg msg(cert_vote_type, 2, 3);
+    VrfPbftMsg msg(cert_vote_type, 2, 2, 3);
     vrf_wrapper::vrf_sk_t vrf_sk(
         "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
         "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
@@ -292,9 +292,10 @@ TEST_F(FullNodeTest, db_test) {
   EXPECT_TRUE(verified_votes.empty());
   auto voted_pbft_block_hash = blk_hash_t(2);
   for (auto i = 0; i < 3; i++) {
+    auto period = i;
     auto round = i;
     auto step = i;
-    VrfPbftMsg msg(next_vote_type, round, step);
+    VrfPbftMsg msg(next_vote_type, period, round, step);
     vrf_wrapper::vrf_sk_t vrf_sk(
         "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
         "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
@@ -317,12 +318,12 @@ TEST_F(FullNodeTest, db_test) {
   EXPECT_TRUE(db.getVerifiedVotes().empty());
 
   // Soft votes
-  auto round = 1, step = 2;
+  auto period = 1, round = 1, step = 2;
   auto soft_votes = db.getSoftVotes(round);
   EXPECT_TRUE(soft_votes.empty());
   for (auto i = 0; i < 3; i++) {
     blk_hash_t voted_pbft_block_hash(i);
-    VrfPbftMsg msg(soft_vote_type, round, step);
+    VrfPbftMsg msg(soft_vote_type, period, round, step);
     vrf_wrapper::vrf_sk_t vrf_sk(
         "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
         "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
@@ -336,7 +337,7 @@ TEST_F(FullNodeTest, db_test) {
   EXPECT_EQ(soft_votes_from_db.size(), 3);
   for (auto i = 3; i < 5; i++) {
     blk_hash_t voted_pbft_block_hash(i);
-    VrfPbftMsg msg(soft_vote_type, round, step);
+    VrfPbftMsg msg(soft_vote_type, period, round, step);
     vrf_wrapper::vrf_sk_t vrf_sk(
         "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
         "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
@@ -357,12 +358,12 @@ TEST_F(FullNodeTest, db_test) {
   EXPECT_TRUE(soft_votes_from_db.empty());
 
   // Next votes
-  round = 3, step = 5;
+  period = 3, round = 3, step = 5;
   auto next_votes = db.getNextVotes(round);
   EXPECT_TRUE(next_votes.empty());
   for (auto i = 0; i < 3; i++) {
     blk_hash_t voted_pbft_block_hash(i);
-    VrfPbftMsg msg(next_vote_type, round, step);
+    VrfPbftMsg msg(next_vote_type, period, round, step);
     vrf_wrapper::vrf_sk_t vrf_sk(
         "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
         "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
@@ -377,7 +378,7 @@ TEST_F(FullNodeTest, db_test) {
   next_votes.clear();
   for (auto i = 3; i < 5; i++) {
     blk_hash_t voted_pbft_block_hash(i);
-    VrfPbftMsg msg(next_vote_type, round, step);
+    VrfPbftMsg msg(next_vote_type, period, round, step);
     vrf_wrapper::vrf_sk_t vrf_sk(
         "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
         "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -178,23 +178,32 @@ TEST_F(FullNodeTest, db_test) {
   EXPECT_FALSE(db.getPbftMgrStatus(PbftMgrStatus::NextVotedNullBlockHash));
 
   // PBFT manager voted value
-  EXPECT_EQ(db.getPbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound), nullptr);
-  EXPECT_EQ(db.getPbftMgrVotedValue(PbftMgrVotedValue::SoftVotedBlockHashInRound), nullptr);
-  EXPECT_EQ(db.getPbftMgrVotedValue(PbftMgrVotedValue::LastCertVotedValue), nullptr);
-  db.savePbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound, blk_hash_t(1));
-  db.savePbftMgrVotedValue(PbftMgrVotedValue::SoftVotedBlockHashInRound, blk_hash_t(2));
-  db.savePbftMgrVotedValue(PbftMgrVotedValue::LastCertVotedValue, blk_hash_t(3));
-  EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound), blk_hash_t(1));
-  EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::SoftVotedBlockHashInRound), blk_hash_t(2));
-  EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::LastCertVotedValue), blk_hash_t(3));
+  EXPECT_EQ(db.getPbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound), std::nullopt);
+  EXPECT_EQ(db.getPbftMgrVotedValue(PbftMgrVotedValue::SoftVotedBlockInRound), std::nullopt);
+  EXPECT_EQ(db.getPbftMgrVotedValue(PbftMgrVotedValue::CertVotedBlockInRound), std::nullopt);
+  db.savePbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound, {blk_hash_t(1), uint64_t(0)});
+  db.savePbftMgrVotedValue(PbftMgrVotedValue::SoftVotedBlockInRound, {blk_hash_t(2), uint64_t(0)});
+  db.savePbftMgrVotedValue(PbftMgrVotedValue::CertVotedBlockInRound, {blk_hash_t(3), uint64_t(0)});
+  EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound),
+            std::make_pair(blk_hash_t(1), uint64_t(0)));
+  EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::SoftVotedBlockInRound),
+            std::make_pair(blk_hash_t(2), uint64_t(0)));
+  EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::CertVotedBlockInRound),
+            std::make_pair(blk_hash_t(3), uint64_t(0)));
   batch = db.createWriteBatch();
-  db.addPbftMgrVotedValueToBatch(PbftMgrVotedValue::OwnStartingValueInRound, blk_hash_t(4), batch);
-  db.addPbftMgrVotedValueToBatch(PbftMgrVotedValue::SoftVotedBlockHashInRound, blk_hash_t(5), batch);
-  db.addPbftMgrVotedValueToBatch(PbftMgrVotedValue::LastCertVotedValue, blk_hash_t(6), batch);
+  db.addPbftMgrVotedValueToBatch(PbftMgrVotedValue::OwnStartingValueInRound, std::make_pair(blk_hash_t(4), uint64_t(0)),
+                                 batch);
+  db.addPbftMgrVotedValueToBatch(PbftMgrVotedValue::SoftVotedBlockInRound, std::make_pair(blk_hash_t(5), uint64_t(0)),
+                                 batch);
+  db.addPbftMgrVotedValueToBatch(PbftMgrVotedValue::CertVotedBlockInRound, std::make_pair(blk_hash_t(6), uint64_t(0)),
+                                 batch);
   db.commitWriteBatch(batch);
-  EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound), blk_hash_t(4));
-  EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::SoftVotedBlockHashInRound), blk_hash_t(5));
-  EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::LastCertVotedValue), blk_hash_t(6));
+  EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound),
+            std::make_pair(blk_hash_t(4), uint64_t(0)));
+  EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::SoftVotedBlockInRound),
+            std::make_pair(blk_hash_t(5), uint64_t(0)));
+  EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::CertVotedBlockInRound),
+            std::make_pair(blk_hash_t(6), uint64_t(0)));
 
   // PBFT cert voted block
   auto pbft_block1 = make_simple_pbft_block(blk_hash_t(1), 1);

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -811,7 +811,6 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_behind_round) {
   std::shared_ptr<PbftManager> pbft_mgr2 = node2->getPbftManager();
   pbft_mgr2->stop();
   pbft_mgr2->setPbftRound(1);  // Make sure node2 PBFT round is less than node1
-  node2->getVoteManager()->clearUnverifiedVotesTable();
 
   // Wait node1 and node2 connect to each other
   EXPECT_HAPPENS({10s, 100ms}, [&](auto& ctx) {
@@ -855,7 +854,7 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_1) {
   auto node2_pbft_2t_plus_1 = pbft_mgr2->getTwoTPlusOne();
   EXPECT_EQ(node2_pbft_2t_plus_1, 1);
 
-  // Generate 2 next votes for noode1
+  // Generate 2 next votes for node1
   std::vector<std::shared_ptr<Vote>> next_votes1;
   uint64_t period = 1;
   uint64_t round = 1;

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -530,7 +530,7 @@ TEST_F(NetworkTest, node_pbft_sync) {
                         node1->getSecretKey(), {});
   std::vector<std::shared_ptr<Vote>> votes_for_pbft_blk1;
   votes_for_pbft_blk1.emplace_back(
-      node1->getPbftManager()->generateVote(pbft_block1.getBlockHash(), cert_vote_type, 1, 3));
+      node1->getPbftManager()->generateVote(pbft_block1.getBlockHash(), cert_vote_type, 1, 1, 3));
   std::cout << "Generate 1 vote for first PBFT block" << std::endl;
   // Add cert votes in DB
   // Add PBFT block in DB
@@ -587,7 +587,7 @@ TEST_F(NetworkTest, node_pbft_sync) {
                         node1->getSecretKey(), {});
   std::vector<std::shared_ptr<Vote>> votes_for_pbft_blk2;
   votes_for_pbft_blk2.emplace_back(
-      node1->getPbftManager()->generateVote(pbft_block2.getBlockHash(), cert_vote_type, 2, 3));
+      node1->getPbftManager()->generateVote(pbft_block2.getBlockHash(), cert_vote_type, 2, 2, 3));
   std::cout << "Generate 1 vote for second PBFT block" << std::endl;
   // node1 put block2 into pbft chain and store into DB
   // Add cert votes in DB
@@ -698,7 +698,7 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
                         node1->getSecretKey(), {});
   std::vector<std::shared_ptr<Vote>> votes_for_pbft_blk1;
   votes_for_pbft_blk1.emplace_back(
-      node1->getPbftManager()->generateVote(pbft_block1.getBlockHash(), cert_vote_type, 1, 3));
+      node1->getPbftManager()->generateVote(pbft_block1.getBlockHash(), cert_vote_type, 1, 1, 3));
   std::cout << "Generate 1 vote for first PBFT block" << std::endl;
   // Add cert votes in DB
   // Add PBFT block in DB
@@ -791,11 +791,12 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_behind_round) {
   // Generate 3 next votes
   std::vector<std::shared_ptr<Vote>> next_votes;
   PbftVoteTypes type = next_vote_type;
+  uint64_t period = 1;
   uint64_t round = 1;
   size_t step = 5;
   for (auto i = 0; i < 3; i++) {
     blk_hash_t voted_pbft_block_hash(i % 2);  // Next votes could vote on 2 values
-    auto vote = pbft_mgr1->generateVote(voted_pbft_block_hash, type, round, step + i);
+    auto vote = pbft_mgr1->generateVote(voted_pbft_block_hash, type, period, round, step + i);
     vote->calculateWeight(1, 1, 1);
     next_votes.push_back(std::move(vote));
   }
@@ -820,7 +821,7 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_behind_round) {
 
   // Node2 wait for getting votes from node1 by sending status packet
   EXPECT_HAPPENS({10s, 500ms}, [&](auto& ctx) {
-    WAIT_EXPECT_EQ(ctx, node2->getVoteManager()->getUnverifiedVotesSize(), next_votes.size())
+    WAIT_EXPECT_EQ(ctx, node2->getVoteManager()->getVerifiedVotesSize(), next_votes.size())
   });
 }
 
@@ -856,12 +857,13 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_1) {
 
   // Generate 2 next votes for noode1
   std::vector<std::shared_ptr<Vote>> next_votes1;
+  uint64_t period = 1;
   uint64_t round = 1;
   size_t step = 5;
   PbftVoteTypes type = next_vote_type;
   for (uint64_t i = 0; i < 2; i++) {
     blk_hash_t voted_pbft_block_hash1(i);  // Next votes could vote on 2 values
-    auto vote = pbft_mgr1->generateVote(voted_pbft_block_hash1, type, round, step);
+    auto vote = pbft_mgr1->generateVote(voted_pbft_block_hash1, type, period, round, step);
     vote->calculateWeight(1, 1, 1);
     next_votes1.push_back(std::move(vote));
   }
@@ -872,7 +874,7 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_1) {
 
   // Generate 1 same next votes with node1, voted same value on NULL_BLOCK_HASH
   blk_hash_t voted_pbft_block_hash2(0);
-  auto vote1 = pbft_mgr1->generateVote(voted_pbft_block_hash2, type, round, step);
+  auto vote1 = pbft_mgr1->generateVote(voted_pbft_block_hash2, type, period, round, step);
   vote1->calculateWeight(1, 1, 1);
   std::vector<std::shared_ptr<Vote>> next_votes2{vote1};
 
@@ -932,9 +934,10 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_2) {
   // Node1 generate 1 next vote voted at NULL_BLOCK_HASH
   blk_hash_t voted_pbft_block_hash1(blk_hash_t(0));
   PbftVoteTypes type = next_vote_type;
+  uint64_t period = 1;
   uint64_t round = 1;
   size_t step = 5;
-  auto vote1 = pbft_mgr1->generateVote(voted_pbft_block_hash1, type, round, step);
+  auto vote1 = pbft_mgr1->generateVote(voted_pbft_block_hash1, type, period, round, step);
   vote1->calculateWeight(1, 1, 1);
   std::vector<std::shared_ptr<Vote>> next_votes1{vote1};
 
@@ -944,7 +947,7 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_2) {
 
   // Node1 generate 1 different next vote for node2, because node2 is not delegated
   blk_hash_t voted_pbft_block_hash2("1234567890000000000000000000000000000000000000000000000000000000");
-  auto vote2 = pbft_mgr1->generateVote(voted_pbft_block_hash2, type, round, step);
+  auto vote2 = pbft_mgr1->generateVote(voted_pbft_block_hash2, type, period, round, step);
   vote2->calculateWeight(1, 1, 1);
   std::vector<std::shared_ptr<Vote>> next_votes2{vote2};
 

--- a/tests/p2p_test.cpp
+++ b/tests/p2p_test.cpp
@@ -94,6 +94,7 @@ TEST_F(P2PTest, capability_send_block) {
   prefs1.discovery = false;
   dev::p2p::NetworkConfig prefs2(localhost, 10003, false, true);
   prefs2.discovery = false;
+
   FullNodeConfig conf;
   conf.network.network_transaction_interval = 1000;
   h256 genesis;
@@ -184,6 +185,7 @@ TEST_F(P2PTest, block_propagate) {
   }
   TaraxaNetworkConfig taraxa_net_conf_1;
   taraxa_net_conf_1.is_boot_node = true;
+
   FullNodeConfig conf;
   conf.network.network_transaction_interval = 1000;
   h256 genesis;

--- a/tests/util_test/util.hpp
+++ b/tests/util_test/util.hpp
@@ -142,62 +142,68 @@ inline bool wait(wait_opts const& opts, std::function<void(wait_ctx&)> const& po
   }
 
 template <uint tests_speed = 1, bool enable_rpc_http = false, bool enable_rpc_ws = false>
-inline auto make_node_cfgs(uint count) {
-  static auto const ret = [] {
-    auto ret = *node_cfgs_original;
-    if constexpr (tests_speed == 1 && enable_rpc_http && enable_rpc_ws) {
-      return ret;
+inline auto make_node_cfgs(size_t total_count, size_t validators_count = 1) {
+  auto default_configs = *node_cfgs_original;
+  assert(total_count <= default_configs.size());
+  assert(validators_count <= total_count);
+
+  // Prepare genesis balances & initial validators
+  state_api::BalanceMap genesis_balances;
+  std::vector<state_api::ValidatorInfo> initial_validators;
+
+  for (size_t idx = 0; idx < total_count; idx++) {
+    const auto& cfg = default_configs[idx];
+    const auto& node_addr = dev::toAddress(cfg.node_secret);
+    genesis_balances[node_addr] = 9007199254740991;
+
+    if (idx >= validators_count) {
+      continue;
     }
-    for (auto& cfg : ret) {
-      addr_t root_node_addr("de2b1203d72d3549ee2f733b00b2789414c7cea5");
-      vrf_wrapper::vrf_pk_t root_node_vrf_key("d05dc12c1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
-      cfg.chain.final_chain.state.genesis_balances[root_node_addr] = 9007199254740991;
-      cfg.chain.final_chain.state.genesis_balances[addr_t("973ecb1c08c8eb5a7eaa0d3fd3aab7924f2838b0")] =
-          9007199254740991;
-      cfg.chain.final_chain.state.genesis_balances[addr_t("4fae949ac2b72960fbe857b56532e2d3c8418d5e")] =
-          9007199254740991;
-      cfg.chain.final_chain.state.genesis_balances[addr_t("415cf514eb6a5a8bd4d325d4874eae8cf26bcfe0")] =
-          9007199254740991;
-      cfg.chain.final_chain.state.genesis_balances[addr_t("b770f7a99d0b7ad9adf6520be77ca20ee99b0858")] =
-          9007199254740991;
-      auto& dpos = *cfg.chain.final_chain.state.dpos;
+
+    state_api::BalanceMap delegations;
+    delegations.emplace(node_addr, cfg.chain.final_chain.state.dpos->eligibility_balance_threshold);
+    initial_validators.emplace_back(state_api::ValidatorInfo{node_addr, node_addr, 100, "", "", delegations});
+  }
+
+  std::vector<taraxa::FullNodeConfig> ret_configs;
+
+  for (size_t idx = 0; idx < total_count; idx++) {
+    auto& cfg = ret_configs.emplace_back(default_configs[idx]);
+    if constexpr (tests_speed == 1 && enable_rpc_http && enable_rpc_ws) {
+      continue;
+    }
 
       state_api::BalanceMap delegations;
       delegations.emplace(root_node_addr, dpos.eligibility_balance_threshold);
 
-      auto initial_validator =
-          state_api::ValidatorInfo{root_node_addr, root_node_addr, root_node_vrf_key, 100, "", "", delegations};
-      dpos.initial_validators.emplace_back(initial_validator);
+    cfg.chain.final_chain.state.dpos->delegation_delay = 5;
+    cfg.chain.final_chain.state.dpos->delegation_locking_period = 5;
 
-      // As test are badly written let's disable it for now
-      cfg.chain.final_chain.state.execution_options.disable_nonce_check = true;
-      cfg.chain.final_chain.state.block_rewards_options.disable_block_rewards = true;
-      cfg.chain.final_chain.state.block_rewards_options.disable_contract_distribution = true;
-      if constexpr (tests_speed != 1) {
-        // VDF config
-        cfg.chain.sortition.vrf.threshold_upper = 0xffff;
-        cfg.chain.sortition.vrf.threshold_range = 0x199a;
-        cfg.chain.sortition.vdf.difficulty_min = 0;
-        cfg.chain.sortition.vdf.difficulty_max = 5;
-        cfg.chain.sortition.vdf.difficulty_stale = 5;
-        cfg.chain.sortition.vdf.lambda_bound = 100;
-        // PBFT config
-        cfg.chain.pbft.lambda_ms_min /= tests_speed;
-        cfg.network.network_transaction_interval /= tests_speed;
-      }
-      if constexpr (!enable_rpc_http) {
-        cfg.rpc->http_port = std::nullopt;
-      }
-      if constexpr (!enable_rpc_ws) {
-        cfg.rpc->ws_port = std::nullopt;
-      }
+    // As test are badly written let's disable it for now
+    cfg.chain.final_chain.state.execution_options.disable_nonce_check = true;
+    cfg.chain.final_chain.state.block_rewards_options.disable_block_rewards = true;
+    cfg.chain.final_chain.state.block_rewards_options.disable_contract_distribution = true;
+    if constexpr (tests_speed != 1) {
+      // VDF config
+      cfg.chain.sortition.vrf.threshold_upper = 0xffff;
+      cfg.chain.sortition.vrf.threshold_range = 0x199a;
+      cfg.chain.sortition.vdf.difficulty_min = 0;
+      cfg.chain.sortition.vdf.difficulty_max = 5;
+      cfg.chain.sortition.vdf.difficulty_stale = 5;
+      cfg.chain.sortition.vdf.lambda_bound = 100;
+      // PBFT config
+      cfg.chain.pbft.lambda_ms_min /= tests_speed;
+      cfg.network.network_transaction_interval /= tests_speed;
     }
-    return ret;
-  }();
-  if (count == ret.size()) {
-    return ret;
+    if constexpr (!enable_rpc_http) {
+      cfg.rpc->http_port = std::nullopt;
+    }
+    if constexpr (!enable_rpc_ws) {
+      cfg.rpc->ws_port = std::nullopt;
+    }
   }
-  return slice(ret, 0, count);
+
+  return ret_configs;
 }
 
 inline auto wait_connect(std::vector<std::shared_ptr<FullNode>> const& nodes) {

--- a/tests/util_test/util.hpp
+++ b/tests/util_test/util.hpp
@@ -162,7 +162,8 @@ inline auto make_node_cfgs(size_t total_count, size_t validators_count = 1) {
 
     state_api::BalanceMap delegations;
     delegations.emplace(node_addr, cfg.chain.final_chain.state.dpos->eligibility_balance_threshold);
-    initial_validators.emplace_back(state_api::ValidatorInfo{node_addr, node_addr, 100, "", "", delegations});
+    initial_validators.emplace_back(state_api::ValidatorInfo{
+        node_addr, node_addr, vrf_wrapper::getVrfPublicKey(cfg.vrf_secret), 100, "", "", delegations});
   }
 
   std::vector<taraxa::FullNodeConfig> ret_configs;
@@ -173,8 +174,8 @@ inline auto make_node_cfgs(size_t total_count, size_t validators_count = 1) {
       continue;
     }
 
-      state_api::BalanceMap delegations;
-      delegations.emplace(root_node_addr, dpos.eligibility_balance_threshold);
+    cfg.chain.final_chain.state.genesis_balances = genesis_balances;
+    cfg.chain.final_chain.state.dpos->initial_validators = initial_validators;
 
     cfg.chain.final_chain.state.dpos->delegation_delay = 5;
     cfg.chain.final_chain.state.dpos->delegation_locking_period = 5;

--- a/tests/vote_test.cpp
+++ b/tests/vote_test.cpp
@@ -51,9 +51,10 @@ TEST_F(VoteTest, unverified_votes) {
   // Generate a vote
   blk_hash_t blockhash(1);
   PbftVoteTypes type = propose_vote_type;
-  auto round = 1;
+  auto period = 1;
+  auto round = period;
   auto step = 1;
-  auto vote = pbft_mgr->generateVote(blockhash, type, round, step);
+  auto vote = pbft_mgr->generateVote(blockhash, type, period, round, step);
 
   auto vote_mgr = node->getVoteManager();
   vote_mgr->addUnverifiedVote(vote);
@@ -62,9 +63,8 @@ TEST_F(VoteTest, unverified_votes) {
   // Generate 3 votes, (round = 1, step = 1) is duplicate
   std::vector<std::shared_ptr<Vote>> unverified_votes;
   for (auto i = 1; i <= 3; i++) {
-    round = i;
-    step = i;
-    auto vote = pbft_mgr->generateVote(blockhash, type, round, step);
+    period = round = step = i;
+    auto vote = pbft_mgr->generateVote(blockhash, type, period, round, step);
     unverified_votes.emplace_back(vote);
   }
 
@@ -94,9 +94,10 @@ TEST_F(VoteTest, verified_votes) {
   // Generate a vote
   blk_hash_t blockhash(1);
   PbftVoteTypes type = soft_vote_type;
+  auto period = 1;
   auto round = 1;
   auto step = 2;
-  auto vote = pbft_mgr->generateVote(blockhash, type, round, step);
+  auto vote = pbft_mgr->generateVote(blockhash, type, period, round, step);
   vote->calculateWeight(1, 1, 1);
 
   auto vote_mgr = node->getVoteManager();
@@ -131,9 +132,10 @@ TEST_F(VoteTest, remove_verified_votes) {
   blk_hash_t blockhash(1);
   PbftVoteTypes type = next_vote_type;
   for (auto i = 1; i <= 3; i++) {
+    auto period = i;
     auto round = i;
     auto step = i;
-    auto vote = pbft_mgr->generateVote(blockhash, type, round, step);
+    auto vote = pbft_mgr->generateVote(blockhash, type, period, round, step);
     vote->calculateWeight(1, 1, 1);
     votes.emplace_back(vote);
     db->saveVerifiedVote(vote);
@@ -167,9 +169,10 @@ TEST_F(VoteTest, add_cleanup_get_votes) {
   PbftVoteTypes type = next_vote_type;
   for (int i = 1; i <= 3; i++) {
     for (int j = 1; j <= 2; j++) {
+      uint64_t period = i;
       uint64_t round = i;
       size_t step = 3 + j;
-      auto vote = pbft_mgr->generateVote(voted_block_hash, type, round, step);
+      auto vote = pbft_mgr->generateVote(voted_block_hash, type, period, round, step);
       vote_mgr->addUnverifiedVote(vote);
     }
   }
@@ -225,9 +228,10 @@ TEST_F(VoteTest, round_determine_from_next_votes) {
   PbftVoteTypes type = next_vote_type;
   for (int i = 10; i <= 12; i++) {
     for (int j = 4; j <= 5; j++) {
+      uint64_t period = i;
       uint64_t round = i;
       size_t step = j;
-      auto vote = pbft_mgr->generateVote(voted_block_hash, type, round, step);
+      auto vote = pbft_mgr->generateVote(voted_block_hash, type, period, round, step);
       vote->calculateWeight(3, 3, 3);
       vote_mgr->addVerifiedVote(vote);
     }
@@ -243,9 +247,10 @@ TEST_F(VoteTest, reconstruct_votes) {
   sig_t vote_sig(9878766);
   blk_hash_t propose_blk_hash(111111);
   PbftVoteTypes type(propose_vote_type);
+  uint64_t period(999);
   uint64_t round(999);
   size_t step(2);
-  VrfPbftMsg msg(type, round, step);
+  VrfPbftMsg msg(type, period, round, step);
   VrfPbftSortition vrf_sortition(g_vrf_sk, msg);
   Vote vote1(g_sk, vrf_sortition, propose_blk_hash);
   auto rlp = vote1.rlp();
@@ -256,6 +261,7 @@ TEST_F(VoteTest, reconstruct_votes) {
 // Generate a vote, send the vote from node2 to node1
 TEST_F(VoteTest, transfer_vote) {
   auto node_cfgs = make_node_cfgs(2);
+
   auto nodes = launch_nodes(node_cfgs);
   auto &node1 = nodes[0];
   auto &node2 = nodes[1];
@@ -274,16 +280,17 @@ TEST_F(VoteTest, transfer_vote) {
   // generate a vote far ahead (never exist in PBFT manager)
   blk_hash_t propose_block_hash(11);
   PbftVoteTypes type = next_vote_type;
-  uint64_t period = 999;
-  size_t step = 1000;
-  auto vote = pbft_mgr2->generateVote(propose_block_hash, type, period, step);
+  uint64_t period = 0;
+  uint64_t round = 1;
+  size_t step = 1;
+  auto vote = pbft_mgr1->generateVote(propose_block_hash, type, period, round, step);
 
-  nw2->getSpecificHandler<network::tarcap::VotePacketHandler>()->sendPbftVotes(nw1->getNodeId(), {vote});
+  nw1->getSpecificHandler<network::tarcap::VotePacketHandler>()->sendPbftVotes(nw2->getNodeId(), {vote});
 
   auto vote_mgr1 = node1->getVoteManager();
   auto vote_mgr2 = node2->getVoteManager();
-  EXPECT_HAPPENS({60s, 100ms}, [&](auto &ctx) { WAIT_EXPECT_EQ(ctx, vote_mgr1->getUnverifiedVotesSize(), 1) });
-  EXPECT_EQ(vote_mgr2->getUnverifiedVotesSize(), 0);
+  EXPECT_HAPPENS({60s, 100ms}, [&](auto &ctx) { WAIT_EXPECT_EQ(ctx, vote_mgr2->getVerifiedVotesSize(), 1) });
+  EXPECT_EQ(vote_mgr1->getVerifiedVotesSize(), 0);
 }
 
 TEST_F(VoteTest, vote_broadcast) {
@@ -308,9 +315,10 @@ TEST_F(VoteTest, vote_broadcast) {
   // generate a vote far ahead (never exist in PBFT manager)
   blk_hash_t propose_block_hash(111);
   PbftVoteTypes type = next_vote_type;
-  uint64_t period = 1000;
-  size_t step = 1002;
-  auto vote = pbft_mgr1->generateVote(propose_block_hash, type, period, step);
+  uint64_t period = 2;
+  uint64_t round = 2;
+  size_t step = 1;
+  auto vote = pbft_mgr1->generateVote(propose_block_hash, type, period, round, step);
 
   node1->getNetwork()->getSpecificHandler<network::tarcap::VotePacketHandler>()->onNewPbftVotes(std::vector{vote});
 
@@ -318,10 +326,10 @@ TEST_F(VoteTest, vote_broadcast) {
   auto vote_mgr2 = node2->getVoteManager();
   auto vote_mgr3 = node3->getVoteManager();
   EXPECT_HAPPENS({60s, 100ms}, [&](auto &ctx) {
-    WAIT_EXPECT_EQ(ctx, vote_mgr2->getUnverifiedVotesSize(), 1)
-    WAIT_EXPECT_EQ(ctx, vote_mgr3->getUnverifiedVotesSize(), 1)
+    WAIT_EXPECT_EQ(ctx, vote_mgr2->getVerifiedVotesSize(), 1)
+    WAIT_EXPECT_EQ(ctx, vote_mgr3->getVerifiedVotesSize(), 1)
   });
-  EXPECT_EQ(vote_mgr1->getUnverifiedVotesSize(), 0);
+  EXPECT_EQ(vote_mgr1->getVerifiedVotesSize(), 0);
 }
 
 TEST_F(VoteTest, previous_round_next_votes) {
@@ -345,10 +353,11 @@ TEST_F(VoteTest, previous_round_next_votes) {
 
   // Generate a vote voted at NULL_BLOCK_HASH
   PbftVoteTypes type = next_vote_type;
+  auto period = 1;
   auto round = 1;
   auto step = 4;
   blk_hash_t voted_pbft_block_hash(0);
-  auto vote1 = pbft_mgr->generateVote(voted_pbft_block_hash, type, round, step);
+  auto vote1 = pbft_mgr->generateVote(voted_pbft_block_hash, type, period, round, step);
   vote1->calculateWeight(1, 1, 1);
   std::vector<std::shared_ptr<Vote>> next_votes_1{vote1};
 
@@ -361,7 +370,7 @@ TEST_F(VoteTest, previous_round_next_votes) {
   // Generate a vote voted at value blk_hash_t(1)
   voted_pbft_block_hash = blk_hash_t(1);
   step = 5;
-  auto vote2 = pbft_mgr->generateVote(voted_pbft_block_hash, type, round, step);
+  auto vote2 = pbft_mgr->generateVote(voted_pbft_block_hash, type, period, round, step);
   vote2->calculateWeight(1, 1, 1);
   std::vector<std::shared_ptr<Vote>> next_votes_2{vote2};
 
@@ -399,8 +408,9 @@ TEST_F(VoteTest, previous_round_next_votes) {
 
   // Generate a vote voted at value blk_hash_t(2)
   voted_pbft_block_hash = blk_hash_t(2);
+  period = 2;
   round = 2;
-  auto vote3 = pbft_mgr->generateVote(voted_pbft_block_hash, type, round, step);
+  auto vote3 = pbft_mgr->generateVote(voted_pbft_block_hash, type, period, round, step);
   vote3->calculateWeight(1, 1, 1);
   std::vector<std::shared_ptr<Vote>> next_votes_4{vote3};
 

--- a/tests/vote_test.cpp
+++ b/tests/vote_test.cpp
@@ -155,8 +155,9 @@ TEST_F(VoteTest, round_determine_from_next_votes) {
     }
   }
 
-  auto new_round = vote_mgr->roundDeterminedFromVotes(two_t_plus_one);
+  auto [new_round, new_period] = vote_mgr->determineRoundAndPeriodFromVotes(two_t_plus_one).value();
   EXPECT_EQ(new_round, 13);
+  EXPECT_EQ(new_period, 12);
 }
 
 TEST_F(VoteTest, reconstruct_votes) {

--- a/tests/vote_test.cpp
+++ b/tests/vote_test.cpp
@@ -198,7 +198,7 @@ TEST_F(VoteTest, transfer_vote) {
   // generate a vote far ahead (never exist in PBFT manager)
   blk_hash_t propose_block_hash(11);
   PbftVoteTypes type = next_vote_type;
-  uint64_t period = 0;
+  uint64_t period = 1;
   uint64_t round = 1;
   size_t step = 1;
   auto vote = pbft_mgr1->generateVote(propose_block_hash, type, period, round, step);
@@ -231,7 +231,7 @@ TEST_F(VoteTest, vote_broadcast) {
   // generate a vote far ahead (never exist in PBFT manager)
   blk_hash_t propose_block_hash(111);
   PbftVoteTypes type = next_vote_type;
-  uint64_t period = 0;
+  uint64_t period = 1;
   size_t step = 1;
   auto vote = pbft_mgr1->generateVote(propose_block_hash, type, period, round, step);
 


### PR DESCRIPTION
## Purpose
<!-- Provide any information reviewers might need to have context on your changes. -->
This PR is removing concept of unverified votes. Previously we would accept every vote and without any validation we would put it into the unverified queue, which could lead to memory grow...

Many possible ddos attacks are now eliminated by these changes, but not all of them. Anyway we could probably merge this PR so Dmitry can use it and then we can have separate PR with additional changes...

## How does the solution address the problem
<!-- Describe your solution. -->
In the new version:

- each vote contains also pbft period so we can validate it against dpos contract as soon as we receive it
- each vote is fully validated in packet handlers and if validation fails, vote is dropped
- there is no unverified queue for votes anymore
- each voter can create only 1 unique vote per round & step & voter address. Exception is next_vote - we allow 2 unique votes - 1 for some specific block hash and 1 for NULL_BLOCK_HASH
- if some voter already sent standard vote with round N, any new vote from him with round N-1 is dropped (reward & sync next) votes are exceptions

#### Round & period checks for different vote types:

##### Standard vote:
`vote_round >= current_pbft_round`
// Here should be vote_period > current_pbft_period but it breaks some tests due to missing rewards vote -> rewards votes need to be revisited
`vote_period >= current_pbft_period && vote_period <= current_pbft_period + dpos_delay(5)`

##### Reward vote:
`vote_round < current_pbft_round`
`vote_period == current_pbft_period`

##### Sync next vote:
`vote_round >= current_pbft_round - 1`
`vote_period >= current_pbft_period && vote_period <= current_pbft_period + dpos_delay(5)`


## Problems

- We differentiate standard & reward simply by checking round, `if vote_round < current_pbgt_round` we identify vote as reward vote and use validation for rewards votes -> this might be a problem as some out of sync node might send us standard vote and we process it as reward vote.... https://github.com/Taraxa-project/taraxa-node/issues/1880
- when running local-net I observed many errors on reward votes validation, when `vote_round < current_pbft_round` but `vote_period > current_pbft_period` -> this does not make sense: how can vote has older round than current_pbft_round and newer period than current_pbft_period ? 
- Standard & sync next vote -> as the rule is `vote_round >= current_pbft_round`, attacker might just keep increasing pbft round and these votes would pass validation and fill up verified queues. How to solve this ? We could put here at least some upper boundary, e.g.  `vote_round <= current_pbft_round + 1000` or some big number ?  

## Things to review properly:
I am now putting period into each placeVote_ call -> this period is then in the vote. In some votes like soft/cert votes I am using period from proposes pbft block, in other votes when we for example vote for NULL_BLOCK_HASH I am using current pbft period -> we should think about this approach if it is 100% valid !

## Changes made
<!-- Summary or changes that have been made. -->
