### PR TITLE
feat: do not enter consensus steps in case node is not eligible to vote

### DIFF
--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -442,7 +442,7 @@ void PbftManager::resetPbftConsensus(uint64_t round) {
   db_->addPbftMgrFieldToBatch(PbftMgrRoundStep::PbftRound, round, batch);
   db_->addPbftMgrFieldToBatch(PbftMgrRoundStep::PbftStep, 1, batch);
 
-  // TODO[2032]: PreviousRound... values probably dont make sense anymore as votesCOunt, threshold, etc... change only
+  // TODO[2032]: PreviousRound... values probably dont make sense anymore as votes count, threshold, etc... change only
   // with periods
   db_->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundSortitionThreshold, sortition_threshold_,
                                      batch);
@@ -730,6 +730,15 @@ bool PbftManager::stateOperations_() {
 
   // 2t+1 next votes were seen
   if (advanceRound()) {
+    return true;
+  }
+
+  // If node is not eligible to vote, always return true so pbft state machine never enters specific consensus steps
+  // (propose, soft-vote, cert-vote, next-vote). Nodes that have no delegation should just observe 2t+1 cert votes
+  // to move to the next period or 2t+1 next votes to move to the next round
+  if (!final_chain_->dpos_eligible_vote_count(period - 1, node_addr_)) {
+    // Check 2t+1 cert/next votes every 20ms
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
     return true;
   }
 


### PR DESCRIPTION
## Purpose
<!-- Provide any information reviewers might need to have context on your changes. -->

  // If node is not eligible to vote, always return true so pbft state machine never enters specific consensus steps
  // (propose, soft-vote, cert-vote, next-vote). Nodes that have no delegation should just observe 2t+1 cert votes
  // to move to the next period or 2t+1 next votes to move to the next round

## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
