### PR TITLE
fix: always send pbft block with propose vote for new round if vote i…

### DIFF
--- a/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_votes_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_votes_packet_handler.cpp
@@ -287,8 +287,10 @@ void ExtVotesPacketHandler::onNewPbftVote(const std::shared_ptr<Vote> &vote, con
       }
     }
 
-    // Peer already has pbft block, do not send it
-    if (peer.second->isPbftBlockKnown(vote->getBlockHash())) {
+    // Peer already has pbft block, do not send it (do not check it for propose votes as it could happen that nodes
+    // re-propose the same block for new round, in which case we need to send the block again
+    if (vote->getType() != PbftVoteTypes::propose_vote_type && vote->getStep() != PbftStates::value_proposal_state &&
+        peer.second->isPbftBlockKnown(vote->getBlockHash())) {
       sendPbftVote(peer.second, vote, nullptr);
     } else {
       sendPbftVote(peer.second, vote, block);


### PR DESCRIPTION
## Purpose
<!-- Provide any information reviewers might need to have context on your changes. -->

Do not check if pbft block is known for peer in case we are sending/gossiping unknown(for peer) propose votes

## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
