### PR TITLE
chore: allow rewards votes with different rounds

### DIFF
--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -302,13 +302,6 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
 
   blk_hash_t getLastPbftBlockHash();
 
-  /**
-   * @brief Get only include reward votes that are list in PBFT block
-   * @param reward_votes_hashes reward votes hashes are list in PBFT block
-   * @return reward votes that are list in PBFT block
-   */
-  std::vector<std::shared_ptr<Vote>> getRewardVotesInBlock(const std::vector<vote_hash_t> &reward_votes_hashes);
-
  private:
   // DPOS
   /**

--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -304,8 +304,22 @@ class VoteManager {
    *
    * @return vector of all reward votes
    */
-
   std::vector<std::shared_ptr<Vote>> getRewardVotes();
+
+  /**
+   * @brief Get reward votes from specified hashes
+   *
+   * @param vote_hashes votes hashes to retrieve
+   * @return reward votes, if any of the votes is missing an empty array is returned
+   */
+  std::vector<std::shared_ptr<Vote>> getRewardVotes(const std::vector<vote_hash_t>& vote_hashes);
+
+  /**
+   * @brief Get reward votes from reward_votes_ with the last block round
+   *
+   * @return vector of reward votes
+   */
+  std::vector<std::shared_ptr<Vote>> getRewardVotesWithLastBlockRound();
 
   /**
    * @brief Send out all reward votes to peers

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
@@ -161,7 +161,7 @@ void PbftSyncPacketHandler::process(const PacketData &packet_data, const std::sh
       return;
     }
     // And now we need to replace it with verified votes
-    if (auto votes = pbft_mgr_->getRewardVotesInBlock(period_data.pbft_blk->getRewardVotes()); votes.size()) {
+    if (auto votes = vote_mgr_->getRewardVotes(period_data.pbft_blk->getRewardVotes()); votes.size()) {
       period_data.previous_block_cert_votes = std::move(votes);
     }
   }


### PR DESCRIPTION
As noticed on devnet although this happens rarely it is possible that the same pbft block can be cert voted and pushed into chain on different nodes in different rounds. This means that it is possible that reward votes for next proposed pbft chain which are cert voted of the previous block can be in different rounds.

The changes in this PR allow us to save and gossip reward votes from different rounds as long as they point to the correct hash of the previous pbft block.

However on proposing a pbft block we only choose to include reward votes from the round that the proposer has cert voted previous block on. So reward votes included in pbft block will always have the same round. 