### PR TITLE
fix: sync queue with old block

### DIFF
--- a/libraries/core_libs/consensus/include/pbft/period_data_queue.hpp
+++ b/libraries/core_libs/consensus/include/pbft/period_data_queue.hpp
@@ -67,6 +67,12 @@ class PeriodDataQueue {
    */
   std::shared_ptr<PbftBlock> lastPbftBlock() const;
 
+  /**
+   * @brief Clean any old blocks below current period
+   * @param period current period
+   */
+  void cleanOldData(uint64_t period);
+
  private:
   std::deque<std::pair<PeriodData, dev::p2p::NodeID>> queue_;
   // We need this variable as for small amount of time block is not part of queue but still being processed

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1715,6 +1715,7 @@ bool PbftManager::pushCertVotedPbftBlockIntoChain_(taraxa::blk_hash_t const &cer
 void PbftManager::pushSyncedPbftBlocksIntoChain() {
   if (auto net = network_.lock()) {
     auto round = getPbftRound();
+    sync_queue_.cleanOldData(getPbftPeriod());
     while (periodDataQueueSize() > 0) {
       auto period_data_opt = processPeriodData();
       if (!period_data_opt) continue;
@@ -2001,7 +2002,9 @@ std::optional<std::pair<PeriodData, std::vector<std::shared_ptr<Vote>>>> PbftMan
 
 blk_hash_t PbftManager::lastPbftBlockHashFromQueueOrChain() {
   auto pbft_block = sync_queue_.lastPbftBlock();
-  if (pbft_block) return pbft_block->getBlockHash();
+  if (pbft_block && pbft_block->getPeriod() >= getPbftPeriod()) {
+    return pbft_block->getBlockHash();
+  }
   return pbft_chain_->getLastPbftBlockHash();
 }
 

--- a/libraries/core_libs/consensus/src/pbft/period_data_queue.cpp
+++ b/libraries/core_libs/consensus/src/pbft/period_data_queue.cpp
@@ -66,4 +66,11 @@ std::shared_ptr<PbftBlock> PeriodDataQueue::lastPbftBlock() const {
   return nullptr;
 }
 
+void PeriodDataQueue::cleanOldData(uint64_t period) {
+  std::unique_lock lock(queue_access_);
+  while (queue_.size() > 0 && queue_.front().first.pbft_blk->getPeriod() < period) {
+    queue_.pop_front();
+  }
+}
+
 }  // namespace taraxa


### PR DESCRIPTION
Fix an issue where old block can get stuck in the sync queue and prevent syncing new blocks