### PR TITLE
chore: optimize dag block processing

### DIFF
--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/dag_block_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/dag_block_packet_handler.hpp
@@ -29,9 +29,15 @@ class DagBlockPacketHandler final : public ExtSyncingPacketHandler {
   void validatePacketRlpFormat(const PacketData &packet_data) const override;
   void process(const PacketData &packet_data, const std::shared_ptr<TaraxaPeer> &peer) override;
 
+  void waitIfAlreadyProcessing(const blk_hash_t &hash);
+  void processingComplete(const blk_hash_t &hash);
+
   std::shared_ptr<TestState> test_state_;
   std::shared_ptr<TransactionManager> trx_mgr_{nullptr};
   ExpirationCache<blk_hash_t> seen_dags_;
+  mutable std::mutex dag_processing_mutex_;
+  std::condition_variable dag_processing_cv_;
+  std::unordered_set<blk_hash_t> blocks_in_processing_;
 };
 
 }  // namespace taraxa::network::tarcap


### PR DESCRIPTION
Currently once we receive same block from multiple nodes we are connected to we often verify the same block multiple times which significantly affects performance.
At the same time each thread that does that should only complete processing after the dag block has been added to the DAG. Returning before this would create disorder in ordering of incoming dag blocks and might lead to a block missing a tip or pivot.

This change makes a thread wait if the block is already being processed but at the same time allows parallel processing of different DAG blocks.