### PR TITLE
chore: optimize transactions processing

### DIFF
--- a/libraries/common/include/common/constants.hpp
+++ b/libraries/common/include/common/constants.hpp
@@ -19,7 +19,7 @@ constexpr uint16_t kOnePercent = 100;
 constexpr uint16_t kMaxLevelsPerPeriod = 100;
 constexpr uint32_t kDagExpiryLevelLimit = 1000;
 
-const uint32_t kMaxTransactionsInPacket{1000};
+const uint32_t kMaxTransactionsInPacket{500};
 
 const uint32_t kPeriodicEventsThreadCount{2};
 

--- a/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
+++ b/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
@@ -30,7 +30,7 @@ class FullNode;
  * transactions and all transactions state change
  *
  * Incoming new transactions can be verified with verifyTransaction functions and than inserted in the transaction pool
- * with insertValidatedTransactions. Transactions are kept in transactions memory pool until they are included in a
+ * with insertValidatedTransaction. Transactions are kept in transactions memory pool until they are included in a
  * proposed dag block or received in an incoming dag block. Transaction verification consist of:
  * - Verifying the format
  * - Verifying signature
@@ -92,13 +92,14 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
   void blockFinalized(uint64_t block_number);
 
   /**
-   * @brief Inserts batch of verified transactions to transaction pool
+   * @brief Inserts verified transaction to transaction pool
    *
-   * @note Some of the transactions might be already processed -> they are not processed and inserted again
-   * @param txs transactions to be processed
-   * @return number of successfully inserted unseen transactions
+   * @note transaction might be already processed -> they are not processed and inserted again
+   * @param tx transaction to be processed
+   * @param status transaction status
+   * @return true if successfully inserted unseen transactions
    */
-  uint32_t insertValidatedTransactions(std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> &&txs);
+  bool insertValidatedTransaction(std::shared_ptr<Transaction> &&tx, const TransactionStatus status);
 
   /**
    * @param trx_hash transaction hash

--- a/libraries/core_libs/consensus/include/transaction/transaction_queue.hpp
+++ b/libraries/core_libs/consensus/include/transaction/transaction_queue.hpp
@@ -36,7 +36,8 @@ class TransactionQueue {
    * @return true
    * @return false
    */
