### PR TITLE
chore: optimize pbft block proposal

### DIFF
--- a/libraries/core_libs/consensus/src/dag/dag_manager.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_manager.cpp
@@ -161,8 +161,8 @@ std::pair<bool, std::vector<blk_hash_t>> DagManager::addDagBlock(DagBlock &&blk,
         trx_mgr_->saveTransactionsFromDagBlock(trxs);
         // Save the dag block
         db_->saveDagBlock(blk);
-        seen_blocks_.insert(blk.getHash(), blk);
       }
+      seen_blocks_.insert(blk.getHash(), blk);
       auto pivot_hash = blk.getPivot();
 
       std::vector<blk_hash_t> tips = blk.getTips();

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1404,16 +1404,10 @@ std::shared_ptr<PbftBlock> PbftManager::proposePbftBlock_() {
       }
     }
   }
-  std::vector<trx_hash_t> non_finalized_transactions;
-  auto trx_finalized = db_->transactionsFinalized(trx_hashes);
-  for (uint32_t i = 0; i < trx_finalized.size(); i++) {
-    if (!trx_finalized[i]) {
-      non_finalized_transactions.emplace_back(trx_hashes[i]);
-    }
-  }
 
-  const auto transactions = trx_mgr_->getNonfinalizedTrx(non_finalized_transactions, true /*sorted*/);
-  non_finalized_transactions.clear();
+  std::vector<trx_hash_t> non_finalized_transactions;
+  non_finalized_transactions.reserve(trx_hashes.size());
+  const auto transactions = trx_mgr_->getNonfinalizedTrx(trx_hashes, true /*sorted*/);
   std::transform(transactions.begin(), transactions.end(), std::back_inserter(non_finalized_transactions),
                  [](const auto &t) { return t->getHash(); });
 

--- a/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
+++ b/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
@@ -229,6 +229,8 @@ void TransactionManager::recoverNonfinalizedTransactions() {
       // line can be removed or replaced with an assert
       db_->removeTransactionToBatch(trx_hash, write_batch);
     } else {
+      // Cache sender now by caling getSender since getting sender later on proposing blocks can affect performance
+      trxs[i]->getSender();
       nonfinalized_transactions_in_dag_.emplace(trx_hash, std::move(trxs[i]));
     }
   }


### PR DESCRIPTION
Remove getting finalized transactions from proposal since it is not needed.
Fill seen_blocks_ cache on startup so that getting dag blocks in pbft block proposal is served from cache and not db
Cache sender in transactions on startup since getSender is expensive to avoid doing it on proposing pbft blocks