### PR TITLE
chore: optimize dag verify

### DIFF
--- a/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
+++ b/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
@@ -56,7 +56,6 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
                      addr_t node_addr);
 
   uint64_t estimateTransactionGas(std::shared_ptr<Transaction> trx, std::optional<uint64_t> proposal_period) const;
-  uint64_t estimateTransactionGasByHash(const trx_hash_t &hash, std::optional<uint64_t> proposal_period) const;
 
   /**
    * @brief Gets transactions from pool to include in the block with specified weight limit
@@ -130,8 +129,13 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
   std::vector<std::shared_ptr<Transaction>> getNonfinalizedTrx(const std::vector<trx_hash_t> &hashes,
                                                                bool sorted = false);
 
-  // Check transactions are present in broadcasted blocks
-  bool checkBlockTransactions(DagBlock const &blk);
+  /**
+   * @brief Get the block transactions
+   *
+   * @param blk
+   * @return transactions retrieved from pool/db
+   */
+  std::optional<std::map<trx_hash_t, std::shared_ptr<Transaction>>> getBlockTransactions(DagBlock const &blk);
 
   /**
    * @brief Updates the status of transactions to finalized
@@ -189,6 +193,7 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
   mutable std::shared_mutex transactions_mutex_;
   TransactionQueue transactions_pool_;
   std::unordered_map<trx_hash_t, std::shared_ptr<Transaction>> nonfinalized_transactions_in_dag_;
+  std::unordered_map<trx_hash_t, std::shared_ptr<Transaction>> last_finalized_block_transactions_;
   uint64_t trx_count_ = 0;
 
   std::shared_ptr<DbStorage> db_{nullptr};

--- a/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
+++ b/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
@@ -370,7 +370,7 @@ std::optional<std::map<trx_hash_t, std::shared_ptr<Transaction>>> TransactionMan
     auto finalizedTransactions = db_->getFinalizedTransactions(finalized_trx_hashes);
     if (finalizedTransactions.first.has_value()) {
       for (auto trx : *finalizedTransactions.first) {
-        transactions.emplace(trx->getHash(), trx);
+        transactions.emplace(trx->getHash(), std::move(trx));
       }
     } else {
       LOG(log_er_) << "Block " << blk.getHash() << " has missing transaction " << finalizedTransactions.second;

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -195,6 +195,17 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   blk_hash_t getPeriodBlockHash(uint64_t period) const;
   std::optional<SharedTransactions> getPeriodTransactions(uint64_t period) const;
 
+  /**
+   * @brief Gets finalized transactions from provided hashes
+   *
+   * @param trx_hashes
+   *
+   * @return Returns transactions found if all transactions are present. If there is a transaction missing, no
+   * transaction is returned and missing trx hash is returned
+   */
+  std::pair<std::optional<SharedTransactions>, trx_hash_t> getFinalizedTransactions(
+      std::vector<trx_hash_t> const& trx_hashes) const;
+
   // DAG
   void saveDagBlock(DagBlock const& blk, Batch* write_batch_p = nullptr);
   std::shared_ptr<DagBlock> getDagBlock(blk_hash_t const& hash);
@@ -223,7 +234,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
 
   void saveTransactionPeriod(trx_hash_t const& trx, uint32_t period, uint32_t position);
   void addTransactionPeriodToBatch(Batch& write_batch, trx_hash_t const& trx, uint32_t period, uint32_t position);
-  std::optional<std::pair<uint32_t, uint32_t>> getTransactionPeriod(trx_hash_t const& hash);
+  std::optional<std::pair<uint32_t, uint32_t>> getTransactionPeriod(trx_hash_t const& hash) const;
   std::unordered_map<trx_hash_t, uint32_t> getAllTransactionPeriod();
 
   // PBFT manager

--- a/libraries/core_libs/storage/src/storage.cpp
+++ b/libraries/core_libs/storage/src/storage.cpp
@@ -557,6 +557,7 @@ std::pair<std::optional<SharedTransactions>, trx_hash_t> DbStorage::getFinalized
   // Map of period to position of transactions within a period
   std::map<uint64_t, std::set<uint32_t>> period_map;
   SharedTransactions transactions;
