### PR TITLE
chore: pbft syncing improvement

### DIFF
--- a/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
@@ -91,6 +91,8 @@ void PbftSyncPacketHandler::process(const PacketData &packet_data, const std::sh
                  << " already present in chain";
     if (pbft_chain_synced) {
       pbftSyncComplete();
+    } else {
+      restartSyncingPbft(true);
     }
     return;
   }


### PR DESCRIPTION
There is a possibility where synced block is already in chain that we are not actually synced. So this actually stops syncing. This can cause sync_five_nodes test to fail. Ensure that we are synced by calling restartSyncing for this case.