### PR TITLE
Rewrite PBFT to simplify algorithm

### DIFF
--- a/libraries/cli/include/cli/config_jsons/default.json
+++ b/libraries/cli/include/cli/config_jsons/default.json
@@ -11,8 +11,11 @@
   "network_sync_level_size": 25,
   "network_packets_processing_threads": 14,
   "network_peer_blacklist_timeout" : 600,
-  "is_light_node" : false,
-  "deep_syncing_threshold" : 10,
+  "is_light_node": false,
+  "deep_syncing_threshold": 10,
+  "vote_accepting_periods": 5,
+  "vote_accepting_rounds": 5,
+  "vote_accepting_steps": 25,
   "network_boot_nodes": [
   ],
   "rpc": {

--- a/libraries/cli/include/cli/config_jsons/devnet.json
+++ b/libraries/cli/include/cli/config_jsons/devnet.json
@@ -13,6 +13,9 @@
   "network_peer_blacklist_timeout": 600,
   "is_light_node": false,
   "deep_syncing_threshold": 10,
+  "vote_accepting_periods": 5,
+  "vote_accepting_rounds": 5,
+  "vote_accepting_steps": 25,
   "network_boot_nodes": [
     {
       "id": "fdcf4c860d9bb1f17608cbf2dd10ac3ae8d0ba41aa20b3e43fb85a72617a356f8609475d68b44e25dd508a0e5b36da75e7ae9aaf93360f4f002464d1d75fd353",

--- a/libraries/cli/include/cli/config_jsons/mainnet.json
+++ b/libraries/cli/include/cli/config_jsons/mainnet.json
@@ -10,9 +10,12 @@
   "network_max_peer_count": 50,
   "network_sync_level_size": 10,
   "network_packets_processing_threads": 14,
-  "network_peer_blacklist_timeout" : 600,
-  "is_light_node" : false,
-  "deep_syncing_threshold" : 10,
+  "network_peer_blacklist_timeout": 600,
+  "is_light_node": false,
+  "deep_syncing_threshold": 10,
+  "vote_accepting_periods": 5,
+  "vote_accepting_rounds": 5,
+  "vote_accepting_steps": 25,
   "network_boot_nodes": [
     {
       "id": "d063098ceca0f5ea06f9455debffe6f6d5b2efdeb179215877e356cf8154afad99f058214bd25d8198a3854a4ed8f7ef97af59b0441a7d30bc4b3918c42764ef",

--- a/libraries/cli/include/cli/config_jsons/testnet.json
+++ b/libraries/cli/include/cli/config_jsons/testnet.json
@@ -13,6 +13,9 @@
   "network_peer_blacklist_timeout": 600,
   "is_light_node": false,
   "deep_syncing_threshold": 10,
+  "vote_accepting_periods": 5,
+  "vote_accepting_rounds": 5,
+  "vote_accepting_steps": 25,
   "network_boot_nodes": [
     {
       "id": "f36f467529fe91a750dfdc8086fd0d2f30bad9f55a5800b6b4aa603c7787501db78dc4ac1bf3cf16e42af7c2ebb53648653013c3da1987494960d751871d598a",

--- a/libraries/config/include/config/config.hpp
+++ b/libraries/config/include/config/config.hpp
@@ -46,6 +46,9 @@ struct NetworkConfig {
   uint16_t network_peer_blacklist_timeout = kBlacklistTimeoutDefaultInSeconds;
   bool disable_peer_blacklist = false;
   uint16_t deep_syncing_threshold = 10;
+  uint16_t vote_accepting_periods = 5;
+  uint16_t vote_accepting_rounds = 5;
+  uint16_t vote_accepting_steps = 25;
 
   void validate() const;
 };

--- a/libraries/config/include/config/state_api_config.hpp
+++ b/libraries/config/include/config/state_api_config.hpp
@@ -52,8 +52,8 @@ struct DPOSConfig {
   uint16_t max_block_author_reward = 0;
   uint16_t commission_change_delta = 0;
   uint32_t commission_change_frequency = 0;  // number of blocks
-  uint32_t delegation_delay = 0;             // number of blocks
-  uint32_t delegation_locking_period = 0;    // number of blocks
+  uint32_t delegation_delay = 5;             // number of blocks
+  uint32_t delegation_locking_period = 5;    // number of blocks
   uint32_t blocks_per_year = 0;              // number of blocks - it is calculated from lambda_ms_min
   uint16_t yield_percentage = 0;             // [%]
   std::vector<ValidatorInfo> initial_validators;

--- a/libraries/config/src/config.cpp
+++ b/libraries/config/src/config.cpp
@@ -302,6 +302,11 @@ void FullNodeConfig::validate() const {
   if (rpc) {
     rpc->validate();
   }
+  if (network.vote_accepting_periods > chain.final_chain.state.dpos->delegation_delay) {
+    throw ConfigException(std::string(
+        "network.vote_accepting_periods(" + std::to_string(network.vote_accepting_periods) +
+        ") must be <= DPOS.delegation_delay(" + std::to_string(chain.final_chain.state.dpos->delegation_delay) + ")"));
+  }
   if (transactions_pool_size < kMinTransactionPoolSize) {
     throw ConfigException(std::string("transactions_pool_size cannot be smaller than ") +
                           std::to_string(kMinTransactionPoolSize) + ".");

--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -267,18 +267,6 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   void resumeSingleState();
 
   /**
-   * @brief Set maximum waiting time for soft vote value. Only to be used for unit tests
-   * @param wait_ms waiting time in milisecond
-   */
-  void setMaxWaitForSoftVotedBlock_ms(uint64_t wait_ms);
-
-  /**
-   * @brief Set maximum waiting time for next vote value. Only to be used for unit tests
-   * @param wait_ms waiting time in milisecond
-   */
-  void setMaxWaitForNextVotedBlock_ms(uint64_t wait_ms);
-
-  /**
    * @brief Calculate DAG blocks ordering hash
    * @param dag_block_hashes DAG blocks hashes
    * @param trx_hashes transactions hashes
@@ -342,6 +330,12 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
    * @return true if PBFT sets round to a forward round number
    */
   bool resetRound_();
+
+  /**
+   * @brief When a node executes a block, having received 2t+1 cert votes or a bundle of cert votes, 
+   *        then advances to next round
+   */
+  void advancePeriod_();
 
   /**
    * @brief Time to sleep for PBFT protocol
@@ -546,18 +540,6 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   bool is_syncing_();
 
   /**
-   * @brief Terminate the next voting value of the PBFT block hash
-   * @return true if terminate the vote value successfully
-   */
-  bool giveUpNextVotedBlock_();
-
-  /**
-   * @brief Terminate the soft voting value of the PBFT block hash
-   * @return true if terminate the vote value successfully
-   */
-  bool giveUpSoftVotedBlock_();
-
-  /**
    * @brief Set initial time for voting value
    */
   void initializeVotedValueTimeouts_();
@@ -619,7 +601,7 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   std::default_random_engine random_engine_{std::random_device{}()};
 
   // Flag that says if node is in sync after it enters new round
-  bool new_round_in_sync_ = false;
+  //bool new_round_in_sync_ = false;
 
   const size_t COMMITTEE_SIZE;
   const size_t NUMBER_OF_PROPOSERS;
@@ -634,7 +616,6 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   size_t step_ = 1;
   size_t startingStepInRound_ = 1;
 
-  std::pair<blk_hash_t, uint64_t /* period */> own_starting_value_for_round_{NULL_BLOCK_HASH, 1};
   std::optional<std::pair<blk_hash_t, uint64_t /* period */>> soft_voted_block_for_round_{};
 
   // TODO: was blk_hash_t last_cert_voted_value_ = NULL_BLOCK_HASH; and it was set to NULL_BLOCK_HASH in pushBlock
@@ -659,16 +640,12 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   u_long elapsed_time_in_round_ms_ = 0;
 
   bool executed_pbft_block_ = false;
-  bool have_executed_this_round_ = false;
   bool should_have_cert_voted_in_this_round_ = false;
   bool next_voted_soft_value_ = false;
   bool next_voted_null_block_hash_ = false;
   bool go_finish_state_ = false;
   bool loop_back_finish_state_ = false;
   bool polling_state_print_log_ = true;
-
-  uint64_t max_wait_for_soft_voted_block_steps_ms_ = 30;
-  uint64_t max_wait_for_next_voted_block_steps_ms_ = 30;
 
   uint64_t pbft_round_last_requested_sync_ = 0;
   size_t pbft_step_last_requested_sync_ = 0;

--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -121,8 +121,14 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   std::pair<bool, uint64_t> getDagBlockPeriod(blk_hash_t const &hash);
 
   /**
-   * @brief Get PBFT round number
-   * @return PBFT round
+   * @brief Get current PBFT period number
+   * @return current PBFT period
+   */
+  uint64_t getPbftPeriod() const;
+
+  /**
+   * @brief Get current PBFT round number
+   * @return current PBFT round
    */
   uint64_t getPbftRound() const;
 
@@ -332,12 +338,16 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   bool advancePeriod();
 
   /**
-   * @brief Resets pbft consensus: current pbft round is set to round, step is set to the beginning value, in case
-   * period is provided, it is reset to the provided value
-   * @param round
-   * @param period
+   * @brief Check if there is 2t+1 cert votes for some valid block, if yes - push it into the chain
+   * @return true if new cert voted block was pushed into the chain, otheriwse false
    */
-  void resetPbftConsensus(uint64_t round, std::optional<u_int64_t> period = {});
+  bool tryPushCertVotesBlock();
+
+  /**
+   * @brief Resets pbft consensus: current pbft round is set to round, step is set to the beginning value
+   * @param round
+   */
+  void resetPbftConsensus(uint64_t round);
 
   /**
    * @brief Time to sleep for PBFT protocol
@@ -603,7 +613,6 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   PbftStates state_ = value_proposal_state;
 
   std::atomic<uint64_t> round_ = 1;
-  std::atomic<uint64_t> period_ = 1;
   size_t step_ = 1;
   size_t startingStepInRound_ = 1;
 

--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -437,9 +437,16 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
    * @param period PBFT period
    * @param round PBFT round
    * @param step PBFT step
-   * @return vote weight
+   * @param step PBFT step
    */
-  size_t placeVote_(blk_hash_t const &blockhash, PbftVoteTypes vote_type, uint64_t period, uint64_t round, size_t step);
+  std::shared_ptr<Vote> generateVoteWithWeight(blk_hash_t const &blockhash, PbftVoteTypes vote_type, uint64_t period,
+                                               uint64_t round, size_t step);
+
+  /**
+   * @brief Place (gossip) vote
+   * @param vote
+   */
+  void placeVote(std::shared_ptr<Vote> &&vote);
 
   /**
    * @brief Get current (based on the latest finalized block) PBFT sortition threshold

--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -251,12 +251,6 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   u_long getPbftInitialLambda() const { return LAMBDA_ms_MIN; }
 
   /**
-   * @brief Set last soft vote value of PBFT block hash
-   * @param soft_voted_value soft vote value of PBFT block hash
-   */
-  void setLastSoftVotedValue(blk_hash_t soft_voted_value);
-
-  /**
    * @brief Resume PBFT daemon. Only to be used for unit tests
    */
   void resume();
@@ -548,17 +542,6 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   bool is_syncing_();
 
   /**
-   * @brief Set initial time for voting value
-   */
-  void initializeVotedValueTimeouts_();
-
-  /**
-   * @brief Update last soft voting value
-   * @param new_soft_voted_value soft voting value
-   */
-  void updateLastSoftVotedValue_(blk_hash_t const new_soft_voted_value);
-
-  /**
    * @brief Check if previous round next voting value has been changed
    */
   void checkPreviousRoundNextVotedValueChange_();
@@ -637,11 +620,6 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
 
   time_point round_clock_initial_datetime_;
   time_point now_;
-
-  time_point time_began_waiting_next_voted_block_;
-  time_point time_began_waiting_soft_voted_block_;
-
-  blk_hash_t last_soft_voted_value_ = NULL_BLOCK_HASH;
 
   std::chrono::duration<double> duration_;
   u_long next_step_time_ms_ = 0;

--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -660,7 +660,7 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
 
   size_t sortition_threshold_ = 0;
   // 2t+1 minimum number of votes for consensus
-  size_t TWO_T_PLUS_ONE = 0;
+  size_t two_t_plus_one_ = 0;
 
   const blk_hash_t dag_genesis_block_hash_;
 

--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -323,19 +323,27 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   /**
    * @brief Reset PBFT step to 1
    */
-  void resetStep_();
+  void resetStep();
 
   /**
-   * @brief If node receives enough next voting votes on a forward PBFT round, set PBFT round to the round number.
-   * @return true if PBFT sets round to a forward round number
+   * @brief If node receives 2t+1 next votes for some block(including NULL_BLOCK_HASH), advance round to + 1.
+   * @return true if PBFT round advanced, otherwise false
    */
-  bool resetRound_();
+  bool advanceRound();
 
   /**
-   * @brief When a node executes a block, having received 2t+1 cert votes or a bundle of cert votes, 
-   *        then advances to next round
+   * @brief If node receives 2t+1 cert votes for some valid block and pushes it to the chain, advance period to + 1.
+   * @return true if PBFT period advanced, otherwise false
    */
-  void advancePeriod_();
+  bool advancePeriod();
+
+  /**
+   * @brief Resets pbft consensus: current pbft round is set to round, step is set to the beginning value, in case
+   * period is provided, it is reset to the provided value
+   * @param round
+   * @param period
+   */
+  void resetPbftConsensus(uint64_t round, std::optional<u_int64_t> period = {});
 
   /**
    * @brief Time to sleep for PBFT protocol
@@ -601,7 +609,7 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   std::default_random_engine random_engine_{std::random_device{}()};
 
   // Flag that says if node is in sync after it enters new round
-  //bool new_round_in_sync_ = false;
+  // bool new_round_in_sync_ = false;
 
   const size_t COMMITTEE_SIZE;
   const size_t NUMBER_OF_PROPOSERS;

--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -182,9 +182,16 @@ class VoteManager {
 
   /**
    * @brief Cleanup votes for previous PBFT rounds
+   * @param pbft_period current PBFT period
    * @param pbft_round current PBFT round
    */
-  void cleanupVotes(uint64_t pbft_period, uint64_t pbft_round);
+  void cleanupVotesByRound(uint64_t pbft_period, uint64_t pbft_round);
+
+  /**
+   * @brief Cleanup votes for previous PBFT periods
+   * @param pbft_period current PBFT period
+   */
+  void cleanupVotesByPeriod(uint64_t pbft_period);
 
   /**
    * @brief Get all verified votes in proposal vote type for the current PBFT round
@@ -303,19 +310,18 @@ class VoteManager {
   // TODO[1907]: this will be part of VerifiedVotes class
   // <PBFT period, <PBFT round, <PBFT step, <voted value, pair<voted weight, <vote hash, vote>>>>>
   std::map<uint64_t,
-           std::map<
-               uint64_t,
-               std::map<size_t,
-                        std::unordered_map<
-                            blk_hash_t, std::pair<uint64_t, std::unordered_map<vote_hash_t, std::shared_ptr<Vote>>>>>>>
+           std::map<uint64_t,
+                    std::map<size_t, std::unordered_map<
+                                         blk_hash_t,
+                                         std::pair<uint64_t, std::unordered_map<vote_hash_t, std::shared_ptr<Vote>>>>>>>
       verified_votes_;
   mutable boost::shared_mutex verified_votes_access_;
 
   // <PBFT period, <PBFT round, <PBFT step, <voter address, pair<vote 1, vote 2>>><>
   // For next votes we enable 2 votes per round & step, one of which must be vote for NULL_BLOCK_HASH
   std::map<uint64_t,
-            std::map<uint64_t, std::unordered_map<
-                         size_t, std::unordered_map<addr_t, std::pair<std::shared_ptr<Vote>, std::shared_ptr<Vote>>>>>>
+           std::map<uint64_t, std::unordered_map<size_t, std::unordered_map<addr_t, std::pair<std::shared_ptr<Vote>,
+                                                                                              std::shared_ptr<Vote>>>>>>
       voters_unique_votes_;
   mutable std::shared_mutex voters_unique_votes_mutex_;
   // TODO[1907]: end of VerifiedVotes class

--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -265,7 +265,7 @@ class VoteManager {
    *
    * @return vector of all reward votes
    */
-  std::vector<std::shared_ptr<Vote>> getRewardVotes();
+  std::vector<std::shared_ptr<Vote>> getAllRewardVotes();
 
   /**
    * @brief Get reward votes from specified hashes
@@ -273,14 +273,14 @@ class VoteManager {
    * @param vote_hashes votes hashes to retrieve
    * @return reward votes, if any of the votes is missing an empty array is returned
    */
-  std::vector<std::shared_ptr<Vote>> getRewardVotes(const std::vector<vote_hash_t>& vote_hashes);
+  std::vector<std::shared_ptr<Vote>> getRewardVotesByHashes(const std::vector<vote_hash_t>& vote_hashes);
 
   /**
-   * @brief Get reward votes from reward_votes_ with the last block round
+   * @brief Get reward votes from reward_votes_ with the round during which was the previous block pushed
    *
    * @return vector of reward votes
    */
-  std::vector<std::shared_ptr<Vote>> getRewardVotesWithLastBlockRound();
+  std::vector<std::shared_ptr<Vote>> getProposeRewardVotes();
 
   /**
    * @brief Send out all reward votes to peers
@@ -328,7 +328,7 @@ class VoteManager {
 
   // TODO[1907]: this will be part of RewardVotes class
   std::pair<blk_hash_t, uint64_t /* period */> reward_votes_pbft_block_;
-  uint64_t last_pbft_block_cert_round_;
+  uint64_t reward_votes_round_;  // round, during which was the block pushed into the chain
   std::unordered_map<vote_hash_t, std::shared_ptr<Vote>> reward_votes_;
   mutable std::shared_mutex reward_votes_mutex_;
   // TODO[1907]: end of RewardVotes class

--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -69,13 +69,6 @@ class NextVotesManager {
   size_t getNextVotesWeight() const;
 
   /**
-   * @brief Add a bunch of next voting type votes to the map
-   * @param next_votes next voting type votes
-   * @param pbft_2t_plus_1 PBFT 2t+1 is 2/3 of PBFT sortition threshold and plus 1
-   */
-  void addNextVotes(std::vector<std::shared_ptr<Vote>> const& next_votes, size_t pbft_2t_plus_1);
-
-  /**
    * @brief Update a bunch of next voting type votes to the map
    * @param next_votes next voting type votes
    * @param pbft_2t_plus_1 PBFT 2t+1 is 2/3 of PBFT sortition threshold and plus 1
@@ -88,6 +81,13 @@ class NextVotesManager {
    * @param pbft_2t_plus_1 PBFT 2t+1 is 2/3 of PBFT sortition threshold and plus 1
    */
   void updateWithSyncedVotes(std::vector<std::shared_ptr<Vote>>& votes, size_t pbft_2t_plus_1);
+
+  /**
+   * @brief Add a bunch of next voting type votes to the map
+   * @param next_votes next voting type votes
+   * @param pbft_2t_plus_1 PBFT 2t+1 is 2/3 of PBFT sortition threshold and plus 1
+   */
+  void addNextVotes(std::vector<std::shared_ptr<Vote>> const& next_votes, size_t pbft_2t_plus_1);
 
  private:
   using UniqueLock = boost::unique_lock<boost::shared_mutex>;

--- a/libraries/core_libs/consensus/src/pbft/pbft_chain.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_chain.cpp
@@ -89,16 +89,18 @@ void PbftChain::updatePbftChain(blk_hash_t const& pbft_block_hash, bool null_anc
 
 bool PbftChain::checkPbftBlockValidation(taraxa::PbftBlock const& pbft_block) const {
   if (getPbftChainSize() + 1 != pbft_block.getPeriod()) {
-    LOG(log_wr_) << "Pbft validation failed. PBFT chain size " << getPbftChainSize()
+    LOG(log_er_) << "Pbft validation failed. PBFT chain size " << getPbftChainSize()
                  << ". Pbft block period: " << pbft_block.getPeriod() << " for block " << pbft_block.getBlockHash();
     return false;
   }
+
   auto last_pbft_block_hash = getLastPbftBlockHash();
   if (pbft_block.getPrevBlockHash() != last_pbft_block_hash) {
     LOG(log_er_) << "PBFT chain last block hash " << last_pbft_block_hash << " Invalid PBFT prev block hash "
                  << pbft_block.getPrevBlockHash() << " in block " << pbft_block.getBlockHash();
     return false;
   }
+
   return true;
 }
 

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -766,14 +766,16 @@ void PbftManager::proposeBlock_() {
     proposed_block_ = proposePbftBlock_();
 
     if (proposed_block_) {
-      if (auto vote_weight = placeVote_(proposed_block_->getBlockHash(), propose_vote_type, period, round, step_);
-          vote_weight) {
+      if (auto vote = generateVoteWithWeight(proposed_block_->getBlockHash(), propose_vote_type, period, round, step_);
+          vote) {
         LOG(log_nf_) << "Placed propose vote for new block " << proposed_block_->getBlockHash() << ", vote weight "
-                     << vote_weight << ", period " << period << ", round " << round << ", step " << step_;
+                     << *vote->getWeight() << ", period " << period << ", round " << round << ", step " << step_;
 
         // broadcast pbft block
         if (auto net = network_.lock()) {
+          // In propose step, send block before vote as we require block to be present during vote validation
           net->getSpecificHandler<network::tarcap::PbftBlockPacketHandler>()->onNewPbftBlock(proposed_block_);
+          net->getSpecificHandler<network::tarcap::VotePacketHandler>()->onNewPbftVotes({std::move(vote)});
         }
       }
     }
@@ -799,15 +801,18 @@ void PbftManager::proposeBlock_() {
       }
     }
 
-    if (auto vote_weight = placeVote_(previous_round_next_voted_value_.first, propose_vote_type, period, round, step_);
-        vote_weight) {
+    if (auto vote =
+            generateVoteWithWeight(previous_round_next_voted_value_.first, propose_vote_type, period, round, step_);
+        vote) {
       LOG(log_nf_) << "Placed propose vote for previous round next voted value "
-                   << previous_round_next_voted_value_.first << ", vote weight " << vote_weight << ", period " << period
-                   << ", round " << round << ", step " << step_;
+                   << previous_round_next_voted_value_.first << ", vote weight " << *vote->getWeight() << ", period "
+                   << period << ", round " << round << ", step " << step_;
 
       // broadcast pbft block
       if (auto net = network_.lock()) {
+        // In propose step, send block before vote as we require block to be present during vote validation
         net->getSpecificHandler<network::tarcap::PbftBlockPacketHandler>()->onNewPbftBlock(pbft_block);
+        net->getSpecificHandler<network::tarcap::VotePacketHandler>()->onNewPbftVotes({std::move(vote)});
       }
     }
     return;
@@ -830,10 +835,11 @@ void PbftManager::identifyBlock_() {
       LOG(log_dg_) << "Leader block identified " << leader_block_hash << ", round " << round << ", period "
                    << leader_block_period;
 
-      if (auto vote_weight = placeVote_(leader_block_hash, soft_vote_type, leader_block_period, round, step_);
-          vote_weight) {
-        LOG(log_nf_) << "Placed soft vote for " << leader_block_hash << ", vote weight " << vote_weight << ", round "
-                     << round << ", period " << leader_block_period << ", step " << step_;
+      if (auto vote = generateVoteWithWeight(leader_block_hash, soft_vote_type, leader_block_period, round, step_);
+          vote) {
+        LOG(log_nf_) << "Placed soft vote for " << leader_block_hash << ", vote weight " << *vote->getWeight()
+                     << ", round " << round << ", period " << leader_block_period << ", step " << step_;
+        placeVote(std::move(vote));
       }
     }
 
@@ -846,11 +852,12 @@ void PbftManager::identifyBlock_() {
     return;
   }
 
-  if (auto vote_weight = placeVote_(previous_round_next_voted_value_.first, soft_vote_type,
-                                    previous_round_next_voted_value_.second, round, step_);
-      vote_weight) {
+  if (auto vote = generateVoteWithWeight(previous_round_next_voted_value_.first, soft_vote_type,
+                                         previous_round_next_voted_value_.second, round, step_);
+      vote) {
+    placeVote(std::move(vote));
     LOG(log_nf_) << "Placed soft vote for block from previous round " << previous_round_next_voted_value_.first
-                 << ", vote weight " << vote_weight << ", round " << round << ", period "
+                 << ", vote weight " << *vote->getWeight() << ", round " << round << ", period "
                  << previous_round_next_voted_value_.second << ", step " << step_;
   }
 }
@@ -952,10 +959,11 @@ void PbftManager::certifyBlock_() {
     should_have_cert_voted_in_this_round_ = true;
 
     // generate cert vote
-    if (auto vote_weight =
-            placeVote_(cert_voted_block->getBlockHash(), cert_vote_type, cert_voted_block->getPeriod(), round, step_);
-        vote_weight) {
-      LOG(log_nf_) << "Placed cert vote " << cert_voted_block->getBlockHash() << ", vote weight " << vote_weight
+    if (auto vote = generateVoteWithWeight(cert_voted_block->getBlockHash(), cert_vote_type,
+                                           cert_voted_block->getPeriod(), round, step_);
+        vote) {
+      placeVote(std::move(vote));
+      LOG(log_nf_) << "Placed cert vote " << cert_voted_block->getBlockHash() << ", vote weight " << *vote->getWeight()
                    << ", round " << round << ", period " << cert_voted_block->getPeriod() << ", step " << step_;
     }
   }
@@ -977,9 +985,13 @@ void PbftManager::firstFinish_() {
       vote_value = NULL_BLOCK_HASH;
     }
 
-    if (auto vote_weight = placeVote_(vote_value, next_vote_type, next_round_period, round, step_); vote_weight) {
-      LOG(log_nf_) << "Placed first finish next vote for " << vote_value << ", vote weight " << vote_weight
-                   << ", round " << round << ", period " << next_round_period << ", step " << step_;
+    if (auto vote = generateVoteWithWeight(vote_value, next_vote_type, next_round_period,
+                                           round, step_);
+        vote) {
+      placeVote(std::move(vote));
+      LOG(log_nf_) << "Placed first finish next vote for " << vote_value << ", vote weight "
+                   << *vote->getWeight() << ", round " << round << ", period " << next_round_period
+                   << ", step " << step_;
     }
 
     // Re-broadcast pbft block in case some nodes do not have it
@@ -995,16 +1007,18 @@ void PbftManager::firstFinish_() {
   } else if (round == 1 || (round >= 2 && (previous_round_next_voted_value_.first == NULL_BLOCK_HASH))) {
     // Starting value in round 1 is always null block hash... So combined with other condition for next
     // voting null block hash...
-    if (auto vote_weight = placeVote_(NULL_BLOCK_HASH, next_vote_type, next_round_period, round, step_); vote_weight) {
-      LOG(log_nf_) << "Placed first finish next vote for " << NULL_BLOCK_HASH << ", vote weight " << vote_weight
+    if (auto vote = generateVoteWithWeight(NULL_BLOCK_HASH, next_vote_type, next_round_period, round, step_); vote) {
+      placeVote(std::move(vote));
+      LOG(log_nf_) << "Placed first finish next vote for " << NULL_BLOCK_HASH << ", vote weight " << *vote->getWeight()
                    << ", round " << round << ", period " << next_round_period << ", step " << step_;
     }
   } else {
-    if (auto vote_weight =
-            placeVote_(previous_round_next_voted_value_.first, next_vote_type, next_round_period, round, step_);
-        vote_weight) {
+    if (auto vote = generateVoteWithWeight(previous_round_next_voted_value_.first, next_vote_type, next_round_period,
+                                           round, step_);
+        vote) {
+      placeVote(std::move(vote));
       LOG(log_nf_) << "Placed first finish next vote for " << previous_round_next_voted_value_.first.abridged()
-                   << ", vote weight " << vote_weight << ", round " << round << ", period " << next_round_period
+                   << ", vote weight " << *vote->getWeight() << ", round " << round << ", period " << next_round_period
                    << ", step " << step_;
     }
   }
@@ -1043,19 +1057,20 @@ void PbftManager::secondFinish_() {
     }
 
     if (!next_voted_soft_value_) {
-      if (auto vote_weight = placeVote_(current_round_soft_voted_block, next_vote_type, period, round, step_);
-          vote_weight) {
+      if (auto vote = generateVoteWithWeight(current_round_soft_voted_block, next_vote_type, period, round, step_);
+          vote) {
+        placeVote(std::move(vote));
         LOG(log_nf_) << "Placed second finish vote for " << current_round_soft_voted_block << ", vote weight "
-                     << vote_weight << ", period " << period << ", round " << round << ", step " << step_;
-
+                     << *vote->getWeight() << ", period " << period << ", round " << round << ", step " << step_;
         db_->savePbftMgrStatus(PbftMgrStatus::NextVotedSoftValue, true);
         next_voted_soft_value_ = true;
       }
     }
   } else if (!next_voted_null_block_hash_ && round >= 2 &&
              (previous_round_next_voted_value_.first == NULL_BLOCK_HASH) && !cert_voted_block_for_round_.has_value()) {
-    if (auto vote_weight = placeVote_(NULL_BLOCK_HASH, next_vote_type, next_round_period, round, step_); vote_weight) {
-      LOG(log_nf_) << "Placed second finish next vote for " << NULL_BLOCK_HASH << ", vote weight " << vote_weight
+    if (auto vote = generateVoteWithWeight(NULL_BLOCK_HASH, next_vote_type, next_round_period, round, step_); vote) {
+      placeVote(std::move(vote));
+      LOG(log_nf_) << "Placed second finish next vote for " << NULL_BLOCK_HASH << ", vote weight " << *vote->getWeight()
                    << ", period " << next_round_period << ", round " << round << ", step " << step_;
       db_->savePbftMgrStatus(PbftMgrStatus::NextVotedNullBlockHash, true);
       next_voted_null_block_hash_ = true;
@@ -1177,8 +1192,8 @@ uint64_t PbftManager::getPbftSortitionThreshold(PbftVoteTypes vote_type, uint64_
   }
 }
 
-size_t PbftManager::placeVote_(taraxa::blk_hash_t const &blockhash, PbftVoteTypes vote_type, uint64_t period,
-                               uint64_t round, size_t step) {
+std::shared_ptr<Vote> PbftManager::generateVoteWithWeight(taraxa::blk_hash_t const &blockhash, PbftVoteTypes vote_type,
+                                                          uint64_t period, uint64_t round, size_t step) {
   uint64_t voter_dpos_votes_count = 0;
   uint64_t total_dpos_votes_count = 0;
   uint64_t pbft_sortition_threshold = 0;
@@ -1196,12 +1211,12 @@ size_t PbftManager::placeVote_(taraxa::blk_hash_t const &blockhash, PbftVoteType
                  << "Period  is too far ahead of actual finalized pbft chain size ("
                  << final_chain_->last_block_number() << "). Err msg: " << e.what();
 
-    return 0;
+    return nullptr;
   }
 
   if (!voter_dpos_votes_count) {
     // No delegation
-    return 0;
+    return nullptr;
   }
 
   auto vote = generateVote(blockhash, vote_type, period, round, step);
@@ -1211,19 +1226,22 @@ size_t PbftManager::placeVote_(taraxa::blk_hash_t const &blockhash, PbftVoteType
     if (auto is_unique_vote = vote_mgr_->isUniqueVote(vote); is_unique_vote.first) {
       db_->saveVerifiedVote(vote);
       vote_mgr_->addVerifiedVote(vote);
-      if (auto net = network_.lock()) {
-        net->getSpecificHandler<network::tarcap::VotePacketHandler>()->onNewPbftVotes({std::move(vote)});
-      }
     } else {
       // This should never happen
       LOG(log_er_) << "Generated vote " << vote->getHash().abridged()
                    << " is not unique. Err: " << is_unique_vote.second;
       assert(false);
-      return 0;
+      return nullptr;
     }
   }
 
-  return weight;
+  return vote;
+}
+
+void PbftManager::placeVote(std::shared_ptr<Vote> &&vote) {
+  if (auto net = network_.lock()) {
+    net->getSpecificHandler<network::tarcap::VotePacketHandler>()->onNewPbftVotes({std::move(vote)});
+  }
 }
 
 blk_hash_t PbftManager::calculateOrderHash(const std::vector<blk_hash_t> &dag_block_hashes,

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -555,7 +555,7 @@ void PbftManager::initialState() {
   next_step_time_ms_ = 0;
 
   updateDposState_();
-  // Initializetwo_t_plus_one_and sortition_threshold
+  // Initialize two_t_plus_one_and sortition_threshold
   updateTwoTPlusOneAndThreshold_();
 
   if (round > 1) {

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -410,33 +410,16 @@ void PbftManager::resetPbftConsensus(uint64_t round) {
                << ", step 1, and resetting clock.";
   round_clock_initial_datetime_ = now_;
 
-  auto batch = db_->createWriteBatch();
-
-  // Round is set to 1 if period advanced - clean all next votes
-  if (round == 1) {
-    const uint64_t previous_period_last_round = round_;
-    db_->removeNextVotesToBatch(previous_period_last_round - 1, batch);
-  } else if (round > 1) { // save previous round votes
-    // Save previous rounf next votes
-    auto next_votes = next_votes_manager_->getNextVotes();
-    db_->addNextVotesToBatch(round - 1, next_votes, batch);
-
-    // Cleanup old previous previous round next votes
-    if (round > 2) {
-      db_->removeNextVotesToBatch(round - 2, batch);
-    }
-  }
-
   // Update current round and reset step to 1
   round_ = round;
   resetStep();
   state_ = value_proposal_state;
 
+  auto batch = db_->createWriteBatch();
+
   // Update in DB first
   db_->addPbftMgrFieldToBatch(PbftMgrRoundStep::PbftRound, round, batch);
   db_->addPbftMgrFieldToBatch(PbftMgrRoundStep::PbftStep, 1, batch);
-
-
 
   db_->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundSortitionThreshold, sortition_threshold_,
                                      batch);
@@ -577,10 +560,7 @@ void PbftManager::initialState() {
 
   if (round > 1) {
     // Get next votes for previous round from DB
-
-    // CONCERN: Cleanup of next votes from previous rounds and periods?
-    //          Since we reset round now back to 1, we need to be sure we clean them up!
-    auto next_votes_in_previous_round = db_->getNextVotes(round - 1);
+    auto next_votes_in_previous_round = db_->getPreviousRoundNextVotes();
     if (next_votes_in_previous_round.empty()) {
       LOG(log_er_) << "Cannot get any next votes in previous round " << round - 1 << ". For period " << getPbftPeriod()
                    << " step " << step;

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -286,7 +286,6 @@ void PbftManager::setSortitionThreshold(size_t const sortition_threshold) {
 }
 
 void PbftManager::updateDposState_() {
-  // CONCERN: Is this choice correct?  How do we handle validation across periods?
   dpos_period_ = pbft_chain_->getPbftChainSize();
   do {
     try {
@@ -340,7 +339,7 @@ void PbftManager::setPbftStep(size_t const pbft_step) {
   }
 }
 
-void PbftManager::resetStep_() {
+void PbftManager::resetStep() {
   last_step_ = step_;
   step_ = 1;
   startingStepInRound_ = 1;
@@ -349,44 +348,94 @@ void PbftManager::resetStep_() {
   LAMBDA_backoff_multiple = 1;
 }
 
-bool PbftManager::resetRound_() {
+bool PbftManager::advancePeriod() {
+  const auto [current_pbft_round, current_pbft_period] = getPbftRoundAndPeriod();
 
-  // CONCERN accessor for period?  
-  auto determined_round = vote_mgr_->determineRoundFromPeriodAndVotes(period_, TWO_T_PLUS_ONE);
-  
-  // current round
-  auto round = getPbftRound();
-  
-  if (determined_round <= round) {
+  if (auto certified_block = vote_mgr_->getVotesBundle(current_pbft_round, current_pbft_period, 3, TWO_T_PLUS_ONE);
+      certified_block.has_value()) {
+    LOG(log_dg_) << "Found enough cert votes for PBFT block " << certified_block->voted_block_hash << ", round "
+                 << current_pbft_round << ", period " << current_pbft_period;
+
+    // Puts pbft block into chain
+    if (pushCertVotedPbftBlockIntoChain_(certified_block->voted_block_hash, std::move(certified_block->votes))) {
+      duration_ = std::chrono::system_clock::now() - now_;
+      auto execute_trxs_in_ms = std::chrono::duration_cast<std::chrono::milliseconds>(duration_).count();
+      LOG(log_dg_) << "PBFT block " << certified_block->voted_block_hash << " certified and pushed into chain in round "
+                   << current_pbft_round << ". Execution time " << execute_trxs_in_ms << " [ms]";
+    } else {
+      LOG(log_er_) << "PBFT block " << certified_block->voted_block_hash
+                   << " certified but not pushed into chain in round " << current_pbft_round;
+    }
+  }
+
+  // Even if node did not see 2t+1 cert votes, chain size might be increased through syncing
+  auto new_period = pbft_chain_->getPbftChainSize() + 1;
+
+  // Chain size was not increased
+  if (new_period <= current_pbft_period) {
+    LOG(log_tr_) << "Period did not advance. current_pbft_period " << current_pbft_period << ", new_period "
+                 << new_period;
     return false;
   }
 
-  LOG(log_nf_) << "Determined round to be: " << determined_round << ", in period " << period_;
+  LOG(log_nf_) << "Period advanced to: " << new_period << ", round reset to 1, previous period " << current_pbft_period;
+
+  resetPbftConsensus(1, {new_period});
+
+  // Move to a new period, cleanup previous period votes
+  vote_mgr_->cleanupVotesByPeriod(new_period);
+
+  // Restart while loop...
+  return true;
+}
+
+bool PbftManager::advanceRound() {
+  const auto [current_pbft_round, current_pbft_period] = getPbftRoundAndPeriod();
+
+  // CONCERN accessor for period?
+  auto determined_round = vote_mgr_->determineRoundFromPeriodAndVotes(current_pbft_period, TWO_T_PLUS_ONE);
+
+  if (determined_round <= current_pbft_round) {
+    return false;
+  }
+
+  LOG(log_nf_) << "Round advanced to: " << determined_round << ", period " << current_pbft_period;
+
+  resetPbftConsensus(determined_round);
+
+  // Move to a new round, cleanup previous round votes
+  vote_mgr_->cleanupVotesByRound(current_pbft_period, determined_round);
+
+  // Restart while loop...
+  return true;
+}
+
+void PbftManager::resetPbftConsensus(uint64_t round, std::optional<u_int64_t> period) {
+  LOG(log_dg_) << "Set pbft round to " << round << ", period " << period_ << ", step 1, and resetting clock.";
   round_clock_initial_datetime_ = now_;
+
+  auto batch = db_->createWriteBatch();
+
+  // Update current period if value provided
+  if (period.has_value()) {
+    period_ = *period;
+    db_->addPbftMgrFieldToBatch(PbftMgrRoundStep::PbftPeriod, period_, batch);
+  }
+
   // Update current round and reset step to 1
-  round_ = determined_round;
-  
-  resetStep_();
+  round_ = round;
+  resetStep();
   state_ = value_proposal_state;
 
-  LOG(log_dg_) << "Advancing clock to pbft round " << determined_round << ", period " << period_
-               << ", step 1, and resetting clock.";
-
-  const auto previous_round = determined_round - 1;
-
+  const auto previous_round = round - 1;
   auto next_votes = next_votes_manager_->getNextVotes();
 
   // Update in DB first
-  auto batch = db_->createWriteBatch();
-
-  // Update PBFT round and reset step to 1
-  
-  //CONCERN: Not necessary now...
-  //db_->addPbftMgrFieldToBatch(PbftMgrRoundStep::PbftPeriod, period_, batch);
-  db_->addPbftMgrFieldToBatch(PbftMgrRoundStep::PbftRound, determined_round, batch);
+  db_->addPbftMgrFieldToBatch(PbftMgrRoundStep::PbftRound, round, batch);
   db_->addPbftMgrFieldToBatch(PbftMgrRoundStep::PbftStep, 1, batch);
 
   db_->addNextVotesToBatch(previous_round, next_votes, batch);
+  // TODO: should be probably refactored
   if (round > 1) {
     // Cleanup old previous round next votes
     db_->removeNextVotesToBatch(round - 1, batch);
@@ -397,39 +446,37 @@ bool PbftManager::resetRound_() {
   db_->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposPeriod, dpos_period_.load(), batch);
   db_->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposTotalVotesCount,
                                      getDposTotalVotesCount(), batch);
-  //db_->addPbftMgrVotedValueToBatch(PbftMgrVotedValue::OwnStartingValueInRound, {NULL_BLOCK_HASH, determined_period}, batch);
   db_->addPbftMgrStatusToBatch(PbftMgrStatus::NextVotedNullBlockHash, false, batch);
   db_->addPbftMgrStatusToBatch(PbftMgrStatus::NextVotedSoftValue, false, batch);
 
-  db_->removePbftMgrVotedValueToBatch(PbftMgrVotedValue::SoftVotedBlockInRound, batch);
-  db_->removePbftMgrVotedValueToBatch(PbftMgrVotedValue::CertVotedBlockInRound, batch);
+  // Reset cert voted block in the new upcoming round
+  if (cert_voted_block_for_round_.has_value() &&
+      cert_voted_block_for_round_->second <= pbft_chain_->getPbftChainSize()) {
+    db_->removePbftMgrVotedValueToBatch(PbftMgrVotedValue::CertVotedBlockInRound, batch);
 
-  if (soft_voted_block_for_round_) {
+    cert_voted_block_for_round_.reset();
+  }
+
+  // Reset soft voted block in the new upcoming round
+  if (soft_voted_block_for_round_.has_value()) {
     // Cleanup soft votes for previous round
     db_->removeSoftVotesToBatch(round, batch);
+    db_->removePbftMgrVotedValueToBatch(PbftMgrVotedValue::SoftVotedBlockInRound, batch);
+
+    soft_voted_block_for_round_.reset();
   }
   db_->commitWriteBatch(batch);
 
   should_have_cert_voted_in_this_round_ = false;
-  
+
   // reset next voted value since start a new round
   // these are used to prevent voting multiple times while polling through the step
   // under current implementation.
   // TODO: Get rid of this way of doing it!
   next_voted_null_block_hash_ = false;
   next_voted_soft_value_ = false;
-  
+
   polling_state_print_log_ = true;
-
-  // Reset soft voting leader & cert voted block values in the new upcoming round
-  soft_voted_block_for_round_.reset();
-  if (cert_voted_block_for_round_.has_value() &&
-      cert_voted_block_for_round_->second <= pbft_chain_->getPbftChainSize()) {
-    cert_voted_block_for_round_.reset();
-  }
-
-  // Move to a new round, cleanup previous round votes
-  vote_mgr_->cleanupVotes(period_, determined_round);
 
   if (executed_pbft_block_) {
     updateDposState_();
@@ -441,26 +488,6 @@ bool PbftManager::resetRound_() {
 
   last_step_clock_initial_datetime_ = current_step_clock_initial_datetime_;
   current_step_clock_initial_datetime_ = std::chrono::system_clock::now();
-
-  // Restart while loop...
-  return true;
-}
-
-void PbftManager::advancePeriod_() {
-  auto new_period = pbft_chain_->getPbftChainSize();
-  
-  // Update in DB first
-  auto batch = db_->createWriteBatch();
-  db_->addPbftMgrFieldToBatch(PbftMgrRoundStep::PbftPeriod, new_period, batch);
-  db_->addPbft2TPlus1ToBatchForPeriod(period_, TWO_T_PLUS_ONE, batch);
-  db_->commitWriteBatch(batch);
-
-  assert(new_period == period_ + 1); 
-  LOG(log_nf_) << "Period advanced to: " << new_period;
-
-  period_ = new_period;
-
-  resetRound_();
 }
 
 void PbftManager::sleep_() {
@@ -485,9 +512,9 @@ void PbftManager::initialState() {
 
   // Time constants...
   LAMBDA_ms = LAMBDA_ms_MIN;
-  
+
   auto round = db_->getPbftMgrField(PbftMgrRoundStep::PbftRound);
-  auto previous_round_period = db_->getPbftMgrField(PbftMgrRoundStep::PbftPeriod);
+  auto period = db_->getPbftMgrField(PbftMgrRoundStep::PbftPeriod);
   auto step = db_->getPbftMgrField(PbftMgrRoundStep::PbftStep);
 
   if (round == 1 && step == 1) {
@@ -512,7 +539,7 @@ void PbftManager::initialState() {
   startingStepInRound_ = step;
   setPbftStep(step);
   round_ = round;
-  period_ = previous_round_period;
+  period_ = period;
 
   if (round > 1) {
     // Get next votes for previous round from DB
@@ -525,7 +552,7 @@ void PbftManager::initialState() {
                    << " step " << step;
       assert(false);
     }
-    auto previous_round_2t_plus_1 = db_->getPbft2TPlus1ForPeriod(period_);
+    auto previous_round_2t_plus_1 = db_->getPbft2TPlus1ForPeriod(period);
     if (previous_round_2t_plus_1 == 0) {
       LOG(log_er_) << "Cannot get PBFT 2t+1 in previous round " << round - 1 << ". For period " << period_ << " step "
                    << step;
@@ -537,7 +564,7 @@ void PbftManager::initialState() {
   previous_round_next_voted_value_ = next_votes_manager_->getVotedValue();
   previous_round_next_voted_null_block_hash_ = next_votes_manager_->haveEnoughVotesForNullBlockHash();
 
-  LOG(log_nf_) << "Node initialize at round " << round << ", r-1 period " << previous_round_period << ", step " << step
+  LOG(log_nf_) << "Node initialize at round " << round << ", period " << period << ", step " << step
                << ". Previous round has enough next votes for NULL_BLOCK_HASH: " << std::boolalpha
                << next_votes_manager_->haveEnoughVotesForNullBlockHash() << ", voted value "
                << previous_round_next_voted_value_ << ", next votes size in previous round is "
@@ -546,19 +573,6 @@ void PbftManager::initialState() {
   // Initial last sync request
   pbft_round_last_requested_sync_ = 0;
   pbft_step_last_requested_sync_ = 0;
-
-  /*
-  TODO: Remove this column from db?
-  auto own_starting_value = db_->getPbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound);
-  if (own_starting_value.has_value()) {
-    // From DB
-    own_starting_value_for_round_ = *own_starting_value;
-  } else {
-    // Default value
-    assert(round == 1);
-    own_starting_value_for_round_ = {NULL_BLOCK_HASH, 1};
-  }
-  */
 
   auto soft_voted_block = db_->getPbftMgrVotedValue(PbftMgrVotedValue::SoftVotedBlockInRound);
   if (soft_voted_block.has_value()) {
@@ -709,38 +723,15 @@ bool PbftManager::stateOperations_() {
   elapsed_time_in_round_ms_ = std::chrono::duration_cast<std::chrono::milliseconds>(duration_).count();
 
   auto [round, period] = getPbftRoundAndPeriod();
-  LOG(log_tr_) << "PBFT current round(r): " << round << ", period: " << period << ", step " << step_;
+  LOG(log_tr_) << "PBFT current round: " << round << ", period: " << period << ", step " << step_;
 
-  // Remove old votes
-  vote_mgr_->cleanupVotes(period, round);
-
-  if (auto certified_block = vote_mgr_->getVotesBundle(round, period, 3, TWO_T_PLUS_ONE); certified_block.has_value()) {
-    LOG(log_dg_) << "PBFT block " << certified_block->voted_block_hash << " has enough cert votes";
-    // put pbft block into chain
-    if (pushCertVotedPbftBlockIntoChain_(certified_block->voted_block_hash, std::move(certified_block->votes))) {
-      LOG(log_nf_) << "Write " << certified_block->votes.size() << " cert votes ... in round " << round;
-
-      duration_ = std::chrono::system_clock::now() - now_;
-      auto execute_trxs_in_ms = std::chrono::duration_cast<std::chrono::milliseconds>(duration_).count();
-      LOG(log_dg_) << "PBFT block " << certified_block->voted_block_hash << " certified and pushed into chain in round "
-                   << round << ". Execution time " << execute_trxs_in_ms << " [ms]";
-
-      advancePeriod_();
-
-      // Restart while loop  CONCERN: still need to do that?
-      return true;
-    
-    } else {
-      LOG(log_er_) << "PBFT block " << certified_block->voted_block_hash
-                   << " certified but not pushed into chain in round " << round;
-
-      // CONCERN: How would we get here?
-      assert(false);
-    }
+  // New block was pushed either through syncing or through seeing 2t+1 cert votes
+  if (advancePeriod()) {
+    return true;
   }
 
-  if (resetRound_()) {
-    //new_round_in_sync_ = false;
+  // 2t+1 next votes were seen
+  if (advanceRound()) {
     return true;
   }
 
@@ -812,87 +803,77 @@ void PbftManager::checkPreviousRoundNextVotedValueChange_() {
 void PbftManager::proposeBlock_() {
   // Value Proposal
   auto [round, period] = getPbftRoundAndPeriod();
-  LOG(log_dg_) << "PBFT value proposal state in round(r): " << round << ", period: " << period;
+  LOG(log_dg_) << "PBFT value proposal state in round: " << round << ", period: " << period;
 
   if (round == 1 || next_votes_manager_->haveEnoughVotesForNullBlockHash()) {
-    
-    if (round > 1) { 
+    if (round > 1) {
       LOG(log_nf_) << "Previous round " << round - 1 << " had next voted NULL_BLOCK_HASH";
     }
 
     proposed_block_ = proposePbftBlock_();
-    
+
     if (proposed_block_) {
-      if (auto vote_weight = placeVote_(proposed_block_->getBlockHash(), propose_vote_type,
-                                        period, round, step_);
+      if (auto vote_weight = placeVote_(proposed_block_->getBlockHash(), propose_vote_type, period, round, step_);
           vote_weight) {
         LOG(log_nf_) << "Placed propose vote for new block " << proposed_block_->getBlockHash() << ", vote weight "
-                     << vote_weight << ", period " << period << ", round " << round << ", step "
-                     << step_;
+                     << vote_weight << ", period " << period << ", round " << round << ", step " << step_;
 
         // broadcast pbft block
         if (auto net = network_.lock()) {
           net->getSpecificHandler<network::tarcap::PbftBlockPacketHandler>()->onNewPbftBlock(proposed_block_);
         }
-
       }
     }
     return;
-  } else if (previous_round_next_voted_value_.first) {  
+  } else if (previous_round_next_voted_value_.first) {
     // Round greater than 1 and next voted some value that is not null block hash
-  
+
     LOG(log_nf_) << "Previous round " << round - 1 << " next voted block is " << previous_round_next_voted_value_.first;
 
     auto pbft_block = pbft_chain_->getUnverifiedPbftBlock(previous_round_next_voted_value_.first);
     if (!pbft_block) {
       LOG(log_dg_) << "Unable to find proposal block " << previous_round_next_voted_value_.first
                    << " from previous round in unverified queue";
-      
+
       pbft_block = db_->getPbftCertVotedBlock(previous_round_next_voted_value_.first);
       if (!pbft_block) {
         LOG(log_dg_) << "Unable to find proposal block " << previous_round_next_voted_value_.first
                      << " from previous round in database";
-        
+
         LOG(log_dg_) << "Unable to find proposal block " << previous_round_next_voted_value_.first
-                     << " from previous round in either unverified queue or database, will not propose it";        
+                     << " from previous round in either unverified queue or database, will not propose it";
         return;
       }
     }
 
-    if (auto vote_weight = placeVote_(previous_round_next_voted_value_.first, propose_vote_type,
-                                      period, round, step_);
+    if (auto vote_weight = placeVote_(previous_round_next_voted_value_.first, propose_vote_type, period, round, step_);
         vote_weight) {
-      LOG(log_nf_) << "Placed propose vote for previous round next voted value " << previous_round_next_voted_value_.first << ", vote weight "
-                   << vote_weight << ", period " << period << ", round " << round << ", step "
-                   << step_;
-
+      LOG(log_nf_) << "Placed propose vote for previous round next voted value "
+                   << previous_round_next_voted_value_.first << ", vote weight " << vote_weight << ", period " << period
+                   << ", round " << round << ", step " << step_;
 
       // broadcast pbft block
       if (auto net = network_.lock()) {
         net->getSpecificHandler<network::tarcap::PbftBlockPacketHandler>()->onNewPbftBlock(pbft_block);
       }
-
     }
     return;
   } else {
     LOG(log_er_) << "Previous round " << round - 1 << " doesn't have enough next votes";
     assert(false);
   }
-
 }
 
 void PbftManager::identifyBlock_() {
   // The Filtering Step
   auto [round, period] = getPbftRoundAndPeriod();
-  LOG(log_dg_) << "PBFT filtering state in round(r): " << round << ", period: " << period;
-
+  LOG(log_dg_) << "PBFT filtering state in round: " << round << ", period: " << period;
 
   if (round == 1 || next_votes_manager_->haveEnoughVotesForNullBlockHash()) {
     // Identity leader
     if (auto leader_block = identifyLeaderBlock_(round, period); leader_block.has_value()) {
       auto [leader_block_hash, leader_block_period] = *leader_block;
-      //own_starting_value_for_round_ = {leader_block_hash, leader_block_period};
-      //db_->savePbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound, own_starting_value_for_round_);
+
       LOG(log_dg_) << "Leader block identified " << leader_block_hash << ", round " << round << ", period "
                    << leader_block_period;
 
@@ -931,7 +912,7 @@ void PbftManager::identifyBlock_() {
 void PbftManager::certifyBlock_() {
   // The Certifying Step
   auto [round, period] = getPbftRoundAndPeriod();
-  LOG(log_dg_) << "PBFT certifying state in round(r): " << round << ", period: " << period;
+  LOG(log_dg_) << "PBFT certifying state in round: " << round << ", period: " << period;
 
   go_finish_state_ = elapsed_time_in_round_ms_ > 4 * LAMBDA_ms - POLLING_INTERVAL_ms;
 
@@ -969,13 +950,12 @@ void PbftManager::certifyBlock_() {
 
   LOG(log_tr_) << "Finished compareBlocksAndRewardVotes_";
 
-  
-  // TODO CONCERN: If we do happen to see 2t+1 cert votes for a value before we have manged 
+  // TODO CONCERN: If we do happen to see 2t+1 cert votes for a value before we have manged
   //               to cert vote it on our own, then we should issue a reward vote to our self no?
   /*
   // NOTE: If we have already executed this round then block won't be found in unverified queue...
   bool executed_soft_voted_block_for_this_round = false;
-  
+
   if (have_executed_this_round_) {
     LOG(log_tr_) << "Have already executed before certifying in step 3 in round " << round;
     auto last_pbft_block_hash = pbft_chain_->getLastPbftBlockHash();
@@ -986,7 +966,7 @@ void PbftManager::certifyBlock_() {
   }*/
 
   auto last_pbft_block_hash = pbft_chain_->getLastPbftBlockHash();
-  if(last_pbft_block_hash == current_round_soft_voted_block) {
+  if (last_pbft_block_hash == current_round_soft_voted_block) {
     LOG(log_er_) << "In certify step, soft voted block is already in chain!" << round;
     assert(false);
   }
@@ -1002,7 +982,7 @@ void PbftManager::certifyBlock_() {
     }
     syncPbftChainFromPeers_(invalid_soft_voted_block, current_round_soft_voted_block);
   }
-  
+
   // CONCERN: We really should avoid doing these checks in both soft vote and cert vote steps!!
 
   if (unverified_soft_vote_block_for_this_round_is_valid) {
@@ -1039,7 +1019,7 @@ void PbftManager::firstFinish_() {
   // Even number steps from 4 are in first finish
   auto [round, period] = getPbftRoundAndPeriod();
   const auto next_round_period = pbft_chain_->getPbftChainSize() + 1;
-  LOG(log_dg_) << "PBFT first finishing state in round(r): " << round << ", period: " << period;
+  LOG(log_dg_) << "PBFT first finishing state in round: " << round << ", period: " << period;
 
   if (cert_voted_block_for_round_.has_value()) {
     auto last_cert_voted_block = getUnfinalizedBlock_(cert_voted_block_for_round_->first);
@@ -1069,26 +1049,26 @@ void PbftManager::firstFinish_() {
   } else if (round == 1 || (round >= 2 && (previous_round_next_voted_value_.first == NULL_BLOCK_HASH))) {
     // Starting value in round 1 is always null block hash... So combined with other condition for next
     // voting null block hash...
-    if (auto vote_weight = placeVote_(NULL_BLOCK_HASH, next_vote_type, next_round_period, round, step_);
-        vote_weight) {
+    if (auto vote_weight = placeVote_(NULL_BLOCK_HASH, next_vote_type, next_round_period, round, step_); vote_weight) {
       LOG(log_nf_) << "Placed first finish next vote for " << NULL_BLOCK_HASH << ", vote weight " << vote_weight
                    << ", round " << round << ", period " << next_round_period << ", step " << step_;
     }
   } else {
-    if (auto vote_weight = placeVote_(previous_round_next_voted_value_.first, next_vote_type, next_round_period, round, step_);
+    if (auto vote_weight =
+            placeVote_(previous_round_next_voted_value_.first, next_vote_type, next_round_period, round, step_);
         vote_weight) {
-      LOG(log_nf_) << "Placed first finish next vote for " << previous_round_next_voted_value_.first.abridged() << ", vote weight " << vote_weight
-                   << ", round " << round << ", period " << next_round_period << ", step " << step_;
+      LOG(log_nf_) << "Placed first finish next vote for " << previous_round_next_voted_value_.first.abridged()
+                   << ", vote weight " << vote_weight << ", round " << round << ", period " << next_round_period
+                   << ", step " << step_;
     }
   }
-
 }
 
 void PbftManager::secondFinish_() {
   // Odd number steps from 5 are in second finish
   auto [round, period] = getPbftRoundAndPeriod();
   const auto next_round_period = pbft_chain_->getPbftChainSize() + 1;
-  LOG(log_dg_) << "PBFT second finishing state in round(r): " << round << ", period: " << period;
+  LOG(log_dg_) << "PBFT second finishing state in round: " << round << ", period: " << period;
 
   assert(step_ >= startingStepInRound_);
   auto end_time_for_step = (2 + step_ - startingStepInRound_) * LAMBDA_ms - POLLING_INTERVAL_ms;
@@ -1096,6 +1076,11 @@ void PbftManager::secondFinish_() {
 
   if (const auto soft_voted_block = getSoftVotedBlockForThisRound_(); soft_voted_block.has_value()) {
     const auto [current_round_soft_voted_block, current_round_soft_votes_period] = *soft_voted_block;
+
+    if (current_round_soft_votes_period != period) {
+      LOG(log_er_) << "Soft voted block " << current_round_soft_voted_block << " period "
+                   << current_round_soft_votes_period << " != current pbft period " << period;
+    }
 
     assert(current_round_soft_votes_period == period);
 
@@ -1112,8 +1097,7 @@ void PbftManager::secondFinish_() {
     }
 
     if (!next_voted_soft_value_) {
-      if (auto vote_weight =
-              placeVote_(current_round_soft_voted_block, next_vote_type, period, round, step_);
+      if (auto vote_weight = placeVote_(current_round_soft_voted_block, next_vote_type, period, round, step_);
           vote_weight) {
         LOG(log_nf_) << "Placed second finish vote for " << current_round_soft_voted_block << ", vote weight "
                      << vote_weight << ", period " << period << ", round " << round << ", step " << step_;
@@ -1122,9 +1106,9 @@ void PbftManager::secondFinish_() {
         next_voted_soft_value_ = true;
       }
     }
-  } else if (!next_voted_null_block_hash_ && round >= 2 && (previous_round_next_voted_value_.first == NULL_BLOCK_HASH) && !cert_voted_block_for_round_.has_value()) {
-    if (auto vote_weight = placeVote_(NULL_BLOCK_HASH, next_vote_type, next_round_period, round, step_);
-        vote_weight) {
+  } else if (!next_voted_null_block_hash_ && round >= 2 &&
+             (previous_round_next_voted_value_.first == NULL_BLOCK_HASH) && !cert_voted_block_for_round_.has_value()) {
+    if (auto vote_weight = placeVote_(NULL_BLOCK_HASH, next_vote_type, next_round_period, round, step_); vote_weight) {
       LOG(log_nf_) << "Placed second finish next vote for " << NULL_BLOCK_HASH << ", vote weight " << vote_weight
                    << ", period " << next_round_period << ", round " << round << ", step " << step_;
       db_->savePbftMgrStatus(PbftMgrStatus::NextVotedNullBlockHash, true);
@@ -1137,8 +1121,8 @@ void PbftManager::secondFinish_() {
   }
 
   if (step_ > MAX_STEPS && (step_ - MAX_STEPS - 2) % 100 == 0 && !broadcastAlreadyThisStep_()) {
-    LOG(log_dg_) << "Node " << node_addr_ << " broadcast next votes for previous round. In period " << period << ", round " << round << " step "
-                 << step_;
+    LOG(log_dg_) << "Node " << node_addr_ << " broadcast next votes for previous round. In period " << period
+                 << ", round " << round << " step " << step_;
     if (auto net = network_.lock()) {
       net->getSpecificHandler<network::tarcap::VotesSyncPacketHandler>()->broadcastPreviousRoundNextVotesBundle();
     }
@@ -1549,7 +1533,26 @@ std::optional<std::pair<blk_hash_t, uint64_t>> PbftManager::identifyLeaderBlock_
       LOG(log_er_) << "Propose block hash should not be NULL. Vote " << v;
       continue;
     }
+
     if (pbft_chain_->findPbftBlockInChain(proposed_block_hash)) {
+      continue;
+    }
+
+    auto pbft_block = pbft_chain_->getUnverifiedPbftBlock(proposed_block_hash);
+    if (!pbft_block) {
+      LOG(log_dg_) << "Unable to find proposed block " << proposed_block_hash;
+      continue;
+    }
+
+    if (!compareBlocksAndRewardVotes_(pbft_block->getBlockHash())) {
+      LOG(log_dg_) << "Incomplete or invalid proposed block " << pbft_block->getBlockHash() << ", period " << period
+                   << ", round " << round;
+      continue;
+    }
+
+    if (!pbft_chain_->checkPbftBlockValidation(*pbft_block)) {
+      LOG(log_dg_) << "Proposed block " << pbft_block->getBlockHash() << " failed validation, period " << period
+                   << ", round " << round;
       continue;
     }
 
@@ -1561,46 +1564,10 @@ std::optional<std::pair<blk_hash_t, uint64_t>> PbftManager::identifyLeaderBlock_
     return {};
   }
 
+  const auto leader = *std::min_element(leader_candidates.begin(), leader_candidates.end(),
+                                        [](const auto &i, const auto &j) { return i.first < j.first; });
 
-  // Sort leader candidates, and then loop through them
-  // looking for one we can verify... 
-
-  // CONCERN: Perhaps its better to just pick the best value and 
-  //          just omit soft voting if it happens to be malicious
-  //          because as implemented, we would possibly produce more possible
-  //          valid values and somehow make a fork easier by malicious player
-
-  std::sort(leader_candidates.begin(), leader_candidates.end(), [](const auto &i, const auto &j) { return i.first < j.first; });
-
-  while (!leader_candidates.empty()) {
-    // Now we make sure we have the block and can validate...
-    // TODO:  I think we could just make sure we have the block
-    //        because if we have the block and can determine its invalid
-    //        then we could give it up (say in proposal step of next round)
-
-    auto pbft_block = pbft_chain_->getUnverifiedPbftBlock(leader_candidates.front().second->getBlockHash());
-    if (!pbft_block) {
-      LOG(log_dg_) << "Unable to find proposed block " << leader_candidates.front().second->getBlockHash()
-                   << " in filtering step";
-      leader_candidates.erase(leader_candidates.begin());
-      continue;
-    } else if (!compareBlocksAndRewardVotes_(pbft_block->getBlockHash())) {
-      LOG(log_dg_) << "Incomplete or invalid proposed block " << pbft_block << ", period " << period << ", round " << round;
-      leader_candidates.erase(leader_candidates.begin());
-      continue;
-    } else if (pbft_chain_->checkPbftBlockValidation(*pbft_block)) {
-      //CONCERN is this still needed??
-      LOG(log_dg_) << "Proposed block " << pbft_block << " failed pbft block validation in pbft chain, period " << period << ", round " << round;
-      leader_candidates.erase(leader_candidates.begin());
-      continue;
-    }
-
-    // We check this period above, should be equal to our current period...
-    assert(leader_candidates.front().second->getPeriod() == period);
-    return {std::make_pair(leader_candidates.front().second->getBlockHash(), period)};
-  }
-
-  return {};  
+  return {std::make_pair(leader.second->getBlockHash(), leader.second->getPeriod())};
 }
 
 bool PbftManager::syncRequestedAlreadyThisStep_() const {
@@ -1814,7 +1781,8 @@ void PbftManager::pushSyncedPbftBlocksIntoChain() {
       LOG(log_nf_) << "Pick pbft block " << pbft_block_hash << " from synced queue in round " << round;
 
       if (pushPbftBlock_(std::move(period_data.first), std::move(period_data.second))) {
-        LOG(log_nf_) << node_addr_ << " push synced PBFT block " << pbft_block_hash << " in period " << period << ", round " << round;
+        LOG(log_nf_) << node_addr_ << " push synced PBFT block " << pbft_block_hash << " in period " << period
+                     << ", round " << round;
       } else {
         LOG(log_er_) << "Failed push PBFT block " << pbft_block_hash << " into chain";
         break;

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -707,7 +707,6 @@ void PbftManager::loopBackFinishState_() {
 }
 
 bool PbftManager::stateOperations_() {
-  
   pushSyncedPbftBlocksIntoChain();
 
   checkPreviousRoundNextVotedValueChange_();

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -412,24 +412,31 @@ void PbftManager::resetPbftConsensus(uint64_t round) {
 
   auto batch = db_->createWriteBatch();
 
+  // Round is set to 1 if period advanced - clean all next votes
+  if (round == 1) {
+    const uint64_t previous_period_last_round = round_;
+    db_->removeNextVotesToBatch(previous_period_last_round - 1, batch);
+  } else if (round > 1) { // save previous round votes
+    // Save previous rounf next votes
+    auto next_votes = next_votes_manager_->getNextVotes();
+    db_->addNextVotesToBatch(round - 1, next_votes, batch);
+
+    // Cleanup old previous previous round next votes
+    if (round > 2) {
+      db_->removeNextVotesToBatch(round - 2, batch);
+    }
+  }
+
   // Update current round and reset step to 1
   round_ = round;
   resetStep();
   state_ = value_proposal_state;
 
-  const auto previous_round = round - 1;
-  auto next_votes = next_votes_manager_->getNextVotes();
-
   // Update in DB first
   db_->addPbftMgrFieldToBatch(PbftMgrRoundStep::PbftRound, round, batch);
   db_->addPbftMgrFieldToBatch(PbftMgrRoundStep::PbftStep, 1, batch);
 
-  db_->addNextVotesToBatch(previous_round, next_votes, batch);
-  // TODO: should be probably refactored
-  if (round > 1) {
-    // Cleanup old previous round next votes
-    db_->removeNextVotesToBatch(round - 1, batch);
-  }
+
 
   db_->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundSortitionThreshold, sortition_threshold_,
                                      batch);

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -707,6 +707,7 @@ void PbftManager::loopBackFinishState_() {
 }
 
 bool PbftManager::stateOperations_() {
+  
   pushSyncedPbftBlocksIntoChain();
 
   checkPreviousRoundNextVotedValueChange_();
@@ -2032,11 +2033,6 @@ void PbftManager::periodDataQueuePush(PeriodData &&period_data, dev::p2p::NodeID
     LOG(log_er_) << "Trying to push period data with " << period << " period, but current period is "
                  << sync_queue_.getPeriod();
   }
-
-  // CONCERN: Added this here to make PbftChainTest.proposal_block_broadcast pass
-  //          Unsure how we expected the pbft chain size to sync with pbft mgr stopped
-  //          in that test.  But do we really want to call this here?
-  pushSyncedPbftBlocksIntoChain();
 }
 
 size_t PbftManager::periodDataQueueSize() const { return sync_queue_.size(); }

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -162,16 +162,6 @@ void PbftManager::resume() {
 }
 
 // Only to be used for tests...
-void PbftManager::setMaxWaitForSoftVotedBlock_ms(uint64_t wait_ms) {
-  max_wait_for_soft_voted_block_steps_ms_ = wait_ms;
-}
-
-// Only to be used for tests...
-void PbftManager::setMaxWaitForNextVotedBlock_ms(uint64_t wait_ms) {
-  max_wait_for_next_voted_block_steps_ms_ = wait_ms;
-}
-
-// Only to be used for tests...
 void PbftManager::resumeSingleState() {
   if (!stopped_.load()) daemon_->join();
   stopped_ = false;
@@ -296,6 +286,7 @@ void PbftManager::setSortitionThreshold(size_t const sortition_threshold) {
 }
 
 void PbftManager::updateDposState_() {
+  // CONCERN: Is this choice correct?  How do we handle validation across periods?
   dpos_period_ = pbft_chain_->getPbftChainSize();
   do {
     try {
@@ -359,28 +350,26 @@ void PbftManager::resetStep_() {
 }
 
 bool PbftManager::resetRound_() {
-  auto determined_round_and_period = vote_mgr_->determineRoundAndPeriodFromVotes(TWO_T_PLUS_ONE);
-  if (!determined_round_and_period.has_value()) {
-    return false;
-  }
 
-  auto [determined_round, determined_period] = *determined_round_and_period;
-
+  // CONCERN accessor for period?  
+  auto determined_round = vote_mgr_->determineRoundFromPeriodAndVotes(period_, TWO_T_PLUS_ONE);
+  
   // current round
   auto round = getPbftRound();
+  
   if (determined_round <= round) {
     return false;
   }
 
-  LOG(log_nf_) << "Round & period reset to: " << determined_round << ", " << determined_period;
+  LOG(log_nf_) << "Determined round to be: " << determined_round << ", in period " << period_;
   round_clock_initial_datetime_ = now_;
   // Update current round and reset step to 1
   round_ = determined_round;
-  period_ = determined_period;
+  
   resetStep_();
   state_ = value_proposal_state;
 
-  LOG(log_dg_) << "Advancing clock to pbft round " << determined_round << ", period " << determined_period
+  LOG(log_dg_) << "Advancing clock to pbft round " << determined_round << ", period " << period_
                << ", step 1, and resetting clock.";
 
   const auto previous_round = determined_round - 1;
@@ -391,11 +380,12 @@ bool PbftManager::resetRound_() {
   auto batch = db_->createWriteBatch();
 
   // Update PBFT round and reset step to 1
+  
+  //CONCERN: Not necessary now...
+  //db_->addPbftMgrFieldToBatch(PbftMgrRoundStep::PbftPeriod, period_, batch);
   db_->addPbftMgrFieldToBatch(PbftMgrRoundStep::PbftRound, determined_round, batch);
-  db_->addPbftMgrFieldToBatch(PbftMgrRoundStep::PbftPeriod, determined_period, batch);
   db_->addPbftMgrFieldToBatch(PbftMgrRoundStep::PbftStep, 1, batch);
 
-  db_->addPbft2TPlus1ToBatch(previous_round, TWO_T_PLUS_ONE, batch);
   db_->addNextVotesToBatch(previous_round, next_votes, batch);
   if (round > 1) {
     // Cleanup old previous round next votes
@@ -407,9 +397,7 @@ bool PbftManager::resetRound_() {
   db_->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposPeriod, dpos_period_.load(), batch);
   db_->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposTotalVotesCount,
                                      getDposTotalVotesCount(), batch);
-  db_->addPbftMgrStatusToBatch(PbftMgrStatus::ExecutedInRound, false, batch);
-  db_->addPbftMgrVotedValueToBatch(PbftMgrVotedValue::OwnStartingValueInRound, {NULL_BLOCK_HASH, determined_period},
-                                   batch);
+  //db_->addPbftMgrVotedValueToBatch(PbftMgrVotedValue::OwnStartingValueInRound, {NULL_BLOCK_HASH, determined_period}, batch);
   db_->addPbftMgrStatusToBatch(PbftMgrStatus::NextVotedNullBlockHash, false, batch);
   db_->addPbftMgrStatusToBatch(PbftMgrStatus::NextVotedSoftValue, false, batch);
 
@@ -422,13 +410,15 @@ bool PbftManager::resetRound_() {
   }
   db_->commitWriteBatch(batch);
 
-  have_executed_this_round_ = false;
   should_have_cert_voted_in_this_round_ = false;
-  // reset starting value to NULL_BLOCK_HASH
-  own_starting_value_for_round_ = {NULL_BLOCK_HASH, determined_period};
+  
   // reset next voted value since start a new round
+  // these are used to prevent voting multiple times while polling through the step
+  // under current implementation.
+  // TODO: Get rid of this way of doing it!
   next_voted_null_block_hash_ = false;
   next_voted_soft_value_ = false;
+  
   polling_state_print_log_ = true;
 
   // Reset soft voting leader & cert voted block values in the new upcoming round
@@ -439,7 +429,7 @@ bool PbftManager::resetRound_() {
   }
 
   // Move to a new round, cleanup previous round votes
-  vote_mgr_->cleanupVotes(determined_round);
+  vote_mgr_->cleanupVotes(period_, determined_round);
 
   if (executed_pbft_block_) {
     updateDposState_();
@@ -454,6 +444,23 @@ bool PbftManager::resetRound_() {
 
   // Restart while loop...
   return true;
+}
+
+void PbftManager::advancePeriod_() {
+  auto new_period = pbft_chain_->getPbftChainSize();
+  
+  // Update in DB first
+  auto batch = db_->createWriteBatch();
+  db_->addPbftMgrFieldToBatch(PbftMgrRoundStep::PbftPeriod, new_period, batch);
+  db_->addPbft2TPlus1ToBatchForPeriod(period_, TWO_T_PLUS_ONE, batch);
+  db_->commitWriteBatch(batch);
+
+  assert(new_period == period_ + 1); 
+  LOG(log_nf_) << "Period advanced to: " << new_period;
+
+  period_ = new_period;
+
+  resetRound_();
 }
 
 void PbftManager::sleep_() {
@@ -478,12 +485,11 @@ void PbftManager::initialState() {
 
   // Time constants...
   LAMBDA_ms = LAMBDA_ms_MIN;
-  max_wait_for_soft_voted_block_steps_ms_ = MAX_WAIT_FOR_SOFT_VOTED_BLOCK_STEPS * 2 * LAMBDA_ms;
-  max_wait_for_next_voted_block_steps_ms_ = MAX_WAIT_FOR_NEXT_VOTED_BLOCK_STEPS * 2 * LAMBDA_ms;
-
+  
   auto round = db_->getPbftMgrField(PbftMgrRoundStep::PbftRound);
   auto previous_round_period = db_->getPbftMgrField(PbftMgrRoundStep::PbftPeriod);
   auto step = db_->getPbftMgrField(PbftMgrRoundStep::PbftStep);
+
   if (round == 1 && step == 1) {
     // Node start from scratch
     state_ = value_proposal_state;
@@ -501,6 +507,7 @@ void PbftManager::initialState() {
     LOG(log_er_) << "Unexpected condition at round " << round << " step " << step;
     assert(false);
   }
+
   // This is used to offset endtime for second finishing step...
   startingStepInRound_ = step;
   setPbftStep(step);
@@ -509,15 +516,18 @@ void PbftManager::initialState() {
 
   if (round > 1) {
     // Get next votes for previous round from DB
+
+    // CONCERN: Cleanup of next votes from previous rounds and periods?
+    //          Since we reset round now back to 1, we need to be sure we clean them up!
     auto next_votes_in_previous_round = db_->getNextVotes(round - 1);
     if (next_votes_in_previous_round.empty()) {
-      LOG(log_er_) << "Cannot get any next votes in previous round " << round - 1 << ". Currrent round " << round
+      LOG(log_er_) << "Cannot get any next votes in previous round " << round - 1 << ". For period " << period_
                    << " step " << step;
       assert(false);
     }
-    auto previous_round_2t_plus_1 = db_->getPbft2TPlus1(round - 1);
+    auto previous_round_2t_plus_1 = db_->getPbft2TPlus1ForPeriod(period_);
     if (previous_round_2t_plus_1 == 0) {
-      LOG(log_er_) << "Cannot get PBFT 2t+1 in previous round " << round - 1 << ". Current round " << round << " step "
+      LOG(log_er_) << "Cannot get PBFT 2t+1 in previous round " << round - 1 << ". For period " << period_ << " step "
                    << step;
       assert(false);
     }
@@ -537,15 +547,18 @@ void PbftManager::initialState() {
   pbft_round_last_requested_sync_ = 0;
   pbft_step_last_requested_sync_ = 0;
 
+  /*
+  TODO: Remove this column from db?
   auto own_starting_value = db_->getPbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound);
   if (own_starting_value.has_value()) {
     // From DB
     own_starting_value_for_round_ = *own_starting_value;
   } else {
     // Default value
-    assert(previous_round_period == 1);
+    assert(round == 1);
     own_starting_value_for_round_ = {NULL_BLOCK_HASH, 1};
   }
+  */
 
   auto soft_voted_block = db_->getPbftMgrVotedValue(PbftMgrVotedValue::SoftVotedBlockInRound);
   if (soft_voted_block.has_value()) {
@@ -575,7 +588,6 @@ void PbftManager::initialState() {
   }
 
   executed_pbft_block_ = db_->getPbftMgrStatus(PbftMgrStatus::ExecutedBlock);
-  have_executed_this_round_ = db_->getPbftMgrStatus(PbftMgrStatus::ExecutedInRound);
   next_voted_soft_value_ = db_->getPbftMgrStatus(PbftMgrStatus::NextVotedSoftValue);
   next_voted_null_block_hash_ = db_->getPbftMgrStatus(PbftMgrStatus::NextVotedNullBlockHash);
 
@@ -699,55 +711,36 @@ bool PbftManager::stateOperations_() {
   auto [round, period] = getPbftRoundAndPeriod();
   LOG(log_tr_) << "PBFT current round(r): " << round << ", period: " << period << ", step " << step_;
 
-  if (!new_round_in_sync_) {
-    // Checks if node is in sync with determined pbft period from votes, if not - do not allow node to place votes
-    // This check is done only at the beginning of new round by purpose as chain size might change after cert vote step
-    // when new cert voted block is pushed into the chain
-    const auto chain_size = pbft_chain_->getPbftChainSize();
-    if (chain_size + 1 < period) {
-      LOG(log_wr_) << "Period determined from next votes: " << period << " != chain size + 1: " << chain_size + 1
-                   << ". Wait to get in sync.";
-      using namespace std::chrono_literals;
-      std::this_thread::sleep_for(50ms);
-      return true;
-    }
-
-    // Node is in sync
-    new_round_in_sync_ = true;
-  }
-
   // Remove old votes
-  vote_mgr_->cleanupVotes(round);
+  vote_mgr_->cleanupVotes(period, round);
 
-  // CHECK IF WE HAVE RECEIVED 2t+1 CERT VOTES FOR A BLOCK IN OUR CURRENT
-  // ROUND.  IF WE HAVE THEN WE EXECUTE THE BLOCK
-  // ONLY CHECK IF HAVE *NOT* YET EXECUTED THIS ROUND...
-  if (state_ == certify_state && !have_executed_this_round_) {
-    if (auto certified_block = vote_mgr_->getVotesBundle(round, period, 3, TWO_T_PLUS_ONE);
-        certified_block.has_value()) {
-      LOG(log_dg_) << "PBFT block " << certified_block->voted_block_hash << " has enough cert votes";
-      // put pbft block into chain
-      if (pushCertVotedPbftBlockIntoChain_(certified_block->voted_block_hash, std::move(certified_block->votes))) {
-        db_->savePbftMgrStatus(PbftMgrStatus::ExecutedInRound, true);
-        have_executed_this_round_ = true;
-        LOG(log_nf_) << "Write " << certified_block->votes.size() << " cert votes ... in round " << round;
+  if (auto certified_block = vote_mgr_->getVotesBundle(round, period, 3, TWO_T_PLUS_ONE); certified_block.has_value()) {
+    LOG(log_dg_) << "PBFT block " << certified_block->voted_block_hash << " has enough cert votes";
+    // put pbft block into chain
+    if (pushCertVotedPbftBlockIntoChain_(certified_block->voted_block_hash, std::move(certified_block->votes))) {
+      LOG(log_nf_) << "Write " << certified_block->votes.size() << " cert votes ... in round " << round;
 
-        duration_ = std::chrono::system_clock::now() - now_;
-        auto execute_trxs_in_ms = std::chrono::duration_cast<std::chrono::milliseconds>(duration_).count();
-        LOG(log_dg_) << "PBFT block " << certified_block->voted_block_hash
-                     << " certified and pushed into chain in round " << round << ". Execution time "
-                     << execute_trxs_in_ms << " [ms]";
-        // Restart while loop
-        return true;
-      } else {
-        LOG(log_er_) << "PBFT block " << certified_block->voted_block_hash
-                     << " certified but not pushed into chain in round " << round;
-      }
+      duration_ = std::chrono::system_clock::now() - now_;
+      auto execute_trxs_in_ms = std::chrono::duration_cast<std::chrono::milliseconds>(duration_).count();
+      LOG(log_dg_) << "PBFT block " << certified_block->voted_block_hash << " certified and pushed into chain in round "
+                   << round << ". Execution time " << execute_trxs_in_ms << " [ms]";
+
+      advancePeriod_();
+
+      // Restart while loop  CONCERN: still need to do that?
+      return true;
+    
+    } else {
+      LOG(log_er_) << "PBFT block " << certified_block->voted_block_hash
+                   << " certified but not pushed into chain in round " << round;
+
+      // CONCERN: How would we get here?
+      assert(false);
     }
   }
 
   if (resetRound_()) {
-    new_round_in_sync_ = false;
+    //new_round_in_sync_ = false;
     return true;
   }
 
@@ -788,6 +781,9 @@ void PbftManager::initializeVotedValueTimeouts_() {
   if (soft_voted_block_for_round_.has_value()) {
     last_soft_voted_value_ = soft_voted_block_for_round_->first;
   }
+
+  // CONCERN Do we still need any of this functionality?
+  LOG(log_er_) << "initializeVotedValueTimeouts_ being called but no longer needed";
 }
 
 // Only for test
@@ -818,84 +814,71 @@ void PbftManager::proposeBlock_() {
   auto [round, period] = getPbftRoundAndPeriod();
   LOG(log_dg_) << "PBFT value proposal state in round(r): " << round << ", period: " << period;
 
-  if (round == 1) {
-    // Round 1 cannot propose block. Everyone has to next vote NULL_BLOCK_HASH in round 1 to make consensus go to next
-    // round
-    return;
-  }
+  if (round == 1 || next_votes_manager_->haveEnoughVotesForNullBlockHash()) {
+    
+    if (round > 1) { 
+      LOG(log_nf_) << "Previous round " << round - 1 << " had next voted NULL_BLOCK_HASH";
+    }
 
-  // Round greater than 1
-  if (next_votes_manager_->haveEnoughVotesForNullBlockHash()) {
-    LOG(log_nf_) << "Previous round " << round - 1 << " next voted block is NULL_BLOCK_HASH";
-  } else if (previous_round_next_voted_value_.first) {
-    LOG(log_nf_) << "Previous round " << round - 1 << " next voted block is " << previous_round_next_voted_value_;
+    proposed_block_ = proposePbftBlock_();
+    
+    if (proposed_block_) {
+      if (auto vote_weight = placeVote_(proposed_block_->getBlockHash(), propose_vote_type,
+                                        period, round, step_);
+          vote_weight) {
+        LOG(log_nf_) << "Placed propose vote for new block " << proposed_block_->getBlockHash() << ", vote weight "
+                     << vote_weight << ", period " << period << ", round " << round << ", step "
+                     << step_;
+
+        // broadcast pbft block
+        if (auto net = network_.lock()) {
+          net->getSpecificHandler<network::tarcap::PbftBlockPacketHandler>()->onNewPbftBlock(proposed_block_);
+        }
+
+      }
+    }
+    return;
+  } else if (previous_round_next_voted_value_.first) {  
+    // Round greater than 1 and next voted some value that is not null block hash
+  
+    LOG(log_nf_) << "Previous round " << round - 1 << " next voted block is " << previous_round_next_voted_value_.first;
+
+    auto pbft_block = pbft_chain_->getUnverifiedPbftBlock(previous_round_next_voted_value_.first);
+    if (!pbft_block) {
+      LOG(log_dg_) << "Unable to find proposal block " << previous_round_next_voted_value_.first
+                   << " from previous round in unverified queue";
+      
+      pbft_block = db_->getPbftCertVotedBlock(previous_round_next_voted_value_.first);
+      if (!pbft_block) {
+        LOG(log_dg_) << "Unable to find proposal block " << previous_round_next_voted_value_.first
+                     << " from previous round in database";
+        
+        LOG(log_dg_) << "Unable to find proposal block " << previous_round_next_voted_value_.first
+                     << " from previous round in either unverified queue or database, will not propose it";        
+        return;
+      }
+    }
+
+    if (auto vote_weight = placeVote_(previous_round_next_voted_value_.first, propose_vote_type,
+                                      period, round, step_);
+        vote_weight) {
+      LOG(log_nf_) << "Placed propose vote for previous round next voted value " << previous_round_next_voted_value_.first << ", vote weight "
+                   << vote_weight << ", period " << period << ", round " << round << ", step "
+                   << step_;
+
+
+      // broadcast pbft block
+      if (auto net = network_.lock()) {
+        net->getSpecificHandler<network::tarcap::PbftBlockPacketHandler>()->onNewPbftBlock(pbft_block);
+      }
+
+    }
+    return;
   } else {
     LOG(log_er_) << "Previous round " << round - 1 << " doesn't have enough next votes";
     assert(false);
   }
 
-  // Propose new block
-  if (giveUpNextVotedBlock_()) {
-    // PBFT block only be able to propose once in each period
-    if (!proposed_block_) {
-      proposed_block_ = proposePbftBlock_();
-    }
-
-    if (proposed_block_) {
-      own_starting_value_for_round_ = {proposed_block_->getBlockHash(), proposed_block_->getPeriod()};
-      db_->savePbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound, own_starting_value_for_round_);
-
-      if (auto vote_weight = placeVote_(proposed_block_->getBlockHash(), propose_vote_type,
-                                        proposed_block_->getPeriod(), round, step_);
-          vote_weight) {
-        LOG(log_nf_) << "Placed propose vote for new block " << proposed_block_->getBlockHash() << ", vote weight "
-                     << vote_weight << ", round " << round << ", period " << proposed_block_->getPeriod() << ", step "
-                     << step_;
-      }
-    }
-    return;
-  }
-
-  // Re-propose block from previous round
-  if (!previous_round_next_voted_value_.first) {
-    // There is no block from previous round, return
-    return;
-  }
-
-  own_starting_value_for_round_ = previous_round_next_voted_value_;
-  db_->savePbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound, own_starting_value_for_round_);
-
-  auto pbft_block = pbft_chain_->getUnverifiedPbftBlock(own_starting_value_for_round_.first);
-  if (!pbft_block) {
-    LOG(log_dg_) << "Unable to find proposal block " << own_starting_value_for_round_.first
-                 << " from previous round in unverified queue";
-    pbft_block = db_->getPbftCertVotedBlock(own_starting_value_for_round_.first);
-    if (!pbft_block) {
-      LOG(log_dg_) << "Unable to find proposal block " << own_starting_value_for_round_.first
-                   << " from previous round in database";
-      return;
-    }
-  }
-
-  if (pbft_block->getPeriod() != own_starting_value_for_round_.second) {
-    LOG(log_er_) << "Previous round next voted block: " << pbft_block->getBlockHash()
-                 << " period: " << pbft_block->getPeriod()
-                 << " != previous round next votes pbft period: " << own_starting_value_for_round_.second;
-    return;
-  }
-
-  // place vote
-  if (auto vote_weight =
-          placeVote_(pbft_block->getBlockHash(), propose_vote_type, pbft_block->getPeriod(), round, step_);
-      vote_weight) {
-    LOG(log_nf_) << "Placed propose vote for previous round block " << pbft_block->getBlockHash() << ", vote weight "
-                 << vote_weight << ", round " << round << ", period " << pbft_block->getPeriod() << ", step " << step_;
-
-    // broadcast pbft block
-    if (auto net = network_.lock()) {
-      net->getSpecificHandler<network::tarcap::PbftBlockPacketHandler>()->onNewPbftBlock(pbft_block);
-    }
-  }
 }
 
 void PbftManager::identifyBlock_() {
@@ -903,12 +886,13 @@ void PbftManager::identifyBlock_() {
   auto [round, period] = getPbftRoundAndPeriod();
   LOG(log_dg_) << "PBFT filtering state in round(r): " << round << ", period: " << period;
 
-  if (giveUpNextVotedBlock_()) {
+
+  if (round == 1 || next_votes_manager_->haveEnoughVotesForNullBlockHash()) {
     // Identity leader
     if (auto leader_block = identifyLeaderBlock_(round, period); leader_block.has_value()) {
       auto [leader_block_hash, leader_block_period] = *leader_block;
-      own_starting_value_for_round_ = {leader_block_hash, leader_block_period};
-      db_->savePbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound, own_starting_value_for_round_);
+      //own_starting_value_for_round_ = {leader_block_hash, leader_block_period};
+      //db_->savePbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound, own_starting_value_for_round_);
       LOG(log_dg_) << "Leader block identified " << leader_block_hash << ", round " << round << ", period "
                    << leader_block_period;
 
@@ -985,8 +969,13 @@ void PbftManager::certifyBlock_() {
 
   LOG(log_tr_) << "Finished compareBlocksAndRewardVotes_";
 
+  
+  // TODO CONCERN: If we do happen to see 2t+1 cert votes for a value before we have manged 
+  //               to cert vote it on our own, then we should issue a reward vote to our self no?
+  /*
   // NOTE: If we have already executed this round then block won't be found in unverified queue...
   bool executed_soft_voted_block_for_this_round = false;
+  
   if (have_executed_this_round_) {
     LOG(log_tr_) << "Have already executed before certifying in step 3 in round " << round;
     auto last_pbft_block_hash = pbft_chain_->getLastPbftBlockHash();
@@ -994,23 +983,29 @@ void PbftManager::certifyBlock_() {
       LOG(log_tr_) << "Having executed, last block in chain is the soft voted block in round " << round;
       executed_soft_voted_block_for_this_round = true;
     }
+  }*/
+
+  auto last_pbft_block_hash = pbft_chain_->getLastPbftBlockHash();
+  if(last_pbft_block_hash == current_round_soft_voted_block) {
+    LOG(log_er_) << "In certify step, soft voted block is already in chain!" << round;
+    assert(false);
   }
 
   bool unverified_soft_vote_block_for_this_round_is_valid = false;
-  if (!executed_soft_voted_block_for_this_round) {
-    auto block = pbft_chain_->getUnverifiedPbftBlock(current_round_soft_voted_block);
-    if (block && pbft_chain_->checkPbftBlockValidation(*block)) {
-      unverified_soft_vote_block_for_this_round_is_valid = true;
-    } else {
-      if (!block) {
-        LOG(log_er_) << "Cannot find the unverified pbft block " << current_round_soft_voted_block << " in round "
-                     << round << ", step 3";
-      }
-      syncPbftChainFromPeers_(invalid_soft_voted_block, current_round_soft_voted_block);
+  auto block = pbft_chain_->getUnverifiedPbftBlock(current_round_soft_voted_block);
+  if (block && pbft_chain_->checkPbftBlockValidation(*block)) {
+    unverified_soft_vote_block_for_this_round_is_valid = true;
+  } else {
+    if (!block) {
+      LOG(log_er_) << "Cannot find the unverified pbft block " << current_round_soft_voted_block << " in round "
+                   << round << ", step 3";
     }
+    syncPbftChainFromPeers_(invalid_soft_voted_block, current_round_soft_voted_block);
   }
+  
+  // CONCERN: We really should avoid doing these checks in both soft vote and cert vote steps!!
 
-  if (executed_soft_voted_block_for_this_round || unverified_soft_vote_block_for_this_round_is_valid) {
+  if (unverified_soft_vote_block_for_this_round_is_valid) {
     // compareBlocksAndRewardVotes_ has checked the cert voted block exist
     auto cert_voted_block = getUnfinalizedBlock_(current_round_soft_voted_block);
     assert(cert_voted_block != nullptr);
@@ -1071,58 +1066,22 @@ void PbftManager::firstFinish_() {
         net->getSpecificHandler<network::tarcap::PbftBlockPacketHandler>()->onNewPbftBlock(pbft_block);
       }
     }
+  } else if (round == 1 || (round >= 2 && (previous_round_next_voted_value_.first == NULL_BLOCK_HASH))) {
+    // Starting value in round 1 is always null block hash... So combined with other condition for next
+    // voting null block hash...
+    if (auto vote_weight = placeVote_(NULL_BLOCK_HASH, next_vote_type, next_round_period, round, step_);
+        vote_weight) {
+      LOG(log_nf_) << "Placed first finish next vote for " << NULL_BLOCK_HASH << ", vote weight " << vote_weight
+                   << ", round " << round << ", period " << next_round_period << ", step " << step_;
+    }
   } else {
-    // We only want to give up soft voted value IF:
-    // 1) haven't cert voted it
-    // 2) we are looking at value that was next voted in previous round
-    // 3) we don't have the block or if have block it can't be cert voted (yet)
-    bool giveUpSoftVotedBlockInFirstFinish =
-        !cert_voted_block_for_round_.has_value() && own_starting_value_for_round_ == previous_round_next_voted_value_ &&
-        giveUpSoftVotedBlock_() && !compareBlocksAndRewardVotes_(own_starting_value_for_round_.first);
-
-    if (round >= 2 && (giveUpNextVotedBlock_() || giveUpSoftVotedBlockInFirstFinish)) {
-      if (auto vote_weight = placeVote_(NULL_BLOCK_HASH, next_vote_type, next_round_period, round, step_);
-          vote_weight) {
-        LOG(log_nf_) << "Placed first finish next vote for " << NULL_BLOCK_HASH << ", vote weight " << vote_weight
-                     << ", round " << round << ", period " << next_round_period << ", step " << step_;
-      }
-    } else {
-      if (own_starting_value_for_round_ != previous_round_next_voted_value_ &&
-          previous_round_next_voted_value_.first != NULL_BLOCK_HASH &&
-          !pbft_chain_->findPbftBlockInChain(previous_round_next_voted_value_.first)) {
-        if (own_starting_value_for_round_.first == NULL_BLOCK_HASH) {
-          own_starting_value_for_round_ = previous_round_next_voted_value_;
-          db_->savePbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound, own_starting_value_for_round_);
-          LOG(log_dg_) << "Updating own starting value of NULL BLOCK HASH to previous round next voted value of "
-                       << previous_round_next_voted_value_;
-        } else if (compareBlocksAndRewardVotes_(previous_round_next_voted_value_.first)) {
-          // Check if we have received the previous round next voted value and its a viable value...
-          // IF it is viable then reset own starting value to it...
-          own_starting_value_for_round_ = previous_round_next_voted_value_;
-          db_->savePbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound, own_starting_value_for_round_);
-          LOG(log_dg_) << "Updating own starting value of " << own_starting_value_for_round_
-                       << " to previous round next voted value of " << previous_round_next_voted_value_;
-        }
-      }
-
-      if (auto vote_weight =
-              placeVote_(own_starting_value_for_round_.first, next_vote_type, next_round_period, round, step_);
-          vote_weight) {
-        LOG(log_nf_) << "Placed first finish next vote for " << own_starting_value_for_round_.first << ", vote weight "
-                     << vote_weight << ", round " << round << ", period " << next_round_period << ", step " << step_;
-
-        // Re-broadcast pbft block in case some nodes do not have it
-        if (step_ % 20 == 0) {
-          auto pbft_block = getUnfinalizedBlock_(own_starting_value_for_round_.first);
-          if (auto net = network_.lock(); net && pbft_block) {
-            LOG(log_nf_) << "Rebroadcasting PBFT block: " << pbft_block->getBlockHash() << " and reward votes "
-                         << pbft_block->getRewardVotes();
-            net->getSpecificHandler<network::tarcap::PbftBlockPacketHandler>()->onNewPbftBlock(pbft_block);
-          }
-        }
-      }
+    if (auto vote_weight = placeVote_(previous_round_next_voted_value_.first, next_vote_type, next_round_period, round, step_);
+        vote_weight) {
+      LOG(log_nf_) << "Placed first finish next vote for " << previous_round_next_voted_value_.first.abridged() << ", vote weight " << vote_weight
+                   << ", round " << round << ", period " << next_round_period << ", step " << step_;
     }
   }
+
 }
 
 void PbftManager::secondFinish_() {
@@ -1135,16 +1094,12 @@ void PbftManager::secondFinish_() {
   auto end_time_for_step = (2 + step_ - startingStepInRound_) * LAMBDA_ms - POLLING_INTERVAL_ms;
   LOG(log_tr_) << "Step " << step_ << " end time " << end_time_for_step;
 
-  // We only want to give up soft voted value IF:
-  // 1) haven't cert voted it
-  // 2) we are looking at value that was next voted in previous round
-  // 3) we don't have the block or if have block it can't be cert voted (yet)
-  bool giveUpSoftVotedBlockInSecondFinish = false;
-
   if (const auto soft_voted_block = getSoftVotedBlockForThisRound_(); soft_voted_block.has_value()) {
     const auto [current_round_soft_voted_block, current_round_soft_votes_period] = *soft_voted_block;
 
-    auto soft_voted_block_votes = vote_mgr_->getVotesBundle(round, current_round_soft_votes_period, 2, TWO_T_PLUS_ONE);
+    assert(current_round_soft_votes_period == period);
+
+    auto soft_voted_block_votes = vote_mgr_->getVotesBundle(round, period, 2, TWO_T_PLUS_ONE);
     if (soft_voted_block_votes.has_value()) {
       // Have enough soft votes for a voting value
       auto net = network_.lock();
@@ -1153,41 +1108,25 @@ void PbftManager::secondFinish_() {
           std::move(soft_voted_block_votes->votes));
       vote_mgr_->sendRewardVotes(getLastPbftBlockHash());
       LOG(log_dg_) << "Node has seen enough soft votes voted at " << soft_voted_block_votes->voted_block_hash
-                   << ", regossip soft votes. In round " << round << ", period " << soft_voted_block_votes->votes_period
-                   << " step " << step_;
+                   << ", regossip soft votes. In period " << period_ << ", round " << round << " step " << step_;
     }
 
-    // we did not cert vote
-    giveUpSoftVotedBlockInSecondFinish =
-        !cert_voted_block_for_round_.has_value() && last_soft_voted_value_ == previous_round_next_voted_value_.first &&
-        giveUpSoftVotedBlock_() && !compareBlocksAndRewardVotes_(current_round_soft_voted_block);
-
-    if (!next_voted_soft_value_ && !giveUpSoftVotedBlockInSecondFinish) {
+    if (!next_voted_soft_value_) {
       if (auto vote_weight =
-              placeVote_(current_round_soft_voted_block, next_vote_type, next_round_period, round, step_);
+              placeVote_(current_round_soft_voted_block, next_vote_type, period, round, step_);
           vote_weight) {
         LOG(log_nf_) << "Placed second finish vote for " << current_round_soft_voted_block << ", vote weight "
-                     << vote_weight << ", round " << round << ", period " << next_round_period << ", step " << step_;
+                     << vote_weight << ", period " << period << ", round " << round << ", step " << step_;
 
         db_->savePbftMgrStatus(PbftMgrStatus::NextVotedSoftValue, true);
         next_voted_soft_value_ = true;
       }
     }
-  } else {
-    LOG(log_dg_) << "Second finish: Not enough soft votes for current round yet. Round " << round << ", period "
-                 << period;
-
-    // we did not cert vote
-    giveUpSoftVotedBlockInSecondFinish = !cert_voted_block_for_round_.has_value() &&
-                                         last_soft_voted_value_ == previous_round_next_voted_value_.first &&
-                                         giveUpSoftVotedBlock_();
-  }
-
-  if (!next_voted_null_block_hash_ && round >= 2 && (giveUpSoftVotedBlockInSecondFinish || giveUpNextVotedBlock_())) {
-    if (auto vote_weight = placeVote_(NULL_BLOCK_HASH, next_vote_type, next_round_period, round, step_); vote_weight) {
-      LOG(log_nf_) << "Placed second finish vote for " << NULL_BLOCK_HASH << ", vote weight " << vote_weight
-                   << ", round " << round << ", period " << next_round_period << ", step " << step_;
-
+  } else if (!next_voted_null_block_hash_ && round >= 2 && (previous_round_next_voted_value_.first == NULL_BLOCK_HASH) && !cert_voted_block_for_round_.has_value()) {
+    if (auto vote_weight = placeVote_(NULL_BLOCK_HASH, next_vote_type, next_round_period, round, step_);
+        vote_weight) {
+      LOG(log_nf_) << "Placed second finish next vote for " << NULL_BLOCK_HASH << ", vote weight " << vote_weight
+                   << ", period " << next_round_period << ", round " << round << ", step " << step_;
       db_->savePbftMgrStatus(PbftMgrStatus::NextVotedNullBlockHash, true);
       next_voted_null_block_hash_ = true;
     }
@@ -1198,7 +1137,7 @@ void PbftManager::secondFinish_() {
   }
 
   if (step_ > MAX_STEPS && (step_ - MAX_STEPS - 2) % 100 == 0 && !broadcastAlreadyThisStep_()) {
-    LOG(log_dg_) << "Node " << node_addr_ << " broadcast next votes for previous round. In round " << round << " step "
+    LOG(log_dg_) << "Node " << node_addr_ << " broadcast next votes for previous round. In period " << period << ", round " << round << " step "
                  << step_;
     if (auto net = network_.lock()) {
       net->getSpecificHandler<network::tarcap::VotesSyncPacketHandler>()->broadcastPreviousRoundNextVotesBundle();
@@ -1576,7 +1515,7 @@ h256 PbftManager::getProposal(const std::shared_ptr<Vote> &vote) const {
 }
 
 std::optional<std::pair<blk_hash_t, uint64_t>> PbftManager::identifyLeaderBlock_(uint64_t round, uint64_t period) {
-  LOG(log_tr_) << "Identify leader block, in round(r): " << round << ", period: " << period;
+  LOG(log_tr_) << "Identify leader block, in period " << period << ", round " << round;
 
   // Get all proposal votes in the round
   auto votes = vote_mgr_->getProposalVotes(round, period);
@@ -1613,10 +1552,6 @@ std::optional<std::pair<blk_hash_t, uint64_t>> PbftManager::identifyLeaderBlock_
     if (pbft_chain_->findPbftBlockInChain(proposed_block_hash)) {
       continue;
     }
-    // Make sure we don't keep soft voting for soft value we want to give up...
-    if (proposed_block_hash == last_soft_voted_value_ && giveUpSoftVotedBlock_()) {
-      continue;
-    }
 
     leader_candidates.emplace_back(std::make_pair(getProposal(v), v));
   }
@@ -1626,10 +1561,46 @@ std::optional<std::pair<blk_hash_t, uint64_t>> PbftManager::identifyLeaderBlock_
     return {};
   }
 
-  const auto leader = *std::min_element(leader_candidates.begin(), leader_candidates.end(),
-                                        [](const auto &i, const auto &j) { return i.first < j.first; });
 
-  return {std::make_pair(leader.second->getBlockHash(), leader.second->getPeriod())};
+  // Sort leader candidates, and then loop through them
+  // looking for one we can verify... 
+
+  // CONCERN: Perhaps its better to just pick the best value and 
+  //          just omit soft voting if it happens to be malicious
+  //          because as implemented, we would possibly produce more possible
+  //          valid values and somehow make a fork easier by malicious player
+
+  std::sort(leader_candidates.begin(), leader_candidates.end(), [](const auto &i, const auto &j) { return i.first < j.first; });
+
+  while (!leader_candidates.empty()) {
+    // Now we make sure we have the block and can validate...
+    // TODO:  I think we could just make sure we have the block
+    //        because if we have the block and can determine its invalid
+    //        then we could give it up (say in proposal step of next round)
+
+    auto pbft_block = pbft_chain_->getUnverifiedPbftBlock(leader_candidates.front().second->getBlockHash());
+    if (!pbft_block) {
+      LOG(log_dg_) << "Unable to find proposed block " << leader_candidates.front().second->getBlockHash()
+                   << " in filtering step";
+      leader_candidates.erase(leader_candidates.begin());
+      continue;
+    } else if (!compareBlocksAndRewardVotes_(pbft_block->getBlockHash())) {
+      LOG(log_dg_) << "Incomplete or invalid proposed block " << pbft_block << ", period " << period << ", round " << round;
+      leader_candidates.erase(leader_candidates.begin());
+      continue;
+    } else if (pbft_chain_->checkPbftBlockValidation(*pbft_block)) {
+      //CONCERN is this still needed??
+      LOG(log_dg_) << "Proposed block " << pbft_block << " failed pbft block validation in pbft chain, period " << period << ", round " << round;
+      leader_candidates.erase(leader_candidates.begin());
+      continue;
+    }
+
+    // We check this period above, should be equal to our current period...
+    assert(leader_candidates.front().second->getPeriod() == period);
+    return {std::make_pair(leader_candidates.front().second->getBlockHash(), period)};
+  }
+
+  return {};  
 }
 
 bool PbftManager::syncRequestedAlreadyThisStep_() const {
@@ -1843,7 +1814,7 @@ void PbftManager::pushSyncedPbftBlocksIntoChain() {
       LOG(log_nf_) << "Pick pbft block " << pbft_block_hash << " from synced queue in round " << round;
 
       if (pushPbftBlock_(std::move(period_data.first), std::move(period_data.second))) {
-        LOG(log_nf_) << node_addr_ << " push synced PBFT block " << pbft_block_hash << " in round " << round;
+        LOG(log_nf_) << node_addr_ << " push synced PBFT block " << pbft_block_hash << " in period " << period << ", round " << round;
       } else {
         LOG(log_er_) << "Failed push PBFT block " << pbft_block_hash << " into chain";
         break;
@@ -1958,8 +1929,6 @@ bool PbftManager::pushPbftBlock_(PeriodData &&period_data, std::vector<std::shar
 
   finalize_(std::move(period_data), std::move(dag_blocks_order));
 
-  // Reset proposed PBFT block hash to NULL for next period PBFT block proposal
-  proposed_block_ = nullptr;
   db_->savePbftMgrStatus(PbftMgrStatus::ExecutedBlock, true);
   executed_pbft_block_ = true;
   return true;
@@ -1972,83 +1941,6 @@ void PbftManager::updateTwoTPlusOneAndThreshold_() {
   TWO_T_PLUS_ONE = sortition_threshold_ * 2 / 3 + 1;
   LOG(log_nf_) << "Committee size " << COMMITTEE_SIZE << ", DPOS total votes count " << dpos_total_votes_count
                << ". Update 2t+1 " << TWO_T_PLUS_ONE << ", Threshold " << sortition_threshold_;
-}
-
-bool PbftManager::giveUpSoftVotedBlock_() {
-  if (last_soft_voted_value_ == NULL_BLOCK_HASH) return false;
-
-  auto now = std::chrono::system_clock::now();
-  auto soft_voted_block_wait_duration = now - time_began_waiting_soft_voted_block_;
-  unsigned long elapsed_wait_soft_voted_block_in_ms =
-      std::chrono::duration_cast<std::chrono::milliseconds>(soft_voted_block_wait_duration).count();
-
-  auto pbft_block = getUnfinalizedBlock_(previous_round_next_voted_value_.first);
-  if (pbft_block) {
-    // Have a block, but is it valid?
-    if (!pbft_chain_->checkPbftBlockValidation(*pbft_block)) {
-      // Received the block, but not valid
-      return true;
-    }
-  }
-
-  if (elapsed_wait_soft_voted_block_in_ms > max_wait_for_soft_voted_block_steps_ms_) {
-    LOG(log_dg_) << "Have been waiting " << elapsed_wait_soft_voted_block_in_ms << "ms for soft voted block "
-                 << last_soft_voted_value_ << ", giving up on this value.";
-    return true;
-  } else {
-    LOG(log_tr_) << "Have only been waiting " << elapsed_wait_soft_voted_block_in_ms << "ms for soft voted block "
-                 << last_soft_voted_value_ << "(after " << max_wait_for_soft_voted_block_steps_ms_
-                 << "ms will give up on this value)";
-  }
-
-  return false;
-}
-
-bool PbftManager::giveUpNextVotedBlock_() {
-  auto round = getPbftRound();
-
-  if (cert_voted_block_for_round_.has_value()) {
-    // Last cert voted value should equal to voted value
-    if (polling_state_print_log_) {
-      LOG(log_nf_) << "In round " << round << " step " << step_ << ", last cert voted value is "
-                   << cert_voted_block_for_round_->first;
-      polling_state_print_log_ = false;
-    }
-    return false;
-  }
-
-  if (previous_round_next_voted_value_.first == NULL_BLOCK_HASH) {
-    // In round 1 also return here
-    LOG(log_nf_) << "In round " << round << " step " << step_
-                 << ", have received 2t+1 next votes for NULL_BLOCK_HASH for previous round.";
-    return true;
-  } else if (next_votes_manager_->haveEnoughVotesForNullBlockHash()) {
-    LOG(log_nf_)
-        << "In round " << round << " step " << step_
-        << ", There are 2 voted values in previous round, and have received 2t+1 next votes for NULL_BLOCK_HASH";
-    return true;
-  }
-
-  if (pbft_chain_->findPbftBlockInChain(previous_round_next_voted_value_.first)) {
-    LOG(log_nf_) << "In round " << round << " step " << step_
-                 << ", find voted value in PBFT chain already. Give up voted value "
-                 << previous_round_next_voted_value_;
-    return true;
-  }
-
-  auto pbft_block = getUnfinalizedBlock_(previous_round_next_voted_value_.first);
-  if (pbft_block) {
-    // Have a block, but is it valid?
-    if (!pbft_chain_->checkPbftBlockValidation(*pbft_block)) {
-      // Received the block, but not valid
-      return true;
-    }
-  } else {
-    LOG(log_dg_) << "Cannot find PBFT block " << previous_round_next_voted_value_
-                 << " in both queue and DB, have not got yet";
-  }
-
-  return false;
 }
 
 std::shared_ptr<PbftBlock> PbftManager::getUnfinalizedBlock_(blk_hash_t const &block_hash) {

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -965,12 +965,9 @@ void PbftManager::firstFinish_() {
       vote_value = NULL_BLOCK_HASH;
     }
 
-    if (auto vote = generateVoteWithWeight(vote_value, next_vote_type, next_round_period,
-                                           round, step_);
-        vote) {
-      LOG(log_nf_) << "Placed first finish next vote for " << vote_value << ", vote weight "
-                   << *vote->getWeight() << ", round " << round << ", period " << next_round_period
-                   << ", step " << step_;
+    if (auto vote = generateVoteWithWeight(vote_value, next_vote_type, next_round_period, round, step_); vote) {
+      LOG(log_nf_) << "Placed first finish next vote for " << vote_value << ", vote weight " << *vote->getWeight()
+                   << ", round " << round << ", period " << next_round_period << ", step " << step_;
       placeVote(std::move(vote));
     }
 

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1093,7 +1093,7 @@ std::shared_ptr<PbftBlock> PbftManager::generatePbftBlock(const blk_hash_t &prev
   const auto propose_period = pbft_chain_->getPbftChainSize() + 1;
   // Reward votes should only include those reward votes with the same round as the round last pbft block was pushed
   // into chain
-  const auto reward_votes = vote_mgr_->getRewardVotesWithLastBlockRound();
+  const auto reward_votes = vote_mgr_->getProposeRewardVotes();
   std::vector<vote_hash_t> reward_votes_hashes;
   std::transform(reward_votes.begin(), reward_votes.end(), std::back_inserter(reward_votes_hashes),
                  [](const auto &v) { return v->getHash(); });
@@ -1709,7 +1709,7 @@ bool PbftManager::pushCertVotedPbftBlockIntoChain_(taraxa::blk_hash_t const &cer
     return false;
   }
 
-  period_data_.previous_block_cert_votes = vote_mgr_->getRewardVotes(period_data_.pbft_blk->getRewardVotes());
+  period_data_.previous_block_cert_votes = vote_mgr_->getRewardVotesByHashes(period_data_.pbft_blk->getRewardVotes());
   if (period_data_.previous_block_cert_votes.size() < period_data_.pbft_blk->getRewardVotes().size()) {
     LOG(log_er_) << "Missing reward votes in cert voted block " << cert_voted_block_hash;
     return false;
@@ -1982,7 +1982,7 @@ std::optional<std::pair<PeriodData, std::vector<std::shared_ptr<Vote>>>> PbftMan
   // pbft_chain_->findPbftBlockInChain(pbft_block_hash) and it's cert votes were not verified here, they are part of
   // vote_manager so we need to replace them as they are not verified period_data structure
   if (period_data.previous_block_cert_votes.size() && !period_data.previous_block_cert_votes.front()->getWeight()) {
-    if (auto votes = vote_mgr_->getRewardVotes(period_data.pbft_blk->getRewardVotes()); votes.size()) {
+    if (auto votes = vote_mgr_->getRewardVotesByHashes(period_data.pbft_blk->getRewardVotes()); votes.size()) {
       if (votes.size() < period_data.pbft_blk->getRewardVotes().size()) {
         LOG(log_er_) << "Failed verifying reward votes. PBFT block " << pbft_block_hash << ".Disconnect malicious peer "
                      << node_id.abridged();

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -362,10 +362,9 @@ bool PbftManager::advancePeriod() {
       auto execute_trxs_in_ms = std::chrono::duration_cast<std::chrono::milliseconds>(duration_).count();
       LOG(log_dg_) << "PBFT block " << certified_block->voted_block_hash << " certified and pushed into chain in round "
                    << current_pbft_round << ". Execution time " << execute_trxs_in_ms << " [ms]";
-    } else {
-      LOG(log_er_) << "PBFT block " << certified_block->voted_block_hash
-                   << " certified but not pushed into chain in round " << current_pbft_round;
     }
+    // Moved error message that was here to be more specific and in pushCertVotedPbftBlockIntoChain_, as it has multiple
+    // reasons it can fail.
   }
 
   // Even if node did not see 2t+1 cert votes, chain size might be increased through syncing
@@ -590,11 +589,6 @@ void PbftManager::initialState() {
     soft_voted_block_for_round_.reset();
   }
 
-  // Used for detecting timeout due to malicious node
-  // failing to gossip PBFT block or DAG blocks
-  // Requires that soft_voted_block_for_round_ already be initialized from db
-  initializeVotedValueTimeouts_();
-
   if (auto cert_voted_block = db_->getPbftMgrVotedValue(PbftMgrVotedValue::CertVotedBlockInRound);
       cert_voted_block.has_value()) {
     cert_voted_block_for_round_ = *cert_voted_block;
@@ -694,8 +688,7 @@ void PbftManager::loopBackFinishState_() {
   LOG(log_dg_) << "CONSENSUS debug round " << round << " , step " << step_
                << " | next_voted_soft_value_ = " << next_voted_soft_value_ << " soft_voted_value_for_round = "
                << (soft_voted_block_for_round_.has_value() ? soft_voted_block_for_round_->first.abridged() : "no value")
-               << " next_voted_null_block_hash_ = " << next_voted_null_block_hash_
-               << " last_soft_voted_value_ = " << last_soft_voted_value_ << " cert_voted_value_for_round = "
+               << " next_voted_null_block_hash_ = " << next_voted_null_block_hash_ << " cert_voted_value_for_round = "
                << (cert_voted_block_for_round_.has_value() ? cert_voted_block_for_round_->first.abridged() : "no value")
                << " previous_round_next_voted_value_ = " << previous_round_next_voted_value_;
   state_ = finish_state;
@@ -764,40 +757,9 @@ std::optional<std::pair<blk_hash_t, uint64_t>> PbftManager::getSoftVotedBlockFor
   return {};
 }
 
-void PbftManager::initializeVotedValueTimeouts_() {
-  time_began_waiting_next_voted_block_ = std::chrono::system_clock::now();
-  time_began_waiting_soft_voted_block_ = std::chrono::system_clock::now();
-
-  // Concern: Requires that soft_voted_block_for_round_ already be initialized from db
-  if (soft_voted_block_for_round_.has_value()) {
-    last_soft_voted_value_ = soft_voted_block_for_round_->first;
-  }
-
-  // CONCERN Do we still need any of this functionality?
-  LOG(log_er_) << "initializeVotedValueTimeouts_ being called but no longer needed";
-}
-
-// Only for test
-void PbftManager::setLastSoftVotedValue(blk_hash_t soft_voted_value) { updateLastSoftVotedValue_(soft_voted_value); }
-
-void PbftManager::updateLastSoftVotedValue_(blk_hash_t const new_soft_voted_value) {
-  if (new_soft_voted_value != last_soft_voted_value_) {
-    time_began_waiting_soft_voted_block_ = std::chrono::system_clock::now();
-  }
-  last_soft_voted_value_ = new_soft_voted_value;
-}
-
 void PbftManager::checkPreviousRoundNextVotedValueChange_() {
-  auto previous_round_next_voted_value = next_votes_manager_->getVotedValue();
-  auto previous_round_next_voted_null_block_hash = next_votes_manager_->haveEnoughVotesForNullBlockHash();
-
-  if (previous_round_next_voted_value != previous_round_next_voted_value_) {
-    time_began_waiting_next_voted_block_ = std::chrono::system_clock::now();
-    previous_round_next_voted_value_ = previous_round_next_voted_value;
-  } else if (previous_round_next_voted_null_block_hash != previous_round_next_voted_null_block_hash_) {
-    time_began_waiting_next_voted_block_ = std::chrono::system_clock::now();
-    previous_round_next_voted_null_block_hash_ = previous_round_next_voted_null_block_hash;
-  }
+  previous_round_next_voted_value_ = next_votes_manager_->getVotedValue();
+  previous_round_next_voted_null_block_hash_ = next_votes_manager_->haveEnoughVotesForNullBlockHash();
 }
 
 void PbftManager::proposeBlock_() {
@@ -882,8 +844,6 @@ void PbftManager::identifyBlock_() {
         LOG(log_nf_) << "Placed soft vote for " << leader_block_hash << ", vote weight " << vote_weight << ", round "
                      << round << ", period " << leader_block_period << ", step " << step_;
       }
-
-      updateLastSoftVotedValue_(leader_block->first);
     }
 
     return;
@@ -902,11 +862,6 @@ void PbftManager::identifyBlock_() {
                  << ", vote weight " << vote_weight << ", round " << round << ", period "
                  << previous_round_next_voted_value_.second << ", step " << step_;
   }
-
-  // Generally this value will either be the same as last soft voted value from previous round
-  // but a node could have observed a previous round next voted value that differs from what they
-  // soft voted.
-  updateLastSoftVotedValue_(previous_round_next_voted_value_.first);
 }
 
 void PbftManager::certifyBlock_() {
@@ -1737,29 +1692,31 @@ bool PbftManager::pushCertVotedPbftBlockIntoChain_(taraxa::blk_hash_t const &cer
                                                    std::vector<std::shared_ptr<Vote>> &&current_round_cert_votes) {
   auto pbft_block = getUnfinalizedBlock_(cert_voted_block_hash);
   if (!pbft_block) {
-    LOG(log_nf_) << "Can not find the cert voted block hash " << cert_voted_block_hash << " in both pbft queue and DB";
+    LOG(log_er_) << "Can not find the cert voted block hash " << cert_voted_block_hash << " in both pbft queue and DB";
     return false;
   }
 
   if (!pbft_chain_->checkPbftBlockValidation(*pbft_block)) {
+    LOG(log_er_) << "Failed pbft chain validation for cert voted block " << cert_voted_block_hash
+                 << ", will call sync pbft chain from peers";
     syncPbftChainFromPeers_(invalid_cert_voted_block, cert_voted_block_hash);
     return false;
   }
 
   auto [dag_blocks_order, ok] = compareBlocksAndRewardVotes_(pbft_block);
   if (!ok) {
-    LOG(log_nf_) << "Failed compare DAG blocks or reward votes with PBFT block " << cert_voted_block_hash;
+    LOG(log_er_) << "Failed compare DAG blocks or reward votes with cert voted block " << cert_voted_block_hash;
     return false;
   }
 
   period_data_.previous_block_cert_votes = vote_mgr_->getRewardVotes(period_data_.pbft_blk->getRewardVotes());
   if (period_data_.previous_block_cert_votes.size() < period_data_.pbft_blk->getRewardVotes().size()) {
-    LOG(log_er_) << "Missing reward votes in " << cert_voted_block_hash;
+    LOG(log_er_) << "Missing reward votes in cert voted block " << cert_voted_block_hash;
     return false;
   }
 
   if (!pushPbftBlock_(std::move(period_data_), std::move(current_round_cert_votes), std::move(dag_blocks_order))) {
-    LOG(log_er_) << "Failed push PBFT block " << pbft_block->getBlockHash() << " into chain";
+    LOG(log_er_) << "Failed push cert voted block " << pbft_block->getBlockHash() << " into PBFT chain";
     return false;
   }
 
@@ -1784,7 +1741,7 @@ void PbftManager::pushSyncedPbftBlocksIntoChain() {
         LOG(log_nf_) << node_addr_ << " push synced PBFT block " << pbft_block_hash << " in period " << period
                      << ", round " << round;
       } else {
-        LOG(log_er_) << "Failed push PBFT block " << pbft_block_hash << " into chain";
+        LOG(log_si_) << "Failed push PBFT block " << pbft_block_hash << " into chain";
         break;
       }
 
@@ -2075,6 +2032,11 @@ void PbftManager::periodDataQueuePush(PeriodData &&period_data, dev::p2p::NodeID
     LOG(log_er_) << "Trying to push period data with " << period << " period, but current period is "
                  << sync_queue_.getPeriod();
   }
+
+  // CONCERN: Added this here to make PbftChainTest.proposal_block_broadcast pass
+  //          Unsure how we expected the pbft chain size to sync with pbft mgr stopped
+  //          in that test.  But do we really want to call this here?
+  pushSyncedPbftBlocksIntoChain();
 }
 
 size_t PbftManager::periodDataQueueSize() const { return sync_queue_.size(); }

--- a/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
+++ b/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
@@ -373,6 +373,7 @@ void VoteManager::cleanupVotesByPeriod(uint64_t pbft_period) {
             for (const auto& v : voted_value.second.second) {
               if (v.second->getType() == cert_vote_type) {
                 // The verified cert vote may be reward vote
+                // TODO: would be nice to get rid of this...
                 addRewardVote(v.second);
               }
 
@@ -562,7 +563,7 @@ bool VoteManager::addRewardVote(const std::shared_ptr<Vote>& vote) {
 
   // If reward vote is from another round it should not be added to last block cert votes which should all be the same
   // round
-  if (last_pbft_block_cert_round_ == vote->getRound()) {
+  if (reward_votes_round_ == vote->getRound()) {
     db_->saveLastBlockCertVote(vote);
   }
 
@@ -614,7 +615,7 @@ std::unordered_map<vote_hash_t, std::shared_ptr<Vote>> VoteManager::replaceRewar
   // It is possible that incoming reward votes might have another round because it is possible that same block was cert
   // voted in different rounds on different nodes but this is a reference round for any pbft block this node might
   // propose
-  last_pbft_block_cert_round_ = cert_votes[0]->getRound();
+  reward_votes_round_ = cert_votes[0]->getRound();
   for (auto& v : cert_votes) {
     assert(v->getWeight());
     reward_votes_.insert({v->getHash(), std::move(v)});
@@ -622,7 +623,7 @@ std::unordered_map<vote_hash_t, std::shared_ptr<Vote>> VoteManager::replaceRewar
   return reward_votes;
 }
 
-std::vector<std::shared_ptr<Vote>> VoteManager::getRewardVotes() {
+std::vector<std::shared_ptr<Vote>> VoteManager::getAllRewardVotes() {
   std::vector<std::shared_ptr<Vote>> reward_votes;
 
   std::shared_lock lock(reward_votes_mutex_);
@@ -633,7 +634,7 @@ std::vector<std::shared_ptr<Vote>> VoteManager::getRewardVotes() {
   return reward_votes;
 }
 
-std::vector<std::shared_ptr<Vote>> VoteManager::getRewardVotes(const std::vector<vote_hash_t>& vote_hashes) {
+std::vector<std::shared_ptr<Vote>> VoteManager::getRewardVotesByHashes(const std::vector<vote_hash_t>& vote_hashes) {
   std::vector<std::shared_ptr<Vote>> reward_votes;
 
   std::shared_lock lock(reward_votes_mutex_);
@@ -650,12 +651,13 @@ std::vector<std::shared_ptr<Vote>> VoteManager::getRewardVotes(const std::vector
   return reward_votes;
 }
 
-std::vector<std::shared_ptr<Vote>> VoteManager::getRewardVotesWithLastBlockRound() {
+std::vector<std::shared_ptr<Vote>> VoteManager::getProposeRewardVotes() {
   std::vector<std::shared_ptr<Vote>> reward_votes;
 
   std::shared_lock lock(reward_votes_mutex_);
   for (const auto& v : reward_votes_) {
-    if (v.second->getRound() == last_pbft_block_cert_round_) {
+    // Select only reward votes with round == round during which node pushed previous block into the chain
+    if (v.second->getRound() == reward_votes_round_) {
       reward_votes.push_back(v.second);
     }
   }
@@ -669,7 +671,7 @@ void VoteManager::sendRewardVotes(const blk_hash_t& pbft_block_hash) {
     if (reward_votes_pbft_block_.first != pbft_block_hash) return;
   }
 
-  auto reward_votes = getRewardVotes();
+  auto reward_votes = getAllRewardVotes();
   if (reward_votes.empty()) return;
 
   auto net = network_.lock();

--- a/libraries/core_libs/network/include/network/tarcap/packet_types.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packet_types.hpp
@@ -12,13 +12,13 @@ namespace taraxa::network::tarcap {
 enum SubprotocolPacketType : uint32_t {
   // Consensus packets with high processing priority
   HighPriorityPackets = 0,
+  PbftBlockPacket,
   VotePacket,
   GetVotesSyncPacket,
   VotesSyncPacket,
 
   // Standard packets with mid processing priority
   MidPriorityPackets,
-  PbftBlockPacket,
   DagBlockPacket,
   // DagSyncPacket has mid priority as it is also used for ad-hoc syncing in case new dag blocks miss tips/pivot
   DagSyncPacket,

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_votes_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_votes_packet_handler.hpp
@@ -19,7 +19,7 @@ class ExtVotesPacketHandler : public PacketHandler {
  public:
   ExtVotesPacketHandler(std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
                         std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<PbftChain> pbft_chain,
-                        std::shared_ptr<VoteManager> vote_mgr, const uint32_t dpos_delay, const addr_t& node_addr,
+                        std::shared_ptr<VoteManager> vote_mgr, uint32_t vote_accepting_periods, const addr_t& node_addr,
                         const std::string& log_channel_name);
 
   virtual ~ExtVotesPacketHandler() = default;
@@ -68,12 +68,11 @@ class ExtVotesPacketHandler : public PacketHandler {
  protected:
   // Dpos contract delay - it is used to validate pbft period in votes -> does not make sense to accept vote
   // with vote period > current pbft period + kDposDelay as the valiation will fail
-  const uint32_t kDposDelay;
+  const uint32_t kVoteAcceptingPeriods;
 
   std::shared_ptr<PbftManager> pbft_mgr_;
   std::shared_ptr<PbftChain> pbft_chain_;
   std::shared_ptr<VoteManager> vote_mgr_;
-
 };
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_votes_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_votes_packet_handler.hpp
@@ -65,20 +65,6 @@ class ExtVotesPacketHandler : public PacketHandler {
    */
   std::pair<bool, std::string> validateVote(const std::shared_ptr<Vote>& vote) const;
 
-  /**
-   * @brief Sets voter max period and round
-   *
-   * @param voter
-   * @param round
-   */
-  void setVoterMaxPeriodAndRound(const addr_t& voter, uint64_t period, uint64_t round);
-
-  /**
-   * @param voter
-   * @return <period, round> based on received votes from them
-   */
-  std::pair<uint64_t, uint64_t> getVoterMaxPeriodAndRound(const addr_t& voter) const;
-
  protected:
   // Dpos contract delay - it is used to validate pbft period in votes -> does not make sense to accept vote
   // with vote period > current pbft period + kDposDelay as the valiation will fail
@@ -88,9 +74,6 @@ class ExtVotesPacketHandler : public PacketHandler {
   std::shared_ptr<PbftChain> pbft_chain_;
   std::shared_ptr<VoteManager> vote_mgr_;
 
-  // <vote addres, max received round>
-  std::unordered_map<addr_t, std::pair<uint64_t, uint64_t>> voters_max_periodound_;
-  mutable std::shared_mutex voters_max_periodround_mutex_;
 };
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_votes_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_votes_packet_handler.hpp
@@ -66,18 +66,18 @@ class ExtVotesPacketHandler : public PacketHandler {
   std::pair<bool, std::string> validateVote(const std::shared_ptr<Vote>& vote) const;
 
   /**
-   * @brief Sets voter max round
+   * @brief Sets voter max period and round
    *
    * @param voter
    * @param round
    */
-  void setVoterMaxRound(const addr_t& voter, uint64_t round);
+  void setVoterMaxPeriodAndRound(const addr_t& voter, uint64_t period, uint64_t round);
 
   /**
    * @param voter
-   * @return voter max round based on received votes from him
+   * @return <period, round> based on received votes from them
    */
-  uint64_t getVoterMaxRound(const addr_t& voter) const;
+  std::pair<uint64_t, uint64_t> getVoterMaxPeriodAndRound(const addr_t& voter) const;
 
  protected:
   // Dpos contract delay - it is used to validate pbft period in votes -> does not make sense to accept vote
@@ -89,8 +89,8 @@ class ExtVotesPacketHandler : public PacketHandler {
   std::shared_ptr<VoteManager> vote_mgr_;
 
   // <vote addres, max received round>
-  std::unordered_map<addr_t, uint64_t> voters_max_rounds_;
-  mutable std::shared_mutex voters_max_rounds_mutex_;
+  std::unordered_map<addr_t, std::pair<uint64_t, uint64_t>> voters_max_periodound_;
+  mutable std::shared_mutex voters_max_periodround_mutex_;
 };
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_votes_sync_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_votes_sync_packet_handler.hpp
@@ -15,7 +15,7 @@ class GetVotesSyncPacketHandler final : public ExtVotesPacketHandler {
   GetVotesSyncPacketHandler(std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
                             std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<PbftChain> pbft_chain,
                             std::shared_ptr<VoteManager> vote_mgr, std::shared_ptr<NextVotesManager> next_votes_mgr,
-                            const uint32_t dpos_delay, const addr_t& node_addr);
+                            uint32_t vote_accepting_periods, const addr_t& node_addr);
 
   // Packet type that is processed by this handler
   static constexpr SubprotocolPacketType kPacketType_ = SubprotocolPacketType::GetVotesSyncPacket;

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/status_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/status_packet_handler.hpp
@@ -31,8 +31,8 @@ class StatusPacketHandler final : public ExtSyncingPacketHandler {
   void syncPbftNextVotesAtPeriodRound(uint64_t pbft_period, uint64_t pbft_round,
                                       size_t pbft_previous_round_next_votes_size);
 
-  static constexpr uint16_t kInitialStatusPacketItemsCount = 13;
-  static constexpr uint16_t kStandardStatusPacketItemsCount = 6;
+  static constexpr uint16_t kInitialStatusPacketItemsCount = 12;
+  static constexpr uint16_t kStandardStatusPacketItemsCount = 5;
   const uint64_t conf_chain_id_;
   const h256 genesis_hash_;
 

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/status_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/status_packet_handler.hpp
@@ -26,12 +26,13 @@ class StatusPacketHandler final : public ExtSyncingPacketHandler {
   void validatePacketRlpFormat(const PacketData& packet_data) const override;
   void process(const PacketData& packet_data, const std::shared_ptr<TaraxaPeer>& peer) override;
 
-  void requestPbftNextVotes(dev::p2p::NodeID const& peerID, uint64_t pbft_round,
-                            size_t pbft_previous_round_next_votes_size);
-  void syncPbftNextVotes(uint64_t pbft_round, size_t pbft_previous_round_next_votes_size);
+  void requestPbftNextVotesAtPeriodRound(dev::p2p::NodeID const& peerID, uint64_t pbft_period, uint64_t pbft_round,
+                                         size_t pbft_previous_round_next_votes_size);
+  void syncPbftNextVotesAtPeriodRound(uint64_t pbft_period, uint64_t pbft_round,
+                                      size_t pbft_previous_round_next_votes_size);
 
-  static constexpr uint16_t kInitialStatusPacketItemsCount = 12;
-  static constexpr uint16_t kStandardStatusPacketItemsCount = 5;
+  static constexpr uint16_t kInitialStatusPacketItemsCount = 13;
+  static constexpr uint16_t kStandardStatusPacketItemsCount = 6;
   const uint64_t conf_chain_id_;
   const h256 genesis_hash_;
 

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/vote_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/vote_packet_handler.hpp
@@ -13,7 +13,7 @@ class VotePacketHandler final : public ExtVotesPacketHandler {
  public:
   VotePacketHandler(std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
                     std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<PbftChain> pbft_chain,
-                    std::shared_ptr<VoteManager> vote_mgr, const uint32_t dpos_delay, const addr_t& node_addr);
+                    std::shared_ptr<VoteManager> vote_mgr, const NetworkConfig& net_config, const addr_t& node_addr);
 
   // Packet type that is processed by this handler
   static constexpr SubprotocolPacketType kPacketType_ = SubprotocolPacketType::VotePacket;
@@ -21,8 +21,13 @@ class VotePacketHandler final : public ExtVotesPacketHandler {
  private:
   void validatePacketRlpFormat(const PacketData& packet_data) const override;
   void process(const PacketData& packet_data, const std::shared_ptr<TaraxaPeer>& peer) override;
+  bool shouldProcessVote(const std::shared_ptr<Vote>& vote, const std::shared_ptr<TaraxaPeer>& peer);
 
+  const uint16_t kVoteAcceptingRounds;
+  const uint16_t kVoteAcceptingSteps;
+  constexpr static std::chrono::seconds kSyncRequestInterval = std::chrono::seconds(10);
   ExpirationCache<vote_hash_t> seen_votes_;
+  std::chrono::system_clock::time_point round_sync_request_time_;
 };
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/vote_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/vote_packet_handler.hpp
@@ -21,7 +21,7 @@ class VotePacketHandler final : public ExtVotesPacketHandler {
  private:
   void validatePacketRlpFormat(const PacketData& packet_data) const override;
   void process(const PacketData& packet_data, const std::shared_ptr<TaraxaPeer>& peer) override;
-  bool shouldProcessVote(const std::shared_ptr<Vote>& vote, const std::shared_ptr<TaraxaPeer>& peer);
+  bool checkVoteMaxPeriodRoundStep(const std::shared_ptr<Vote>& vote, const std::shared_ptr<TaraxaPeer>& peer);
 
   const uint16_t kVoteAcceptingRounds;
   const uint16_t kVoteAcceptingSteps;

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/votes_sync_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/votes_sync_packet_handler.hpp
@@ -16,7 +16,7 @@ class VotesSyncPacketHandler final : public ExtVotesPacketHandler {
   VotesSyncPacketHandler(std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
                          std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<PbftChain> pbft_chain,
                          std::shared_ptr<VoteManager> vote_mgr, std::shared_ptr<NextVotesManager> next_votes_mgr,
-                         std::shared_ptr<DbStorage> db, const uint32_t dpos_delay, const addr_t& node_addr);
+                         std::shared_ptr<DbStorage> db, uint32_t vote_accepting_periods, const addr_t& node_addr);
 
   void broadcastPreviousRoundNextVotesBundle();
 

--- a/libraries/core_libs/network/include/network/tarcap/stats/node_stats.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/stats/node_stats.hpp
@@ -45,7 +45,9 @@ class NodeStats {
   std::shared_ptr<const TarcapThreadPool> thread_pool_;
 
   level_t local_max_level_in_dag_prev_interval_{0};
+  uint64_t local_pbft_period_prev_interval_{0};
   uint64_t local_pbft_round_prev_interval_{0};
+  uint64_t local_pbft_step_prev_interval_{0};
   uint64_t local_chain_size_prev_interval_{0};
   uint64_t local_pbft_sync_period_prev_interval_{0};
   uint64_t intervals_in_sync_since_launch_{0};

--- a/libraries/core_libs/network/include/network/tarcap/stats/node_stats.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/stats/node_stats.hpp
@@ -45,9 +45,7 @@ class NodeStats {
   std::shared_ptr<const TarcapThreadPool> thread_pool_;
 
   level_t local_max_level_in_dag_prev_interval_{0};
-  uint64_t local_pbft_period_prev_interval_{0};
   uint64_t local_pbft_round_prev_interval_{0};
-  uint64_t local_pbft_step_prev_interval_{0};
   uint64_t local_chain_size_prev_interval_{0};
   uint64_t local_pbft_sync_period_prev_interval_{0};
   uint64_t intervals_in_sync_since_launch_{0};

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
@@ -86,6 +86,8 @@ class TaraxaPeer : public boost::noncopyable {
   std::atomic<bool> syncing_ = false;
   std::atomic<uint64_t> dag_level_ = 0;
   std::atomic<uint64_t> pbft_chain_size_ = 0;
+  // CONCERN: period different from chain size? how?
+  std::atomic<uint64_t> pbft_period_ = 1;
   std::atomic<uint64_t> pbft_round_ = 1;
   std::atomic<size_t> pbft_previous_round_next_votes_size_ = 0;
   std::atomic<uint64_t> last_status_pbft_chain_size_ = 0;

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
@@ -86,8 +86,7 @@ class TaraxaPeer : public boost::noncopyable {
   std::atomic<bool> syncing_ = false;
   std::atomic<uint64_t> dag_level_ = 0;
   std::atomic<uint64_t> pbft_chain_size_ = 0;
-  // CONCERN: period different from chain size? how?
-  std::atomic<uint64_t> pbft_period_ = 1;
+  std::atomic<uint64_t> pbft_period_ = pbft_chain_size_ = 1;
   std::atomic<uint64_t> pbft_round_ = 1;
   std::atomic<size_t> pbft_previous_round_next_votes_size_ = 0;
   std::atomic<uint64_t> last_status_pbft_chain_size_ = 0;

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_votes_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_votes_packet_handler.cpp
@@ -78,10 +78,9 @@ std::pair<bool, std::string> ExtVotesPacketHandler::validateNextSyncVote(const s
 std::pair<bool, std::string> ExtVotesPacketHandler::validateRewardVote(const std::shared_ptr<Vote> &vote) const {
   const auto [current_pbft_round, current_pbft_period] = pbft_mgr_->getPbftRoundAndPeriod();
 
-  if (vote->getPeriod() < current_pbft_period - 1 || vote->getPeriod() > current_pbft_period ||
-      vote->getRound() >= current_pbft_round) {
+  if (vote->getPeriod() != current_pbft_period - 1) {
     std::stringstream err;
-    err << "Invalid round: Vote round: " << vote->getRound() << ", current pbft round: " << current_pbft_round;
+    err << "Invalid period: Vote period: " << vote->getPeriod() << ", current pbft period: " << current_pbft_period;
     return {false, err.str()};
   }
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_votes_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_votes_packet_handler.cpp
@@ -10,10 +10,10 @@ ExtVotesPacketHandler::ExtVotesPacketHandler(std::shared_ptr<PeersState> peers_s
                                              std::shared_ptr<PacketsStats> packets_stats,
                                              std::shared_ptr<PbftManager> pbft_mgr,
                                              std::shared_ptr<PbftChain> pbft_chain,
-                                             std::shared_ptr<VoteManager> vote_mgr, const uint32_t dpos_delay,
+                                             std::shared_ptr<VoteManager> vote_mgr, uint32_t vote_accepting_periods,
                                              const addr_t &node_addr, const std::string &log_channel_name)
     : PacketHandler(std::move(peers_state), std::move(packets_stats), node_addr, log_channel_name),
-      kDposDelay(dpos_delay),
+      kVoteAcceptingPeriods(vote_accepting_periods),
       pbft_mgr_(std::move(pbft_mgr)),
       pbft_chain_(std::move(pbft_chain)),
       vote_mgr_(std::move(vote_mgr)) {}
@@ -26,7 +26,7 @@ std::pair<bool, std::string> ExtVotesPacketHandler::validateStandardVote(const s
   // reward votes -> whole rewards votes gossiping need to be checked...
 
   // CONCERN: Why the minus one on the vote period?
-  if (vote->getPeriod() < current_pbft_period || vote->getPeriod() - 1 > current_pbft_period + kDposDelay) {
+  if (vote->getPeriod() < current_pbft_period || vote->getPeriod() - 1 > current_pbft_period + kVoteAcceptingPeriods) {
     std::stringstream err;
     err << "Invalid period: Vote period: " << vote->getPeriod() << ", current pbft period: " << current_pbft_period;
     return {false, err.str()};
@@ -46,7 +46,7 @@ std::pair<bool, std::string> ExtVotesPacketHandler::validateNextSyncVote(const s
 
   // Old vote or vote from too far in the future, can be dropped
   // CONCERN: Why the minus one on the vote period?
-  if (vote->getPeriod() < current_pbft_period || vote->getPeriod() - 1 > current_pbft_period + kDposDelay) {
+  if (vote->getPeriod() < current_pbft_period || vote->getPeriod() - 1 > current_pbft_period + kVoteAcceptingPeriods) {
     std::stringstream err;
     err << "Invalid period: Vote period: " << vote->getPeriod() << ", current pbft period: " << current_pbft_period;
     return {false, err.str()};

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_votes_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_votes_packet_handler.cpp
@@ -19,12 +19,13 @@ ExtVotesPacketHandler::ExtVotesPacketHandler(std::shared_ptr<PeersState> peers_s
       vote_mgr_(std::move(vote_mgr)) {}
 
 std::pair<bool, std::string> ExtVotesPacketHandler::validateStandardVote(const std::shared_ptr<Vote> &vote) const {
-  const uint64_t current_pbft_period = pbft_chain_->getPbftChainSize();
-  const auto current_pbft_round = pbft_mgr_->getPbftRound();
+  const auto [current_pbft_round, current_pbft_period] = pbft_mgr_->getPbftRoundAndPeriod();
 
   // Old vote or vote from too far in the future, can be dropped
   // TODO[1880]: should be vote->getPeriod() <= current_pbft_period - if <=, some tests are failing due to missing
   // reward votes -> whole rewards votes gossiping need to be checked...
+
+  // CONCERN: Why the minus one on the vote period?
   if (vote->getPeriod() < current_pbft_period || vote->getPeriod() - 1 > current_pbft_period + kDposDelay) {
     std::stringstream err;
     err << "Invalid period: Vote period: " << vote->getPeriod() << ", current pbft period: " << current_pbft_period;
@@ -37,10 +38,11 @@ std::pair<bool, std::string> ExtVotesPacketHandler::validateStandardVote(const s
     return {false, err.str()};
   }
 
-  if (auto voter_max_round = getVoterMaxRound(vote->getVoterAddr()); vote->getRound() + 1 < voter_max_round) {
+  if (const auto [voter_max_period, voter_max_round] = getVoterMaxPeriodAndRound(vote->getVoterAddr());
+      vote->getPeriod() < voter_max_period || vote->getRound() + 1 < voter_max_round) {
     std::stringstream err;
-    err << "Invalid round: Vote round: " << vote->getRound()
-        << ", voter current max received round: " << voter_max_round;
+    err << "Invalid voute period, round: Vote period, round: {" << vote->getPeriod() << ", " << vote->getRound()
+        << "}, voter current max received period, round: {" << voter_max_period << ", " << voter_max_round << "}";
     return {false, err.str()};
   }
 
@@ -48,10 +50,10 @@ std::pair<bool, std::string> ExtVotesPacketHandler::validateStandardVote(const s
 }
 
 std::pair<bool, std::string> ExtVotesPacketHandler::validateNextSyncVote(const std::shared_ptr<Vote> &vote) const {
-  const uint64_t current_pbft_period = pbft_chain_->getPbftChainSize();
-  const auto current_pbft_round = pbft_mgr_->getPbftRound();
+  const auto [current_pbft_round, current_pbft_period] = pbft_mgr_->getPbftRoundAndPeriod();
 
   // Old vote or vote from too far in the future, can be dropped
+  // CONCERN: Why the minus one on the vote period?
   if (vote->getPeriod() < current_pbft_period || vote->getPeriod() - 1 > current_pbft_period + kDposDelay) {
     std::stringstream err;
     err << "Invalid period: Vote period: " << vote->getPeriod() << ", current pbft period: " << current_pbft_period;
@@ -74,9 +76,10 @@ std::pair<bool, std::string> ExtVotesPacketHandler::validateNextSyncVote(const s
 }
 
 std::pair<bool, std::string> ExtVotesPacketHandler::validateRewardVote(const std::shared_ptr<Vote> &vote) const {
-  const auto current_pbft_round = pbft_mgr_->getPbftRound();
+  const auto [current_pbft_round, current_pbft_period] = pbft_mgr_->getPbftRoundAndPeriod();
 
-  if (vote->getRound() >= current_pbft_round) {
+  if (vote->getPeriod() < current_pbft_period - 1 || vote->getPeriod() > current_pbft_period ||
+      vote->getRound() >= current_pbft_round) {
     std::stringstream err;
     err << "Invalid round: Vote round: " << vote->getRound() << ", current pbft round: " << current_pbft_round;
     return {false, err.str()};
@@ -89,7 +92,8 @@ std::pair<bool, std::string> ExtVotesPacketHandler::validateRewardVote(const std
 }
 
 std::pair<bool, std::string> ExtVotesPacketHandler::validateVote(const std::shared_ptr<Vote> &vote) const {
-  // Check is vote is unique per round & step & voter -> each address can generate just 1 vote per round & step
+  // Check is vote is unique per period, round & step & voter -> each address can generate just 1 vote
+  // (for a value that isn't NBH) per period, round & step
   if (auto unique_vote_validation = vote_mgr_->isUniqueVote(vote); !unique_vote_validation.first) {
     return unique_vote_validation;
   }
@@ -102,24 +106,27 @@ std::pair<bool, std::string> ExtVotesPacketHandler::validateVote(const std::shar
   return vote_valid;
 }
 
-void ExtVotesPacketHandler::setVoterMaxRound(const addr_t &voter, uint64_t round) {
-  if (getVoterMaxRound(voter) >= round) {
+void ExtVotesPacketHandler::setVoterMaxPeriodAndRound(const addr_t &voter, uint64_t period, uint64_t round) {
+  if (const auto [voter_max_period, voter_max_round] = getVoterMaxPeriodAndRound(voter);
+      period < voter_max_period || (period == voter_max_period && voter_max_round >= round)) {
     return;
   }
 
-  std::unique_lock lock(voters_max_rounds_mutex_);
-  if (auto inserted_value = voters_max_rounds_.insert({voter, round}); !inserted_value.second) {
-    if (round > inserted_value.first->second) {
-      inserted_value.first->second = round;
+  std::unique_lock lock(voters_max_periodround_mutex_);
+  if (auto inserted_value = voters_max_periodound_.insert({voter, {period, round}}); !inserted_value.second) {
+    if (period > inserted_value.first->second.first ||
+        (period == inserted_value.first->second.first && round > inserted_value.first->second.second)) {
+      inserted_value.first->second = {period, round};
     }
   }
 }
 
-uint64_t ExtVotesPacketHandler::getVoterMaxRound(const addr_t &voter) const {
-  std::shared_lock lock(voters_max_rounds_mutex_);
+std::pair<uint64_t, uint64_t> ExtVotesPacketHandler::getVoterMaxPeriodAndRound(const addr_t &voter) const {
+  std::shared_lock lock(voters_max_periodround_mutex_);
 
-  auto voter_max_round = voters_max_rounds_.find(voter);
-  return voter_max_round == voters_max_rounds_.end() ? 0 : voter_max_round->second;
+  auto voter_max_periodround = voters_max_periodound_.find(voter);
+  return voter_max_periodround == voters_max_periodound_.end() ? std::make_pair<uint64_t, uint64_t>(1, 0)
+                                                               : voter_max_periodround->second;
 }
 
 void ExtVotesPacketHandler::onNewPbftVotes(std::vector<std::shared_ptr<Vote>> &&votes) {
@@ -133,7 +140,8 @@ void ExtVotesPacketHandler::onNewPbftVotes(std::vector<std::shared_ptr<Vote>> &&
     std::vector<std::shared_ptr<Vote>> send_votes;
     for (const auto &v : votes) {
       if (!peer.second->isVoteKnown(v->getHash()) &&
-          (peer.second->pbft_round_ <= v->getRound() ||
+          // CONCERN ... should we be using a period stored in peer state?
+          (peer.second->pbft_chain_size_ <= v->getPeriod() - 1 || peer.second->pbft_round_ <= v->getRound() ||
            (v->getType() == cert_vote_type && v->getBlockHash() == rewards_votes_block.first /* reward vote */))) {
         send_votes.push_back(v);
       }

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/get_votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/get_votes_sync_packet_handler.cpp
@@ -8,9 +8,10 @@ namespace taraxa::network::tarcap {
 GetVotesSyncPacketHandler::GetVotesSyncPacketHandler(
     std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
     std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<VoteManager> vote_mgr,
-    std::shared_ptr<NextVotesManager> next_votes_mgr, const uint32_t dpos_delay, const addr_t &node_addr)
+    std::shared_ptr<NextVotesManager> next_votes_mgr, uint32_t vote_accepting_periods, const addr_t &node_addr)
     : ExtVotesPacketHandler(std::move(peers_state), std::move(packets_stats), std::move(pbft_mgr),
-                            std::move(pbft_chain), std::move(vote_mgr), dpos_delay, node_addr, "GET_VOTES_SYNC_PH"),
+                            std::move(pbft_chain), std::move(vote_mgr), vote_accepting_periods, node_addr,
+                            "GET_VOTES_SYNC_PH"),
       next_votes_mgr_(std::move(next_votes_mgr)) {}
 
 void GetVotesSyncPacketHandler::validatePacketRlpFormat(const PacketData &packet_data) const {

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/get_votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/get_votes_sync_packet_handler.cpp
@@ -14,7 +14,7 @@ GetVotesSyncPacketHandler::GetVotesSyncPacketHandler(
       next_votes_mgr_(std::move(next_votes_mgr)) {}
 
 void GetVotesSyncPacketHandler::validatePacketRlpFormat(const PacketData &packet_data) const {
-  if (constexpr size_t required_size = 2; packet_data.rlp_.itemCount() != required_size) {
+  if (constexpr size_t required_size = 3; packet_data.rlp_.itemCount() != required_size) {
     throw InvalidRlpItemsCountException(packet_data.type_str_, packet_data.rlp_.itemCount(), required_size);
   }
 }
@@ -22,17 +22,20 @@ void GetVotesSyncPacketHandler::validatePacketRlpFormat(const PacketData &packet
 void GetVotesSyncPacketHandler::process(const PacketData &packet_data, const std::shared_ptr<TaraxaPeer> &peer) {
   LOG(log_dg_) << "Received GetVotesSyncPacket request";
 
-  const uint64_t peer_pbft_round = packet_data.rlp_[0].toPositiveInt64();
-  const size_t peer_pbft_previous_round_next_votes_size = packet_data.rlp_[1].toInt<unsigned>();
-  const uint64_t pbft_round = pbft_mgr_->getPbftRound();
+  const uint64_t peer_pbft_period = packet_data.rlp_[0].toPositiveInt64();
+  const uint64_t peer_pbft_round = packet_data.rlp_[1].toPositiveInt64();
+  const size_t peer_pbft_previous_round_next_votes_size = packet_data.rlp_[2].toInt<unsigned>();
+  const auto [pbft_round, pbft_period] = pbft_mgr_->getPbftRoundAndPeriod();
   const size_t pbft_previous_round_next_votes_size = next_votes_mgr_->getNextVotesWeight();
 
-  if (pbft_round > peer_pbft_round || (pbft_round == peer_pbft_round && pbft_previous_round_next_votes_size >
-                                                                            peer_pbft_previous_round_next_votes_size)) {
-    LOG(log_dg_) << "Current PBFT round is " << pbft_round << " previous round next votes size "
-                 << pbft_previous_round_next_votes_size << ", and peer PBFT round is " << peer_pbft_round
-                 << " previous round next votes size " << peer_pbft_previous_round_next_votes_size
-                 << ". Will send out bundle of next votes";
+  if (pbft_period == peer_pbft_period &&
+      (pbft_round > peer_pbft_round ||
+       (pbft_round == peer_pbft_round &&
+        pbft_previous_round_next_votes_size > peer_pbft_previous_round_next_votes_size))) {
+    LOG(log_dg_) << "In PBFT period " << pbft_period << ", current PBFT round is " << pbft_round
+                 << " previous round next votes size " << pbft_previous_round_next_votes_size
+                 << ", and peer PBFT round is " << peer_pbft_round << " previous round next votes size "
+                 << peer_pbft_previous_round_next_votes_size << ". Will send out bundle of next votes";
 
     auto next_votes_bundle = next_votes_mgr_->getNextVotes();
     std::vector<std::shared_ptr<Vote>> send_next_votes_bundle;

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
@@ -169,7 +169,7 @@ void PbftSyncPacketHandler::process(const PacketData &packet_data, const std::sh
       return;
     }
     // And now we need to replace it with verified votes
-    if (auto votes = vote_mgr_->getRewardVotes(period_data.pbft_blk->getRewardVotes()); votes.size()) {
+    if (auto votes = vote_mgr_->getRewardVotesByHashes(period_data.pbft_blk->getRewardVotes()); votes.size()) {
       period_data.previous_block_cert_votes = std::move(votes);
     }
   }

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/status_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/status_packet_handler.cpp
@@ -56,6 +56,7 @@ void StatusPacketHandler::process(const PacketData& packet_data, const std::shar
     auto const genesis_hash = (*it++).toHash<blk_hash_t>();
     auto const peer_pbft_chain_size = (*it++).toInt<uint64_t>();
     auto const peer_syncing = (*it++).toInt();
+    auto const peer_pbft_period = (*it++).toInt<uint64_t>();
     auto const peer_pbft_round = (*it++).toInt<uint64_t>();
     auto const peer_pbft_previous_round_next_votes_size = (*it++).toInt<unsigned>();
     auto const node_major_version = (*it++).toInt<unsigned>();
@@ -95,6 +96,7 @@ void StatusPacketHandler::process(const PacketData& packet_data, const std::shar
     selected_peer->dag_level_ = peer_dag_level;
     selected_peer->pbft_chain_size_ = peer_pbft_chain_size;
     selected_peer->syncing_ = peer_syncing;
+    selected_peer->pbft_period_ = peer_pbft_period;
     selected_peer->pbft_round_ = peer_pbft_round;
     selected_peer->pbft_previous_round_next_votes_size_ = peer_pbft_previous_round_next_votes_size;
 
@@ -103,10 +105,10 @@ void StatusPacketHandler::process(const PacketData& packet_data, const std::shar
     LOG(log_dg_) << "Received initial status message from " << packet_data.from_node_id_ << ", network id "
                  << peer_chain_id << ", peer DAG max level " << selected_peer->dag_level_ << ", genesis "
                  << genesis_hash << ", peer pbft chain size " << selected_peer->pbft_chain_size_ << ", peer syncing "
-                 << std::boolalpha << selected_peer->syncing_ << ", peer pbft round " << selected_peer->pbft_round_
-                 << ", peer pbft previous round next votes size " << selected_peer->pbft_previous_round_next_votes_size_
-                 << ", node major version" << node_major_version << ", node minor version" << node_minor_version
-                 << ", node patch version" << node_patch_version;
+                 << std::boolalpha << selected_peer->syncing_ << ", peer pbft period " << selected_peer->pbft_period_
+                 << ", peer pbft round " << selected_peer->pbft_round_ << ", peer pbft previous round next votes size "
+                 << selected_peer->pbft_previous_round_next_votes_size_ << ", node major version" << node_major_version
+                 << ", node minor version" << node_minor_version << ", node patch version" << node_patch_version;
 
   } else {  // Standard status packet
     // TODO: initial and standard status packet could be separated...
@@ -121,6 +123,7 @@ void StatusPacketHandler::process(const PacketData& packet_data, const std::shar
     selected_peer->dag_level_ = (*it++).toInt<uint64_t>();
     selected_peer->pbft_chain_size_ = (*it++).toInt<uint64_t>();
     selected_peer->syncing_ = (*it++).toInt();
+    selected_peer->pbft_period_ = (*it++).toInt<uint64_t>();
     selected_peer->pbft_round_ = (*it++).toInt<uint64_t>();
     selected_peer->pbft_previous_round_next_votes_size_ = (*it++).toInt<unsigned>();
 
@@ -142,17 +145,20 @@ void StatusPacketHandler::process(const PacketData& packet_data, const std::shar
         // if not syncing and the peer period is matching our period request any pending dag blocks
         requestPendingDagBlocks(selected_peer);
       }
-      const auto pbft_current_round = pbft_mgr_->getPbftRound();
+      const auto [pbft_current_round, pbft_current_period] = pbft_mgr_->getPbftRoundAndPeriod();
       const auto pbft_previous_round_next_votes_size = next_votes_mgr_->getNextVotesWeight();
-      if (pbft_current_round < selected_peer->pbft_round_) {
-        syncPbftNextVotes(pbft_current_round, pbft_previous_round_next_votes_size);
-      } else if (pbft_current_round == selected_peer->pbft_round_) {
-        const auto two_times_2t_plus_1 = pbft_mgr_->getTwoTPlusOne() * 2;
-        // Node at lease have one next vote value for previoud PBFT round. There may have 2 next vote values for
-        // previous PBFT round. If node own have one next vote value and peer have two, need sync here.
-        if (pbft_previous_round_next_votes_size < two_times_2t_plus_1 &&
-            selected_peer->pbft_previous_round_next_votes_size_ >= two_times_2t_plus_1) {
-          syncPbftNextVotes(pbft_current_round, pbft_previous_round_next_votes_size);
+      if (pbft_current_period == selected_peer->pbft_period_) {
+        if (pbft_current_round < selected_peer->pbft_round_) {
+          syncPbftNextVotesAtPeriodRound(pbft_current_period, pbft_current_round, pbft_previous_round_next_votes_size);
+        } else if (pbft_current_round == selected_peer->pbft_round_) {
+          const auto two_times_2t_plus_1 = pbft_mgr_->getTwoTPlusOne() * 2;
+          // Node at lease have one next vote value for previoud PBFT round. There may have 2 next vote values for
+          // previous PBFT round. If node own have one next vote value and peer have two, need sync here.
+          if (pbft_previous_round_next_votes_size < two_times_2t_plus_1 &&
+              selected_peer->pbft_previous_round_next_votes_size_ >= two_times_2t_plus_1) {
+            syncPbftNextVotesAtPeriodRound(pbft_current_period, pbft_current_round,
+                                           pbft_previous_round_next_votes_size);
+          }
         }
       }
     }
@@ -178,7 +184,7 @@ bool StatusPacketHandler::sendStatus(const dev::p2p::NodeID& node_id, bool initi
 
     auto dag_max_level = dag_mgr_->getMaxLevel();
     auto pbft_chain_size = pbft_chain_->getPbftChainSize();
-    auto pbft_round = pbft_mgr_->getPbftRound();
+    const auto [pbft_round, pbft_period] = pbft_mgr_->getPbftRoundAndPeriod();
     auto pbft_previous_round_next_votes_size = next_votes_mgr_->getNextVotesWeight();
 
     if (initial) {
@@ -186,14 +192,14 @@ bool StatusPacketHandler::sendStatus(const dev::p2p::NodeID& node_id, bool initi
           sealAndSend(node_id, StatusPacket,
                       std::move(dev::RLPStream(kInitialStatusPacketItemsCount)
                                 << conf_chain_id_ << dag_max_level << genesis_hash_ << pbft_chain_size
-                                << pbft_syncing_state_->isPbftSyncing() << pbft_round
+                                << pbft_syncing_state_->isPbftSyncing() << pbft_period << pbft_round
                                 << pbft_previous_round_next_votes_size << TARAXA_MAJOR_VERSION << TARAXA_MINOR_VERSION
                                 << TARAXA_PATCH_VERSION << dag_mgr_->isLightNode() << dag_mgr_->getLightNodeHistory()));
     } else {
       success = sealAndSend(node_id, StatusPacket,
                             std::move(dev::RLPStream(kStandardStatusPacketItemsCount)
                                       << dag_max_level << pbft_chain_size << pbft_syncing_state_->isDeepPbftSyncing()
-                                      << pbft_round << pbft_previous_round_next_votes_size));
+                                      << pbft_period << pbft_round << pbft_previous_round_next_votes_size));
     }
   }
 
@@ -212,21 +218,25 @@ void StatusPacketHandler::sendStatusToPeers() {
   }
 }
 
-void StatusPacketHandler::syncPbftNextVotes(uint64_t pbft_round, size_t pbft_previous_round_next_votes_size) {
+void StatusPacketHandler::syncPbftNextVotesAtPeriodRound(uint64_t pbft_period, uint64_t pbft_round,
+                                                         size_t pbft_previous_round_next_votes_size) {
   dev::p2p::NodeID peer_node_ID;
+  uint64_t peer_max_pbft_period = 1;
   uint64_t peer_max_pbft_round = 1;
   size_t peer_max_previous_round_next_votes_size = 0;
 
   auto peers = peers_state_->getAllPeers();
-  // Find max peer PBFT round
+  // Find max peer PBFT period, round...
   for (auto const& peer : peers) {
-    if (peer.second->pbft_round_ > peer_max_pbft_round) {
+    if ((peer.second->pbft_period_ > peer_max_pbft_period) ||
+        (peer.second->pbft_period_ == peer_max_pbft_period && peer.second->pbft_round_ > peer_max_pbft_round)) {
+      peer_max_pbft_period = peer.second->pbft_period_;
       peer_max_pbft_round = peer.second->pbft_round_;
       peer_node_ID = peer.first;
     }
   }
 
-  if (pbft_round == peer_max_pbft_round) {
+  if (pbft_period == peer_max_pbft_period && pbft_round == peer_max_pbft_round) {
     // No peers ahead, find peer PBFT previous round max next votes size
     for (auto const& peer : peers) {
       if (peer.second->pbft_previous_round_next_votes_size_ > peer_max_previous_round_next_votes_size) {
@@ -236,23 +246,27 @@ void StatusPacketHandler::syncPbftNextVotes(uint64_t pbft_round, size_t pbft_pre
     }
   }
 
-  if (pbft_round < peer_max_pbft_round ||
-      (pbft_round == peer_max_pbft_round &&
-       pbft_previous_round_next_votes_size < peer_max_previous_round_next_votes_size)) {
-    LOG(log_dg_) << "Syncing PBFT next votes. Current PBFT round " << pbft_round << ", previous round next votes size "
-                 << pbft_previous_round_next_votes_size << ". Peer " << peer_node_ID << " is in PBFT round "
-                 << peer_max_pbft_round << ", previous round next votes size "
+  if (peer_max_pbft_period != pbft_period) {
+    LOG(log_dg_) << "Syncing PBFT next votes not needed. Current PBFT period " << pbft_period
+                 << ". Peer with max period: " << peer_node_ID << ", is in PBFT period: " << peer_max_pbft_period;
+  } else if (pbft_round < peer_max_pbft_round ||
+             (pbft_round == peer_max_pbft_round &&
+              pbft_previous_round_next_votes_size < peer_max_previous_round_next_votes_size)) {
+    LOG(log_dg_) << "Syncing PBFT next votes. In period " << pbft_period << ", current PBFT round " << pbft_round
+                 << ", previous round next votes size " << pbft_previous_round_next_votes_size << ". Peer "
+                 << peer_node_ID << " is in PBFT round " << peer_max_pbft_round << ", previous round next votes size "
                  << peer_max_previous_round_next_votes_size;
-    requestPbftNextVotes(peer_node_ID, pbft_round, pbft_previous_round_next_votes_size);
+    requestPbftNextVotesAtPeriodRound(peer_node_ID, pbft_period, pbft_round, pbft_previous_round_next_votes_size);
   }
 }
 
-void StatusPacketHandler::requestPbftNextVotes(dev::p2p::NodeID const& peerID, uint64_t pbft_round,
-                                               size_t pbft_previous_round_next_votes_size) {
+void StatusPacketHandler::requestPbftNextVotesAtPeriodRound(dev::p2p::NodeID const& peerID, uint64_t pbft_period,
+                                                            uint64_t pbft_round,
+                                                            size_t pbft_previous_round_next_votes_size) {
   LOG(log_dg_) << "Sending GetVotesSyncPacket with round " << pbft_round << " previous round next votes size "
                << pbft_previous_round_next_votes_size;
   sealAndSend(peerID, GetVotesSyncPacket,
-              std::move(dev::RLPStream(2) << pbft_round << pbft_previous_round_next_votes_size));
+              std::move(dev::RLPStream(3) << pbft_period << pbft_round << pbft_previous_round_next_votes_size));
 }
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
@@ -54,7 +54,6 @@ void VotePacketHandler::process(const PacketData &packet_data, const std::shared
         continue;
       }
 
-      setVoterMaxPeriodAndRound(vote->getVoterAddr(), vote->getPeriod(), vote->getRound());
     } else if (vote->getPeriod() == current_pbft_period - 1 && vote->getType() == PbftVoteTypes::cert_vote_type) {
       // potential reward vote
       if (vote_mgr_->isInRewardsVotes(vote->getHash())) {

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
@@ -8,9 +8,12 @@ namespace taraxa::network::tarcap {
 VotePacketHandler::VotePacketHandler(std::shared_ptr<PeersState> peers_state,
                                      std::shared_ptr<PacketsStats> packets_stats, std::shared_ptr<PbftManager> pbft_mgr,
                                      std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<VoteManager> vote_mgr,
-                                     const uint32_t dpos_delay, const addr_t &node_addr)
+                                     const NetworkConfig &net_config, const addr_t &node_addr)
     : ExtVotesPacketHandler(std::move(peers_state), std::move(packets_stats), std::move(pbft_mgr),
-                            std::move(pbft_chain), std::move(vote_mgr), dpos_delay, node_addr, "PBFT_VOTE_PH"),
+                            std::move(pbft_chain), std::move(vote_mgr), net_config.vote_accepting_periods, node_addr,
+                            "PBFT_VOTE_PH"),
+      kVoteAcceptingRounds(net_config.vote_accepting_rounds),
+      kVoteAcceptingSteps(net_config.vote_accepting_steps),
       seen_votes_(1000000, 1000) {}
 
 void VotePacketHandler::validatePacketRlpFormat([[maybe_unused]] const PacketData &packet_data) const {
@@ -18,6 +21,67 @@ void VotePacketHandler::validatePacketRlpFormat([[maybe_unused]] const PacketDat
   if (items == 0 || items > kMaxVotesInPacket) {
     throw InvalidRlpItemsCountException(packet_data.type_str_, items, kMaxVotesInPacket);
   }
+}
+
+bool VotePacketHandler::shouldProcessVote(const std::shared_ptr<Vote> &vote, const std::shared_ptr<TaraxaPeer> &peer) {
+  const auto [current_pbft_round, current_pbft_period] = pbft_mgr_->getPbftRoundAndPeriod();
+  const auto current_pbft_step = pbft_mgr_->getPbftStep();
+  const auto vote_hash = vote->getHash();
+
+  if (vote->getPeriod() - 1 > pbft_chain_->getPbftChainSize() + kVoteAcceptingPeriods) {
+    // Do not request round sync too often here
+    if (std::chrono::system_clock::now() - round_sync_request_time_ > kSyncRequestInterval) {
+      // request PBFT chain sync from this node
+      sealAndSend(peer->getId(), SubprotocolPacketType::GetPbftSyncPacket,
+                  std::move(dev::RLPStream(1) << std::max(vote->getPeriod() - 1, peer->pbft_chain_size_.load())));
+      round_sync_request_time_ = std::chrono::system_clock::now();
+    }
+    LOG(log_dg_) << "Skip vote " << vote_hash.abridged()
+                 << ". Failed period validation against current state. Vote: {period: " << vote->getPeriod()
+                 << ", round: " << vote->getRound() << ", step: " << vote->getStep()
+                 << "}. Current state: {period: " << current_pbft_period << ", round: " << current_pbft_round
+                 << ", step: " << pbft_mgr_->getPbftStep() << "}";
+    return false;
+  }
+
+  auto checking_round = current_pbft_round;
+  // If period is not the same we assuming current round is equal to 1
+  // So we won't accept votes for future period with round bigger than kVoteAcceptingSteps
+  if (current_pbft_period != vote->getPeriod()) {
+    checking_round = 1;
+  }
+  if (vote->getRound() >= checking_round + kVoteAcceptingRounds) {
+    LOG(log_dg_) << "Skip vote " << vote_hash.abridged()
+                 << ". Failed round validation against current state. Checking round " << checking_round
+                 << ". Vote: {period: " << vote->getPeriod() << ", round: " << vote->getRound()
+                 << ", step: " << vote->getStep() << "}. Current state: {period: " << current_pbft_period
+                 << ", round: " << current_pbft_round << ", step: " << current_pbft_step << "}";
+    // Do not request round sync too often here
+    if (std::chrono::system_clock::now() - round_sync_request_time_ > kSyncRequestInterval) {
+      // request round votes sync from this node
+      sealAndSend(peer->getId(), GetVotesSyncPacket,
+                  std::move(dev::RLPStream(3) << current_pbft_period << current_pbft_round << 0));
+      round_sync_request_time_ = std::chrono::system_clock::now();
+    }
+    return false;
+  }
+
+  auto checking_step = pbft_mgr_->getPbftStep();
+  // If round is not the same we assuming current step is equal to 1
+  // So we won't accept votes for future rounds with step bigger than kVoteAcceptingSteps
+  if (current_pbft_round != vote->getRound()) {
+    checking_step = 1;
+  }
+  if (vote->getStep() >= checking_step + kVoteAcceptingSteps) {
+    LOG(log_dg_) << "Skip vote " << vote_hash.abridged()
+                 << ". Failed step validation against current state. Checking step " << checking_step
+                 << ". Vote: {period: " << vote->getPeriod() << ", round: " << vote->getRound()
+                 << ", step: " << vote->getStep() << "}. Current state: {period: " << current_pbft_period
+                 << ", round: " << current_pbft_round << ", step: " << current_pbft_step << "}";
+    return false;
+  }
+
+  return true;
 }
 
 void VotePacketHandler::process(const PacketData &packet_data, const std::shared_ptr<TaraxaPeer> &peer) {
@@ -36,22 +100,26 @@ void VotePacketHandler::process(const PacketData &packet_data, const std::shared
                    << ") already seen.";
       continue;
     }
-    peer->markVoteAsKnown(vote_hash);
 
     // Standard vote
     if (vote->getPeriod() >= current_pbft_period) {
       if (vote_mgr_->voteInVerifiedMap(vote)) {
         LOG(log_dg_) << "Vote " << vote_hash.abridged() << " already inserted in verified queue";
-      }
+        // We don't need to validate and process it, but should add to votes for gossiping
+      } else {
+        if (!shouldProcessVote(vote, peer)) {
+          continue;
+        }
 
-      if (auto vote_is_valid = validateStandardVote(vote); vote_is_valid.first == false) {
-        LOG(log_wr_) << "Vote " << vote_hash.abridged() << " validation failed. Err: " << vote_is_valid.second;
-        continue;
-      }
+        if (auto vote_is_valid = validateStandardVote(vote); vote_is_valid.first == false) {
+          LOG(log_wr_) << "Vote " << vote_hash.abridged() << " validation failed. Err: " << vote_is_valid.second;
+          continue;
+        }
 
-      if (!vote_mgr_->addVerifiedVote(vote)) {
-        LOG(log_dg_) << "Vote " << vote_hash << " already inserted in verified queue(race condition)";
-        continue;
+        if (!vote_mgr_->addVerifiedVote(vote)) {
+          LOG(log_dg_) << "Vote " << vote_hash << " already inserted in verified queue(race condition)";
+          continue;
+        }
       }
 
     } else if (vote->getPeriod() == current_pbft_period - 1 && vote->getType() == PbftVoteTypes::cert_vote_type) {

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
@@ -31,15 +31,15 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
 
   // Accept only votes, which period is >= current pbft period
   if (peer_pbft_period < pbft_current_period) {
-    LOG(log_dg_) << "Dropping votes sync packet due to period. Votes period: " << peer_pbft_period
+    LOG(log_er_) << "Dropping votes sync packet due to period. Votes period: " << peer_pbft_period
                  << ", current pbft period: " << peer_pbft_period;
     return;
   }
 
   // Accept only votes, which round is >= previous round(current pbft round - 1) in case their period == current pbft
   // period
-  if (peer_pbft_period == pbft_current_period && (pbft_current_round - 1) < peer_pbft_round) {
-    LOG(log_dg_) << "Dropping votes sync packet due to round. Votes round: " << peer_pbft_round
+  if (peer_pbft_period == pbft_current_period && peer_pbft_round < pbft_current_round - 1) {
+    LOG(log_er_) << "Dropping votes sync packet due to round. Votes round: " << peer_pbft_round
                  << ", current pbft round: " << pbft_current_round;
     return;
   }

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
@@ -25,11 +25,13 @@ void VotesSyncPacketHandler::validatePacketRlpFormat([[maybe_unused]] const Pack
 void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::shared_ptr<TaraxaPeer> &peer) {
   auto vote = std::make_shared<Vote>(packet_data.rlp_[0].data().toBytes());
 
+  const auto [round, period] = pbft_mgr_->getPbftRoundAndPeriod();
   const auto pbft_current_round = pbft_mgr_->getPbftRound();
+  const auto peer_pbft_period = vote->getPeriod();
   const auto peer_pbft_round = vote->getRound() + 1;
 
   // Next votes are from too old
-  if (pbft_current_round > peer_pbft_round) {
+  if (peer_pbft_period != period || (peer_pbft_period == period && pbft_current_round > peer_pbft_round)) {
     LOG(log_dg_) << "Dropping votes sync packet due to round. Votes round: " << peer_pbft_round
                  << ", current pbft round: " << pbft_current_round;
     return;
@@ -42,6 +44,13 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
     const auto next_vote_hash = next_vote->getHash();
     if (next_vote->getRound() != peer_pbft_round - 1) {
       LOG(log_er_) << "Received next votes bundle with unmatched rounds from " << packet_data.from_node_id_
+                   << ". The peer may be a malicious player, will be disconnected";
+      disconnect(packet_data.from_node_id_, dev::p2p::UserReason);
+      return;
+    }
+
+    if (next_vote->getPeriod() != peer_pbft_period) {
+      LOG(log_er_) << "Received next votes bundle with unmatched periods from " << packet_data.from_node_id_
                    << ". The peer may be a malicious player, will be disconnected";
       disconnect(packet_data.from_node_id_, dev::p2p::UserReason);
       return;
@@ -70,6 +79,8 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
         continue;
       }
 
+      // CONCERN: Huh? Race condition...
+
       if (!vote_mgr_->insertUniqueVote(vote)) {
         LOG(log_dg_) << "Non unique vote " << next_vote_hash.abridged() << " (race condition)";
         continue;
@@ -84,13 +95,18 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
   LOG(log_nf_) << "Received " << next_votes_count << " next votes from peer " << packet_data.from_node_id_
                << " node current round " << pbft_current_round << ", peer pbft round " << peer_pbft_round;
 
+
+
   if (pbft_current_round < peer_pbft_round) {
     onNewPbftVotes(std::move(next_votes));
   } else {  // pbft_current_round == peer_pbft_round
+  
+    // CONCERN... quite unsure about the following modification...
+
     // Update previous round next votes
-    const auto pbft_2t_plus_1 = db_->getPbft2TPlus1(pbft_current_round - 1);
+    const auto pbft_2t_plus_1 = db_->getPbft2TPlus1ForPeriod(pbft_current_round);
     if (!pbft_2t_plus_1) {
-      LOG(log_er_) << "Cannot get PBFT 2t+1 in PBFT round " << pbft_current_round - 1;
+      LOG(log_er_) << "Cannot get PBFT 2t+1 in PBFT period " << pbft_current_round;
       return;
     }
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
@@ -96,10 +96,7 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
       }
     } else {
       // Standard vote -> peer_pbft_period > pbft_current_period || (pbft_current_round - 1) > peer_pbft_round
-      if (vote_mgr_->voteInVerifiedMap(next_vote)) {
-        LOG(log_dg_) << "Vote " << next_vote_hash.abridged() << " already inserted in verified queue";
-        // We don't need to perform other checks, but it shouldn't be removed as it is used for next calls
-      } else {
+      if (!vote_mgr_->voteInVerifiedMap(next_vote)) {
         if (auto vote_is_valid = validateStandardVote(next_vote); vote_is_valid.first == false) {
           LOG(log_wr_) << "Vote " << next_vote_hash.abridged() << " validation failed. Err: " << vote_is_valid.second;
           continue;

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
@@ -122,15 +122,8 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
   if (peer_pbft_period == pbft_current_period && (pbft_current_round - 1) == peer_pbft_round) {
     // CONCERN... quite unsure about the following modification...
 
-    // Update previous round next votes
-    const auto pbft_2t_plus_1 = db_->getPbft2TPlus1ForPeriod(pbft_current_period);
-    if (!pbft_2t_plus_1) {
-      LOG(log_er_) << "Cannot get PBFT 2t+1 for period " << pbft_current_period;
-      return;
-    }
-
     // Update our previous round next vote bundles...
-    next_votes_mgr_->updateWithSyncedVotes(next_votes, pbft_2t_plus_1);
+    next_votes_mgr_->updateWithSyncedVotes(next_votes, pbft_mgr_->getTwoTPlusOne());
     // Pass them on to our peers...
     const auto updated_next_votes_size = next_votes_mgr_->getNextVotesWeight();
     for (auto const &peer_to_share_to : peers_state_->getAllPeers()) {

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
@@ -95,7 +95,7 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
         continue;
       }
     } else {
-      // Standard vote -> peer_pbft_period > pbft_current_period || (pbft_current_round - 1) > peer_pbft_round
+      // Standard vote -> peer_pbft_period > pbft_current_period || (pbft_current_round - 1) >= peer_pbft_round
       if (!vote_mgr_->voteInVerifiedMap(next_vote)) {
         if (auto vote_is_valid = validateStandardVote(next_vote); vote_is_valid.first == false) {
           LOG(log_wr_) << "Vote " << next_vote_hash.abridged() << " validation failed. Err: " << vote_is_valid.second;
@@ -158,7 +158,8 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
       sendPbftVotes(peer_to_share_to.first, std::move(send_next_votes_bundle), true);
     }
   } else {
-    // Standard votes -> peer_pbft_period > pbft_current_period || (pbft_current_round - 1) > peer_pbft_round
+    // Standard votes -> peer_pbft_period > pbft_current_period || (peer_pbft_period == pbft_current_period &&
+    // peer_pbft_round > pbft_current_round - 1)
     onNewPbftVotes(std::move(next_votes));
   }
 }

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
@@ -8,10 +8,11 @@ namespace taraxa::network::tarcap {
 VotesSyncPacketHandler::VotesSyncPacketHandler(
     std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
     std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<VoteManager> vote_mgr,
-    std::shared_ptr<NextVotesManager> next_votes_mgr, std::shared_ptr<DbStorage> db, const uint32_t dpos_delay,
+    std::shared_ptr<NextVotesManager> next_votes_mgr, std::shared_ptr<DbStorage> db, uint32_t vote_accepting_periods,
     const addr_t &node_addr)
     : ExtVotesPacketHandler(std::move(peers_state), std::move(packets_stats), std::move(pbft_mgr),
-                            std::move(pbft_chain), std::move(vote_mgr), dpos_delay, node_addr, "VOTES_SYNC_PH"),
+                            std::move(pbft_chain), std::move(vote_mgr), vote_accepting_periods, node_addr,
+                            "VOTES_SYNC_PH"),
       next_votes_mgr_(std::move(next_votes_mgr)),
       db_(std::move(db)) {}
 
@@ -45,10 +46,26 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
   }
 
   std::vector<std::shared_ptr<Vote>> next_votes;
+  blk_hash_t voted_value = NULL_BLOCK_HASH;
+
   const auto next_votes_count = packet_data.rlp_.itemCount();
+  //  It is done in separate cycle because we don't need to process this next_votes if some of checks will fail
   for (size_t i = 0; i < next_votes_count; i++) {
     auto next_vote = std::make_shared<Vote>(packet_data.rlp_[i].data().toBytes());
-    const auto next_vote_hash = next_vote->getHash();
+    const auto &next_vote_hash = next_vote->getHash();
+    if (voted_value == NULL_BLOCK_HASH && next_vote->getBlockHash() != NULL_BLOCK_HASH) {
+      // initialize voted value with first block hash that not equal to NULL_BLOCK_HASH
+      voted_value = next_vote->getBlockHash();
+    } else if (next_vote->getBlockHash() != NULL_BLOCK_HASH && voted_value != NULL_BLOCK_HASH &&
+               next_vote->getBlockHash() != voted_value) {
+      // we see different voted value, so bundle is invalid
+      LOG(log_er_) << "Received next votes bundle with unmatched voted values(" << voted_value << ", "
+                   << next_vote->getBlockHash() << ") from " << packet_data.from_node_id_
+                   << ". The peer may be a malicious player, will be disconnected";
+      disconnect(packet_data.from_node_id_, dev::p2p::UserReason);
+      return;
+    }
+
     if (next_vote->getRound() != peer_pbft_round) {
       LOG(log_er_) << "Received next votes bundle with unmatched rounds from " << packet_data.from_node_id_
                    << ". The peer may be a malicious player, will be disconnected";
@@ -81,18 +98,18 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
       // Standard vote -> peer_pbft_period > pbft_current_period || (pbft_current_round - 1) > peer_pbft_round
       if (vote_mgr_->voteInVerifiedMap(next_vote)) {
         LOG(log_dg_) << "Vote " << next_vote_hash.abridged() << " already inserted in verified queue";
-      }
+        // We don't need to perform other checks, but it shouldn't be removed as it is used for next calls
+      } else {
+        if (auto vote_is_valid = validateStandardVote(next_vote); vote_is_valid.first == false) {
+          LOG(log_wr_) << "Vote " << next_vote_hash.abridged() << " validation failed. Err: " << vote_is_valid.second;
+          continue;
+        }
 
-      if (auto vote_is_valid = validateStandardVote(next_vote); vote_is_valid.first == false) {
-        LOG(log_wr_) << "Vote " << next_vote_hash.abridged() << " validation failed. Err: " << vote_is_valid.second;
-        continue;
+        if (!vote_mgr_->addVerifiedVote(next_vote)) {
+          LOG(log_dg_) << "Vote " << next_vote_hash.abridged() << " already inserted in verified queue(race condition)";
+          continue;
+        }
       }
-
-      if (!vote_mgr_->addVerifiedVote(next_vote)) {
-        LOG(log_dg_) << "Vote " << next_vote_hash.abridged() << " already inserted in verified queue(race condition)";
-        continue;
-      }
-
     }
 
     LOG(log_dg_) << "Received PBFT next vote " << next_vote_hash.abridged();
@@ -100,8 +117,9 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
     next_votes.push_back(std::move(next_vote));
   }
 
-  LOG(log_nf_) << "Received " << next_votes_count << " next votes from peer " << packet_data.from_node_id_
-               << " node current round " << pbft_current_round << ", peer pbft round " << peer_pbft_round;
+  LOG(log_nf_) << "Received " << next_votes_count << " processing " << next_votes.size() << " next votes from peer "
+               << packet_data.from_node_id_ << " node current round " << pbft_current_round << ", peer pbft round "
+               << peer_pbft_round;
 
   // Previous round votes
   if (peer_pbft_period == pbft_current_period && (pbft_current_round - 1) == peer_pbft_round) {

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
@@ -93,7 +93,6 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
         continue;
       }
 
-      setVoterMaxPeriodAndRound(vote->getVoterAddr(), vote->getPeriod(), vote->getRound());
     }
 
     LOG(log_dg_) << "Received PBFT next vote " << next_vote_hash.abridged();

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
@@ -70,7 +70,7 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
         continue;
       }
 
-      setVoterMaxRound(vote->getVoterAddr(), vote->getRound());
+      setVoterMaxPeriodAndRound(vote->getVoterAddr(), vote->getPeriod(), vote->getRound());
     } else {  // pbft_current_round == peer_pbft_round
       if (auto vote_is_valid = validateNextSyncVote(next_vote); vote_is_valid.first == false) {
         LOG(log_wr_) << "Next vote " << next_vote_hash.abridged()

--- a/libraries/core_libs/network/src/tarcap/stats/node_stats.cpp
+++ b/libraries/core_libs/network/src/tarcap/stats/node_stats.cpp
@@ -28,6 +28,14 @@ NodeStats::NodeStats(std::shared_ptr<PeersState> peers_state, std::shared_ptr<Pb
       packets_stats_(std::move(packets_stats)),
       thread_pool_(std::move(thread_pool)) {
   LOG_OBJECTS_CREATE("SUMMARY");
+
+  local_pbft_step_prev_interval_ = pbft_mgr_->getPbftStep();
+  const auto [local_pbft_round, local_pbft_period] = pbft_mgr_->getPbftRoundAndPeriod();
+  local_pbft_round_prev_interval_ = local_pbft_round;
+  local_pbft_period_prev_interval_ = local_pbft_period;
+  local_chain_size_prev_interval_ = pbft_chain_->getPbftChainSize();
+  local_pbft_sync_period_prev_interval_ = pbft_mgr_->pbftSyncingPeriod();
+  local_max_level_in_dag_prev_interval_ = dag_mgr_->getMaxLevel();
 }
 
 uint64_t NodeStats::syncTimeSeconds() const { return syncing_duration_seconds; }
@@ -72,6 +80,7 @@ void NodeStats::logNodeStats() {
 
   // Local pbft info...
   const auto [local_pbft_round, local_pbft_period] = pbft_mgr_->getPbftRoundAndPeriod();
+  const auto local_pbft_step = pbft_mgr_->getPbftStep();
   const auto local_chain_size = pbft_chain_->getPbftChainSize();
   const auto local_chain_size_without_empty_blocks = pbft_chain_->getPbftChainSizeExcludingEmptyPbftBlocks();
 
@@ -83,12 +92,15 @@ void NodeStats::logNodeStats() {
   const auto local_pbft_sync_period = pbft_mgr_->pbftSyncingPeriod();
 
   // Decide if making progress...
-  const auto pbft_consensus_rounds_advanced = local_pbft_round - local_pbft_round_prev_interval_;
+  const auto pbft_consensus_periods_advanced = local_pbft_period - local_pbft_period_prev_interval_;
+  const auto pbft_consensus_rounds_advanced =
+      pbft_consensus_periods_advanced > 0 ? 0 : local_pbft_round - local_pbft_round_prev_interval_;
   const auto pbft_chain_size_growth = local_chain_size - local_chain_size_prev_interval_;
   const auto pbft_sync_period_progress = local_pbft_sync_period - local_pbft_sync_period_prev_interval_;
   const auto dag_level_growh = local_max_level_in_dag - local_max_level_in_dag_prev_interval_;
 
-  const bool making_pbft_consensus_progress = (pbft_consensus_rounds_advanced > 0);
+  const bool making_pbft_consensus_progress =
+      (pbft_consensus_periods_advanced > 0) || (pbft_consensus_rounds_advanced > 0);
   const bool making_pbft_chain_progress = (pbft_chain_size_growth > 0);
   const bool making_pbft_sync_period_progress = (pbft_sync_period_progress > 0);
   const bool making_dag_progress = (dag_level_growh > 0);
@@ -147,6 +159,7 @@ void NodeStats::logNodeStats() {
                << local_chain_size_without_empty_blocks << ")";
   LOG(log_nf_) << "Current PBFT period:             " << local_pbft_period;
   LOG(log_nf_) << "Current PBFT round:              " << local_pbft_round;
+  LOG(log_nf_) << "Current PBFT step:               " << local_pbft_step;
   LOG(log_nf_) << "DPOS total votes count:          " << local_dpos_total_votes_count;
   LOG(log_nf_) << "PBFT consensus 2t+1 threshold:   " << local_twotplusone;
   LOG(log_nf_) << "Node elligible vote count:       " << local_weighted_votes;
@@ -206,14 +219,18 @@ void NodeStats::logNodeStats() {
   }
 
   LOG(log_nf_) << "PBFT chain blocks added:        " << pbft_chain_size_growth;
-  LOG(log_nf_) << "PBFT rounds advanced:           " << pbft_consensus_rounds_advanced;
+  LOG(log_nf_) << "PBFT (period, round, step):     (" << local_pbft_period_prev_interval_ << ", "
+               << local_pbft_round_prev_interval_ << ", " << local_pbft_step_prev_interval_ << ") -> ("
+               << local_pbft_period << ", " << local_pbft_round << ", " << local_pbft_step << ")";
   LOG(log_nf_) << "DAG level growth:               " << dag_level_growh;
 
   LOG(log_nf_) << "##################################";
 
   // Node stats info history
   local_max_level_in_dag_prev_interval_ = local_max_level_in_dag;
+  local_pbft_period_prev_interval_ = local_pbft_period;
   local_pbft_round_prev_interval_ = local_pbft_round;
+  local_pbft_step_prev_interval_ = local_pbft_step;
   local_chain_size_prev_interval_ = local_chain_size;
   local_pbft_sync_period_prev_interval_ = local_pbft_sync_period;
 }

--- a/libraries/core_libs/network/src/tarcap/stats/node_stats.cpp
+++ b/libraries/core_libs/network/src/tarcap/stats/node_stats.cpp
@@ -71,7 +71,7 @@ void NodeStats::logNodeStats() {
   const auto local_max_level_in_dag = dag_mgr_->getMaxLevel();
 
   // Local pbft info...
-  uint64_t local_pbft_round = pbft_mgr_->getPbftRound();
+  const auto [local_pbft_round, local_pbft_period] = pbft_mgr_->getPbftRoundAndPeriod();
   const auto local_chain_size = pbft_chain_->getPbftChainSize();
   const auto local_chain_size_without_empty_blocks = pbft_chain_->getPbftChainSizeExcludingEmptyPbftBlocks();
 
@@ -133,8 +133,8 @@ void NodeStats::logNodeStats() {
     LOG(log_nf_) << "Currently syncing from node " << pbft_syncing_state_->syncingPeer();
     LOG(log_nf_) << "Max peer PBFT chain size:       " << peer_max_pbft_chain_size << " (peer "
                  << max_pbft_chain_node_id << ")";
-    LOG(log_nf_) << "Max peer PBFT consensus round:  " << peer_max_pbft_round << " (peer " << max_pbft_round_node_id
-                 << ")";
+    LOG(log_nf_) << "Max peer PBFT consensus round FOR SYNCING:  " << peer_max_pbft_round << " (peer "
+                 << max_pbft_round_node_id << ")";
     LOG(log_nf_) << "Max peer DAG level:             " << peer_max_node_dag_level << " (peer "
                  << max_node_dag_level_node_id << ")";
   } else {
@@ -145,6 +145,7 @@ void NodeStats::logNodeStats() {
   LOG(log_nf_) << "Max DAG block level in DAG:      " << local_max_level_in_dag;
   LOG(log_nf_) << "PBFT chain size:                 " << local_chain_size << " ("
                << local_chain_size_without_empty_blocks << ")";
+  LOG(log_nf_) << "Current PBFT period:             " << local_pbft_period;
   LOG(log_nf_) << "Current PBFT round:              " << local_pbft_round;
   LOG(log_nf_) << "DPOS total votes count:          " << local_dpos_total_votes_count;
   LOG(log_nf_) << "PBFT consensus 2t+1 threshold:   " << local_twotplusone;

--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -196,14 +196,13 @@ void TaraxaCapability::registerPacketHandlers(
 
   // Consensus packets with high processing priority
   packets_handlers_->registerHandler<VotePacketHandler>(peers_state_, packets_stats, pbft_mgr, pbft_chain, vote_mgr,
-                                                        kConf.chain.final_chain.state.dpos->delegation_delay,
-                                                        node_addr);
-  packets_handlers_->registerHandler<GetVotesSyncPacketHandler>(
-      peers_state_, packets_stats, pbft_mgr, pbft_chain, vote_mgr, next_votes_mgr,
-      kConf.chain.final_chain.state.dpos->delegation_delay, node_addr);
-  packets_handlers_->registerHandler<VotesSyncPacketHandler>(
-      peers_state_, packets_stats, pbft_mgr, pbft_chain, vote_mgr, next_votes_mgr, db,
-      kConf.chain.final_chain.state.dpos->delegation_delay, node_addr);
+                                                        kConf.network, node_addr);
+  packets_handlers_->registerHandler<GetVotesSyncPacketHandler>(peers_state_, packets_stats, pbft_mgr, pbft_chain,
+                                                                vote_mgr, next_votes_mgr,
+                                                                kConf.network.vote_accepting_periods, node_addr);
+  packets_handlers_->registerHandler<VotesSyncPacketHandler>(peers_state_, packets_stats, pbft_mgr, pbft_chain,
+                                                             vote_mgr, next_votes_mgr, db,
+                                                             kConf.network.vote_accepting_periods, node_addr);
 
   // Standard packets with mid processing priority
   packets_handlers_->registerHandler<PbftBlockPacketHandler>(peers_state_, packets_stats, pbft_chain, pbft_mgr,

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -292,11 +292,9 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   std::vector<std::shared_ptr<Vote>> getCertVotes(uint64_t period);
 
   // Next votes
-  std::vector<std::shared_ptr<Vote>> getNextVotes(uint64_t pbft_round);
-  void saveNextVotes(uint64_t pbft_round, std::vector<std::shared_ptr<Vote>> const& next_votes);
-  void addNextVotesToBatch(uint64_t pbft_round, std::vector<std::shared_ptr<Vote>> const& next_votes,
-                           Batch& write_batch);
-  void removeNextVotesToBatch(uint64_t pbft_round, Batch& write_batch);
+  std::vector<std::shared_ptr<Vote>> getPreviousRoundNextVotes();
+  void savePreviousRoundNextVotes(std::vector<std::shared_ptr<Vote>> const& next_votes);
+  void removePreviousRoundNextVotes();
 
   // last block cert votes
   void saveLastBlockCertVote(const std::shared_ptr<Vote>& cert_vote);

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -246,10 +246,6 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   void savePbftMgrField(PbftMgrRoundStep field, uint64_t value);
   void addPbftMgrFieldToBatch(PbftMgrRoundStep field, uint64_t value, Batch& write_batch);
 
-  size_t getPbft2TPlus1ForPeriod(uint64_t pbft_period);
-  void savePbft2TPlus1ForPeriod(uint64_t pbft_period, size_t pbft_2t_plus_1);
-  void addPbft2TPlus1ToBatchForPeriod(uint64_t pbft_period, size_t pbft_2t_plus_1, Batch& write_batch);
-
   bool getPbftMgrStatus(PbftMgrStatus field);
   void savePbftMgrStatus(PbftMgrStatus field, bool const& value);
   void addPbftMgrStatusToBatch(PbftMgrStatus field, bool const& value, Batch& write_batch);

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -46,7 +46,7 @@ enum PbftMgrStatus : uint8_t {
   NextVotedNullBlockHash,
 };
 
-enum PbftMgrVotedValue : uint8_t { OwnStartingValueInRound = 0, SoftVotedBlockInRound, CertVotedBlockInRound };
+enum PbftMgrVotedValue : uint8_t { SoftVotedBlockInRound, CertVotedBlockInRound };
 
 class DbException : public std::exception {
  public:
@@ -246,7 +246,6 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   void savePbftMgrField(PbftMgrRoundStep field, uint64_t value);
   void addPbftMgrFieldToBatch(PbftMgrRoundStep field, uint64_t value, Batch& write_batch);
 
-  // CONCERN: These need to be by period not round now!
   size_t getPbft2TPlus1ForPeriod(uint64_t pbft_period);
   void savePbft2TPlus1ForPeriod(uint64_t pbft_period, size_t pbft_2t_plus_1);
   void addPbft2TPlus1ToBatchForPeriod(uint64_t pbft_period, size_t pbft_2t_plus_1, Batch& write_batch);

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -37,7 +37,7 @@ enum PbftMgrPreviousRoundStatus : uint8_t {
   PreviousRoundDposTotalVotesCount
 };
 
-enum PbftMgrRoundStep : uint8_t { PbftRound = 0, PbftPeriod, PbftStep };
+enum PbftMgrRoundStep : uint8_t { PbftRound = 0, PbftStep };
 
 enum PbftMgrStatus : uint8_t {
   ExecutedBlock = 0,

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -105,7 +105,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
     COLUMN(status);
     COLUMN(pbft_mgr_previous_round_status);
     COLUMN(pbft_mgr_round_step);
-    COLUMN(pbft_round_2t_plus_1);
+    COLUMN(pbft_period_2t_plus_1);
     COLUMN(pbft_mgr_status);
     COLUMN(pbft_mgr_voted_value);
     COLUMN(pbft_cert_voted_block);
@@ -246,9 +246,10 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   void savePbftMgrField(PbftMgrRoundStep field, uint64_t value);
   void addPbftMgrFieldToBatch(PbftMgrRoundStep field, uint64_t value, Batch& write_batch);
 
-  size_t getPbft2TPlus1(uint64_t pbft_round);
-  void savePbft2TPlus1(uint64_t pbft_round, size_t pbft_2t_plus_1);
-  void addPbft2TPlus1ToBatch(uint64_t pbft_round, size_t pbft_2t_plus_1, Batch& write_batch);
+  // CONCERN: These need to be by period not round now!
+  size_t getPbft2TPlus1ForPeriod(uint64_t pbft_period);
+  void savePbft2TPlus1ForPeriod(uint64_t pbft_period, size_t pbft_2t_plus_1);
+  void addPbft2TPlus1ToBatchForPeriod(uint64_t pbft_period, size_t pbft_2t_plus_1, Batch& write_batch);
 
   bool getPbftMgrStatus(PbftMgrStatus field);
   void savePbftMgrStatus(PbftMgrStatus field, bool const& value);

--- a/libraries/core_libs/storage/src/storage.cpp
+++ b/libraries/core_libs/storage/src/storage.cpp
@@ -681,27 +681,6 @@ void DbStorage::addPbftMgrFieldToBatch(PbftMgrRoundStep field, uint64_t value, B
   insert(write_batch, DbStorage::Columns::pbft_mgr_round_step, toSlice(field), toSlice(value));
 }
 
-size_t DbStorage::getPbft2TPlus1ForPeriod(uint64_t period) {
-  auto status = lookup(toSlice(period), Columns::pbft_period_2t_plus_1);
-
-  if (!status.empty()) {
-    size_t value;
-    memcpy(&value, status.data(), sizeof(size_t));
-    return value;
-  }
-
-  return 0;
-}
-
-// Only for test
-void DbStorage::savePbft2TPlus1ForPeriod(uint64_t pbft_period, size_t pbft_2t_plus_1) {
-  insert(Columns::pbft_period_2t_plus_1, toSlice(pbft_period), toSlice(pbft_2t_plus_1));
-}
-
-void DbStorage::addPbft2TPlus1ToBatchForPeriod(uint64_t pbft_period, size_t pbft_2t_plus_1, Batch& write_batch) {
-  insert(write_batch, Columns::pbft_period_2t_plus_1, toSlice(pbft_period), toSlice(pbft_2t_plus_1));
-}
-
 bool DbStorage::getPbftMgrStatus(PbftMgrStatus field) {
   auto status = lookup(toSlice(field), Columns::pbft_mgr_status);
   if (!status.empty()) {

--- a/libraries/core_libs/storage/src/storage.cpp
+++ b/libraries/core_libs/storage/src/storage.cpp
@@ -681,8 +681,8 @@ void DbStorage::addPbftMgrFieldToBatch(PbftMgrRoundStep field, uint64_t value, B
   insert(write_batch, DbStorage::Columns::pbft_mgr_round_step, toSlice(field), toSlice(value));
 }
 
-size_t DbStorage::getPbft2TPlus1(uint64_t round) {
-  auto status = lookup(toSlice(round), Columns::pbft_round_2t_plus_1);
+size_t DbStorage::getPbft2TPlus1ForPeriod(uint64_t period) {
+  auto status = lookup(toSlice(period), Columns::pbft_period_2t_plus_1);
 
   if (!status.empty()) {
     size_t value;
@@ -694,12 +694,12 @@ size_t DbStorage::getPbft2TPlus1(uint64_t round) {
 }
 
 // Only for test
-void DbStorage::savePbft2TPlus1(uint64_t pbft_round, size_t pbft_2t_plus_1) {
-  insert(Columns::pbft_round_2t_plus_1, toSlice(pbft_round), toSlice(pbft_2t_plus_1));
+void DbStorage::savePbft2TPlus1ForPeriod(uint64_t pbft_period, size_t pbft_2t_plus_1) {
+  insert(Columns::pbft_period_2t_plus_1, toSlice(pbft_period), toSlice(pbft_2t_plus_1));
 }
 
-void DbStorage::addPbft2TPlus1ToBatch(uint64_t pbft_round, size_t pbft_2t_plus_1, Batch& write_batch) {
-  insert(write_batch, DbStorage::Columns::pbft_round_2t_plus_1, toSlice(pbft_round), toSlice(pbft_2t_plus_1));
+void DbStorage::addPbft2TPlus1ToBatchForPeriod(uint64_t pbft_period, size_t pbft_2t_plus_1, Batch& write_batch) {
+  insert(write_batch, Columns::pbft_period_2t_plus_1, toSlice(pbft_period), toSlice(pbft_2t_plus_1));
 }
 
 bool DbStorage::getPbftMgrStatus(PbftMgrStatus field) {

--- a/libraries/core_libs/storage/src/storage.cpp
+++ b/libraries/core_libs/storage/src/storage.cpp
@@ -735,7 +735,7 @@ void DbStorage::addPbftMgrVotedValueToBatch(PbftMgrVotedValue field, const std::
 }
 
 void DbStorage::removePbftMgrVotedValueToBatch(PbftMgrVotedValue field, Batch& write_batch) {
-  remove(write_batch, Columns::dag_blocks, toSlice(field));
+  remove(write_batch, Columns::pbft_mgr_voted_value, toSlice(field));
 }
 std::optional<std::pair<blk_hash_t, uint64_t>> DbStorage::getPbftMgrVotedValue(PbftMgrVotedValue field) {
   auto value = asBytes(lookup(toSlice(field), Columns::pbft_mgr_voted_value));

--- a/libraries/core_libs/storage/src/storage.cpp
+++ b/libraries/core_libs/storage/src/storage.cpp
@@ -851,9 +851,9 @@ std::vector<std::shared_ptr<Vote>> DbStorage::getCertVotes(uint64_t period) {
   return cert_votes;
 }
 
-std::vector<std::shared_ptr<Vote>> DbStorage::getNextVotes(uint64_t pbft_round) {
+std::vector<std::shared_ptr<Vote>> DbStorage::getPreviousRoundNextVotes() {
   std::vector<std::shared_ptr<Vote>> next_votes;
-  auto next_votes_raw = asBytes(lookup(toSlice(pbft_round), Columns::next_votes));
+  auto next_votes_raw = asBytes(lookup(0, Columns::next_votes));
   auto next_votes_rlp = dev::RLP(next_votes_raw);
   next_votes.reserve(next_votes_rlp.size());
 
@@ -864,22 +864,15 @@ std::vector<std::shared_ptr<Vote>> DbStorage::getNextVotes(uint64_t pbft_round) 
   return next_votes;
 }
 
-void DbStorage::saveNextVotes(uint64_t pbft_round, std::vector<std::shared_ptr<Vote>> const& next_votes) {
+void DbStorage::savePreviousRoundNextVotes(std::vector<std::shared_ptr<Vote>> const& next_votes) {
   dev::RLPStream s(next_votes.size());
   for (auto const& v : next_votes) {
     s.appendRaw(v->rlp(true, true));
   }
-  insert(Columns::next_votes, toSlice(pbft_round), toSlice(s.out()));
+  insert(Columns::next_votes, 0, toSlice(s.out()));
 }
 
-void DbStorage::addNextVotesToBatch(uint64_t pbft_round, std::vector<std::shared_ptr<Vote>> const& next_votes,
-                                    Batch& write_batch) {
-  dev::RLPStream s(next_votes.size());
-  for (auto const& v : next_votes) {
-    s.appendRaw(v->rlp(true, true));
-  }
-  insert(write_batch, Columns::next_votes, toSlice(pbft_round), toSlice(s.out()));
-}
+void DbStorage::removePreviousRoundNextVotes() { remove(Columns::next_votes, 0); }
 
 void DbStorage::saveLastBlockCertVote(const std::shared_ptr<Vote>& cert_vote) {
   insert(Columns::last_block_cert_votes, toSlice(cert_vote->getHash()), toSlice(cert_vote->rlp(true, true)));
@@ -911,9 +904,6 @@ void DbStorage::removeLastBlockCertVotes(const vote_hash_t& hash) {
   remove(Columns::last_block_cert_votes, toSlice(hash));
 }
 
-void DbStorage::removeNextVotesToBatch(uint64_t pbft_round, Batch& write_batch) {
-  remove(write_batch, Columns::next_votes, toSlice(pbft_round));
-}
 
 void DbStorage::addPbftBlockPeriodToBatch(uint64_t period, taraxa::blk_hash_t const& pbft_block_hash,
                                           Batch& write_batch) {

--- a/libraries/core_libs/storage/src/storage.cpp
+++ b/libraries/core_libs/storage/src/storage.cpp
@@ -904,7 +904,6 @@ void DbStorage::removeLastBlockCertVotes(const vote_hash_t& hash) {
   remove(Columns::last_block_cert_votes, toSlice(hash));
 }
 
-
 void DbStorage::addPbftBlockPeriodToBatch(uint64_t period, taraxa::blk_hash_t const& pbft_block_hash,
                                           Batch& write_batch) {
   insert(write_batch, Columns::pbft_block_period, toSlice(pbft_block_hash.asBytes()), toSlice(period));

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -144,14 +144,14 @@ TEST_F(FullNodeTest, db_test) {
   EXPECT_EQ(db.getPbftMgrField(PbftMgrRoundStep::PbftStep), pbft_step);
 
   // PBFT 2t+1
-  db.savePbft2TPlus1(10, 3);
-  EXPECT_EQ(db.getPbft2TPlus1(10), 3);
+  db.savePbft2TPlus1ForPeriod(10, 3);
+  EXPECT_EQ(db.getPbft2TPlus1ForPeriod(10), 3);
   batch = db.createWriteBatch();
-  db.addPbft2TPlus1ToBatch(10, 6, batch);
-  db.addPbft2TPlus1ToBatch(11, 3, batch);
+  db.addPbft2TPlus1ToBatchForPeriod(10, 6, batch);
+  db.addPbft2TPlus1ToBatchForPeriod(11, 3, batch);
   db.commitWriteBatch(batch);
-  EXPECT_EQ(db.getPbft2TPlus1(10), 6);
-  EXPECT_EQ(db.getPbft2TPlus1(11), 3);
+  EXPECT_EQ(db.getPbft2TPlus1ForPeriod(10), 6);
+  EXPECT_EQ(db.getPbft2TPlus1ForPeriod(11), 3);
 
   // PBFT manager status
   EXPECT_FALSE(db.getPbftMgrStatus(PbftMgrStatus::ExecutedBlock));
@@ -178,28 +178,20 @@ TEST_F(FullNodeTest, db_test) {
   EXPECT_FALSE(db.getPbftMgrStatus(PbftMgrStatus::NextVotedNullBlockHash));
 
   // PBFT manager voted value
-  EXPECT_EQ(db.getPbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound), std::nullopt);
   EXPECT_EQ(db.getPbftMgrVotedValue(PbftMgrVotedValue::SoftVotedBlockInRound), std::nullopt);
   EXPECT_EQ(db.getPbftMgrVotedValue(PbftMgrVotedValue::CertVotedBlockInRound), std::nullopt);
-  db.savePbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound, {blk_hash_t(1), uint64_t(0)});
   db.savePbftMgrVotedValue(PbftMgrVotedValue::SoftVotedBlockInRound, {blk_hash_t(2), uint64_t(0)});
   db.savePbftMgrVotedValue(PbftMgrVotedValue::CertVotedBlockInRound, {blk_hash_t(3), uint64_t(0)});
-  EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound),
-            std::make_pair(blk_hash_t(1), uint64_t(0)));
   EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::SoftVotedBlockInRound),
             std::make_pair(blk_hash_t(2), uint64_t(0)));
   EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::CertVotedBlockInRound),
             std::make_pair(blk_hash_t(3), uint64_t(0)));
   batch = db.createWriteBatch();
-  db.addPbftMgrVotedValueToBatch(PbftMgrVotedValue::OwnStartingValueInRound, std::make_pair(blk_hash_t(4), uint64_t(0)),
-                                 batch);
   db.addPbftMgrVotedValueToBatch(PbftMgrVotedValue::SoftVotedBlockInRound, std::make_pair(blk_hash_t(5), uint64_t(0)),
                                  batch);
   db.addPbftMgrVotedValueToBatch(PbftMgrVotedValue::CertVotedBlockInRound, std::make_pair(blk_hash_t(6), uint64_t(0)),
                                  batch);
   db.commitWriteBatch(batch);
-  EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::OwnStartingValueInRound),
-            std::make_pair(blk_hash_t(4), uint64_t(0)));
   EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::SoftVotedBlockInRound),
             std::make_pair(blk_hash_t(5), uint64_t(0)));
   EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::CertVotedBlockInRound),

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -538,7 +538,7 @@ TEST_F(FullNodeTest, sync_five_nodes) {
 
   std::cout << "Waiting until transactions are executed" << std::endl;
   const auto trx_count = context.getIssuedTrxCount();
-  EXPECT_HAPPENS({60s, 200ms}, [&](auto &ctx) {
+  ASSERT_HAPPENS({20s, 500ms}, [&](auto &ctx) {
     for (size_t i = 0; i < nodes.size(); ++i)
       WAIT_EXPECT_EQ(ctx, nodes[i]->getDB()->getNumTransactionExecuted(), trx_count)
   });
@@ -593,16 +593,6 @@ TEST_F(FullNodeTest, sync_five_nodes) {
 
     taraxa::thisThreadSleepForMilliSeconds(500);
   }
-
-  auto num_proposed_blocks = nodes[0]->getNumProposedBlocks();
-  // wait for next block
-  wait({20s, 500ms}, [&](auto &ctx) {
-    if (nodes[0]->getNumProposedBlocks() == num_proposed_blocks + 1) ctx.fail();
-    if (nodes[1]->getNumProposedBlocks() == num_proposed_blocks + 1) ctx.fail();
-    if (nodes[2]->getNumProposedBlocks() == num_proposed_blocks + 1) ctx.fail();
-    if (nodes[3]->getNumProposedBlocks() == num_proposed_blocks + 1) ctx.fail();
-    if (nodes[4]->getNumProposedBlocks() == num_proposed_blocks + 1) ctx.fail();
-  });
 
   ASSERT_EQ(nodes[0]->getTransactionManager()->getTransactionCount(), context.getIssuedTrxCount());
   ASSERT_EQ(nodes[1]->getTransactionManager()->getTransactionCount(), context.getIssuedTrxCount());
@@ -1448,8 +1438,8 @@ TEST_F(FullNodeTest, chain_config_json) {
     },
     "state": {
       "dpos": {
-        "delegation_delay": "0x0",
-        "delegation_locking_period": "0x0",
+        "delegation_delay": "0x5",
+        "delegation_locking_period": "0x5",
         "eligibility_balance_threshold": "0x3b9aca00",
         "vote_eligibility_balance_step": "0x3b9aca00",
         "validator_maximum_stake":"0x84595161401484a000000",

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -350,7 +350,7 @@ TEST_F(FullNodeTest, db_test) {
 
   // Next votes
   period = 3, round = 3, step = 5;
-  auto next_votes = db.getNextVotes(round);
+  auto next_votes = db.getPreviousRoundNextVotes();
   EXPECT_TRUE(next_votes.empty());
   for (auto i = 0; i < 3; i++) {
     blk_hash_t voted_pbft_block_hash(i);
@@ -362,8 +362,8 @@ TEST_F(FullNodeTest, db_test) {
     Vote vote(g_secret, vrf_sortition, voted_pbft_block_hash);
     next_votes.emplace_back(std::make_shared<Vote>(vote));
   }
-  db.saveNextVotes(round, next_votes);
-  auto next_votes_from_db = db.getNextVotes(round);
+  db.savePreviousRoundNextVotes(next_votes);
+  auto next_votes_from_db = db.getPreviousRoundNextVotes();
   EXPECT_EQ(next_votes.size(), next_votes_from_db.size());
   EXPECT_EQ(next_votes_from_db.size(), 3);
   next_votes.clear();
@@ -377,16 +377,14 @@ TEST_F(FullNodeTest, db_test) {
     Vote vote(g_secret, vrf_sortition, voted_pbft_block_hash);
     next_votes.emplace_back(std::make_shared<Vote>(vote));
   }
-  batch = db.createWriteBatch();
-  db.addNextVotesToBatch(round, next_votes, batch);
-  db.commitWriteBatch(batch);
-  next_votes_from_db = db.getNextVotes(round);
+  db.savePreviousRoundNextVotes(next_votes);
+  next_votes_from_db = db.getPreviousRoundNextVotes();
   EXPECT_EQ(next_votes.size(), next_votes_from_db.size());
   EXPECT_EQ(next_votes_from_db.size(), 2);
   batch = db.createWriteBatch();
-  db.removeNextVotesToBatch(round, batch);
+  db.removePreviousRoundNextVotes();
   db.commitWriteBatch(batch);
-  next_votes_from_db = db.getNextVotes(round);
+  next_votes_from_db = db.getPreviousRoundNextVotes();
   EXPECT_TRUE(next_votes_from_db.empty());
 
   // period_pbft_block

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -143,16 +143,6 @@ TEST_F(FullNodeTest, db_test) {
   EXPECT_EQ(db.getPbftMgrField(PbftMgrRoundStep::PbftRound), pbft_round);
   EXPECT_EQ(db.getPbftMgrField(PbftMgrRoundStep::PbftStep), pbft_step);
 
-  // PBFT 2t+1
-  db.savePbft2TPlus1ForPeriod(10, 3);
-  EXPECT_EQ(db.getPbft2TPlus1ForPeriod(10), 3);
-  batch = db.createWriteBatch();
-  db.addPbft2TPlus1ToBatchForPeriod(10, 6, batch);
-  db.addPbft2TPlus1ToBatchForPeriod(11, 3, batch);
-  db.commitWriteBatch(batch);
-  EXPECT_EQ(db.getPbft2TPlus1ForPeriod(10), 6);
-  EXPECT_EQ(db.getPbft2TPlus1ForPeriod(11), 3);
-
   // PBFT manager status
   EXPECT_FALSE(db.getPbftMgrStatus(PbftMgrStatus::ExecutedBlock));
   EXPECT_FALSE(db.getPbftMgrStatus(PbftMgrStatus::ExecutedInRound));

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -888,7 +888,7 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_1) {
   // Set PBFT previous round 2t+1, sortition threshold, DPOS period and DPOS total votes count for syncing
   auto db = node2->getDB();
   auto batch = db->createWriteBatch();
-  db->addPbft2TPlus1ToBatch(pbft_previous_round, node2_pbft_2t_plus_1, batch);
+  db->addPbft2TPlus1ToBatchForPeriod(pbft_previous_round, node2_pbft_2t_plus_1, batch);
   db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundSortitionThreshold, 1, batch);
   db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposPeriod, 0, batch);
   db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposTotalVotesCount, 1, batch);
@@ -961,7 +961,7 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_2) {
   // Set node2 PBFT previous round 2t+1, sortition threshold, DPOS period and DPOS total votes count for syncing
   auto node2_db = node2->getDB();
   auto batch = node2_db->createWriteBatch();
-  node2_db->addPbft2TPlus1ToBatch(pbft_previous_round, node2_pbft_2t_plus_1, batch);
+  node2_db->addPbft2TPlus1ToBatchForPeriod(pbft_previous_round, node2_pbft_2t_plus_1, batch);
   node2_db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundSortitionThreshold, 1, batch);
   node2_db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposPeriod, 0, batch);
   node2_db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposTotalVotesCount, 1, batch);
@@ -983,7 +983,7 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_2) {
   // Set node1 PBFT previous round 2t+1, sortition threshold, DPOS period and DPOS total votes count for syncing
   auto node1_db = node1->getDB();
   batch = node1_db->createWriteBatch();
-  node1_db->addPbft2TPlus1ToBatch(pbft_previous_round, node1_pbft_2t_plus_1, batch);
+  node1_db->addPbft2TPlus1ToBatchForPeriod(pbft_previous_round, node1_pbft_2t_plus_1, batch);
   node1_db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundSortitionThreshold, 1, batch);
   node1_db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposPeriod, 0, batch);
   node1_db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposTotalVotesCount, 1, batch);

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -827,8 +827,6 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_behind_round) {
 
 // Test PBFT next votes sycning when nodes stay at same PBFT round, but node2 has less previous round next votes size
 TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_1) {
-  auto pbft_previous_round = 1;
-
   auto node_cfgs = make_node_cfgs<20>(2);
   std::vector<std::shared_ptr<FullNode>> nodes;
   for (auto i(0); i < 2; i++) {
@@ -889,7 +887,6 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_1) {
   // Set PBFT previous round 2t+1, sortition threshold, DPOS period and DPOS total votes count for syncing
   auto db = node2->getDB();
   auto batch = db->createWriteBatch();
-  db->addPbft2TPlus1ToBatchForPeriod(pbft_previous_round, node2_pbft_2t_plus_1, batch);
   db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundSortitionThreshold, 1, batch);
   db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposPeriod, 0, batch);
   db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposTotalVotesCount, 1, batch);
@@ -903,8 +900,6 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_1) {
 // Test PBFT next votes sycning when nodes stay at same PBFT round, node1 and node2 have different previous round next
 // votes set
 TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_2) {
-  auto pbft_previous_round = 1;
-
   auto node_cfgs = make_node_cfgs<20>(2);
   std::vector<std::shared_ptr<FullNode>> nodes;
   for (auto i(0); i < 2; i++) {
@@ -962,7 +957,6 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_2) {
   // Set node2 PBFT previous round 2t+1, sortition threshold, DPOS period and DPOS total votes count for syncing
   auto node2_db = node2->getDB();
   auto batch = node2_db->createWriteBatch();
-  node2_db->addPbft2TPlus1ToBatchForPeriod(pbft_previous_round, node2_pbft_2t_plus_1, batch);
   node2_db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundSortitionThreshold, 1, batch);
   node2_db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposPeriod, 0, batch);
   node2_db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposTotalVotesCount, 1, batch);
@@ -984,7 +978,6 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_2) {
   // Set node1 PBFT previous round 2t+1, sortition threshold, DPOS period and DPOS total votes count for syncing
   auto node1_db = node1->getDB();
   batch = node1_db->createWriteBatch();
-  node1_db->addPbft2TPlus1ToBatchForPeriod(pbft_previous_round, node1_pbft_2t_plus_1, batch);
   node1_db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundSortitionThreshold, 1, batch);
   node1_db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposPeriod, 0, batch);
   node1_db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposTotalVotesCount, 1, batch);

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -796,6 +796,7 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_behind_round) {
   size_t step = 5;
   for (auto i = 0; i < 3; i++) {
     blk_hash_t voted_pbft_block_hash(i % 2);  // Next votes could vote on 2 values
+    std::cout << voted_pbft_block_hash << std::endl;
     auto vote = pbft_mgr1->generateVote(voted_pbft_block_hash, type, period, round, step + i);
     vote->calculateWeight(1, 1, 1);
     next_votes.push_back(std::move(vote));

--- a/tests/pbft_chain_test.cpp
+++ b/tests/pbft_chain_test.cpp
@@ -105,7 +105,7 @@ TEST_F(PbftChainTest, proposal_block_broadcast) {
   std::shared_ptr<Network> nw3 = node3->getNetwork();
 
   // Check all 3 nodes PBFT chain synced
-  EXPECT_HAPPENS({30s, 200ms}, [&](auto &ctx) {
+  EXPECT_HAPPENS({300s, 200ms}, [&](auto &ctx) {
     WAIT_EXPECT_EQ(ctx, pbft_chain1->getPbftChainSize(), pbft_chain2->getPbftChainSize())
     WAIT_EXPECT_EQ(ctx, pbft_chain1->getPbftChainSize(), pbft_chain3->getPbftChainSize())
     WAIT_EXPECT_EQ(ctx, pbft_chain2->getPbftChainSize(), pbft_chain3->getPbftChainSize())

--- a/tests/pbft_chain_test.cpp
+++ b/tests/pbft_chain_test.cpp
@@ -106,10 +106,16 @@ TEST_F(PbftChainTest, proposal_block_broadcast) {
 
   // Check all 3 nodes PBFT chain synced
   EXPECT_HAPPENS({300s, 200ms}, [&](auto &ctx) {
-    WAIT_EXPECT_EQ(ctx, pbft_chain1->getPbftChainSize(), pbft_chain2->getPbftChainSize())
-    WAIT_EXPECT_EQ(ctx, pbft_chain1->getPbftChainSize(), pbft_chain3->getPbftChainSize())
-    WAIT_EXPECT_EQ(ctx, pbft_chain2->getPbftChainSize(), pbft_chain3->getPbftChainSize())
+    WAIT_EXPECT_EQ(ctx, node1->getPbftManager()->pbftSyncingPeriod(), node2->getPbftManager()->pbftSyncingPeriod())
+    WAIT_EXPECT_EQ(ctx, node1->getPbftManager()->pbftSyncingPeriod(), node3->getPbftManager()->pbftSyncingPeriod())
+    WAIT_EXPECT_EQ(ctx, node2->getPbftManager()->pbftSyncingPeriod(), node3->getPbftManager()->pbftSyncingPeriod())
   });
+
+  // EXPECT_HAPPENS({300s, 200ms}, [&](auto &ctx) {
+  //   WAIT_EXPECT_EQ(ctx, pbft_chain1->getPbftChainSize(), pbft_chain2->getPbftChainSize())
+  //   WAIT_EXPECT_EQ(ctx, pbft_chain1->getPbftChainSize(), pbft_chain3->getPbftChainSize())
+  //   WAIT_EXPECT_EQ(ctx, pbft_chain2->getPbftChainSize(), pbft_chain3->getPbftChainSize())
+  // });
 
   auto node1_pbft_chain_size = pbft_chain1->getPbftChainSize();
 

--- a/tests/pbft_manager_test.cpp
+++ b/tests/pbft_manager_test.cpp
@@ -199,12 +199,12 @@ TEST_F(PbftManagerTest, terminate_soft_voting_pbft_block) {
 
   pbft_mgr->setLastSoftVotedValue(stale_block_hash);
 
-  uint64_t time_till_stale_ms = 1000;
-  std::cout << "Set max wait for soft voted value to " << time_till_stale_ms << "ms..." << std::endl;
-  pbft_mgr->setMaxWaitForSoftVotedBlock_ms(time_till_stale_ms);
-  pbft_mgr->setMaxWaitForNextVotedBlock_ms(std::numeric_limits<uint64_t>::max());
+  //uint64_t time_till_stale_ms = 1000;
+  //std::cout << "Set max wait for soft voted value to " << time_till_stale_ms << "ms..." << std::endl;
+  //pbft_mgr->setMaxWaitForSoftVotedBlock_ms(time_till_stale_ms);
+  //pbft_mgr->setMaxWaitForNextVotedBlock_ms(std::numeric_limits<uint64_t>::max());
 
-  auto sleep_time = time_till_stale_ms + 100;
+  auto sleep_time = 1100;
   std::cout << "Sleep " << sleep_time << "ms so that last soft voted value of " << stale_block_hash.abridged()
             << " becomes stale..." << std::endl;
   taraxa::thisThreadSleepForMilliSeconds(sleep_time);
@@ -240,6 +240,10 @@ TEST_F(PbftManagerTest, terminate_soft_voting_pbft_block) {
 
 // Test that after some amount of elapsed time will give up on the next voting value if corresponding DAG blocks can't
 // be found
+
+// TODO: Replace with test that we won't soft vote and invalid block...
+
+/*
 TEST_F(PbftManagerTest, terminate_bogus_dag_anchor) {
   auto node_cfgs = make_node_cfgs<20>(1);
   auto nodes = launch_nodes(node_cfgs);
@@ -375,6 +379,7 @@ TEST_F(PbftManagerTest, terminate_missing_proposed_pbft_block) {
   auto start_round = pbft_mgr->getPbftRound();
   EXPECT_HAPPENS({60s, 50ms}, [&](auto &ctx) { WAIT_EXPECT_NE(ctx, start_round, pbft_mgr->getPbftRound()) });
 }
+*/
 
 TEST_F(PbftManagerTest, full_node_lambda_input_test) {
   auto node = create_nodes(1, true).front();

--- a/tests/pbft_manager_test.cpp
+++ b/tests/pbft_manager_test.cpp
@@ -777,19 +777,27 @@ TEST_F(PbftManagerWithDagCreation, produce_overweighted_block) {
   node->getBlockProposer()->stop();
   generateAndApplyInitialDag();
 
-  const auto trxs_before = node->getTransactionManager()->getTransactionCount();
+  auto trx_count = node->getTransactionManager()->getTransactionCount();
   EXPECT_HAPPENS({10s, 500ms},
-                 [&](auto &ctx) { WAIT_EXPECT_EQ(ctx, trxs_before, node->getDB()->getNumTransactionExecuted()); });
+                 [&](auto &ctx) { WAIT_EXPECT_EQ(ctx, trx_count, node->getDB()->getNumTransactionExecuted()); });
 
-  const auto starting_block_number = node->getFinalChain()->last_block_number();
+  auto starting_block_number = node->getFinalChain()->last_block_number();
   const auto trx_in_block = dag_gas_limit / trxEstimation() + 2;
   insertBlocks(generateDagBlocks(1, 5, trx_in_block));
 
-  uint64_t tx_count = 5 * trx_in_block;
+  // We need to move one block forward when we will start applying those generated DAGs and transactions
+  EXPECT_HAPPENS({10s, 100ms}, [&](auto &ctx) {
+    WAIT_EXPECT_EQ(ctx, node->getFinalChain()->last_block_number(), starting_block_number + 1);
+  });
+  // check that new created transaction wasn't executed in that previous block
+  ASSERT_EQ(trx_count, node->getDB()->getNumTransactionExecuted());
+  ++starting_block_number;
 
-  EXPECT_HAPPENS({60s, 500ms}, [&](auto &ctx) {
+  trx_count += 5 * trx_in_block;
+  // We are starting to process new dag blocks only from the next period(block), so add 1
+  EXPECT_HAPPENS({10s, 100ms}, [&](auto &ctx) {
     // all transactions should be included in 2 blocks
-    WAIT_EXPECT_EQ(ctx, node->getDB()->getNumTransactionExecuted(), trxs_before + tx_count);
+    WAIT_EXPECT_EQ(ctx, node->getDB()->getNumTransactionExecuted(), trx_count);
     WAIT_EXPECT_EQ(ctx, node->getFinalChain()->last_block_number(), starting_block_number + 2);
   });
 

--- a/tests/pbft_manager_test.cpp
+++ b/tests/pbft_manager_test.cpp
@@ -197,8 +197,6 @@ TEST_F(PbftManagerTest, terminate_soft_voting_pbft_block) {
   propose_vote->calculateWeight(1, 1, 1);
   vote_mgr->addVerifiedVote(propose_vote);
 
-  pbft_mgr->setLastSoftVotedValue(stale_block_hash);
-
   // uint64_t time_till_stale_ms = 1000;
   // std::cout << "Set max wait for soft voted value to " << time_till_stale_ms << "ms..." << std::endl;
   // pbft_mgr->setMaxWaitForSoftVotedBlock_ms(time_till_stale_ms);

--- a/tests/pbft_manager_test.cpp
+++ b/tests/pbft_manager_test.cpp
@@ -199,10 +199,10 @@ TEST_F(PbftManagerTest, terminate_soft_voting_pbft_block) {
 
   pbft_mgr->setLastSoftVotedValue(stale_block_hash);
 
-  //uint64_t time_till_stale_ms = 1000;
-  //std::cout << "Set max wait for soft voted value to " << time_till_stale_ms << "ms..." << std::endl;
-  //pbft_mgr->setMaxWaitForSoftVotedBlock_ms(time_till_stale_ms);
-  //pbft_mgr->setMaxWaitForNextVotedBlock_ms(std::numeric_limits<uint64_t>::max());
+  // uint64_t time_till_stale_ms = 1000;
+  // std::cout << "Set max wait for soft voted value to " << time_till_stale_ms << "ms..." << std::endl;
+  // pbft_mgr->setMaxWaitForSoftVotedBlock_ms(time_till_stale_ms);
+  // pbft_mgr->setMaxWaitForNextVotedBlock_ms(std::numeric_limits<uint64_t>::max());
 
   auto sleep_time = 1100;
   std::cout << "Sleep " << sleep_time << "ms so that last soft voted value of " << stale_block_hash.abridged()

--- a/tests/util_test/util.hpp
+++ b/tests/util_test/util.hpp
@@ -195,6 +195,7 @@ inline auto make_node_cfgs(size_t total_count, size_t validators_count = 1) {
       // PBFT config
       cfg.chain.pbft.lambda_ms_min /= tests_speed;
       cfg.network.network_transaction_interval /= tests_speed;
+      cfg.network.vote_accepting_rounds *= tests_speed;
     }
     if constexpr (!enable_rpc_http) {
       cfg.rpc->http_port = std::nullopt;

--- a/tests/vote_test.cpp
+++ b/tests/vote_test.cpp
@@ -51,7 +51,10 @@ std::pair<uint64_t, uint64_t> clearAllVotes(const std::vector<std::shared_ptr<Fu
     db->commitWriteBatch(batch);
 
     vote_mgr->cleanupVotesByPeriod(max_period);
-    vote_mgr->cleanupVotesByRound(max_period, max_round + 1);
+
+    if (vote_mgr->getVerifiedVotesSize()) {
+      vote_mgr->cleanupVotesByRound(max_period, max_round + 1);
+    }
   }
 
   return {max_period, max_round};
@@ -65,6 +68,7 @@ TEST_F(VoteTest, verified_votes) {
   pbft_mgr->stop();
 
   auto [period, round] = clearAllVotes({node});
+  std::cout << "[TODO REMOVE] Clear all votes returned period " << period << ", round " << round << std::endl;
 
   // Generate a vote
   blk_hash_t blockhash(1);
@@ -81,7 +85,9 @@ TEST_F(VoteTest, verified_votes) {
   EXPECT_EQ(vote_mgr->getVerifiedVotesSize(), 1);
   EXPECT_EQ(vote_mgr->getVerifiedVotes().size(), 1);
 
-  clearAllVotes({node});
+  auto [period2, round2] = clearAllVotes({node});
+  std::cout << "[TODO REMOVE] Clear all votes returned period " << period2 << ", round " << round2 << std::endl;
+
   EXPECT_FALSE(vote_mgr->voteInVerifiedMap(vote));
   EXPECT_EQ(vote_mgr->getVerifiedVotesSize(), 0);
   EXPECT_EQ(vote_mgr->getVerifiedVotes().size(), 0);
@@ -91,7 +97,7 @@ TEST_F(VoteTest, verified_votes) {
 
 // Add votes round 1, 2 and 3 into unverified vote table
 // Verify votes by round 2, will remove round 1 in the table, and keep round 2 & 3 votes
-TEST_F(VoteTest, add_cleanup_get_votes) {
+TEST_F(VoteTest, DISABLED_add_cleanup_get_votes) {
   auto node = create_nodes(1, true /*start*/).front();
 
   // stop PBFT manager, that will place vote

--- a/tests/vote_test.cpp
+++ b/tests/vote_test.cpp
@@ -32,7 +32,7 @@ std::pair<uint64_t, uint64_t> clearAllVotes(const std::vector<std::shared_ptr<Fu
     if (node_period > max_period) {
       max_period = node_period;
     }
-    if (node_period == max_period && node_round > max_round ) {
+    if (node_period == max_period && node_round > max_round) {
       max_round = node_round;
     }
   }
@@ -50,7 +50,8 @@ std::pair<uint64_t, uint64_t> clearAllVotes(const std::vector<std::shared_ptr<Fu
     }
     db->commitWriteBatch(batch);
 
-    vote_mgr->cleanupVotes(max_period, max_round + 1);
+    vote_mgr->cleanupVotesByPeriod(max_period);
+    vote_mgr->cleanupVotesByRound(max_period, max_round + 1);
   }
 
   return {max_period, max_round};
@@ -119,7 +120,7 @@ TEST_F(VoteTest, add_cleanup_get_votes) {
   EXPECT_EQ(votes_size, 6);
 
   // Test cleanup votes
-  vote_mgr->cleanupVotes(1, 2);  // cleanup more
+  vote_mgr->cleanupVotesByRound(1, 2);  // cleanup more
   auto verified_votes_size = vote_mgr->getVerifiedVotesSize();
   EXPECT_EQ(verified_votes_size, 3);
   auto votes = vote_mgr->getVerifiedVotes();
@@ -128,7 +129,7 @@ TEST_F(VoteTest, add_cleanup_get_votes) {
     EXPECT_GT(v->getRound(), 1);
   }
 
-  vote_mgr->cleanupVotes(2,2);  // cleanup more
+  vote_mgr->cleanupVotesByRound(2, 2);  // cleanup more
   verified_votes_size = vote_mgr->getVerifiedVotesSize();
   EXPECT_EQ(verified_votes_size, 0);
   votes = vote_mgr->getVerifiedVotes();
@@ -163,7 +164,7 @@ TEST_F(VoteTest, round_determine_from_next_votes) {
 
   auto new_round = vote_mgr->determineRoundFromPeriodAndVotes(12, two_t_plus_one);
   EXPECT_EQ(new_round, 13);
-  //EXPECT_EQ(new_period, 12);
+  // EXPECT_EQ(new_period, 12);
 }
 
 TEST_F(VoteTest, reconstruct_votes) {


### PR DESCRIPTION
## Purpose

The introduction of periods in to PBFT votes created both challenges and a major opportunity to solve PBFT complexity.

## Changes made

This PR (draft) is attempting to make the following changes...
1. Votes in vote manager are stored by period, round, step not round, period, step
2. 2t+1 votes requirement is stored in db by period not round
3. As soon as 2t+1 cert votes are observed a block is pushed into the chain for execution and period is advanced 1 and round is reset to 1
4. We only identify leader value if we have the block and have verified it. (Having done so we should not do it again in cert voting, but that change hasn't been made)
5. Remove giveUpNextVoted and giveUpSoftVoted functions and need for such logic
6. Remove storing "own starting value" in the db.  
7. Should never get a next voted value that is not a valid value.
8. Period used for all votes within a round should be unchanged (only advance period upon pushing block into chain)

Tests are definitely not passing, so probably both problems with implementation and with tests, particularly the vote creation in the tests often seems to assume no longer valid reasoning about period and round relationship. 
