### PR TITLE
fix: PbftManager::lastPbftBlockHashFromQueueOrChain returning incorrect block hash

### DIFF
--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -989,8 +989,8 @@ void PbftManager::firstFinish_() {
       placeVote(std::move(vote));
     }
   } else {
-    if (auto vote = generateVoteWithWeight(previous_round_next_voted_value_.first, next_vote_type, period,
-                                           round, step_);
+    if (auto vote =
+            generateVoteWithWeight(previous_round_next_voted_value_.first, next_vote_type, period, round, step_);
         vote) {
       LOG(log_nf_) << "Placed first finish next vote for " << previous_round_next_voted_value_.first.abridged()
                    << ", vote weight " << *vote->getWeight() << ", round " << round << ", period " << period
@@ -2007,7 +2007,9 @@ std::optional<std::pair<PeriodData, std::vector<std::shared_ptr<Vote>>>> PbftMan
 
 blk_hash_t PbftManager::lastPbftBlockHashFromQueueOrChain() {
   auto pbft_block = sync_queue_.lastPbftBlock();
-  if (pbft_block) return pbft_block->getBlockHash();
+  if (pbft_block && pbft_block->getPeriod() >= getPbftPeriod()) {
+    return pbft_block->getBlockHash();
+  }
   return pbft_chain_->getLastPbftBlockHash();
 }
 

--- a/libraries/core_libs/consensus/src/pbft/period_data_queue.cpp
+++ b/libraries/core_libs/consensus/src/pbft/period_data_queue.cpp
@@ -60,7 +60,8 @@ std::tuple<PeriodData, std::vector<std::shared_ptr<Vote>>, dev::p2p::NodeID> Per
 
 std::shared_ptr<PbftBlock> PeriodDataQueue::lastPbftBlock() const {
   std::shared_lock lock(queue_access_);
-  if (queue_.size() > 0) {
+  // using modified size method to not return potentially incorrect block
+  if (size() > 0) {
     return queue_.back().first.pbft_blk;
   }
   return nullptr;


### PR DESCRIPTION
Fix returning of incorrect(old) block hash by lastPbftBlockHashFromQueueOrChain that was stuck in the sync queue and prevent syncing of new blocks