-  bool insert(std::pair<std::shared_ptr<Transaction>, TransactionStatus>&& transaction, uint64_t last_block_number = 0);
+  bool insert(std::shared_ptr<Transaction>&& transaction, const TransactionStatus status,
+              uint64_t last_block_number = 0);
 
   /**
    * @brief remove transaction from queue

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/transaction_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/transaction_packet_handler.hpp
@@ -19,8 +19,15 @@ class TransactionPacketHandler final : public PacketHandler {
                            std::shared_ptr<TransactionManager> trx_mgr, std::shared_ptr<TestState> test_state,
                            const addr_t& node_addr);
 
-  void onNewTransactions(std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>>&& transactions);
-  void sendTransactions(dev::p2p::NodeID const& peer_id, std::vector<taraxa::bytes> const& transactions);
+  /**
+   * @brief Send transactions
+   *
+   * @param peer peer to send transactions to
+   * @param transactions serialized transactions
+   *
+   */
+  void sendTransactions(std::shared_ptr<TaraxaPeer> const& peer,
+                        std::vector<std::shared_ptr<Transaction>>&& transactions);
 
   /**
    * @brief Sends batch of transactions to all connected peers
@@ -32,6 +39,12 @@ class TransactionPacketHandler final : public PacketHandler {
 
   // Packet type that is processed by this handler
   static constexpr SubprotocolPacketType kPacketType_ = SubprotocolPacketType::TransactionPacket;
+
+  // 2 items: hashes and transactions
+  static constexpr uint32_t kTransactionPacketItemCount = 2;
+
+  // Used only for unit tests
+  void onNewTransactions(const SharedTransactions& transactions);
 
  private:
   void validatePacketRlpFormat(const PacketData& packet_data) const override;

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/dag_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/dag_sync_packet_handler.cpp
@@ -52,7 +52,6 @@ void DagSyncPacketHandler::process(const PacketData& packet_data, const std::sha
     throw MaliciousPeerException(err_msg.str());
   }
 
-  std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> new_transactions;
   std::string transactions_to_log;
 
   for (const auto tx_rlp : (*it++)) {
@@ -93,13 +92,11 @@ void DagSyncPacketHandler::process(const PacketData& packet_data, const std::sha
         assert(false);
     }
     if (!trx_mgr_->isTransactionPoolFull()) [[likely]] {
-      new_transactions.push_back({std::move(trx), std::move(status)});
+      trx_mgr_->insertValidatedTransaction(std::move(trx), std::move(status));
     } else {
-      new_transactions.push_back({std::move(trx), std::move(TransactionStatus::Forced)});
+      trx_mgr_->insertValidatedTransaction(std::move(trx), std::move(TransactionStatus::Forced));
     }
   }
-
-  trx_mgr_->insertValidatedTransactions(std::move(new_transactions));
 
   for (const auto block_rlp : *it) {
     DagBlock block(block_rlp);

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -53,8 +53,7 @@ TEST_F(NetworkTest, transfer_block) {
                {g_signed_trx_samples[0]->getHash(), g_signed_trx_samples[1]->getHash()}, sig_t(7777), blk_hash_t(888),
                addr_t(999));
 
-  std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> transactions{
-      {g_signed_trx_samples[0], TransactionStatus::Verified}, {g_signed_trx_samples[1], TransactionStatus::Verified}};
+  SharedTransactions transactions({g_signed_trx_samples[0], g_signed_trx_samples[1]});
   nw2->getSpecificHandler<network::tarcap::TransactionPacketHandler>()->onNewTransactions(std::move(transactions));
 
   EXPECT_HAPPENS({10s, 200ms}, [&](auto& ctx) {
@@ -116,13 +115,13 @@ TEST_F(NetworkTest, transfer_lot_of_blocks) {
 
   // creating lot of blocks just for size
   std::vector<trx_hash_t> trx_hashes;
-  std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> verified_transactions;
+  std::vector<std::shared_ptr<Transaction>> verified_transactions;
   trx_hashes.reserve(trxs.size());
   verified_transactions.reserve(trxs.size());
 
   for (const auto& trx : trxs) {
     trx_hashes.push_back(trx->getHash());
-    verified_transactions.push_back({trx, TransactionStatus::Verified});
+    verified_transactions.push_back(trx);
   }
 
   for (int i = 0; i < 100; ++i) {
@@ -135,8 +134,8 @@ TEST_F(NetworkTest, transfer_lot_of_blocks) {
     dag_blocks.emplace_back(std::make_shared<DagBlock>(blk));
   }
 
-  nw1->getSpecificHandler<network::tarcap::TransactionPacketHandler>()->onNewTransactions(
-      std::move(verified_transactions));
+  for (auto trx : verified_transactions)
+    node1->getTransactionManager()->insertValidatedTransaction(std::move(trx), TransactionStatus::Verified);
   for (size_t i = 0; i < dag_blocks.size(); i++) {
     if (dag_mgr1->verifyBlock(*dag_blocks[i]) == DagManager::VerifyBlockReturnType::Verified)
       dag_mgr1->addDagBlock(DagBlock(*dag_blocks[i]), {trxs[i]});
@@ -335,12 +334,13 @@ TEST_F(NetworkTest, transfer_transaction) {
   EXPECT_NE(nw1->getPeer(nw2_nodeid), nullptr);
   EXPECT_NE(nw2->getPeer(nw1_nodeid), nullptr);
 
-  std::vector<taraxa::bytes> transactions;
-  transactions.push_back(g_signed_trx_samples[0]->rlp());
-  transactions.push_back(g_signed_trx_samples[1]->rlp());
-  transactions.push_back(g_signed_trx_samples[2]->rlp());
+  SharedTransactions transactions;
+  transactions.push_back(g_signed_trx_samples[0]);
+  transactions.push_back(g_signed_trx_samples[1]);
+  transactions.push_back(g_signed_trx_samples[2]);
 
-  nw2->getSpecificHandler<network::tarcap::TransactionPacketHandler>()->sendTransactions(nw1_nodeid, transactions);
+  nw2->getSpecificHandler<network::tarcap::TransactionPacketHandler>()->sendTransactions(nw2->getPeer(nw1_nodeid),
+                                                                                         std::move(transactions));
 
   EXPECT_HAPPENS({2s, 200ms}, [&](auto& ctx) { WAIT_EXPECT_EQ(ctx, nw1->getReceivedTransactionsCount(), 3) });
 }
@@ -480,7 +480,7 @@ TEST_F(NetworkTest, node_sync) {
   blks.push_back(std::make_pair(blk6, g_signed_trx_samples[6]));
 
   for (size_t i = 0; i < blks.size(); ++i) {
-    node1->getTransactionManager()->insertValidatedTransactions({{blks[i].second, TransactionStatus::Verified}});
+    node1->getTransactionManager()->insertValidatedTransaction(std::move(blks[i].second), TransactionStatus::Verified);
     EXPECT_EQ(node1->getDagManager()->verifyBlock(blks[i].first), DagManager::VerifyBlockReturnType::Verified);
     node1->getDagManager()->addDagBlock(std::move(blks[i].first));
   }
@@ -528,10 +528,10 @@ TEST_F(NetworkTest, node_pbft_sync) {
   vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
   DagBlock blk1(dag_genesis, 1, {}, {g_signed_trx_samples[0]->getHash(), g_signed_trx_samples[1]->getHash()}, 0, vdf1,
                 sk);
-  std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> txs1{
-      {g_signed_trx_samples[0], TransactionStatus::Verified}, {g_signed_trx_samples[1], TransactionStatus::Verified}};
-
-  node1->getTransactionManager()->insertValidatedTransactions(std::move(txs1));
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr<Transaction>(g_signed_trx_samples[0]),
+                                                             TransactionStatus::Verified);
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr<Transaction>(g_signed_trx_samples[1]),
+                                                             TransactionStatus::Verified);
   node1->getDagManager()->verifyBlock(DagBlock(blk1));
   node1->getDagManager()->addDagBlock(DagBlock(blk1));
 
@@ -581,10 +581,10 @@ TEST_F(NetworkTest, node_pbft_sync) {
   vdf2.computeVdfSolution(vdf_config, blk1.getHash().asBytes(), false);
   DagBlock blk2(blk1.getHash(), 2, {}, {g_signed_trx_samples[2]->getHash(), g_signed_trx_samples[3]->getHash()}, 0,
                 vdf2, sk);
-  std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> txs2{
-      {g_signed_trx_samples[2], TransactionStatus::Verified}, {g_signed_trx_samples[3], TransactionStatus::Verified}};
-
-  node1->getTransactionManager()->insertValidatedTransactions(std::move(txs2));
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[2]),
+                                                             TransactionStatus::Verified);
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[3]),
+                                                             TransactionStatus::Verified);
   node1->getDagManager()->verifyBlock(DagBlock(blk2));
   node1->getDagManager()->addDagBlock(DagBlock(blk2));
 
@@ -692,10 +692,10 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
   DagBlock blk1(dag_genesis, 1, {}, {g_signed_trx_samples[0]->getHash(), g_signed_trx_samples[1]->getHash()}, 0, vdf1,
                 sk);
-  std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> tr1{
-      {g_signed_trx_samples[0], TransactionStatus::Verified}, {g_signed_trx_samples[1], TransactionStatus::Verified}};
-
-  node1->getTransactionManager()->insertValidatedTransactions(std::move(tr1));
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[0]),
+                                                             TransactionStatus::Verified);
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[1]),
+                                                             TransactionStatus::Verified);
   node1->getDagManager()->verifyBlock(DagBlock(blk1));
   node1->getDagManager()->addDagBlock(DagBlock(blk1));
 
@@ -735,10 +735,10 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   vdf2.computeVdfSolution(vdf_config, blk1.getHash().asBytes(), false);
   DagBlock blk2(blk1.getHash(), 2, {}, {g_signed_trx_samples[2]->getHash(), g_signed_trx_samples[3]->getHash()}, 0,
                 vdf2, sk);
-  std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> tr2{
-      {g_signed_trx_samples[2], TransactionStatus::Verified}, {g_signed_trx_samples[3], TransactionStatus::Verified}};
-
-  node1->getTransactionManager()->insertValidatedTransactions(std::move(tr2));
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[2]),
+                                                             TransactionStatus::Verified);
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[3]),
+                                                             TransactionStatus::Verified);
   node1->getDagManager()->verifyBlock(DagBlock(blk2));
   node1->getDagManager()->addDagBlock(DagBlock(blk2));
 
@@ -1072,22 +1072,36 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
   std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> tr6{
       {g_signed_trx_samples[9], TransactionStatus::Verified}};
 
-  node1->getTransactionManager()->insertValidatedTransactions(std::move(tr1));
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[0]),
+                                                             TransactionStatus::Verified);
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[1]),
+                                                             TransactionStatus::Verified);
   EXPECT_EQ(node1->getDagManager()->verifyBlock(std::move(blk1)), DagManager::VerifyBlockReturnType::Verified);
   node1->getDagManager()->addDagBlock(DagBlock(blk1));
-  node1->getTransactionManager()->insertValidatedTransactions(std::move(tr2));
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[2]),
+                                                             TransactionStatus::Verified);
   EXPECT_EQ(node1->getDagManager()->verifyBlock(std::move(blk2)), DagManager::VerifyBlockReturnType::Verified);
   node1->getDagManager()->addDagBlock(DagBlock(blk2));
-  node1->getTransactionManager()->insertValidatedTransactions(std::move(tr3));
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[3]),
+                                                             TransactionStatus::Verified);
   EXPECT_EQ(node1->getDagManager()->verifyBlock(std::move(blk3)), DagManager::VerifyBlockReturnType::Verified);
   node1->getDagManager()->addDagBlock(DagBlock(blk3));
-  node1->getTransactionManager()->insertValidatedTransactions(std::move(tr4));
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[4]),
+                                                             TransactionStatus::Verified);
   EXPECT_EQ(node1->getDagManager()->verifyBlock(std::move(blk4)), DagManager::VerifyBlockReturnType::Verified);
   node1->getDagManager()->addDagBlock(DagBlock(blk4));
-  node1->getTransactionManager()->insertValidatedTransactions(std::move(tr5));
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[5]),
+                                                             TransactionStatus::Verified);
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[6]),
+                                                             TransactionStatus::Verified);
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[7]),
+                                                             TransactionStatus::Verified);
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[8]),
+                                                             TransactionStatus::Verified);
   EXPECT_EQ(node1->getDagManager()->verifyBlock(std::move(blk5)), DagManager::VerifyBlockReturnType::Verified);
   node1->getDagManager()->addDagBlock(DagBlock(blk5));
-  node1->getTransactionManager()->insertValidatedTransactions(std::move(tr6));
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[9]),
+                                                             TransactionStatus::Verified);
   EXPECT_EQ(node1->getDagManager()->verifyBlock(std::move(blk6)), DagManager::VerifyBlockReturnType::Verified);
   node1->getDagManager()->addDagBlock(DagBlock(blk6));
   // To make sure blocks are stored before starting node 2
@@ -1247,9 +1261,8 @@ TEST_F(NetworkTest, node_sync2) {
   trxs.push_back(tr12);
 
   for (size_t i = 0; i < blks.size(); ++i) {
-    std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> ver_trxs;
-    for (auto t : trxs[i]) ver_trxs.push_back({t, TransactionStatus::Verified});
-    node1->getTransactionManager()->insertValidatedTransactions(std::move(ver_trxs));
+    for (auto t : trxs[i])
+      node1->getTransactionManager()->insertValidatedTransaction(std::move(t), TransactionStatus::Verified);
     node1->getDagManager()->verifyBlock(std::move(blks[i]));
     node1->getDagManager()->addDagBlock(DagBlock(blks[i]));
   }
@@ -1277,9 +1290,8 @@ TEST_F(NetworkTest, node_transaction_sync) {
   auto& node1 = nodes[0];
   auto& node2 = nodes[1];
 
-  std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> ver_trxs;
-  for (auto t : *g_signed_trx_samples) ver_trxs.push_back({t, TransactionStatus::Verified});
-  node1->getTransactionManager()->insertValidatedTransactions(std::move(ver_trxs));
+  for (auto t : *g_signed_trx_samples)
+    node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(t), TransactionStatus::Verified);
 
   std::cout << "Waiting Sync for 2000 milliseconds ..." << std::endl;
   taraxa::thisThreadSleepForMilliSeconds(2000);
@@ -1307,10 +1319,10 @@ TEST_F(NetworkTest, node_full_sync) {
   std::uniform_int_distribution<std::mt19937::result_type> distNodes(0, numberOfNodes - 2);  // range [0, 3]
 
   int num_of_trxs = 50;
-  const auto trxs = samples::createSignedTrxSamples(0, num_of_trxs, g_secret);
+  auto trxs = samples::createSignedTrxSamples(0, num_of_trxs, g_secret);
   for (auto i = 0; i < num_of_trxs; ++i) {
-    nodes[distNodes(rng)]->getTransactionManager()->insertValidatedTransactions(
-        {{trxs[i], TransactionStatus::Verified}});
+    nodes[distNodes(rng)]->getTransactionManager()->insertValidatedTransaction(std::move(trxs[i]),
+                                                                               TransactionStatus::Verified);
     thisThreadSleepForMilliSeconds(distTransactions(rng));
   }
   ASSERT_EQ(num_of_trxs, 50);  // 50 transactions
@@ -1470,8 +1482,8 @@ TEST_F(NetworkTest, suspicious_packets) {
   }
   EXPECT_TRUE(peer.reportSuspiciousPacket());
 
-  // This part of unit tests is commented out since it takes about one minute to actually test, run it if there are any
-  // issues with this functionality
+  // This part of unit tests is commented out since it takes about one minute to actually test, run it if there are
+  // any issues with this functionality
 
   /*thisThreadSleepForSeconds(60);
   for (int i = 0; i < 1000; i++) {

--- a/tests/util_test/samples.hpp
+++ b/tests/util_test/samples.hpp
@@ -173,7 +173,7 @@ inline SharedTransactions createSignedTrxSamples(unsigned start, unsigned num, s
   assert(start + num < std::numeric_limits<unsigned>::max());
   SharedTransactions trxs;
   for (auto i = start; i < num; ++i) {
-    trxs.emplace_back(std::make_shared<Transaction>(i, i * 100, 0, 1000000, data, sk, addr_t::random()));
+    trxs.emplace_back(std::make_shared<Transaction>(i, i * 100, 0, 100000, data, sk, addr_t::random()));
   }
   return trxs;
 }


### PR DESCRIPTION
When transactions are gossiped around the network it is normal if a node is connected to lot of other nodes that it will receive the same transaction multiple times coming from different nodes. It is even probable that it will receive it from almost every node it is connected to. Deserializing transactions (converting transaction rlp to Transaction object) takes about 20 millisseconds per 1000 transactions which is not that small considering that even with 1000 new transactions per second appearing on the network we might receive the same transaction a lot of times, so for instance an RPC node on devnet connected to 20 other nodes will probably receive 10000 transactions per second although it will actually be only 1000 unique transactions per second.

To avoid this excessive processing we add transaction hash to the transaction packet. Deserializing just transactions hashes of all the transactions instead of deserializing the full transaction and calculating the hash, allows us to quickly remove all the known transactions from further processing and to quickly marked transaction as known for the peer we received it from so that some other thread might not unnecessarily send transactions back to the peer we received it from.

The downside of this approach is that we are increasing the size of the transaction packet by adding the hash, but with the faster processing we should reduce the actual number of transactions/packets being gossiped so the actual total size of data being sent might even be reduced but this would have to be proved by additional testing.

-------------------

On processing transaction packet that could contain up to 1000 transactions inside, so far node would first verified all the transactions and only then inserted them into transactions pool. This caused unneeded delay in transactions insertion which can cause us to process the same transactions on other threads in parallel and delay gossiping already processed transactions. There was no gain in inserting transactions in bunch. Now as soon as transaction is verified it is inserted in the pool. 

-------------------

Transaction packet max size is reduced from 1000 transactions to 500 to increase parallel processing. Multiple packets are processed in parallel on packet handler threads but transactions within the same packet are processed in series.