### PR TITLE
chore: fix sent packet stats

### DIFF
--- a/libraries/core_libs/network/src/tarcap/stats/packets_stats.cpp
+++ b/libraries/core_libs/network/src/tarcap/stats/packets_stats.cpp
@@ -59,7 +59,7 @@ void PacketsStats::logAndUpdateStats() {
   };
 
   auto tmp_received_packets_stats = received_packets_stats_.getStatsCopy();
-  auto tmp_sent_packets_stats = received_packets_stats_.getStatsCopy();
+  auto tmp_sent_packets_stats = sent_packets_stats_.getStatsCopy();
 
   auto period_received_packets_stats = tmp_received_packets_stats - previous_received_packets_stats;
   auto period_sent_packets_stats = tmp_sent_packets_stats - previous_sent_packets_stats;


### PR DESCRIPTION
## Purpose
While looking into devnet I've noticed received == sent packet stats.

## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
