### PR TITLE
chore: enable syncing on missing vote reward

### DIFF
--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -31,6 +31,7 @@ enum PbftStates { value_proposal_state = 1, filter_state, certify_state, finish_
 
 enum PbftSyncRequestReason {
   missing_dag_blk = 1,
+  missing_reward_vote,
   invalid_cert_voted_block,
   invalid_soft_voted_block,
   exceeded_max_steps

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1432,6 +1432,9 @@ void PbftManager::syncPbftChainFromPeers_(PbftSyncRequestReason reason, taraxa::
                        << " not present in DAG.";
 
           break;
+        case missing_reward_vote:
+          LOG(log_nf_) << "Proposed PBFT block " << relevant_blk_hash << " is missing reward vote. We need to resync";
+          break;
         case invalid_cert_voted_block:
           // Get partition, need send request to get missing pbft blocks from peers
           LOG(log_nf_) << "Cert voted block " << relevant_blk_hash
@@ -1491,7 +1494,7 @@ std::pair<vec_blk_t, bool> PbftManager::compareBlocksAndRewardVotes_(std::shared
 
   // Check reward votes
   if (!vote_mgr_->checkRewardVotes(pbft_block)) {
-    LOG(log_er_) << "Failed verifying reward votes for proposed PBFT block " << proposal_block_hash;
+    syncPbftChainFromPeers_(missing_reward_vote, proposal_block_hash);
     return {{}, false};
   }
 

--- a/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
+++ b/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
@@ -28,7 +28,7 @@ VoteManager::VoteManager(size_t pbft_committee_size, const addr_t& node_addr, st
 
   // Retrieve votes from DB
   daemon_ = std::make_unique<std::thread>([this]() { retreieveVotes_(); });
-  
+
   current_period_final_chain_block_hash_ = final_chain_->block_header()->hash;
 }
 


### PR DESCRIPTION
## Purpose
So in the latest PR we enable check for reward votes on propose PBFT block https://github.com/Taraxa-project/taraxa-node/pull/1922/files#diff-40aae7b8b2c553b53c6fed1680de77bef59fe19a7dedfe95c7693f10bce4a7aeR1494
but we just return false and to nothing. Instead we should re-sync IMHO as for missing DAG blocks

## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
