### PR TITLE
chore: verify reward votes round

### DIFF
--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -365,6 +365,7 @@ class VoteManager {
   std::weak_ptr<Network> network_;
 
   blk_hash_t reward_votes_pbft_block_hash_;
+  uint64_t reward_votes_pbft_block_round_;
   std::unordered_map<vote_hash_t, std::shared_ptr<Vote>> reward_votes_;
   mutable std::shared_mutex reward_votes_mutex_;
 


### PR DESCRIPTION
When verifying reward vote verify that this is a cert vote which has the same round as the round that previous pbft block pushed in the chain was cert voted on