### PR TITLE
chore: remove incorrect assert in dag expiry

### DIFF
--- a/libraries/core_libs/consensus/src/dag/dag_manager.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_manager.cpp
@@ -435,7 +435,6 @@ bool DagManager::validateBlockNotExpired(
     LOG(log_nf_) << "Dropping expired block in setDagBlockOrder: " << blk_hash
                  << ". Expiry level: " << dag_expiry_level_ << ". Block level: " << dag_block->getLevel();
     expired_dag_blocks_to_remove[blk_hash] = dag_block;
-    assert(blk_hash != frontier_.pivot);
     return false;
   }
   return true;


### PR DESCRIPTION
This assert was incorrect. There is no valid reason why frontier_.pivot could not point to expired dag block and if this is the case it should be expired and removed. After validateBlockNotExpired is run, frontier value is always updated to a new proper value. So it should be safe to remove this assert.