### PR TITLE
chore: improve trx estimates

### DIFF
--- a/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
+++ b/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
@@ -196,6 +196,8 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
   std::unordered_map<trx_hash_t, std::shared_ptr<Transaction>> last_finalized_block_transactions_;
   uint64_t trx_count_ = 0;
 
+  const uint64_t kEstimateGasLimit = 200000;
+
   std::shared_ptr<DbStorage> db_{nullptr};
   std::shared_ptr<FinalChain> final_chain_{nullptr};
 

--- a/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
+++ b/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
@@ -286,7 +286,12 @@ std::pair<SharedTransactions, std::vector<uint64_t>> TransactionManager::packTrx
     trxs = transactions_pool_.get(max_transactions_in_block);
   }
   for (uint64_t i = 0; i < trxs.size(); i++) {
-    uint64_t weight = estimateTransactionGas(trxs[i], proposal_period);
+    uint64_t weight;
+    if (trxs[i]->getGas() > kEstimateGasLimit) {
+      weight = estimateTransactionGas(trxs[i], proposal_period);
+    } else {
+      weight = trxs[i]->getGas();
+    }
     total_weight += weight;
     if (total_weight > weight_limit) {
       trxs.resize(i);


### PR DESCRIPTION
Block proposer will use transactions gas limit for estimates if the limit is under 200k. For any transaction above that the estimate will be run using dry_run_transaction.

This limit of 200k is not part of protocol. Proposer could change the limit and not break protocol. When verifying the estimates in a dag block, we allow for any transaction to have one of the two allowed values:
- transaction gas limit
- estimate of dry_run_transaction

Proposer could change this limit but lowering the limit might fit more transactions in the block but at the same time dag block will be created with a delay which might cause other nodes to create transactions faster so proposer would lose the benefit of having more transactions.