### PR TITLE
chore: optimize identify pbft leader block

### DIFF
--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -581,6 +581,10 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
 
   std::atomic<bool> stopped_ = true;
 
+  // Multiple proposed pbft blocks could have same dag block anchor at same period so this cache improves retrieval of
+  // dag block order for specific anchor
+  std::unordered_map<blk_hash_t, vec_blk_t> anchor_dag_block_order_cache;
+
   // Ensures that only one PBFT block per period can be proposed
   std::shared_ptr<PbftBlock> proposed_block_ = nullptr;
 


### PR DESCRIPTION
On devnet in low transactions flow identify leader takes about 5ms
On high tps where dag blocks have a lot of transactions and pbft blocks can have lot of dag blocks identify leader took over 1 second for 15 candidates or about 80ms per candidate.

Identify leader verified all the candidates and then selects a leader. Optimization is done that we first select the leader (vote with minimum hash) and if it is verified there is no need for verifying other blocks. So in the case above instead of verifying 15 blocks we only verify 1 (or more if leader fails verification).

Around 90% of pbft block verification time is verifying pbft block anchor (dag block order and gas limit check). Different pbft blocks might have same dag anchor so there is no need to do this verification multiple time for same anchor at same period.  anchor_dag_block_order_cache now stores the order for anchors that were already verified. 