### PR TITLE
chore: optimize dag block processing

### DIFF
--- a/libraries/core_libs/network/include/network/tarcap/threadpool/packets_blocking_mask.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/threadpool/packets_blocking_mask.hpp
@@ -22,12 +22,16 @@ class PacketsBlockingMask {
   void setDagBlockLevelBeingProcessed(const PacketData& packet);
   void unsetDagBlockLevelBeingProcessed(const PacketData& packet);
 
+  void setDagBlockBeingProcessed(const PacketData& packet);
+  void unsetDagBlockBeingProcessed(const PacketData& packet);
+
   bool isPacketBlocked(const PacketData& packet_data) const;
 
  private:
   bool isPacketHardBlocked(const PacketData& packet_data) const;
   bool isPacketPeerOrderBlocked(const PacketData& packet_data) const;
   bool isDagBlockPacketBlockedByLevel(const PacketData& packet_data) const;
+  bool isDagBlockPacketBlockedBySameDagBlock(const PacketData& packet_data) const;
 
   std::optional<taraxa::level_t> getSmallestDagLevelBeingProcessed() const;
 
@@ -58,6 +62,11 @@ class PacketsBlockingMask {
   //    concurrently
   // Order of levels must be preserved, therefore using std::map
   std::map<taraxa::level_t, std::unordered_set<PacketData::PacketId>> processing_dag_levels_;
+
+  // This "blocking dependency" is specific just for DagBlockPacket. Multiple nodes can send same dag blocks
+  // concurrently, to reduce perofrmance impact only one packet/block will be processsed and others will be waiting.
+  //  This map contains dag blocks that are currently processed with the associated packet id
+  std::map<taraxa::sig_t, PacketData::PacketId> processing_dag_blocks_;
 };
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/src/tarcap/threadpool/priority_queue.cpp
+++ b/libraries/core_libs/network/src/tarcap/threadpool/priority_queue.cpp
@@ -161,6 +161,7 @@ void PriorityQueue::updateDependenciesStart(const PacketData& packet) {
 
     case SubprotocolPacketType::DagBlockPacket:
       blocked_packets_mask_.setDagBlockLevelBeingProcessed(packet);
+      blocked_packets_mask_.setDagBlockBeingProcessed(packet);
       break;
 
     default:
@@ -203,6 +204,7 @@ void PriorityQueue::updateDependenciesFinish(const PacketData& packet, std::mute
     case SubprotocolPacketType::DagBlockPacket: {
       std::unique_lock<std::mutex> lock(queue_mutex);
       blocked_packets_mask_.unsetDagBlockLevelBeingProcessed(packet);
+      blocked_packets_mask_.unsetDagBlockBeingProcessed(packet);
       cond_var.notify_all();
       break;
     }

--- a/libraries/types/dag_block/include/dag/dag_block.hpp
+++ b/libraries/types/dag_block/include/dag/dag_block.hpp
@@ -33,6 +33,8 @@ class DagBlock {
   vdf_sortition::VdfSortition vdf_;
   mutable addr_t cached_sender_;  // block creater
   mutable util::DefaultConstructCopyableMovable<std::mutex> cached_sender_mu_;
+  static const size_t kLevelPosInRlp{1};
+  static const size_t kSigPosInRlp{6};
 
  public:
   DagBlock() = default;
@@ -57,6 +59,14 @@ class DagBlock {
    * @return
    */
   static level_t extract_dag_level_from_rlp(const dev::RLP &rlp);
+
+  /**
+   * @brief Extracts signature from rlp representation
+   *
+   * @param rlp
+   * @return signature
+   */
+  static sig_t extract_signature_from_rlp(const dev::RLP &rlp);
 
   friend std::ostream &operator<<(std::ostream &str, DagBlock const &u) {
     str << "	pivot		= " << u.pivot_.abridged() << std::endl;

--- a/libraries/types/dag_block/src/dag_block.cpp
+++ b/libraries/types/dag_block/src/dag_block.cpp
@@ -75,7 +75,8 @@ DagBlock::DagBlock(dev::RLP const &rlp) {
   vdf_ = vdf_sortition::VdfSortition(vdf_bytes);
 }
 
-level_t DagBlock::extract_dag_level_from_rlp(const dev::RLP &rlp) { return rlp[1].toInt<level_t>(); }
+level_t DagBlock::extract_dag_level_from_rlp(const dev::RLP &rlp) { return rlp[kLevelPosInRlp].toInt<level_t>(); }
+sig_t DagBlock::extract_signature_from_rlp(const dev::RLP &rlp) { return rlp[kSigPosInRlp].toHash<sig_t>(); }
 
 Json::Value DagBlock::getJson(bool with_derived_fields) const {
   Json::Value res;


### PR DESCRIPTION
Block processing of same dag blocks concurrently.
For large dag blocks this was causing a major bottleneck with the same block being verified multiple times in parallel on multiple threads since all connected nodes might send it in short time frame.