### PR TITLE
fix: reward votes replace

### DIFF
--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -243,8 +243,11 @@ class VoteManager {
    * @brief When finalize a new PBFT block, clear reward_votes_ and add the new cert votes to reward_votes_
    *
    * @param cert votes for last finalized PBFT block
+   *
+   * @return old reward votes
    */
-  void replaceRewardVotes(std::vector<std::shared_ptr<Vote>>&& cert_votes);
+  std::unordered_map<vote_hash_t, std::shared_ptr<Vote>> replaceRewardVotes(
+      const std::vector<std::shared_ptr<Vote>>& cert_votes);
 
   /**
    * @brief Get all reward votes in reward_votes_

--- a/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
+++ b/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
@@ -542,10 +542,12 @@ bool VoteManager::checkRewardVotes(const std::shared_ptr<PbftBlock>& pbft_block)
   return true;
 }
 
-void VoteManager::replaceRewardVotes(std::vector<std::shared_ptr<Vote>>&& cert_votes) {
-  if (cert_votes.empty()) return;
+std::unordered_map<vote_hash_t, std::shared_ptr<Vote>> VoteManager::replaceRewardVotes(
+    const std::vector<std::shared_ptr<Vote>>& cert_votes) {
+  if (cert_votes.empty()) return {};
 
   std::unique_lock lock(reward_votes_mutex_);
+  auto reward_votes = std::move(reward_votes_);
   reward_votes_.clear();
   reward_votes_pbft_block_ = {cert_votes[0]->getBlockHash(), cert_votes[0]->getPeriod()};
 
@@ -557,6 +559,7 @@ void VoteManager::replaceRewardVotes(std::vector<std::shared_ptr<Vote>>&& cert_v
     assert(v->getWeight());
     reward_votes_.insert({v->getHash(), std::move(v)});
   }
+  return reward_votes;
 }
 
 std::vector<std::shared_ptr<Vote>> VoteManager::getRewardVotes() {

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -305,8 +305,10 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   // last block cert votes
   void saveLastBlockCertVote(const std::shared_ptr<Vote>& cert_vote);
   void addLastBlockCertVotesToBatch(std::vector<std::shared_ptr<Vote>> const& cert_votes,
-                                    std::vector<std::shared_ptr<Vote>> const& old_cert_votes, Batch& write_batch);
+                                    std::unordered_map<vote_hash_t, std::shared_ptr<Vote>> const& old_cert_votes,
+                                    Batch& write_batch);
   std::vector<std::shared_ptr<Vote>> getLastBlockCertVotes();
+  void removeLastBlockCertVotes(const vote_hash_t& hash);
 
   // period_pbft_block
   void addPbftBlockPeriodToBatch(uint64_t period, taraxa::blk_hash_t const& pbft_block_hash, Batch& write_batch);

--- a/libraries/core_libs/storage/src/storage.cpp
+++ b/libraries/core_libs/storage/src/storage.cpp
@@ -906,11 +906,11 @@ void DbStorage::saveLastBlockCertVote(const std::shared_ptr<Vote>& cert_vote) {
   insert(Columns::last_block_cert_votes, toSlice(cert_vote->getHash()), toSlice(cert_vote->rlp(true, true)));
 }
 
-void DbStorage::addLastBlockCertVotesToBatch(std::vector<std::shared_ptr<Vote>> const& cert_votes,
-                                             std::vector<std::shared_ptr<Vote>> const& old_cert_votes,
-                                             Batch& write_batch) {
+void DbStorage::addLastBlockCertVotesToBatch(
+    std::vector<std::shared_ptr<Vote>> const& cert_votes,
+    std::unordered_map<vote_hash_t, std::shared_ptr<Vote>> const& old_cert_votes, Batch& write_batch) {
   for (auto const& v : old_cert_votes) {
-    remove(write_batch, Columns::last_block_cert_votes, toSlice(v->getHash()));
+    remove(write_batch, Columns::last_block_cert_votes, toSlice(v.second->getHash()));
   }
 
   dev::RLPStream s(cert_votes.size());
@@ -927,6 +927,8 @@ std::vector<std::shared_ptr<Vote>> DbStorage::getLastBlockCertVotes() {
   }
   return votes;
 }
+
+void DbStorage::removeLastBlockCertVotes(const vote_hash_t& hash) { remove(Columns::next_votes, toSlice(hash)); }
 
 void DbStorage::removeNextVotesToBatch(uint64_t pbft_round, Batch& write_batch) {
   remove(write_batch, Columns::next_votes, toSlice(pbft_round));


### PR DESCRIPTION
There was a race condition where if some thread called addRewardVote between calls to:
db_->addLastBlockCertVotesToBatch and vote_mgr_->replaceRewardVotes(std::move(cert_votes))

reward vote from the old period would get saved into Columns::last_block_cert_votes and it would never be deleted.

The fix is that replaceRewardVotes now replace the votes in memory before deleting them from the db. After this only new reward votes are accepted into VoteMgr and old votes are deleted from the db with the return value of replaceRewardVotes.

On node restart last_block_cert_votes vote are verified that they point to the last block in the chain before being stored in memory as reward votes
