### PR TITLE
fix: corrupt reward votes

### DIFF
--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -314,7 +314,6 @@ class VoteManager {
    */
   void sendRewardVotes(const blk_hash_t& pbft_block_hash);
 
- private:
   /**
    * @brief Verify reward vote
    *
@@ -324,6 +323,7 @@ class VoteManager {
    */
   bool verifyRewardVote(const std::shared_ptr<Vote>& vote);
 
+ private:
   /**
    * @brief Retrieve all verified votes from DB to the verified votes map. And broadcast all next voting type votes to
    * peers if node has extended the partition steps (1000). That only happens when nodes start.

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -119,12 +119,9 @@ void PbftManager::run() {
     }
     // We need this section because votes need to be verified for reward distribution
     for (const auto &v : period_data.previous_block_cert_votes) {
-      vote_mgr_->addRewardVote(v);
+      vote_mgr_->verifyRewardVote(v);
     }
-    if (!vote_mgr_->checkRewardVotes(period_data.pbft_blk)) {
-      LOG(log_er_) << "Invalid reward votes in block " << period_data.pbft_blk->getBlockHash() << " in DB.";
-      assert(false);
-    }
+
     finalize_(std::move(period_data), db_->getFinalizedDagBlockHashesByPeriod(period), period == curr_period);
   }
 


### PR DESCRIPTION
Votes need to be verified for finalization but if the period is already pushed to pbft chain reward votes should not be added to vote manager because this corrupts the node since it adds reward votes for previous period while at the same time vote manager can already contain reward votes from current period which than incorrectly mixes votes from multiple periods.

