### PR TITLE
chore: previous round next votes sync imrpovement

### DIFF
--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1087,7 +1087,7 @@ void PbftManager::secondFinish_() {
     syncPbftChainFromPeers_(exceeded_max_steps, NULL_BLOCK_HASH);
   }
 
-  if (round > 1 && step_ > MAX_STEPS && (step_ - MAX_STEPS - 2) % 100 == 0 && !broadcastAlreadyThisStep_()) {
+  if (round > 1 && step_ > MAX_STEPS && (step_ - MAX_STEPS - 2) % 20 == 0 && !broadcastAlreadyThisStep_()) {
     LOG(log_dg_) << "Node " << node_addr_ << " broadcast next votes for previous round. In period " << period
                  << ", round " << round << " step " << step_;
     if (auto net = network_.lock()) {

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/vote_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/vote_packet_handler.hpp
@@ -5,6 +5,7 @@
 namespace taraxa {
 class PbftManager;
 class VoteManager;
+class NextVotesManager;
 }  // namespace taraxa
 
 namespace taraxa::network::tarcap {
@@ -13,7 +14,8 @@ class VotePacketHandler final : public ExtVotesPacketHandler {
  public:
   VotePacketHandler(std::shared_ptr<PeersState> peers_state, std::shared_ptr<PacketsStats> packets_stats,
                     std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<PbftChain> pbft_chain,
-                    std::shared_ptr<VoteManager> vote_mgr, const NetworkConfig& net_config, const addr_t& node_addr);
+                    std::shared_ptr<VoteManager> vote_mgr, std::shared_ptr<NextVotesManager> next_votes_mgr,
+                    const NetworkConfig& net_config, const addr_t& node_addr);
 
   // Packet type that is processed by this handler
   static constexpr SubprotocolPacketType kPacketType_ = SubprotocolPacketType::VotePacket;
@@ -28,6 +30,7 @@ class VotePacketHandler final : public ExtVotesPacketHandler {
   constexpr static std::chrono::seconds kSyncRequestInterval = std::chrono::seconds(10);
   ExpirationCache<vote_hash_t> seen_votes_;
   std::chrono::system_clock::time_point round_sync_request_time_;
+  std::shared_ptr<NextVotesManager> next_votes_mgr_;
 };
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
@@ -171,9 +171,7 @@ void VotesSyncPacketHandler::broadcastPreviousRoundNextVotesBundle() {
     if (!peer.second->syncing_ && peer.second->pbft_round_ <= pbft_current_round) {
       std::vector<std::shared_ptr<Vote>> send_next_votes_bundle;
       for (const auto &v : next_votes_bundle) {
-        if (!peer.second->isVoteKnown(v->getHash())) {
-          send_next_votes_bundle.push_back(v);
-        }
+        send_next_votes_bundle.push_back(v);
       }
       sendPbftVotes(peer.first, std::move(send_next_votes_bundle), true);
     }

--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -196,7 +196,7 @@ void TaraxaCapability::registerPacketHandlers(
 
   // Consensus packets with high processing priority
   packets_handlers_->registerHandler<VotePacketHandler>(peers_state_, packets_stats, pbft_mgr, pbft_chain, vote_mgr,
-                                                        kConf.network, node_addr);
+                                                        next_votes_mgr, kConf.network, node_addr);
   packets_handlers_->registerHandler<GetVotesSyncPacketHandler>(peers_state_, packets_stats, pbft_mgr, pbft_chain,
                                                                 vote_mgr, next_votes_mgr,
                                                                 kConf.network.vote_accepting_periods, node_addr);


### PR DESCRIPTION
1. In VotePacketHandler::process process next votes from previous round same as it is done in VotesSyncPacketHandler::process
2. In broadcastPreviousRoundNextVotesBundle rebroadcast all votes even though we think that other nodes know about it
3. broadcastPreviousRoundNextVotesBundle is called in secondFinish each 100 steps, changed it to 20 steps

In first and second finish we rebroadcast pbft block, reward votes and these next votes from previous round. And this is done each N steps, I am not sure if it makes sense to configure how often we do it or we just stick with hard coded values?