### PR TITLE
chore: add ccls cache dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ compile_commands.json
 # clangd indexer cache
 .cache
 
+# ccls indexer cache 
+.ccls-cache
+
 .idea
 *.iml
 


### PR DESCRIPTION
Add cache dir of ccls code indexer to .gitignore