### PR TITLE
Minor fixes

### DIFF
--- a/for_devs/local-net
+++ b/for_devs/local-net
@@ -70,7 +70,7 @@ def config(binary, boot_nodes, rpc_nodes):
 
         private_keys[worker_name] = private_key
         vrf_secrets[worker_name] = vrf_secret
-        boot_nodes_public_addresses[worker_name] = {public_address, vrf_public}
+        boot_nodes_public_addresses[worker_name] = [public_address, vrf_public]
 
         boot_nodes_flags.append(
             f'127.0.0.1:10{i+1}02/{public_key}')

--- a/libraries/common/include/common/types.hpp
+++ b/libraries/common/include/common/types.hpp
@@ -79,27 +79,4 @@ inline std::string toString(val_t const &val) {
   return strm.str();
 }
 
-inline bytes str2bytes(std::string const &str) {
-  assert(str.size() % 2 == 0);
-  bytes data;
-  // convert it to byte stream
-  for (size_t i = 0; i < str.size(); i += 2) {
-    std::string s = str.substr(i, 2);
-    auto t = std::stoul(s, nullptr, 16);
-    assert(t < 256);
-    data.push_back(static_cast<uint8_t>(t));
-  }
-  return data;
-}
-
-inline std::string bytes2str(bytes const &data) {
-  // convert it to str
-  std::stringstream ss;
-  ss << std::hex << std::noshowbase << std::setfill('0');
-  for (auto const &d : data) {
-    ss << std::setfill('0') << std::setw(2) << unsigned(d);
-  }
-  return ss.str();
-}
-
 }  // namespace taraxa

