### PR TITLE
chore: optimize pbft block proposal and verification

### DIFF
--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -282,10 +282,10 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
 
   /**
    * @brief Check a block weight of gas estimation
-   * @param period_data period data
+   * @param dag_blocks dag blocks
    * @return true if total weight of gas estimation is less or equal to gas limit. Otherwise return false
    */
-  bool checkBlockWeight(const PeriodData &period_data) const;
+  bool checkBlockWeight(const std::vector<DagBlock> &dag_blocks) const;
 
   /**
    * @brief Get finalized DPOS period
@@ -504,18 +504,10 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   /**
    * @brief Check that there are all DAG blocks with correct ordering, total gas estimation is not greater than gas
    * limit, and PBFT block includes all reward votes.
-   * @param pbft_block_hash PBFT block hash
+   * @param pbft_block PBFT block
    * @return true if pass verification
    */
-  bool compareBlocksAndRewardVotes_(const blk_hash_t &pbft_block_hash);
-
-  /**
-   * @brief Check that there are all DAG blocks with correct ordering, total gas estimation is not greater than gas
-   * limit, and PBFT block include all reward votes.
-   * @param pbft_block PBFT block
-   * @return true with DAG blocks hashes in order if passed verification. Otherwise return false
-   */
-  std::pair<vec_blk_t, bool> compareBlocksAndRewardVotes_(std::shared_ptr<PbftBlock> pbft_block);
+  bool compareBlocksAndRewardVotes_(const std::shared_ptr<PbftBlock> &pbft_block);
 
   /**
    * @brief If there are enough certify votes, push the vote PBFT block in PBFT chain
@@ -539,11 +531,9 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
    * @brief Push a new PBFT block into the PBFT chain
    * @param period_data PBFT block, cert votes for previous period, DAG blocks, and transactions
    * @param cert_votes cert votes for pbft block period
-   * @param dag_blocks_order DAG blocks hashes
    * @return true if push a new PBFT block into the PBFT chain
    */
-  bool pushPbftBlock_(PeriodData &&period_data, std::vector<std::shared_ptr<Vote>> &&cert_votes,
-                      vec_blk_t &&dag_blocks_order = {});
+  bool pushPbftBlock_(PeriodData &&period_data, std::vector<std::shared_ptr<Vote>> &&cert_votes);
 
   /**
    * @brief Update PBFT 2t+1 and PBFT sortition threshold
@@ -583,7 +573,7 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
 
   // Multiple proposed pbft blocks could have same dag block anchor at same period so this cache improves retrieval of
   // dag block order for specific anchor
-  std::unordered_map<blk_hash_t, vec_blk_t> anchor_dag_block_order_cache;
+  std::unordered_map<blk_hash_t, std::vector<DagBlock>> anchor_dag_block_order_cache_;
 
   // Ensures that only one PBFT block per period can be proposed
   std::shared_ptr<PbftBlock> proposed_block_ = nullptr;
@@ -631,9 +621,6 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
 
   std::optional<std::pair<blk_hash_t, uint64_t /* period */>> previous_round_next_voted_value_{};
   bool previous_round_next_voted_null_block_hash_ = false;
-
-  // Period data for pbft block that is being currently cert voted for
-  PeriodData period_data_;
 
   time_point round_clock_initial_datetime_;
   time_point now_;

--- a/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
+++ b/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
@@ -141,7 +141,7 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
    * @param blk
    * @return transactions retrieved from pool/db
    */
