### PR TITLE
fix: some issues related to previous PRs

### DIFF
--- a/libraries/core_libs/consensus/include/final_chain/final_chain.hpp
+++ b/libraries/core_libs/consensus/include/final_chain/final_chain.hpp
@@ -47,6 +47,8 @@ class FinalChain {
 
   virtual void stop() = 0;
 
+  virtual uint64_t delegation_delay() const = 0;
+
   /**
    * @brief Method which finalizes a block and executes it in EVM
    *

--- a/libraries/core_libs/consensus/src/final_chain/final_chain.cpp
+++ b/libraries/core_libs/consensus/src/final_chain/final_chain.cpp
@@ -138,6 +138,8 @@ class FinalChainImpl final : public FinalChain {
     return p->get_future();
   }
 
+  uint64_t delegation_delay() const override { return delegation_delay_; }
+
   std::shared_ptr<FinalizationResult> finalize_(PeriodData&& new_blk, std::vector<h256>&& finalized_dag_blk_hashes,
                                                 finalize_precommit_ext const& precommit_ext) {
     auto batch = db_->createWriteBatch();

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -1353,6 +1353,10 @@ TEST_F(FullNodeTest, db_rebuild) {
     auto node_cfgs = make_node_cfgs<5>(1);
     node_cfgs[0].db_config.rebuild_db = true;
     auto nodes = launch_nodes(node_cfgs);
+    ASSERT_HAPPENS({10s, 100ms}, [&](auto &ctx) {
+      WAIT_EXPECT_EQ(ctx, nodes[0]->getDB()->getNumTransactionExecuted(), trxs_count)
+      WAIT_EXPECT_EQ(ctx, nodes[0]->getFinalChain()->last_block_number(), executed_chain_size)
+    });
   }
 
   {


### PR DESCRIPTION
Have some fixes related to previously merged PRs:
1. Wait for `block - delegation_delay` in `waitForPeriodFinalization` to not slow down syncing
2. Check peer period in `broadcastPreviousRoundNextVotesBundle` 