### PR TITLE
fix: reward votes race condition

### DIFF
--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -316,6 +316,8 @@ class VoteManager {
                                          blk_hash_t,
                                          std::pair<uint64_t, std::unordered_map<vote_hash_t, std::shared_ptr<Vote>>>>>>>
       verified_votes_;
+  // Current period, it should only be used under verified_votes_access_ mutex
+  uint64_t period_;
   mutable boost::shared_mutex verified_votes_access_;
 
   // <PBFT period, <PBFT round, <PBFT step, <voter address, pair<vote 1, vote 2>>><>

--- a/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
+++ b/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
@@ -21,6 +21,7 @@ VoteManager::VoteManager(const addr_t& node_addr, std::shared_ptr<DbStorage> db,
       final_chain_(std::move(final_chain)),
       next_votes_manager_(std::move(next_votes_mgr)) {
   LOG_OBJECTS_CREATE("VOTE_MGR");
+  period_ = pbft_chain_->getPbftChainSize() + 1;
 
   // Retrieve votes from DB
   daemon_ = std::make_unique<std::thread>([this]() { retreieveVotes_(); });
@@ -106,6 +107,18 @@ bool VoteManager::addVerifiedVote(std::shared_ptr<Vote> const& vote) {
   }
 
   UniqueLock lock(verified_votes_access_);
+
+  if (vote->getPeriod() < period_) {
+    // Old vote, ignore unless it is a reward vote
+    if (vote->getPeriod() == period_ - 1 && vote->getType() == cert_vote_type) {
+      addRewardVote(vote);
+      return true;
+    }
+    // Old vote, ignore it
+    LOG(log_tr_) << "Old vote " << vote->getHash().abridged() << " vote period" << vote->getPeriod()
+                 << " current period " << period_;
+    return false;
+  }
 
   auto found_period_it = verified_votes_.find(vote->getPeriod());
   // Add period
@@ -387,6 +400,7 @@ void VoteManager::cleanupVotesByPeriod(uint64_t pbft_period) {
 
       it = verified_votes_.erase(it);
     }
+    period_ = pbft_period;
   }
 
   db_->commitWriteBatch(batch);

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_votes_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_votes_packet_handler.hpp
@@ -32,25 +32,32 @@ class ExtVotesPacketHandler : public PacketHandler {
    * @brief Validates standard vote
    *
    * @param vote to be validated
+   * @param period
+   * @param round
    * @return <true, ""> vote validation passed, otherwise <false, "err msg">
    */
-  std::pair<bool, std::string> validateStandardVote(const std::shared_ptr<Vote>& vote) const;
+  std::pair<bool, std::string> validateStandardVote(const std::shared_ptr<Vote>& vote, uint64_t period,
+                                                    uint64_t round) const;
 
   /**
    * @brief Validates reward vote
    *
    * @param vote to be validated
+   * @param period
    * @return <true, ""> vote validation passed, otherwise <false, "err msg">
    */
-  std::pair<bool, std::string> validateRewardVote(const std::shared_ptr<Vote>& vote) const;
+  std::pair<bool, std::string> validateRewardVote(const std::shared_ptr<Vote>& vote, uint64_t period) const;
 
   /**
    * @brief Validates next vote
    *
    * @param vote to be validated
+   * @param period
+   * @param round
    * @return <true, ""> vote validation passed, otherwise <false, "err msg">
    */
-  std::pair<bool, std::string> validateNextSyncVote(const std::shared_ptr<Vote>& vote) const;
+  std::pair<bool, std::string> validateNextSyncVote(const std::shared_ptr<Vote>& vote, uint64_t period,
+                                                    uint64_t round) const;
 
   void onNewPbftVotes(std::vector<std::shared_ptr<Vote>>&& votes);
   void sendPbftVotes(const dev::p2p::NodeID& peer_id, std::vector<std::shared_ptr<Vote>>&& votes,

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
@@ -92,6 +92,7 @@ void PbftSyncPacketHandler::process(const PacketData &packet_data, const std::sh
     if (pbft_chain_synced) {
       pbftSyncComplete();
     }
+    restartSyncingPbft(true);
     return;
   }
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
@@ -107,7 +107,8 @@ void VotePacketHandler::process(const PacketData &packet_data, const std::shared
 
     // We could switch round before other nodes, so we need to process previous round next votes here./bi
     if (vote->getPeriod() == current_pbft_period && (current_pbft_round - 1) == vote->getRound()) {
-      if (auto vote_is_valid = validateNextSyncVote(vote); vote_is_valid.first == false) {
+      if (auto vote_is_valid = validateNextSyncVote(vote, current_pbft_period, current_pbft_round);
+          vote_is_valid.first == false) {
         LOG(log_wr_) << "Vote " << vote->getHash()
                      << " from previous round validation failed. Err: " << vote_is_valid.second;
         continue;
@@ -129,7 +130,8 @@ void VotePacketHandler::process(const PacketData &packet_data, const std::shared
           continue;
         }
 
-        if (auto vote_is_valid = validateStandardVote(vote); vote_is_valid.first == false) {
+        if (auto vote_is_valid = validateStandardVote(vote, current_pbft_period, current_pbft_round);
+            vote_is_valid.first == false) {
           LOG(log_wr_) << "Vote " << vote_hash.abridged() << " validation failed. Err: " << vote_is_valid.second;
           continue;
         }
@@ -142,7 +144,7 @@ void VotePacketHandler::process(const PacketData &packet_data, const std::shared
     } else if (vote->getPeriod() == current_pbft_period - 1 && vote->getType() == PbftVoteTypes::cert_vote_type) {
       // potential reward vote
       if (!vote_mgr_->isInRewardsVotes(vote->getHash())) {
-        if (auto vote_is_valid = validateRewardVote(vote); vote_is_valid.first == false) {
+        if (auto vote_is_valid = validateRewardVote(vote, current_pbft_period); vote_is_valid.first == false) {
           LOG(log_wr_) << "Reward vote " << vote_hash.abridged() << " validation failed. Err: \""
                        << vote_is_valid.second << "\", vote round " << vote->getRound()
                        << ", current round: " << current_pbft_round << ", vote period: " << vote->getPeriod()

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
@@ -82,7 +82,8 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
 
     // Previous round vote
     if (peer_pbft_period == pbft_current_period && (pbft_current_round - 1) == peer_pbft_round) {
-      if (auto vote_is_valid = validateNextSyncVote(next_vote); vote_is_valid.first == false) {
+      if (auto vote_is_valid = validateNextSyncVote(next_vote, pbft_current_period, pbft_current_round);
+          vote_is_valid.first == false) {
         LOG(log_wr_) << "Next vote " << next_vote_hash.abridged()
                      << " validation failed. Err: " << vote_is_valid.second;
         continue;
@@ -97,7 +98,8 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
     } else {
       // Standard vote -> peer_pbft_period > pbft_current_period || (pbft_current_round - 1) >= peer_pbft_round
       if (!vote_mgr_->voteInVerifiedMap(next_vote)) {
-        if (auto vote_is_valid = validateStandardVote(next_vote); vote_is_valid.first == false) {
+        if (auto vote_is_valid = validateStandardVote(next_vote, pbft_current_period, pbft_current_round);
+            vote_is_valid.first == false) {
           LOG(log_wr_) << "Vote " << next_vote_hash.abridged() << " validation failed. Err: " << vote_is_valid.second;
           continue;
         }


### PR DESCRIPTION
We have a following race condition which keeps happening all the time on devnet on every nodes:
Node received 2t+1 cert votes and it is ready to move to next period
Node receives additional cert vote and starts processing it in VotePacketHandler::process and starts the processing as a normal cert vote
While vote is being processed, node pushes the pbft block to the chain and moves to the next period
Vote validation now reports that cert vote is invalid since it started processing it as cert vote and not as reward vote

Example of logs:
PBFT_VOTE_PH [2022-09-07 06:34:39.196487] DEBUG: Received PBFT vote #56e8d471…
PBFT_MGR [2022-09-07 06:34:39.206854] DEBUG: Reset PBFT consensus to: round 1, period 28013, step 1, and resetting clock.
PBFT_VOTE_PH [2022-09-07 06:34:39.213300] WARN: Vote 56e8d471… validation failed. Err: Invalid period: Vote period: 28012, current pbft period: 28013
PBFT_VOTE_PH [2022-09-07 06:34:39.411146] DEBUG: Received PBFT vote #56e8d471…
PBFT_VOTE_PH [2022-09-07 06:34:39.414010] DEBUG: Received vote #56e8d471… (from 1755f430…) already seen.
VOTE_MGR [2022-09-07 06:34:40.530379] ERROR: Missing reward vote #56e8d471…
VOTE_MGR [2022-09-07 06:34:40.530825] ERROR: Missing reward vote #56e8d471…
VOTE_MGR [2022-09-07 06:34:41.030508] ERROR: Missing reward vote #56e8d471…

The fix consists of: 
1. having the packet handler and validate methods use the same period/round when validating votes
2. Inside of VoteManager::addVerifiedVote use case for handling reward votes is added when period has increased between vote validation and inserting the vote.  

This PR also includes a minor fix in PbftSyncPacketHandler::process which cause sync_five_nodes to fail sometimes and it could delay pbft syncing.