### PR TITLE
chore: optimize proposing pbft block

### DIFF
--- a/libraries/core_libs/consensus/include/pbft/pbft_chain.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_chain.hpp
@@ -53,6 +53,12 @@ class PbftChain {
   blk_hash_t getLastPbftBlockHash() const;
 
   /**
+   * @brief Get last non null PBFT block anchor
+   * @return anchor hash
+   */
+  blk_hash_t getLastNonNullPbftBlockAnchor() const;
+
+  /**
    * @brief Get a PBFT block in chain
    * @param pbft_block_hash PBFT block hash
    * @return PBFT block
@@ -110,9 +116,9 @@ class PbftChain {
   /**
    * @brief Update PBFT chain size, non empty chain size, and last PBFT block hash
    * @param pbft_block_hash last PBFT block hash
-   * @param null_anchor if the PBFT block include an empty DAG anchor
+   * @param anchor DAG anchor hash
    */
-  void updatePbftChain(blk_hash_t const& pbft_block_hash, bool null_anchor = false);
+  void updatePbftChain(blk_hash_t const& pbft_block_hash, blk_hash_t const& anchor_hash);
 
   /**
    * @brief Verify a PBFT block
@@ -134,7 +140,8 @@ class PbftChain {
   uint64_t size_;            // PBFT chain size, includes both executed and unexecuted PBFT blocks
   uint64_t non_empty_size_;  // PBFT chain size excluding blocks with null anchor, includes both executed and unexecuted
                              // PBFT blocks
-  blk_hash_t last_pbft_block_hash_;  // last PBFT block hash in PBFT chain, may not execute yet
+  blk_hash_t last_pbft_block_hash_;                // last PBFT block hash in PBFT chain, may not execute yet
+  blk_hash_t last_non_null_pbft_dag_anchor_hash_;  // last dag block anchor which is not null
 
   std::shared_ptr<DbStorage> db_ = nullptr;
 

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -262,7 +262,7 @@ TEST_F(FullNodeTest, db_test) {
   db.savePbftHead(pbft_chain.getHeadHash(), pbft_chain.getJsonStr());
   EXPECT_EQ(db.getPbftHead(pbft_chain.getHeadHash()), pbft_chain.getJsonStr());
   batch = db.createWriteBatch();
-  pbft_chain.updatePbftChain(blk_hash_t(123));
+  pbft_chain.updatePbftChain(blk_hash_t(123), blk_hash_t(1));
   db.addPbftHeadToBatch(pbft_chain.getHeadHash(), pbft_chain.getJsonStr(), batch);
   db.commitWriteBatch(batch);
   EXPECT_EQ(db.getPbftHead(pbft_chain.getHeadHash()), pbft_chain.getJsonStr());

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -541,7 +541,7 @@ TEST_F(NetworkTest, node_pbft_sync) {
   db1->savePeriodData(period_data1, batch);
   // Update period_pbft_block in DB
   // Update pbft chain
-  pbft_chain1->updatePbftChain(pbft_block1.getBlockHash());
+  pbft_chain1->updatePbftChain(pbft_block1.getBlockHash(), pbft_block1.getPivotDagBlockHash());
   // Update PBFT chain head block
   blk_hash_t pbft_chain_head_hash = pbft_chain1->getHeadHash();
   std::string pbft_chain_head_str = pbft_chain1->getJsonStr();
@@ -600,7 +600,7 @@ TEST_F(NetworkTest, node_pbft_sync) {
   db1->savePeriodData(period_data2, batch);
 
   // Update pbft chain
-  pbft_chain1->updatePbftChain(pbft_block2.getBlockHash());
+  pbft_chain1->updatePbftChain(pbft_block2.getBlockHash(), pbft_block2.getPivotDagBlockHash());
   // Update PBFT chain head block
   pbft_chain_head_hash = pbft_chain1->getHeadHash();
   pbft_chain_head_str = pbft_chain1->getJsonStr();
@@ -704,7 +704,7 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
 
   db1->savePeriodData(period_data1, batch);
   // Update pbft chain
-  pbft_chain1->updatePbftChain(pbft_block1.getBlockHash());
+  pbft_chain1->updatePbftChain(pbft_block1.getBlockHash(), pbft_block1.getPivotDagBlockHash());
   // Update PBFT chain head block
   blk_hash_t pbft_chain_head_hash = pbft_chain1->getHeadHash();
   std::string pbft_chain_head_str = pbft_chain1->getJsonStr();
@@ -750,7 +750,7 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   db1->savePeriodData(period_data2, batch);
   db1->addLastBlockCertVotesToBatch(votes_for_pbft_blk1, {}, batch);
   // Update pbft chain
-  pbft_chain1->updatePbftChain(pbft_block2.getBlockHash());
+  pbft_chain1->updatePbftChain(pbft_block2.getBlockHash(), pbft_block2.getPivotDagBlockHash());
   // Update PBFT chain head block
   pbft_chain_head_hash = pbft_chain1->getHeadHash();
   pbft_chain_head_str = pbft_chain1->getJsonStr();

--- a/tests/pbft_chain_test.cpp
+++ b/tests/pbft_chain_test.cpp
@@ -69,7 +69,7 @@ TEST_F(PbftChainTest, pbft_db_test) {
   db->savePeriodData(period_data, batch);
 
   // Update PBFT chain
-  pbft_chain->updatePbftChain(pbft_block.getBlockHash());
+  pbft_chain->updatePbftChain(pbft_block.getBlockHash(), pbft_block.getPivotDagBlockHash());
   // Update PBFT chain head block
   std::string pbft_chain_head_str = pbft_chain->getJsonStr();
   db->addPbftHeadToBatch(pbft_chain_head_hash, pbft_chain_head_str, batch);
@@ -148,7 +148,7 @@ TEST_F(PbftChainTest, proposal_block_broadcast) {
   db1->addPbftHeadToBatch(pbft_chain_head_hash, pbft_chain_head_str, batch);
   db1->commitWriteBatch(batch);
   // Update pbft chain
-  pbft_chain1->updatePbftChain(pbft_block->getBlockHash(), true);
+  pbft_chain1->updatePbftChain(pbft_block->getBlockHash(), blk_hash_t(0));
 
   EXPECT_EQ(pbft_chain1->getPbftChainSize(), node1_pbft_chain_size + 1);
   EXPECT_EQ(pbft_chain1->getPbftChainSizeExcludingEmptyPbftBlocks(), 0);


### PR DESCRIPTION
In PbftManager::proposePbftBlock_ loop to retrieve last anchor that is not null can take a long time if there is a long series of pbft blocks in the chain with null anchor. This can make pbft blocks be proposed too late and blocks may not be voted on.

The last non null anchor is now kept in pbft chain and can be quickly retrieved