### PR TITLE
chore: fix period advancing + synchronous vs asynchronous processing …

### DIFF
--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -533,9 +533,10 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
    * @brief Final chain executes a finalized PBFT block
    * @param period_data PBFT block, cert votes, DAG blocks, and transactions
    * @param finalized_dag_blk_hashes DAG blocks hashes
-   * @param sync it's true when it's last finalized block
+   * @param synchronous_processing wait for block finalization to finish
    */
-  void finalize_(PeriodData &&period_data, std::vector<h256> &&finalized_dag_blk_hashes, bool sync = false);
+  void finalize_(PeriodData &&period_data, std::vector<h256> &&finalized_dag_blk_hashes,
+                 bool synchronous_processing = false);
 
   /**
    * @brief Push a new PBFT block into the PBFT chain

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
@@ -253,6 +253,7 @@ void PbftSyncPacketHandler::handleMaliciousSyncPeer(dev::p2p::NodeID const &id) 
   peers_state_->set_peer_malicious(id);
 
   if (auto host = peers_state_->host_.lock(); host) {
+    LOG(log_nf_) << "Disconnect peer " << id;
     host->disconnect(id, dev::p2p::UserReason);
   } else {
     LOG(log_er_) << "Unable to handleMaliciousSyncPeer, host == nullptr";


### PR DESCRIPTION
## Purpose
<!-- Provide any information reviewers might need to have context on your changes. -->
There was a bug for networks with delegation_delay set to 0:
advancePeriod() must be called after chain size is increased(updatePbftChain) as well as finalize_ function on final chain is called, otherwise consesnus might get stuck due to infinite waiting inside updateDposState_(), which is waiting for block to be finalized...


This should not affect devnet though

## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
