### PR TITLE
feat: process VotesSyncPacket only from the nodes we requested

### DIFF
--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1091,7 +1091,9 @@ void PbftManager::secondFinish_() {
     LOG(log_dg_) << "Node " << node_addr_ << " broadcast next votes for previous round. In period " << period
                  << ", round " << round << " step " << step_;
     if (auto net = network_.lock()) {
-      net->getSpecificHandler<network::tarcap::VotesSyncPacketHandler>()->broadcastPreviousRoundNextVotesBundle();
+      // Broadcast previous round next votes
+      net->getSpecificHandler<network::tarcap::VotePacketHandler>()->broadcastNextVotesBundle(
+          next_votes_manager_->getNextVotes());
     }
     pbft_round_last_broadcast_ = round;
     pbft_step_last_broadcast_ = step_;

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1092,8 +1092,7 @@ void PbftManager::secondFinish_() {
                  << ", round " << round << " step " << step_;
     if (auto net = network_.lock()) {
       // Broadcast previous round next votes
-      net->getSpecificHandler<network::tarcap::VotePacketHandler>()->broadcastNextVotesBundle(
-          next_votes_manager_->getNextVotes());
+      net->getSpecificHandler<network::tarcap::VotePacketHandler>()->broadcastPreviousRoundNextVotesBundle();
     }
     pbft_round_last_broadcast_ = round;
     pbft_step_last_broadcast_ = step_;

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/packet_handler.hpp
@@ -39,7 +39,7 @@ class PacketHandler {
    */
   void processPacket(const PacketData& packet_data);
 
-  void requestPbftNextVotesAtPeriodRound(dev::p2p::NodeID const& peerID, uint64_t pbft_period, uint64_t pbft_round,
+  void requestPbftNextVotesAtPeriodRound(const dev::p2p::NodeID& peerID, uint64_t pbft_period, uint64_t pbft_round,
                                          size_t pbft_previous_round_next_votes_size);
 
  private:
@@ -69,7 +69,7 @@ class PacketHandler {
   void checkPacketRlpIsList(const PacketData& packet_data) const;
 
   bool sealAndSend(const dev::p2p::NodeID& nodeID, SubprotocolPacketType packet_type, dev::RLPStream&& rlp);
-  void disconnect(dev::p2p::NodeID const& node_id, dev::p2p::DisconnectReason reason);
+  void disconnect(const dev::p2p::NodeID& node_id, dev::p2p::DisconnectReason reason);
 
  protected:
   std::shared_ptr<PeersState> peers_state_{nullptr};

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/packet_handler.hpp
@@ -39,6 +39,9 @@ class PacketHandler {
    */
   void processPacket(const PacketData& packet_data);
 
+  void requestPbftNextVotesAtPeriodRound(dev::p2p::NodeID const& peerID, uint64_t pbft_period, uint64_t pbft_round,
+                                         size_t pbft_previous_round_next_votes_size);
+
  private:
   void handle_caught_exception(std::string_view exception_msg, const PacketData& packet_data,
                                dev::p2p::DisconnectReason disconnect_reason = dev::p2p::DisconnectReason::UserReason,

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/status_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/status_packet_handler.hpp
@@ -26,8 +26,6 @@ class StatusPacketHandler final : public ExtSyncingPacketHandler {
   void validatePacketRlpFormat(const PacketData& packet_data) const override;
   void process(const PacketData& packet_data, const std::shared_ptr<TaraxaPeer>& peer) override;
 
-  void requestPbftNextVotesAtPeriodRound(dev::p2p::NodeID const& peerID, uint64_t pbft_period, uint64_t pbft_round,
-                                         size_t pbft_previous_round_next_votes_size);
   void syncPbftNextVotesAtPeriodRound(uint64_t pbft_period, uint64_t pbft_round,
                                       size_t pbft_previous_round_next_votes_size);
 

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/vote_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/vote_packet_handler.hpp
@@ -20,7 +20,7 @@ class VotePacketHandler final : public ExtVotesPacketHandler {
   // Packet type that is processed by this handler
   static constexpr SubprotocolPacketType kPacketType_ = SubprotocolPacketType::VotePacket;
 
-  void broadcastNextVotesBundle(const std::vector<std::shared_ptr<Vote>>& next_votes_bundle);
+  void broadcastPreviousRoundNextVotesBundle();
 
  private:
   void validatePacketRlpFormat(const PacketData& packet_data) const override;

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/vote_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/vote_packet_handler.hpp
@@ -20,6 +20,8 @@ class VotePacketHandler final : public ExtVotesPacketHandler {
   // Packet type that is processed by this handler
   static constexpr SubprotocolPacketType kPacketType_ = SubprotocolPacketType::VotePacket;
 
+  void broadcastNextVotesBundle(const std::vector<std::shared_ptr<Vote>>& next_votes_bundle);
+
  private:
   void validatePacketRlpFormat(const PacketData& packet_data) const override;
   void process(const PacketData& packet_data, const std::shared_ptr<TaraxaPeer>& peer) override;

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/votes_sync_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/votes_sync_packet_handler.hpp
@@ -18,8 +18,6 @@ class VotesSyncPacketHandler final : public ExtVotesPacketHandler {
                          std::shared_ptr<VoteManager> vote_mgr, std::shared_ptr<NextVotesManager> next_votes_mgr,
                          std::shared_ptr<DbStorage> db, const NetworkConfig& net_config, const addr_t& node_addr);
 
-  void broadcastPreviousRoundNextVotesBundle();
-
   // Packet type that is processed by this handler
   static constexpr SubprotocolPacketType kPacketType_ = SubprotocolPacketType::VotesSyncPacket;
 

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
@@ -23,6 +23,7 @@ class TaraxaPeer : public boost::noncopyable {
         known_pbft_blocks_(10000, 1000),
         known_votes_(100000, 1000) {}
 
+  const dev::p2p::NodeID &getId() const { return id_; }
   /**
    * @brief Mark dag block as known
    *
@@ -63,8 +64,6 @@ class TaraxaPeer : public boost::noncopyable {
   bool markPbftBlockAsKnown(blk_hash_t const &_hash) { return known_pbft_blocks_.insert(_hash); }
   bool isPbftBlockKnown(blk_hash_t const &_hash) const { return known_pbft_blocks_.contains(_hash); }
 
-  const dev::p2p::NodeID &getId() const { return id_; }
-
   /**
    * @brief Reports suspicious pacet
    *
@@ -95,6 +94,7 @@ class TaraxaPeer : public boost::noncopyable {
   std::atomic_bool peer_requested_dag_syncing_ = false;
   std::atomic_bool peer_light_node = false;
   std::atomic<uint64_t> peer_light_node_history = 0;
+  std::atomic_bool votes_sync_requested_ = false;
 
   // Mutex used to prevent race condition between dag syncing and gossiping
   mutable boost::shared_mutex mutex_for_sending_dag_blocks_;

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_votes_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_votes_packet_handler.cpp
@@ -136,8 +136,7 @@ std::pair<bool, std::string> ExtVotesPacketHandler::validateStandardVote(const s
       // Do not request round sync too often here
       if (std::chrono::system_clock::now() - last_votes_sync_request_time_ > kSyncRequestInterval) {
         // request round votes sync from this node
-        sealAndSend(peer->getId(), GetVotesSyncPacket,
-                    std::move(dev::RLPStream(3) << current_pbft_period << current_pbft_round << 0));
+        requestPbftNextVotesAtPeriodRound(peer->getId(), current_pbft_period, current_pbft_round, 0);
         last_votes_sync_request_time_ = std::chrono::system_clock::now();
       }
     }

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/common/packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/common/packet_handler.cpp
@@ -109,7 +109,7 @@ bool PacketHandler::sealAndSend(const dev::p2p::NodeID& node_id, SubprotocolPack
   return true;
 }
 
-void PacketHandler::disconnect(dev::p2p::NodeID const& node_id, dev::p2p::DisconnectReason reason) {
+void PacketHandler::disconnect(const dev::p2p::NodeID& node_id, dev::p2p::DisconnectReason reason) {
   if (auto host = peers_state_->host_.lock(); host) {
     host->disconnect(node_id, reason);
   } else {
@@ -117,10 +117,10 @@ void PacketHandler::disconnect(dev::p2p::NodeID const& node_id, dev::p2p::Discon
   }
 }
 
-void PacketHandler::requestPbftNextVotesAtPeriodRound(dev::p2p::NodeID const& peerID, uint64_t pbft_period,
+void PacketHandler::requestPbftNextVotesAtPeriodRound(const dev::p2p::NodeID& peerID, uint64_t pbft_period,
                                                       uint64_t pbft_round, size_t pbft_previous_round_next_votes_size) {
-  LOG(log_er_) << "Sending GetVotesSyncPacket with round " << pbft_round << " previous round next votes size "
-               << pbft_previous_round_next_votes_size;
+  LOG(log_nf_) << "Sending GetVotesSyncPacket with period:" << pbft_period << ", round:" << pbft_round
+               << ", previous_round_next_votes_size:" << pbft_previous_round_next_votes_size;
   peers_state_->getPeer(peerID)->votes_sync_requested_ = true;
   sealAndSend(peerID, GetVotesSyncPacket,
               std::move(dev::RLPStream(3) << pbft_period << pbft_round << pbft_previous_round_next_votes_size));

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/common/packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/common/packet_handler.cpp
@@ -117,4 +117,13 @@ void PacketHandler::disconnect(dev::p2p::NodeID const& node_id, dev::p2p::Discon
   }
 }
 
+void PacketHandler::requestPbftNextVotesAtPeriodRound(dev::p2p::NodeID const& peerID, uint64_t pbft_period,
+                                                      uint64_t pbft_round, size_t pbft_previous_round_next_votes_size) {
+  LOG(log_er_) << "Sending GetVotesSyncPacket with round " << pbft_round << " previous round next votes size "
+               << pbft_previous_round_next_votes_size;
+  peers_state_->getPeer(peerID)->votes_sync_requested_ = true;
+  sealAndSend(peerID, GetVotesSyncPacket,
+              std::move(dev::RLPStream(3) << pbft_period << pbft_round << pbft_previous_round_next_votes_size));
+}
+
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/status_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/status_packet_handler.cpp
@@ -259,13 +259,4 @@ void StatusPacketHandler::syncPbftNextVotesAtPeriodRound(uint64_t pbft_period, u
   }
 }
 
-void StatusPacketHandler::requestPbftNextVotesAtPeriodRound(dev::p2p::NodeID const& peerID, uint64_t pbft_period,
-                                                            uint64_t pbft_round,
-                                                            size_t pbft_previous_round_next_votes_size) {
-  LOG(log_dg_) << "Sending GetVotesSyncPacket with round " << pbft_round << " previous round next votes size "
-               << pbft_previous_round_next_votes_size;
-  sealAndSend(peerID, GetVotesSyncPacket,
-              std::move(dev::RLPStream(3) << pbft_period << pbft_round << pbft_previous_round_next_votes_size));
-}
-
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
@@ -82,7 +82,8 @@ void VotePacketHandler::process(const PacketData &packet_data, const std::shared
   onNewPbftVotes(std::move(votes));
 }
 
-void VotePacketHandler::broadcastNextVotesBundle(const std::vector<std::shared_ptr<Vote>> &next_votes_bundle) {
+void VotePacketHandler::broadcastPreviousRoundNextVotesBundle() {
+  auto next_votes_bundle = next_votes_mgr_->getNextVotes();
   if (next_votes_bundle.empty()) {
     LOG(log_er_) << "There are empty next votes for previous PBFT round";
     return;
@@ -90,7 +91,7 @@ void VotePacketHandler::broadcastNextVotesBundle(const std::vector<std::shared_p
 
   const auto pbft_current_round = pbft_mgr_->getPbftRound();
 
-  for (auto const &peer : peers_state_->getAllPeers()) {
+  for (const auto &peer : peers_state_->getAllPeers()) {
     // Nodes may vote at different values at previous round, so need less or equal
     if (!peer.second->syncing_ && peer.second->pbft_round_ <= pbft_current_round) {
       std::vector<std::shared_ptr<Vote>> send_next_votes_bundle;

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -14,9 +14,11 @@
 #include "logger/logger.hpp"
 #include "network/tarcap/packets_handlers/dag_block_packet_handler.hpp"
 #include "network/tarcap/packets_handlers/get_dag_sync_packet_handler.hpp"
+#include "network/tarcap/packets_handlers/get_votes_sync_packet_handler.hpp"
 #include "network/tarcap/packets_handlers/pbft_block_packet_handler.hpp"
+#include "network/tarcap/packets_handlers/status_packet_handler.hpp"
 #include "network/tarcap/packets_handlers/transaction_packet_handler.hpp"
-#include "network/tarcap/packets_handlers/votes_sync_packet_handler.hpp"
+#include "network/tarcap/packets_handlers/vote_packet_handler.hpp"
 #include "pbft/pbft_manager.hpp"
 #include "util_test/samples.hpp"
 #include "util_test/util.hpp"
@@ -958,7 +960,8 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_2) {
   std::shared_ptr<Network> nw2 = node2->getNetwork();
 
   // Node1 broadcast next votes1 to node2
-  nw1->getSpecificHandler<network::tarcap::VotesSyncPacketHandler>()->broadcastPreviousRoundNextVotesBundle();
+  nw1->getSpecificHandler<network::tarcap::VotePacketHandler>()->broadcastNextVotesBundle(
+      node1_next_votes_mgr->getNextVotes());
 
   auto node2_expect_size = next_votes1.size() + next_votes2.size();
   EXPECT_HAPPENS({5s, 100ms},
@@ -976,7 +979,8 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_2) {
   node1_db->commitWriteBatch(batch);
 
   // Node2 broadcast updated next votes to node1
-  nw2->getSpecificHandler<network::tarcap::VotesSyncPacketHandler>()->broadcastPreviousRoundNextVotesBundle();
+  nw2->getSpecificHandler<network::tarcap::VotePacketHandler>()->broadcastNextVotesBundle(
+      node2_next_votes_mgr->getNextVotes());
 
   auto node1_expect_size = next_votes1.size() + next_votes2.size();
   EXPECT_HAPPENS({5s, 100ms},
@@ -1463,6 +1467,106 @@ TEST_F(NetworkTest, suspicious_packets) {
     EXPECT_FALSE(peer.reportSuspiciousPacket());
   }
   EXPECT_TRUE(peer.reportSuspiciousPacket());*/
+}
+
+TEST_F(NetworkTest, unexpected_votes_sync_packet) {
+  auto node_cfgs = make_node_cfgs<20>(2);
+  std::vector<std::shared_ptr<FullNode>> nodes;
+  for (const auto& cfg : node_cfgs) {
+    nodes.emplace_back(std::make_shared<FullNode>(cfg));
+    nodes.back()->start();
+    // Stop PBFT manager, that will place vote
+    nodes.back()->getPbftManager()->stop();
+  }
+  EXPECT_TRUE(wait_connect(nodes));
+
+  // Clear next votes components
+  auto node0_next_votes_mgr = nodes[0]->getNextVotesManager();
+  auto node1_next_votes_mgr = nodes[1]->getNextVotesManager();
+  node0_next_votes_mgr->clearVotes();
+  node1_next_votes_mgr->clearVotes();
+
+  auto pbft_mgr0 = nodes[0]->getPbftManager();
+
+  // Node1 generate 1 next vote voted at NULL_BLOCK_HASH
+  blk_hash_t voted_pbft_block_hash1(blk_hash_t(0));
+  auto vote = pbft_mgr0->generateVote(voted_pbft_block_hash1, next_vote_type, 1, 1, 5);
+  vote->calculateWeight(1, 1, 1);
+
+  // Set both node1 and node2 pbft manager round to 2
+  std::shared_ptr<Network> nw0 = nodes[0]->getNetwork();
+  std::shared_ptr<Network> nw1 = nodes[1]->getNetwork();
+
+  EXPECT_EQ(nw0->getPeerCount(), 1);
+  EXPECT_EQ(nw1->getPeerCount(), 1);
+  // Node1 broadcast next votes1 to node2
+  std::cout << "Node1 broadcast VotesSyncPacket to Node2" << std::endl;
+  nw0->getSpecificHandler<network::tarcap::VotePacketHandler>()->sendPbftVotes(nw1->getNodeId(), {vote}, true);
+
+  EXPECT_HAPPENS({5s, 100ms}, [&](auto& ctx) {
+    WAIT_EXPECT_EQ(ctx, nw0->getPeerCount(), 0);
+    WAIT_EXPECT_EQ(ctx, nw1->getPeerCount(), 0);
+  });
+}
+
+TEST_F(NetworkTest, request_and_get_votes_sync_packet) {
+  auto node_cfgs = make_node_cfgs<20>(2);
+  std::vector<std::shared_ptr<FullNode>> nodes;
+  for (const auto& cfg : node_cfgs) {
+    nodes.emplace_back(std::make_shared<FullNode>(cfg));
+    nodes.back()->start();
+    // Stop PBFT manager, that will place vote
+    nodes.back()->getPbftManager()->stop();
+  }
+  EXPECT_TRUE(wait_connect(nodes));
+
+  auto pbft_mgr0 = nodes[0]->getPbftManager();
+  auto pbft_mgr1 = nodes[1]->getPbftManager();
+  pbft_mgr0->setPbftRound(2);
+  pbft_mgr1->setPbftRound(2);
+
+  // Clear next votes components
+  auto node0_next_votes_mgr = nodes[0]->getNextVotesManager();
+  auto node1_next_votes_mgr = nodes[1]->getNextVotesManager();
+  node0_next_votes_mgr->clearVotes();
+  node1_next_votes_mgr->clearVotes();
+
+  // Node1 generate 1 next vote voted at NULL_BLOCK_HASH
+  blk_hash_t voted_pbft_block_hash1(blk_hash_t(0));
+  PbftVoteTypes type = next_vote_type;
+  uint64_t period = 1;
+  uint64_t round = 1;
+  size_t step = 5;
+  auto vote0 = pbft_mgr0->generateVote(voted_pbft_block_hash1, type, period, round, step);
+  vote0->calculateWeight(1, 1, 1);
+  std::vector<std::shared_ptr<Vote>> next_votes0{vote0};
+
+  // Update node1 next votes bundle
+  node0_next_votes_mgr->updateNextVotes(next_votes0, pbft_mgr0->getTwoTPlusOne());
+  EXPECT_EQ(node0_next_votes_mgr->getNextVotesWeight(), next_votes0.size());
+
+  // Node1 generate 1 different next vote for node2, because node2 is not delegated
+  blk_hash_t voted_pbft_block_hash2("1234567890000000000000000000000000000000000000000000000000000000");
+  auto vote1 = pbft_mgr1->generateVote(voted_pbft_block_hash2, type, period, round, step);
+  vote1->calculateWeight(1, 1, 1);
+  std::vector<std::shared_ptr<Vote>> next_votes1{vote1};
+
+  // Update node1 next votes bundle
+  node1_next_votes_mgr->updateNextVotes(next_votes1, pbft_mgr1->getTwoTPlusOne());
+  EXPECT_EQ(node1_next_votes_mgr->getNextVotesWeight(), next_votes1.size());
+
+  // Set both node1 and node2 pbft manager round to 2
+  std::shared_ptr<Network> nw0 = nodes[0]->getNetwork();
+  std::shared_ptr<Network> nw1 = nodes[1]->getNetwork();
+
+  // Node1 broadcast next votes1 to node2
+  std::cout << "Node1 broadcast VotesSyncPacket to Node2" << std::endl;
+  nw1->getSpecificHandler<network::tarcap::StatusPacketHandler>()->requestPbftNextVotesAtPeriodRound(nw0->getNodeId(),
+                                                                                                     1, 1, 0);
+
+  ASSERT_HAPPENS({5s, 200ms}, [&](auto& ctx) {
+    WAIT_EXPECT_EQ(ctx, node1_next_votes_mgr->getNextVotesWeight(), next_votes0.size() + next_votes1.size());
+  });
 }
 
 }  // namespace taraxa::core_tests

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -960,8 +960,7 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_2) {
   std::shared_ptr<Network> nw2 = node2->getNetwork();
 
   // Node1 broadcast next votes1 to node2
-  nw1->getSpecificHandler<network::tarcap::VotePacketHandler>()->broadcastNextVotesBundle(
-      node1_next_votes_mgr->getNextVotes());
+  nw1->getSpecificHandler<network::tarcap::VotePacketHandler>()->broadcastPreviousRoundNextVotesBundle();
 
   auto node2_expect_size = next_votes1.size() + next_votes2.size();
   EXPECT_HAPPENS({5s, 100ms},
@@ -979,8 +978,7 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_2) {
   node1_db->commitWriteBatch(batch);
 
   // Node2 broadcast updated next votes to node1
-  nw2->getSpecificHandler<network::tarcap::VotePacketHandler>()->broadcastNextVotesBundle(
-      node2_next_votes_mgr->getNextVotes());
+  nw2->getSpecificHandler<network::tarcap::VotePacketHandler>()->broadcastPreviousRoundNextVotesBundle();
 
   auto node1_expect_size = next_votes1.size() + next_votes2.size();
   EXPECT_HAPPENS({5s, 100ms},


### PR DESCRIPTION
#1977 
After this change we are sending previous round next votes from `PbftManager` with regular votes packet. 
Node will accept `VotesSyncPacket` only from the nodes we requested