### PR TITLE
chore: pbft sync while block cert voted

### DIFF
--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -291,6 +291,13 @@ class VoteManager {
    */
   void sendRewardVotes(const blk_hash_t& pbft_block_hash);
 
+  /**
+   * @brief Get current reward votes pbft block period
+   *
+   * @return period
+   */
+  uint64_t getRewardVotesPbftBlockPeriod();
+
  private:
   /**
    * @brief Retrieve all verified votes from DB to the verified votes map. And broadcast all next voting type votes to

--- a/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
+++ b/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
@@ -546,6 +546,11 @@ std::pair<blk_hash_t, uint64_t> VoteManager::getCurrentRewardsVotesBlock() const
   return reward_votes_pbft_block_;
 }
 
+uint64_t VoteManager::getRewardVotesPbftBlockPeriod() {
+  std::shared_lock lock(reward_votes_mutex_);
+  return reward_votes_pbft_block_.second;
+}
+
 bool VoteManager::addRewardVote(const std::shared_ptr<Vote>& vote) {
   std::unique_lock lock(reward_votes_mutex_);
   if (vote->getType() != cert_vote_type) {


### PR DESCRIPTION
Checking reward votes in PbftSyncPacketHandler can sometimes fail if we are moving to the next period at the same time which should not be handled as malicious behaviors. If it does fail, a check is added if we actually moved to next period and in that case we restart syncing because it is very likely that we are already synced and restartSyncingPbft will verify this.