### PR TITLE
fix: sporadic transaction_pool_overflow fails

### DIFF
--- a/libraries/core_libs/network/src/tarcap/packets_handlers/dag_block_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/dag_block_packet_handler.cpp
@@ -162,7 +162,7 @@ void DagBlockPacketHandler::onNewBlockReceived(DagBlock &&block, const std::shar
 
 void DagBlockPacketHandler::onNewBlockVerified(DagBlock &&block, bool proposed, SharedTransactions &&trxs) {
   // If node is pbft syncing and block is not proposed by us, this is an old block that has been verified - no block
-  // goosip is needed
+  // gossip is needed
   if (!proposed && pbft_syncing_state_->isDeepPbftSyncing()) {
     return;
   }


### PR DESCRIPTION
Fix sporadic fails of `transaction_pool_overflow` test by increasing count of validators. Without this change all consensus is done by one node and other is permanently syncing from it. Because of this we could be in situation when nodes has different chain size and dag syncing isn't working because we are still in pbft syncing process