### PR TITLE
feat: share same logger objects between steps and rounds

### DIFF
--- a/libraries/core_libs/consensus/include/pbft/node_face.hpp
+++ b/libraries/core_libs/consensus/include/pbft/node_face.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "common/types.hpp"
+#include "logger/shared_logger.hpp"
 #include "network/network.hpp"
 
 namespace taraxa {
@@ -26,7 +27,9 @@ struct NodeFace {
         dag_mgr_(std::move(dm)),
         dag_blk_mgr_(std::move(dbm)),
         trx_mgr_(std::move(tm)),
-        final_chain_(std::move(fc)) {}
+        final_chain_(std::move(fc)),
+        step_logger("STEP", addr),
+        round_logger("ROUND", addr) {}
   // TODO:  circular dependency. should be resolved
   std::weak_ptr<PbftManager> pbft_manager_;
 
@@ -43,6 +46,9 @@ struct NodeFace {
   std::shared_ptr<DagBlockManager> dag_blk_mgr_;
   std::shared_ptr<TransactionManager> trx_mgr_;
   std::shared_ptr<FinalChain> final_chain_;
+
+  logger::SharedLogger step_logger;
+  logger::SharedLogger round_logger;
 };
 
 }  // namespace taraxa

--- a/libraries/core_libs/consensus/include/pbft/round.hpp
+++ b/libraries/core_libs/consensus/include/pbft/round.hpp
@@ -57,7 +57,7 @@ class Round : public RoundFace {
 
   void initDbValues();
 
-  LOG_OBJECTS_DEFINE
+  LOG_OBJECTS_REF_DEFINE
 };
 
 }  // namespace taraxa

--- a/libraries/core_libs/consensus/include/pbft/step/step.hpp
+++ b/libraries/core_libs/consensus/include/pbft/step/step.hpp
@@ -44,6 +44,6 @@ class Step {
   std::shared_ptr<RoundFace> round_;
   std::shared_ptr<NodeFace> node_;
 
-  LOG_OBJECTS_DEFINE
+  LOG_OBJECTS_REF_DEFINE
 };
 }  // namespace taraxa

--- a/libraries/core_libs/consensus/src/pbft/round.cpp
+++ b/libraries/core_libs/consensus/src/pbft/round.cpp
@@ -11,9 +11,8 @@
 
 namespace taraxa {
 
-Round::Round(uint64_t id, std::shared_ptr<NodeFace> node) : RoundFace(id, std::move(node)) {
-  const auto& node_addr = getNode()->node_addr_;
-  LOG_OBJECTS_CREATE("ROUND_" + std::to_string(getId()));
+Round::Round(uint64_t id, std::shared_ptr<NodeFace> node)
+    : RoundFace(id, std::move(node)), LOG_OBJECTS_INITIALIZE_FROM_SHARED(node_->round_logger) {
   previous_round_next_voted_value_ = node_->next_votes_manager_->getVotedValue();
   previous_round_next_voted_null_block_hash_ = node_->next_votes_manager_->haveEnoughVotesForNullBlockHash();
 }

--- a/libraries/core_libs/consensus/src/pbft/step/step.cpp
+++ b/libraries/core_libs/consensus/src/pbft/step/step.cpp
@@ -7,10 +7,12 @@
 namespace taraxa {
 
 Step::Step(uint64_t id, std::shared_ptr<RoundFace> round)
-    : id_(id), type_(stepTypeFromId(id)), round_(std::move(round)), node_(round_->getNode()) {
-  const auto& node_addr = node_->node_addr_;
-  LOG_OBJECTS_CREATE("STEP_" + std::to_string(id_));
-}
+    : id_(id),
+      type_(stepTypeFromId(id)),
+      round_(std::move(round)),
+      node_(round_->getNode()),
+      LOG_OBJECTS_INITIALIZE_FROM_SHARED(node_->step_logger) {}
+
 bool Step::giveUpNextVotedBlock_() {
   auto pm = node_->pbft_manager_.lock();
   if (!pm) {

--- a/libraries/logger/CMakeLists.txt
+++ b/libraries/logger/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(HEADERS
     include/logger/logger.hpp
+    include/logger/shared_logger.hpp
     include/logger/logger_config.hpp
 )
 

--- a/libraries/logger/include/logger/logger.hpp
+++ b/libraries/logger/include/logger/logger.hpp
@@ -66,6 +66,14 @@ void InitLogging(Config& logging_config, const addr_t& node_id);
   mutable taraxa::logger::Logger log_dg_; \
   mutable taraxa::logger::Logger log_tr_;
 
+#define LOG_OBJECTS_REF_DEFINE     \
+  taraxa::logger::Logger& log_si_; \
+  taraxa::logger::Logger& log_er_; \
+  taraxa::logger::Logger& log_wr_; \
+  taraxa::logger::Logger& log_nf_; \
+  taraxa::logger::Logger& log_dg_; \
+  taraxa::logger::Logger& log_tr_;
+
 #define LOG_OBJECTS_DEFINE_SUB(group)               \
   mutable taraxa::logger::Logger log_si_##group##_; \
   mutable taraxa::logger::Logger log_er_##group##_; \
@@ -89,3 +97,7 @@ void InitLogging(Config& logging_config, const addr_t& node_id);
   log_nf_##group##_ = taraxa::logger::createLogger(taraxa::logger::Verbosity::Info, channel, node_addr);    \
   log_tr_##group##_ = taraxa::logger::createLogger(taraxa::logger::Verbosity::Trace, channel, node_addr);   \
   log_dg_##group##_ = taraxa::logger::createLogger(taraxa::logger::Verbosity::Debug, channel, node_addr);
+
+#define LOG_OBJECTS_INITIALIZE_FROM_SHARED(shared)                                                    \
+  log_si_(shared.log_si_), log_er_(shared.log_er_), log_wr_(shared.log_wr_), log_nf_(shared.log_nf_), \
+      log_dg_(shared.log_dg_), log_tr_(shared.log_tr_)

--- a/libraries/logger/include/logger/shared_logger.hpp
+++ b/libraries/logger/include/logger/shared_logger.hpp
@@ -1,0 +1,9 @@
+#include "logger/logger.hpp"
+
+namespace taraxa::logger {
+struct SharedLogger {
+  SharedLogger(const std::string& channel, const addr_t& node_addr) { LOG_OBJECTS_CREATE(channel); }
+
+  LOG_OBJECTS_DEFINE
+};
+}  // namespace taraxa::logger


### PR DESCRIPTION
Share same created logger objects between all steps and rounds to not create it every time 