### PR TITLE
chore: light node test improvement

### DIFF
--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -1576,12 +1576,12 @@ TEST_F(FullNodeTest, transaction_validation) {
 
 TEST_F(FullNodeTest, light_node) {
   auto node_cfgs = make_node_cfgs<10>(2);
-  node_cfgs[0].is_light_node = true;
-  node_cfgs[0].light_node_history = 10;
   node_cfgs[0].dag_expiry_limit = 5;
   node_cfgs[0].max_levels_per_period = 3;
   node_cfgs[1].dag_expiry_limit = 5;
   node_cfgs[1].max_levels_per_period = 3;
+  node_cfgs[1].is_light_node = true;
+  node_cfgs[1].light_node_history = 10;
   auto nodes = launch_nodes(node_cfgs);
   uint64_t nonce = 0;
   while (nodes[1]->getPbftChain()->getPbftChainSizeExcludingEmptyPbftBlocks() < 20) {
@@ -1597,15 +1597,16 @@ TEST_F(FullNodeTest, light_node) {
                    nodes[1]->getPbftChain()->getPbftChainSizeExcludingEmptyPbftBlocks())
   });
   uint32_t non_empty_counter = 0;
-  for (uint64_t i = 0; i < nodes[0]->getPbftChain()->getPbftChainSize(); i++) {
-    const auto pbft_block = nodes[0]->getDB()->getPbftBlock(i);
+  for (uint64_t i = 0; i < nodes[1]->getPbftChain()->getPbftChainSize(); i++) {
+    const auto pbft_block = nodes[1]->getDB()->getPbftBlock(i);
     if (pbft_block) {
       non_empty_counter++;
     }
   }
   // Verify light node stores only expected number of period_data
-  EXPECT_GE(non_empty_counter, node_cfgs[0].light_node_history);
-  EXPECT_LE(non_empty_counter, node_cfgs[0].light_node_history + 1);
+  // const uint64_t expected_non_emp = std::min(period_ - light_node_history_, *proposal_period);
+  EXPECT_GE(non_empty_counter, node_cfgs[1].light_node_history);
+  EXPECT_LE(non_empty_counter, node_cfgs[1].light_node_history + 2);
 }
 
 TEST_F(FullNodeTest, clear_period_data) {


### PR DESCRIPTION
Light node test was sometimes failing. I have found and fixed two such issues and now it is passing 100/100 on my machine. I did not find anything wrong with the loght node implementation, only with the test itself.
Issues fixed:
1. Due to small light_node_history in test sometimes data would be deleted before it was synced to the other node. To prevent this transactions are now inserted into a non-light node and light node is the one that is syncing
2. There was a race condition between creating a new pbft block and deleting old blocks in a light node. Fix is simply allowing one extra pbft block to be present in a light node by increasing the limit that we verify in line 1609