### PR TITLE
chore: improve trx retrieval

### DIFF
--- a/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
+++ b/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
@@ -193,10 +193,11 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
   mutable std::shared_mutex transactions_mutex_;
   TransactionQueue transactions_pool_;
   std::unordered_map<trx_hash_t, std::shared_ptr<Transaction>> nonfinalized_transactions_in_dag_;
-  std::unordered_map<trx_hash_t, std::shared_ptr<Transaction>> last_finalized_block_transactions_;
+  std::unordered_map<trx_hash_t, std::shared_ptr<Transaction>> recently_finalized_transactions_;
   uint64_t trx_count_ = 0;
 
   const uint64_t kEstimateGasLimit = 200000;
+  const uint64_t kRecentlyFinalizedTransactionsMax = 50000;
 
   std::shared_ptr<DbStorage> db_{nullptr};
   std::shared_ptr<FinalChain> final_chain_{nullptr};


### PR DESCRIPTION
On high tps tests on devnet, there is still some slow processing when verifying dag blocks. This happens when verifying DAG blocks which include a lot of transactions that are already finalized.

last_finalized_block_transactions_ was cleared even for blocks that had no transactions or a small number of transactions so instead of keeping only last block transactions in memory we now keep up to 50k recently finalized transactions in memory before clearing it.