+  transactions.reserve(trx_hashes.size());
   for (auto const& tx_hash : trx_hashes) {
     auto trx_period = getTransactionPeriod(tx_hash);
     if (trx_period.has_value()) {

--- a/tests/dag_block_test.cpp
+++ b/tests/dag_block_test.cpp
@@ -254,7 +254,7 @@ TEST_F(DagBlockMgrTest, too_big_dag_block) {
     auto [ok, err_msg] = node->getTransactionManager()->insertTransaction(create_trx);
     EXPECT_EQ(ok, true);
     hashes.emplace_back(create_trx->getHash());
-    const auto& e = node->getTransactionManager()->estimateTransactionGasByHash(create_trx->getHash(), std::nullopt);
+    const auto& e = node->getTransactionManager()->estimateTransactionGas(create_trx, std::nullopt);
     estimations.emplace_back(e);
   }
 

--- a/tests/transaction_test.cpp
+++ b/tests/transaction_test.cpp
@@ -234,21 +234,21 @@ TEST_F(TransactionTest, transaction_low_nonce) {
                                                          secret_t::random());
 
   // Verify dag blocks will pass verification if contain low nonce or insufficient balance transactions
-  EXPECT_FALSE(trx_mgr.checkBlockTransactions(dag_blk_with_low_nonce_transaction));
+  EXPECT_FALSE(trx_mgr.getBlockTransactions(dag_blk_with_low_nonce_transaction).has_value());
   trx_mgr.insertValidatedTransactions({{trx_low_nonce, TransactionStatus::LowNonce}});
-  EXPECT_TRUE(trx_mgr.checkBlockTransactions(dag_blk_with_low_nonce_transaction));
-  EXPECT_FALSE(trx_mgr.checkBlockTransactions(dag_blk_with_insufficient_balance_transaction));
+  EXPECT_TRUE(trx_mgr.getBlockTransactions(dag_blk_with_low_nonce_transaction).has_value());
+  EXPECT_FALSE(trx_mgr.getBlockTransactions(dag_blk_with_insufficient_balance_transaction).has_value());
   trx_mgr.insertValidatedTransactions({{trx_insufficient_balance, TransactionStatus::InsufficentBalance}});
-  EXPECT_TRUE(trx_mgr.checkBlockTransactions(dag_blk_with_insufficient_balance_transaction));
+  EXPECT_TRUE(trx_mgr.getBlockTransactions(dag_blk_with_insufficient_balance_transaction).has_value());
 
   trx_mgr.blockFinalized(11);
-  EXPECT_TRUE(trx_mgr.checkBlockTransactions(dag_blk_with_low_nonce_transaction));
-  EXPECT_TRUE(trx_mgr.checkBlockTransactions(dag_blk_with_insufficient_balance_transaction));
+  EXPECT_TRUE(trx_mgr.getBlockTransactions(dag_blk_with_low_nonce_transaction).has_value());
+  EXPECT_TRUE(trx_mgr.getBlockTransactions(dag_blk_with_insufficient_balance_transaction).has_value());
 
   // Verify that after 10 executed blocks transactions expire
   trx_mgr.blockFinalized(12);
-  EXPECT_FALSE(trx_mgr.checkBlockTransactions(dag_blk_with_low_nonce_transaction));
-  EXPECT_FALSE(trx_mgr.checkBlockTransactions(dag_blk_with_insufficient_balance_transaction));
+  EXPECT_FALSE(trx_mgr.getBlockTransactions(dag_blk_with_low_nonce_transaction).has_value());
+  EXPECT_FALSE(trx_mgr.getBlockTransactions(dag_blk_with_insufficient_balance_transaction).has_value());
 }
 
 TEST_F(TransactionTest, transaction_concurrency) {


### PR DESCRIPTION
When verifying received DAG block all transactions need to be retrieved from pool or database to be able to verify block weight. If there is a lot of transactions in the block that are already finalized these transactions are retrieved from the database from period data which is very slow. A block with 10000 transactions took almost 3 minutes to verify when transactions are pulled from period data.

Following optimizations are made:
Check both the pool and nonfinalized_transactions_in_dag_ where transactions are stored in memory before checking the db for finalized transactions.
Keep last finalized block transactions in memory since DAG block might often have transactions which have just been finalized
When actually retrieving transactions from database, group transactions per period so that multiple finalized transactions from same period are all fetched in the same period data retrieval