### PR TITLE
fix: reward votes race condition

### DIFF
--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -317,6 +317,8 @@ class VoteManager {
                                          blk_hash_t,
                                          std::pair<uint64_t, std::unordered_map<vote_hash_t, std::shared_ptr<Vote>>>>>>>
       verified_votes_;
+  // Current period, it should only be used under verified_votes_access_ mutex
+  uint64_t verified_votes_last_period_;
   mutable boost::shared_mutex verified_votes_access_;
 
   // <PBFT period, <PBFT round, <PBFT step, <voter address, pair<vote 1, vote 2>>><>


### PR DESCRIPTION
This change makes sure that a cert vote/reward vote being processed at the same time as period is advanced is not discarded.