### PR TITLE
chore: optimize pbft propose and verify

### DIFF
--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -269,19 +269,16 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   /**
    * @brief Calculate DAG blocks ordering hash
    * @param dag_block_hashes DAG blocks hashes
-   * @param trx_hashes transactions hashes
    * @return DAG blocks ordering hash
    */
-  static blk_hash_t calculateOrderHash(const std::vector<blk_hash_t> &dag_block_hashes,
-                                       const std::vector<trx_hash_t> &trx_hashes);
+  static blk_hash_t calculateOrderHash(const std::vector<blk_hash_t> &dag_block_hashes);
 
   /**
    * @brief Calculate DAG blocks ordering hash
    * @param dag_blocks DAG blocks
-   * @param transactions transactions
    * @return DAG blocks ordering hash
    */
-  static blk_hash_t calculateOrderHash(const std::vector<DagBlock> &dag_blocks, const SharedTransactions &transactions);
+  static blk_hash_t calculateOrderHash(const std::vector<DagBlock> &dag_blocks);
 
   /**
    * @brief Check a block weight of gas estimation

--- a/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
+++ b/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
@@ -123,11 +123,17 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
    * @brief Get the Nonfinalized Trx objects from cache
    *
    * @param hashes
-   * @param sorted
    * @return std::vector<std::shared_ptr<Transaction>>
    */
-  std::vector<std::shared_ptr<Transaction>> getNonfinalizedTrx(const std::vector<trx_hash_t> &hashes,
-                                                               bool sorted = false);
+  std::vector<std::shared_ptr<Transaction>> getNonfinalizedTrx(const std::vector<trx_hash_t> &hashes);
+
+  /**
+   * @brief Exclude Finalized transactions
+   *
+   * @param hashes
+   * @return Only transactions that are not finalized
+   */
+  std::vector<trx_hash_t> excludeFinalizedTransactions(const std::vector<trx_hash_t> &hashes);
 
   /**
    * @brief Get the block transactions

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
@@ -126,7 +126,7 @@ void PbftSyncPacketHandler::process(const PacketData &packet_data, const std::sh
     }
   }
 
-  auto order_hash = PbftManager::calculateOrderHash(period_data.dag_blocks, period_data.transactions);
+  auto order_hash = PbftManager::calculateOrderHash(period_data.dag_blocks);
   if (order_hash != period_data.pbft_blk->getOrderHash()) {
     {  // This is just log related stuff
       std::vector<trx_hash_t> trx_order;

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -520,11 +520,9 @@ TEST_F(NetworkTest, node_pbft_sync) {
   node1->getDagManager()->verifyBlock(DagBlock(blk1));
   node1->getDagManager()->addDagBlock(DagBlock(blk1));
 
-  dev::RLPStream order_stream(2);
+  dev::RLPStream order_stream(1);
   order_stream.appendList(1);
   order_stream << blk1.getHash();
-  order_stream.appendList(2);
-  order_stream << g_signed_trx_samples[0]->getHash() << g_signed_trx_samples[1]->getHash();
 
   PbftBlock pbft_block1(prev_block_hash, blk1.getHash(), dev::sha3(order_stream.out()), period, beneficiary,
                         node1->getSecretKey(), {});
@@ -578,11 +576,9 @@ TEST_F(NetworkTest, node_pbft_sync) {
   batch = db1->createWriteBatch();
   period = 2;
   beneficiary = addr_t(654);
-  dev::RLPStream order_stream2(2);
+  dev::RLPStream order_stream2(1);
   order_stream2.appendList(1);
   order_stream2 << blk2.getHash();
-  order_stream2.appendList(2);
-  order_stream2 << g_signed_trx_samples[2]->getHash() << g_signed_trx_samples[3]->getHash();
   PbftBlock pbft_block2(prev_block_hash, blk2.getHash(), dev::sha3(order_stream2.out()), period, beneficiary,
                         node1->getSecretKey(), {});
   std::vector<std::shared_ptr<Vote>> votes_for_pbft_blk2;
@@ -688,11 +684,9 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   node1->getDagManager()->verifyBlock(DagBlock(blk1));
   node1->getDagManager()->addDagBlock(DagBlock(blk1));
 
-  dev::RLPStream order_stream(2);
+  dev::RLPStream order_stream(1);
   order_stream.appendList(1);
   order_stream << blk1.getHash();
-  order_stream.appendList(2);
-  order_stream << g_signed_trx_samples[0]->getHash() << g_signed_trx_samples[1]->getHash();
 
   PbftBlock pbft_block1(prev_block_hash, blk1.getHash(), dev::sha3(order_stream.out()), period, beneficiary,
                         node1->getSecretKey(), {});
@@ -737,11 +731,9 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   period = 2;
   beneficiary = addr_t(654);
 
-  dev::RLPStream order_stream2(2);
+  dev::RLPStream order_stream2(1);
   order_stream2.appendList(1);
   order_stream2 << blk2.getHash();
-  order_stream2.appendList(2);
-  order_stream2 << g_signed_trx_samples[2]->getHash() << g_signed_trx_samples[3]->getHash();
 
   PbftBlock pbft_block2(prev_block_hash, blk2.getHash(), dev::sha3(order_stream2.out()), period, beneficiary,
                         node1->getSecretKey(), {});

--- a/tests/pbft_manager_test.cpp
+++ b/tests/pbft_manager_test.cpp
@@ -844,12 +844,7 @@ TEST_F(PbftManagerWithDagCreation, DISABLED_pbft_block_is_overweighted) {
       std::transform(bt.trxs.begin(), bt.trxs.end(), std::back_inserter(trx_hashes),
                      [](const auto &t) { return t->getHash(); });
     }
-    const auto transactions = node->getTransactionManager()->getNonfinalizedTrx(trx_hashes, true /*sorted*/);
-    trx_hashes.clear();
-    std::transform(transactions.begin(), transactions.end(), std::back_inserter(trx_hashes),
-                   [](const auto &t) { return t->getHash(); });
-
-    auto order_hash = node->getPbftManager()->calculateOrderHash(dag_block_order, trx_hashes);
+    auto order_hash = node->getPbftManager()->calculateOrderHash(dag_block_order);
 
     const auto &last_hash = node->getPbftChain()->getLastPbftBlockHash();
     auto reward_votes = node->getDB()->getLastBlockCertVotes();


### PR DESCRIPTION
Pbft block contains an order_hash which previously was created from order of dag blocks and order of transactions. This creates performance issues when pbft block has large number of transactions(100k transactions) at two points in consensus process:
1. On proposing pbft block large number of transactions needed to be retrieved and sorted to be able to generate the order_hash
2. On verifying proposed pbft blocks large number of transactions needed to be retrieved and sorted to be able to verify the order_hash

This change has removed transactions from the order_hash. Order hash now is only order of dag blocks. It is assumed that the order of dag blocks at same period will always have same set of unique non-finalized transactions.

By removing transactions from order hash these changes were done as well:
1. On syncing when receiving period_data to make sure that the transactions in period_data is valid and not maliciously altered, transactions are now retrieved locally and compared
2. On finalizing the data transactions need to be sorted before being executed