-  std::optional<std::map<trx_hash_t, std::shared_ptr<Transaction>>> getBlockTransactions(DagBlock const &blk);
+  std::optional<SharedTransactions> getBlockTransactions(DagBlock const &blk);
 
   /**
    * @brief Updates the status of transactions to finalized

--- a/libraries/core_libs/consensus/src/dag/block_proposer.cpp
+++ b/libraries/core_libs/consensus/src/dag/block_proposer.cpp
@@ -221,8 +221,10 @@ void BlockProposer::proposeBlock(DagFrontier&& frontier, level_t level, SharedTr
   for (const auto& trx : trxs) {
     trx_hashes.push_back(trx->getHash());
   }
-  DagBlock blk(frontier.pivot, std::move(level), std::move(frontier.tips), std::move(trx_hashes),
-               std::move(estimations), std::move(vdf), node_sk_);
+  uint64_t block_estimation = 0;
+  for (const auto& e : estimations) block_estimation += e;
+  DagBlock blk(frontier.pivot, std::move(level), std::move(frontier.tips), std::move(trx_hashes), block_estimation,
+               std::move(vdf), node_sk_);
 
   LOG(log_nf_) << "Add proposed DAG block " << blk.getHash() << ", pivot " << blk.getPivot() << " , number of trx ("
                << blk.getTrxs().size() << ")";

--- a/libraries/types/dag_block/include/dag/dag_block.hpp
+++ b/libraries/types/dag_block/include/dag/dag_block.hpp
@@ -24,7 +24,7 @@ class DagBlock {
   level_t level_ = 0;
   vec_blk_t tips_;
   vec_trx_t trxs_;  // transactions
-  std::vector<uint64_t> trxs_gas_estimations_;
+  uint64_t gas_estimation_;
   sig_t sig_;
   u256 block_weight_;
   mutable blk_hash_t hash_;
@@ -39,14 +39,14 @@ class DagBlock {
  public:
   DagBlock() = default;
   // fixme: This constructor is bogus, used only in tests. Eliminate it
-  DagBlock(blk_hash_t pivot, level_t level, vec_blk_t tips, vec_trx_t trxs, std::vector<uint64_t> est, sig_t signature,
+  DagBlock(blk_hash_t pivot, level_t level, vec_blk_t tips, vec_trx_t trxs, uint64_t est, sig_t signature,
            blk_hash_t hash, addr_t sender);
   DagBlock(blk_hash_t pivot, level_t level, vec_blk_t tips, vec_trx_t trxs, sig_t signature, blk_hash_t hash,
            addr_t sender);
   // fixme: used only in tests, Eliminate it
   DagBlock(blk_hash_t const &pivot, level_t level, vec_blk_t tips, vec_trx_t trxs, secret_t const &sk);
-  DagBlock(blk_hash_t const &pivot, level_t level, vec_blk_t tips, vec_trx_t trxs, std::vector<uint64_t> est,
-           VdfSortition vdf, secret_t const &sk);
+  DagBlock(blk_hash_t const &pivot, level_t level, vec_blk_t tips, vec_trx_t trxs, uint64_t est, VdfSortition vdf,
+           secret_t const &sk);
   explicit DagBlock(Json::Value const &doc);
   explicit DagBlock(string const &json);
   explicit DagBlock(dev::RLP const &_rlp);
@@ -90,7 +90,7 @@ class DagBlock {
   auto getTimestamp() const { return timestamp_; }
   auto const &getTips() const { return tips_; }
   auto const &getTrxs() const { return trxs_; }
-  auto const &getTrxsGasEstimations() const { return trxs_gas_estimations_; }
+  auto const &getGasEstimation() const { return gas_estimation_; }
   auto const &getSig() const { return sig_; }
   blk_hash_t const &getHash() const;
   uint16_t getDifficulty() const { return vdf_.getDifficulty(); }

--- a/tests/dag_block_test.cpp
+++ b/tests/dag_block_test.cpp
@@ -232,7 +232,7 @@ TEST_F(DagBlockMgrTest, incorrect_tx_estimation) {
 
   // wrong estimated tx
   {
-    DagBlock blk(dag_genesis, propose_level, {}, {trx->getHash()}, {100}, vdf1, node->getSecretKey());
+    DagBlock blk(dag_genesis, propose_level, {}, {trx->getHash()}, 100, vdf1, node->getSecretKey());
     EXPECT_EQ(node->getDagManager()->verifyBlock(std::move(blk)),
               DagManager::VerifyBlockReturnType::IncorrectTransactionsEstimation);
   }
@@ -247,19 +247,19 @@ TEST_F(DagBlockMgrTest, too_big_dag_block) {
   auto db = node->getDB();
 
   std::vector<trx_hash_t> hashes;
-  std::vector<uint64_t> estimations;
+  uint64_t estimations = 0;
   for (size_t i = 0; i < 5; ++i) {
-    auto create_trx =
-        std::make_shared<Transaction>(i, 100, 0, 0, dev::fromHex(samples::greeter_contract_code), node->getSecretKey());
+    auto create_trx = std::make_shared<Transaction>(i, 100, 0, 200001, dev::fromHex(samples::greeter_contract_code),
+                                                    node->getSecretKey());
     auto [ok, err_msg] = node->getTransactionManager()->insertTransaction(create_trx);
     EXPECT_EQ(ok, true);
     hashes.emplace_back(create_trx->getHash());
     const auto& e = node->getTransactionManager()->estimateTransactionGas(create_trx, std::nullopt);
-    estimations.emplace_back(e);
+    estimations += e;
   }
 
   for (size_t i = 0; i < hashes.size(); ++i) {
-    std::cout << hashes[i] << ": " << estimations[i] << std::endl;
+    std::cout << hashes[i] << ": " << estimations << std::endl;
   }
 
   // Generate DAG block

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -1417,7 +1417,7 @@ TEST_F(FullNodeTest, chain_config_json) {
     "timestamp": "0x5d422b80",
     "tips": [],
     "transactions": [],
-    "trx_estimations" : []
+    "trx_estimations" : "0x0"
   },
   "final_chain": {
     "genesis_block_fields": {
@@ -1692,7 +1692,7 @@ TEST_F(FullNodeTest, transaction_pool_overflow) {
   const auto estimation = node0->getTransactionManager()->estimateTransactionGas(trx, proposal_period);
   vdf.computeVdfSolution(sortition_params, dag_genesis.asBytes(), false);
 
-  DagBlock blk(dag_genesis, proposal_level, {}, {trx->getHash()}, {estimation}, vdf, node0->getSecretKey());
+  DagBlock blk(dag_genesis, proposal_level, {}, {trx->getHash()}, estimation, vdf, node0->getSecretKey());
   const auto blk_hash = blk.getHash();
   EXPECT_TRUE(nodes[1]->getDagManager()->addDagBlock(std::move(blk), {trx}).first);
 

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -108,7 +108,7 @@ TEST_F(NetworkTest, transfer_lot_of_blocks) {
                                   VrfSortitionBase::makeVrfInput(proposal_level, period_block_hash));
   const auto dag_genesis = node1->getConfig().chain.dag_genesis_block.getHash();
   vdf.computeVdfSolution(sortition_params, dag_genesis.asBytes(), false);
-  DagBlock blk(dag_genesis, proposal_level, {}, {trxs[0]->getHash()}, {estimation}, vdf, node1->getSecretKey());
+  DagBlock blk(dag_genesis, proposal_level, {}, {trxs[0]->getHash()}, estimation, vdf, node1->getSecretKey());
   auto block_hash = blk.getHash();
   std::vector<std::shared_ptr<DagBlock>> dag_blocks;
   dag_blocks.emplace_back(std::make_shared<DagBlock>(std::move(blk)));
@@ -424,38 +424,38 @@ TEST_F(NetworkTest, node_sync) {
   vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
   vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
-  DagBlock blk1(dag_genesis, propose_level, {}, {g_signed_trx_samples[1]->getHash()}, {estimation}, vdf1, sk);
+  DagBlock blk1(dag_genesis, propose_level, {}, {g_signed_trx_samples[1]->getHash()}, estimation, vdf1, sk);
 
   propose_level = 2;
   vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
   vdf2.computeVdfSolution(vdf_config, blk1.getHash().asBytes(), false);
-  DagBlock blk2(blk1.getHash(), propose_level, {}, {g_signed_trx_samples[2]->getHash()}, {estimation}, vdf2, sk);
+  DagBlock blk2(blk1.getHash(), propose_level, {}, {g_signed_trx_samples[2]->getHash()}, estimation, vdf2, sk);
 
   propose_level = 3;
   vdf_sortition::VdfSortition vdf3(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
   vdf3.computeVdfSolution(vdf_config, blk2.getHash().asBytes(), false);
-  DagBlock blk3(blk2.getHash(), propose_level, {}, {g_signed_trx_samples[3]->getHash()}, {estimation}, vdf3, sk);
+  DagBlock blk3(blk2.getHash(), propose_level, {}, {g_signed_trx_samples[3]->getHash()}, estimation, vdf3, sk);
 
   propose_level = 4;
   vdf_sortition::VdfSortition vdf4(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
   vdf4.computeVdfSolution(vdf_config, blk3.getHash().asBytes(), false);
-  DagBlock blk4(blk3.getHash(), propose_level, {}, {g_signed_trx_samples[4]->getHash()}, {estimation}, vdf4, sk);
+  DagBlock blk4(blk3.getHash(), propose_level, {}, {g_signed_trx_samples[4]->getHash()}, estimation, vdf4, sk);
 
   propose_level = 5;
   vdf_sortition::VdfSortition vdf5(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
   vdf5.computeVdfSolution(vdf_config, blk4.getHash().asBytes(), false);
-  DagBlock blk5(blk4.getHash(), propose_level, {}, {g_signed_trx_samples[5]->getHash()}, {estimation}, vdf5, sk);
+  DagBlock blk5(blk4.getHash(), propose_level, {}, {g_signed_trx_samples[5]->getHash()}, estimation, vdf5, sk);
 
   propose_level = 6;
   vdf_sortition::VdfSortition vdf6(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
   vdf6.computeVdfSolution(vdf_config, blk5.getHash().asBytes(), false);
   DagBlock blk6(blk5.getHash(), propose_level, {blk4.getHash(), blk3.getHash()}, {g_signed_trx_samples[6]->getHash()},
-                {estimation}, vdf6, sk);
+                estimation, vdf6, sk);
 
   blks.push_back(std::make_pair(blk1, g_signed_trx_samples[1]));
   blks.push_back(std::make_pair(blk2, g_signed_trx_samples[2]));
@@ -511,8 +511,8 @@ TEST_F(NetworkTest, node_pbft_sync) {
   level_t level = 1;
   vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk, getRlpBytes(level));
   vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
-  DagBlock blk1(dag_genesis, 1, {}, {g_signed_trx_samples[0]->getHash(), g_signed_trx_samples[1]->getHash()}, {0, 0},
-                vdf1, sk);
+  DagBlock blk1(dag_genesis, 1, {}, {g_signed_trx_samples[0]->getHash(), g_signed_trx_samples[1]->getHash()}, 0, vdf1,
+                sk);
   std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> txs1{
       {g_signed_trx_samples[0], TransactionStatus::Verified}, {g_signed_trx_samples[1], TransactionStatus::Verified}};
 
@@ -564,7 +564,7 @@ TEST_F(NetworkTest, node_pbft_sync) {
   level = 2;
   vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk, getRlpBytes(level));
   vdf2.computeVdfSolution(vdf_config, blk1.getHash().asBytes(), false);
-  DagBlock blk2(blk1.getHash(), 2, {}, {g_signed_trx_samples[2]->getHash(), g_signed_trx_samples[3]->getHash()}, {0, 0},
+  DagBlock blk2(blk1.getHash(), 2, {}, {g_signed_trx_samples[2]->getHash(), g_signed_trx_samples[3]->getHash()}, 0,
                 vdf2, sk);
   std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> txs2{
       {g_signed_trx_samples[2], TransactionStatus::Verified}, {g_signed_trx_samples[3], TransactionStatus::Verified}};
@@ -675,8 +675,8 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   level_t level = 1;
   vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk, getRlpBytes(level));
   vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
-  DagBlock blk1(dag_genesis, 1, {}, {g_signed_trx_samples[0]->getHash(), g_signed_trx_samples[1]->getHash()}, {0, 0},
-                vdf1, sk);
+  DagBlock blk1(dag_genesis, 1, {}, {g_signed_trx_samples[0]->getHash(), g_signed_trx_samples[1]->getHash()}, 0, vdf1,
+                sk);
   std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> tr1{
       {g_signed_trx_samples[0], TransactionStatus::Verified}, {g_signed_trx_samples[1], TransactionStatus::Verified}};
 
@@ -718,7 +718,7 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   level = 2;
   vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk, getRlpBytes(level));
   vdf2.computeVdfSolution(vdf_config, blk1.getHash().asBytes(), false);
-  DagBlock blk2(blk1.getHash(), 2, {}, {g_signed_trx_samples[2]->getHash(), g_signed_trx_samples[3]->getHash()}, {0, 0},
+  DagBlock blk2(blk1.getHash(), 2, {}, {g_signed_trx_samples[2]->getHash(), g_signed_trx_samples[3]->getHash()}, 0,
                 vdf2, sk);
   std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> tr2{
       {g_signed_trx_samples[2], TransactionStatus::Verified}, {g_signed_trx_samples[3], TransactionStatus::Verified}};
@@ -1006,8 +1006,7 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
   vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
   DagBlock blk1(dag_genesis, propose_level, {},
-                {g_signed_trx_samples[0]->getHash(), g_signed_trx_samples[1]->getHash()}, {estimation, estimation},
-                vdf1, sk);
+                {g_signed_trx_samples[0]->getHash(), g_signed_trx_samples[1]->getHash()}, 2 * estimation, vdf1, sk);
   std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> tr1{
       {g_signed_trx_samples[0], TransactionStatus::Verified}, {g_signed_trx_samples[1], TransactionStatus::Verified}};
 
@@ -1015,7 +1014,7 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
   vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
   vdf2.computeVdfSolution(vdf_config, blk1.getHash().asBytes(), false);
-  DagBlock blk2(blk1.getHash(), propose_level, {}, {g_signed_trx_samples[2]->getHash()}, {estimation}, vdf2, sk);
+  DagBlock blk2(blk1.getHash(), propose_level, {}, {g_signed_trx_samples[2]->getHash()}, estimation, vdf2, sk);
   std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> tr2{
       {g_signed_trx_samples[2], TransactionStatus::Verified}};
 
@@ -1023,7 +1022,7 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
   vdf_sortition::VdfSortition vdf3(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
   vdf3.computeVdfSolution(vdf_config, blk2.getHash().asBytes(), false);
-  DagBlock blk3(blk2.getHash(), propose_level, {}, {g_signed_trx_samples[3]->getHash()}, {estimation}, vdf3, sk);
+  DagBlock blk3(blk2.getHash(), propose_level, {}, {g_signed_trx_samples[3]->getHash()}, estimation, vdf3, sk);
   std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> tr3{
       {g_signed_trx_samples[3], TransactionStatus::Verified}};
 
@@ -1031,7 +1030,7 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
   vdf_sortition::VdfSortition vdf4(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
   vdf4.computeVdfSolution(vdf_config, blk3.getHash().asBytes(), false);
-  DagBlock blk4(blk3.getHash(), propose_level, {}, {g_signed_trx_samples[4]->getHash()}, {estimation}, vdf4, sk);
+  DagBlock blk4(blk3.getHash(), propose_level, {}, {g_signed_trx_samples[4]->getHash()}, estimation, vdf4, sk);
   std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> tr4{
       {g_signed_trx_samples[4], TransactionStatus::Verified}};
 
@@ -1042,7 +1041,7 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
   DagBlock blk5(blk4.getHash(), propose_level, {},
                 {g_signed_trx_samples[5]->getHash(), g_signed_trx_samples[6]->getHash(),
                  g_signed_trx_samples[7]->getHash(), g_signed_trx_samples[8]->getHash()},
-                {estimation, estimation, estimation, estimation}, vdf5, sk);
+                4 * estimation, vdf5, sk);
   std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> tr5{
       {g_signed_trx_samples[5], TransactionStatus::Verified},
       {g_signed_trx_samples[6], TransactionStatus::Verified},
@@ -1054,7 +1053,7 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
   vdf6.computeVdfSolution(vdf_config, blk5.getHash().asBytes(), false);
   DagBlock blk6(blk5.getHash(), propose_level, {blk4.getHash(), blk3.getHash()}, {g_signed_trx_samples[9]->getHash()},
-                {estimation}, vdf6, sk);
+                estimation, vdf6, sk);
   std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> tr6{
       {g_signed_trx_samples[9], TransactionStatus::Verified}};
 
@@ -1107,23 +1106,22 @@ TEST_F(NetworkTest, node_sync2) {
   const SortitionConfig vdf_config(node_cfgs[0].chain.sortition);
   const auto transactions = samples::createSignedTrxSamples(0, 25, sk);
   const auto estimation = node1->getTransactionManager()->estimateTransactionGas(transactions[0], {});
-  const auto estimations = {estimation, estimation};
   // DAG block1
   auto propose_level = 1;
   const auto period_block_hash = node1->getDB()->getPeriodBlockHash(propose_level);
   vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
   vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
-  DagBlock blk1(dag_genesis, propose_level, {}, {transactions[0]->getHash(), transactions[1]->getHash()}, estimations,
-                vdf1, sk);
+  DagBlock blk1(dag_genesis, propose_level, {}, {transactions[0]->getHash(), transactions[1]->getHash()},
+                2 * estimation, vdf1, sk);
   SharedTransactions tr1({transactions[0], transactions[1]});
   // DAG block2
   propose_level = 1;
   vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
   vdf2.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
-  DagBlock blk2(dag_genesis, propose_level, {}, {transactions[2]->getHash(), transactions[3]->getHash()}, estimations,
-                vdf2, sk);
+  DagBlock blk2(dag_genesis, propose_level, {}, {transactions[2]->getHash(), transactions[3]->getHash()},
+                2 * estimation, vdf2, sk);
   SharedTransactions tr2({transactions[2], transactions[3]});
   // DAG block3
   propose_level = 2;
@@ -1131,7 +1129,7 @@ TEST_F(NetworkTest, node_sync2) {
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
   vdf3.computeVdfSolution(vdf_config, blk1.getHash().asBytes(), false);
   DagBlock blk3(blk1.getHash(), propose_level, {}, {transactions[4]->getHash(), transactions[5]->getHash()},
-                estimations, vdf3, sk);
+                2 * estimation, vdf3, sk);
   SharedTransactions tr3({transactions[4], transactions[5]});
   // DAG block4
   propose_level = 3;
@@ -1139,7 +1137,7 @@ TEST_F(NetworkTest, node_sync2) {
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
   vdf4.computeVdfSolution(vdf_config, blk3.getHash().asBytes(), false);
   DagBlock blk4(blk3.getHash(), propose_level, {}, {transactions[6]->getHash(), transactions[7]->getHash()},
-                estimations, vdf4, sk);
+                2 * estimation, vdf4, sk);
   SharedTransactions tr4({transactions[6], transactions[7]});
   // DAG block5
   propose_level = 2;
@@ -1147,7 +1145,7 @@ TEST_F(NetworkTest, node_sync2) {
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
   vdf5.computeVdfSolution(vdf_config, blk2.getHash().asBytes(), false);
   DagBlock blk5(blk2.getHash(), propose_level, {}, {transactions[8]->getHash(), transactions[9]->getHash()},
-                estimations, vdf5, sk);
+                2 * estimation, vdf5, sk);
   SharedTransactions tr5({transactions[8], transactions[9]});
   // DAG block6
   propose_level = 2;
@@ -1155,7 +1153,7 @@ TEST_F(NetworkTest, node_sync2) {
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
   vdf6.computeVdfSolution(vdf_config, blk1.getHash().asBytes(), false);
   DagBlock blk6(blk1.getHash(), propose_level, {}, {transactions[10]->getHash(), transactions[11]->getHash()},
-                estimations, vdf6, sk);
+                2 * estimation, vdf6, sk);
   SharedTransactions tr6({transactions[10], transactions[11]});
   // DAG block7
   propose_level = 3;
@@ -1163,7 +1161,7 @@ TEST_F(NetworkTest, node_sync2) {
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
   vdf7.computeVdfSolution(vdf_config, blk6.getHash().asBytes(), false);
   DagBlock blk7(blk6.getHash(), propose_level, {}, {transactions[12]->getHash(), transactions[13]->getHash()},
-                estimations, vdf7, sk);
+                2 * estimation, vdf7, sk);
   SharedTransactions tr7({transactions[12], transactions[13]});
   // DAG block8
   propose_level = 4;
@@ -1171,7 +1169,7 @@ TEST_F(NetworkTest, node_sync2) {
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
   vdf8.computeVdfSolution(vdf_config, blk1.getHash().asBytes(), false);
   DagBlock blk8(blk1.getHash(), propose_level, {blk7.getHash()},
-                {transactions[14]->getHash(), transactions[15]->getHash()}, estimations, vdf8, sk);
+                {transactions[14]->getHash(), transactions[15]->getHash()}, 2 * estimation, vdf8, sk);
   SharedTransactions tr8({transactions[14], transactions[15]});
   // DAG block9
   propose_level = 2;
@@ -1179,7 +1177,7 @@ TEST_F(NetworkTest, node_sync2) {
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
   vdf9.computeVdfSolution(vdf_config, blk1.getHash().asBytes(), false);
   DagBlock blk9(blk1.getHash(), propose_level, {}, {transactions[16]->getHash(), transactions[17]->getHash()},
-                estimations, vdf9, sk);
+                2 * estimation, vdf9, sk);
   SharedTransactions tr9({transactions[16], transactions[17]});
   // DAG block10
   propose_level = 5;
@@ -1187,7 +1185,7 @@ TEST_F(NetworkTest, node_sync2) {
                                     VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
   vdf10.computeVdfSolution(vdf_config, blk8.getHash().asBytes(), false);
   DagBlock blk10(blk8.getHash(), propose_level, {}, {transactions[18]->getHash(), transactions[19]->getHash()},
-                 estimations, vdf10, sk);
+                 2 * estimation, vdf10, sk);
   SharedTransactions tr10({transactions[18], transactions[19]});
   // DAG block11
   propose_level = 3;
@@ -1195,7 +1193,7 @@ TEST_F(NetworkTest, node_sync2) {
                                     VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
   vdf11.computeVdfSolution(vdf_config, blk3.getHash().asBytes(), false);
   DagBlock blk11(blk3.getHash(), propose_level, {}, {transactions[20]->getHash(), transactions[21]->getHash()},
-                 estimations, vdf11, sk);
+                 2 * estimation, vdf11, sk);
   SharedTransactions tr11({transactions[20], transactions[21]});
   // DAG block12
   propose_level = 3;
@@ -1203,7 +1201,7 @@ TEST_F(NetworkTest, node_sync2) {
                                     VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
   vdf12.computeVdfSolution(vdf_config, blk5.getHash().asBytes(), false);
   DagBlock blk12(blk5.getHash(), propose_level, {}, {transactions[22]->getHash(), transactions[23]->getHash()},
-                 estimations, vdf12, sk);
+                 2 * estimation, vdf12, sk);
   SharedTransactions tr12({transactions[22], transactions[23]});
 
   blks.push_back(blk1);

--- a/tests/pbft_manager_test.cpp
+++ b/tests/pbft_manager_test.cpp
@@ -811,7 +811,7 @@ TEST_F(PbftManagerWithDagCreation, produce_overweighted_block) {
   auto period_raw = node->getDB()->getPeriodDataRaw(period);
   ASSERT_FALSE(period_raw.empty());
   PeriodData period_data(period_raw);
-  EXPECT_FALSE(node->getPbftManager()->checkBlockWeight(period_data));
+  EXPECT_FALSE(node->getPbftManager()->checkBlockWeight(period_data.dag_blocks));
 }
 
 TEST_F(PbftManagerWithDagCreation, DISABLED_pbft_block_is_overweighted) {

--- a/tests/util_test/node_dag_creation_fixture.hpp
+++ b/tests/util_test/node_dag_creation_fixture.hpp
@@ -153,8 +153,7 @@ struct NodeDagCreationFixture : BaseTest {
         std::vector<trx_hash_t> trx_hashes;
         std::transform(trx_itr, trx_itr_next, std::back_inserter(trx_hashes),
                        [](std::shared_ptr<Transaction> trx) { return trx->getHash(); });
-        DagBlock blk(pivot, level, tips, trx_hashes, std::vector<uint64_t>(trx_per_block, trx_estimation), vdf,
-                     node->getSecretKey());
+        DagBlock blk(pivot, level, tips, trx_hashes, trx_per_block * trx_estimation, vdf, node->getSecretKey());
         this_level_blocks.push_back(blk.getHash());
         result.emplace_back(DagBlockWithTxs{blk, SharedTransactions(trx_itr, trx_itr_next)});
         trx_itr = trx_itr_next;
@@ -171,8 +170,8 @@ struct NodeDagCreationFixture : BaseTest {
       vdf_sortition::VdfSortition vdf(vdf_config, node->getVrfSecretKey(),
                                       vrf_wrapper::VrfSortitionBase::makeVrfInput(level, period_block_hash));
       vdf.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
-      DagBlock blk(pivot, level + i, tips, {transactions.rbegin()->get()->getHash()},
-                   std::vector<uint64_t>(trx_per_block, trx_estimation), vdf, node->getSecretKey());
+      DagBlock blk(pivot, level + i, tips, {transactions.rbegin()->get()->getHash()}, trx_per_block * trx_estimation,
+                   vdf, node->getSecretKey());
       result.emplace_back(DagBlockWithTxs{blk, SharedTransactions(transactions.rbegin(), transactions.rbegin() + 1)});
       pivot = blk.getHash();
       tips = {blk.getHash()};


### PR DESCRIPTION
Pbft block proposal and verification is time sensitive for pbft steps.

Several recent changes were introduced to remove unneeded transactions processing in this process. To completely remove transactions processing from PbftManager::compareBlocksAndRewardVotes_ I have made changes in how we calculate gas limit for a pbft block. Previously gas limit was calculated for unique non-finalized transactions included in pbft block which required retrieving and processing these transactions for all transactions in pbft block. This is now changed and the gas limit check is done per weight of the dag block. This check is now no longer for unique transactions but for all transactions in dag block. I don't think we lose much with this change and we significantly improve the performance and we reduce the size of the dag block because now it only contains the gas estimation for the block and not for each individual transaction.

Besides this period_data_ was unnecessarily set within compareBlocksAndRewardVotes_ and it only needed to be set when pushing a block into chain.