--- a/libraries/vdf/src/sortition.cpp
+++ b/libraries/vdf/src/sortition.cpp
@@ -81,14 +81,14 @@ void VdfSortition::verifyVdf(SortitionParams const& config, bytes const& vrf_inp
                              bytes const& vdf_input) const {
   // Verify VRF output
   if (!verifyVrf(pk, vrf_input)) {
-    throw InvalidVdfSortition("VRF verify failed. VRF input " + bytes2str(vrf_input));
+    throw InvalidVdfSortition("VRF verify failed. VRF input " + dev::toHex(vrf_input));
   }
 
   if (!isOmitVdf(config)) {
     const auto expected = calculateDifficulty(config);
     if (difficulty_ != expected) {
       throw InvalidVdfSortition("VDF solution verification failed. Incorrect difficulty. VDF input " +
-                                bytes2str(vdf_input) + ", lambda " + std::to_string(config.vdf.lambda_bound) +
+                                dev::toHex(vdf_input) + ", lambda " + std::to_string(config.vdf.lambda_bound) +
                                 ", difficulty " + std::to_string(getDifficulty()) +
                                 ", expected: " + std::to_string(expected) +
                                 ", vrf_params: ( range: " + std::to_string(config.vrf.threshold_range) +
@@ -99,7 +99,7 @@ void VdfSortition::verifyVdf(SortitionParams const& config, bytes const& vrf_inp
     // Verify VDF solution
     VerifierWesolowski verifier(config.vdf.lambda_bound, getDifficulty(), vdf_input, N);
     if (!verifier(vdf_sol_)) {
-      throw InvalidVdfSortition("VDF solution verification failed. VDF input " + bytes2str(vdf_input) + ", lambda " +
+      throw InvalidVdfSortition("VDF solution verification failed. VDF input " + dev::toHex(vdf_input) + ", lambda " +
                                 std::to_string(config.vdf.lambda_bound) + ", difficulty " +
                                 std::to_string(getDifficulty()));
     }

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -1406,7 +1406,7 @@ TEST_F(FullNodeTest, transfer_to_self) {
   uint64_t trx_count(100);
   EXPECT_TRUE(initial_bal.second);
   for (uint64_t i = 0; i < trx_count; ++i) {
-    const auto trx = std::make_shared<Transaction>(i, i * 100, 0, 1000000, str2bytes("00FEDCBA9876543210000000"),
+    const auto trx = std::make_shared<Transaction>(i, i * 100, 0, 1000000, dev::fromHex("00FEDCBA9876543210000000"),
                                                    g_secret, node_addr);
     nodes[0]->getTransactionManager()->insertTransaction(trx);
   }
@@ -1542,34 +1542,34 @@ TEST_F(FullNodeTest, transaction_validation) {
   const uint32_t gasprice = 1;
   const uint32_t gas = 100000;
 
-  auto trx = std::make_shared<Transaction>(nonce++, 0, gasprice, gas, str2bytes("00FEDCBA9876543210000000"),
+  auto trx = std::make_shared<Transaction>(nonce++, 0, gasprice, gas, dev::fromHex("00FEDCBA9876543210000000"),
                                            nodes[0]->getSecretKey(), addr_t::random());
   // PASS on GAS
   EXPECT_TRUE(nodes[0]->getTransactionManager()->insertTransaction(trx).first);
-  trx =
-      std::make_shared<Transaction>(nonce++, 0, gasprice, FinalChain::GAS_LIMIT + 1,
-                                    str2bytes("00FEDCBA9876543210000000"), nodes[0]->getSecretKey(), addr_t::random());
+  trx = std::make_shared<Transaction>(nonce++, 0, gasprice, FinalChain::GAS_LIMIT + 1,
+                                      dev::fromHex("00FEDCBA9876543210000000"), nodes[0]->getSecretKey(),
+                                      addr_t::random());
   // FAIL on GAS
   EXPECT_FALSE(nodes[0]->getTransactionManager()->insertTransaction(trx).first);
 
-  trx = std::make_shared<Transaction>(nonce++, 0, gasprice, gas, str2bytes("00FEDCBA9876543210000000"),
+  trx = std::make_shared<Transaction>(nonce++, 0, gasprice, gas, dev::fromHex("00FEDCBA9876543210000000"),
                                       nodes[0]->getSecretKey(), addr_t::random());
   // PASS on NONCE
   EXPECT_TRUE(nodes[0]->getTransactionManager()->insertTransaction(trx).first);
   wait({60s, 200ms}, [&](auto &ctx) { WAIT_EXPECT_EQ(ctx, nodes[0]->getDB()->getNumTransactionExecuted(), 2) });
-  trx = std::make_shared<Transaction>(0, 0, gasprice, gas, str2bytes("00FEDCBA9876543210000000"),
+  trx = std::make_shared<Transaction>(0, 0, gasprice, gas, dev::fromHex("00FEDCBA9876543210000000"),
                                       nodes[0]->getSecretKey(), addr_t::random());
   // FAIL on NONCE
   EXPECT_FALSE(nodes[0]->getTransactionManager()->insertTransaction(trx).first);
 
-  trx = std::make_shared<Transaction>(nonce++, 0, gasprice, gas, str2bytes("00FEDCBA9876543210000000"),
+  trx = std::make_shared<Transaction>(nonce++, 0, gasprice, gas, dev::fromHex("00FEDCBA9876543210000000"),
                                       nodes[0]->getSecretKey(), addr_t::random());
   // PASS on BALANCE
   EXPECT_TRUE(nodes[0]->getTransactionManager()->insertTransaction(trx).first);
 
-  trx =
-      std::make_shared<Transaction>(nonce++, own_effective_genesis_bal(nodes[0]->getConfig()) + 1, 0, gas,
-                                    str2bytes("00FEDCBA9876543210000000"), nodes[0]->getSecretKey(), addr_t::random());
+  trx = std::make_shared<Transaction>(nonce++, own_effective_genesis_bal(nodes[0]->getConfig()) + 1, 0, gas,
+                                      dev::fromHex("00FEDCBA9876543210000000"), nodes[0]->getSecretKey(),
+                                      addr_t::random());
   // FAIL on BALANCE
   EXPECT_FALSE(nodes[0]->getTransactionManager()->insertTransaction(trx).first);
 }

--- a/tests/transaction_test.cpp
+++ b/tests/transaction_test.cpp
@@ -315,9 +315,9 @@ TEST_F(TransactionTest, priority_queue) {
   {
     TransactionQueue priority_queue;
     uint32_t nonce = 0;
-    auto trx = std::make_shared<Transaction>(nonce++, 1, 1, 100, str2bytes("00FEDCBA9876543210000000"), g_secret,
+    auto trx = std::make_shared<Transaction>(nonce++, 1, 1, 100, dev::fromHex("00FEDCBA9876543210000000"), g_secret,
                                              addr_t::random());
-    auto trx2 = std::make_shared<Transaction>(nonce, 1, 1, 100, str2bytes("00FEDCBA9876543210000000"), g_secret,
+    auto trx2 = std::make_shared<Transaction>(nonce, 1, 1, 100, dev::fromHex("00FEDCBA9876543210000000"), g_secret,
                                               addr_t::random());
     const auto trx_hash = trx->getHash();
     priority_queue.insert({trx2, TransactionStatus::Verified}, 1);
@@ -330,7 +330,7 @@ TEST_F(TransactionTest, priority_queue) {
   {
     TransactionQueue priority_queue;
     uint32_t nonce = 0;
-    auto trx = std::make_shared<Transaction>(nonce, 1, 1, 100, str2bytes("00FEDCBA9876543210000000"), g_secret,
+    auto trx = std::make_shared<Transaction>(nonce, 1, 1, 100, dev::fromHex("00FEDCBA9876543210000000"), g_secret,
                                              addr_t::random());
     auto trx2 = trx;
     EXPECT_TRUE(priority_queue.insert({trx, TransactionStatus::Verified}, 1));
@@ -342,9 +342,9 @@ TEST_F(TransactionTest, priority_queue) {
   {
     TransactionQueue priority_queue;
     uint32_t nonce = 0;
-    auto trx = std::make_shared<Transaction>(nonce, 1, 10, 100, str2bytes("00FEDCBA9876543210000000"), g_secret,
+    auto trx = std::make_shared<Transaction>(nonce, 1, 10, 100, dev::fromHex("00FEDCBA9876543210000000"), g_secret,
                                              addr_t::random());
-    auto trx2 = std::make_shared<Transaction>(nonce, 1, 1, 100, str2bytes("00FEDCBA9876543210000000"), g_secret,
+    auto trx2 = std::make_shared<Transaction>(nonce, 1, 1, 100, dev::fromHex("00FEDCBA9876543210000000"), g_secret,
                                               addr_t::random());
     auto trx_hash = trx->getHash();
     priority_queue.insert({trx2, TransactionStatus::Verified}, 1);
@@ -363,11 +363,11 @@ TEST_F(TransactionTest, priority_queue) {
   */
   {
     TransactionQueue priority_queue;
-    auto trxa1 = std::make_shared<Transaction>(1 /*nonce*/, 1, 5 /*fee*/, 100, str2bytes("00FEDCBA9876543210000000"),
+    auto trxa1 = std::make_shared<Transaction>(1 /*nonce*/, 1, 5 /*fee*/, 100, dev::fromHex("00FEDCBA9876543210000000"),
                                                g_secret, addr_t::random());
-    auto trxa2 = std::make_shared<Transaction>(2 /*nonce*/, 1, 6 /*fee*/, 100, str2bytes("00FEDCBA9876543210000000"),
+    auto trxa2 = std::make_shared<Transaction>(2 /*nonce*/, 1, 6 /*fee*/, 100, dev::fromHex("00FEDCBA9876543210000000"),
                                                g_secret, addr_t::random());
-    auto trxb1 = std::make_shared<Transaction>(1 /*nonce*/, 1, 4 /*fee*/, 100, str2bytes("00FEDCBA9876543210000000"),
+    auto trxb1 = std::make_shared<Transaction>(1 /*nonce*/, 1, 4 /*fee*/, 100, dev::fromHex("00FEDCBA9876543210000000"),
                                                secret_t::random(), addr_t::random());
     auto trxa1_hash = trxa1->getHash();
     auto trxa2_hash = trxa2->getHash();

--- a/tests/util_test/node_dag_creation_fixture.hpp
+++ b/tests/util_test/node_dag_creation_fixture.hpp
@@ -53,7 +53,7 @@ struct NodeDagCreationFixture : BaseTest {
   }
 
   void deployContract() {
-    auto trx = std::make_shared<Transaction>(nonce, 100, 0, TEST_TX_GAS_LIMIT,
+    auto trx = std::make_shared<Transaction>(nonce, 0, 0, TEST_TX_GAS_LIMIT,
                                              dev::fromHex(samples::greeter_contract_code), node->getSecretKey());
     auto [ok, err_msg] = node->getTransactionManager()->insertTransaction(trx);
     ASSERT_TRUE(ok);

--- a/tests/util_test/samples.hpp
+++ b/tests/util_test/samples.hpp
@@ -85,7 +85,7 @@ class TxGenerator {
     SharedTransactions trxs;
     for (auto i = start_nonce; i < start_nonce + trx_num; ++i) {
       trxs.emplace_back(std::make_shared<Transaction>(i, value, 0, TEST_TX_GAS_LIMIT,
-                                                      str2bytes("00FEDCBA9876543210000000"),
+                                                      dev::fromHex("00FEDCBA9876543210000000"),
                                                       getRandomUniqueSenderSecret(), receiver));
     }
     return trxs;
@@ -168,7 +168,7 @@ inline std::map<int, TestAccount> createTestAccountTable(std::string const &file
 }
 
 inline SharedTransactions createSignedTrxSamples(unsigned start, unsigned num, secret_t const &sk,
-                                                 bytes data = str2bytes("00FEDCBA9876543210000000")) {
+                                                 bytes data = dev::fromHex("00FEDCBA9876543210000000")) {
   assert(start + num < std::numeric_limits<unsigned>::max());
   SharedTransactions trxs;
   for (auto i = start; i < num; ++i) {


### PR DESCRIPTION
During some tests I found a few issues:
1. In `local-net` script `address` and `vrf_key` was reordering sometimes and was leading to incorrect behaviour. For example if that was happening for 1 boot-node then it just can't finalize blocks because of not enought votes(incorrect address was specified in config). If few became incorrect then it wasn't starting because of `Validator already exist` error
2. Found that `str2bytes` was working incorrectly in my new test, so removed this and replaced it with `dev::fromHex` method that we already have. Did the same thing with `bytes2str` just because we already have `dev::toHex`