### PR TITLE
chore: cert vote choosing round

### DIFF
--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -389,7 +389,7 @@ class VoteManager {
   std::weak_ptr<Network> network_;
 
   blk_hash_t reward_votes_pbft_block_hash_;
-  uint64_t reward_votes_pbft_block_round_;
+  uint64_t last_pbft_block_cert_round_;
   std::unordered_map<vote_hash_t, std::shared_ptr<Vote>> reward_votes_;
   mutable std::shared_mutex reward_votes_mutex_;
 

--- a/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
+++ b/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
@@ -55,7 +55,8 @@ std::pair<TransactionStatus, std::string> TransactionManager::verifyTransaction(
   }
 
   if (trx->getChainID() != kConf.chain_id) {
-    return {TransactionStatus::Invalid, "chain_id mismatch"};
+    return {TransactionStatus::Invalid,
+            "chain_id mismatch" + std::to_string(trx->getChainID()) + " " + std::to_string(kConf.chain_id)};
   }
 
   // Ensure the transaction doesn't exceed the current block limit gas.


### PR DESCRIPTION
I have renamed reward_votes_pbft_block_round_ to last_pbft_block_cert_round_ because this variable actually keeps the round in which we cert voted last pbft block.

In VoteManager::addRewardVote we would save any reward vote to last cert vote table but only votes of the same round last block was cert voted on should be kept there since it is used to serve sync requests from other nodes. 

