### PR TITLE
chore: votes logging and minor optimization

### DIFF
--- a/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_votes_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_votes_packet_handler.cpp
@@ -268,6 +268,7 @@ void ExtVotesPacketHandler::onNewPbftVote(const std::shared_ptr<Vote> &vote, con
 
   for (const auto &peer : peers_state_->getAllPeers()) {
     if (peer.second->syncing_) {
+      LOG(log_dg_) << " PBFT vote " << vote->getHash() << " not sent to " << peer.first << " peer syncing";
       continue;
     }
 
@@ -279,10 +280,14 @@ void ExtVotesPacketHandler::onNewPbftVote(const std::shared_ptr<Vote> &vote, con
     if (!(vote->getType() == cert_vote_type && vote->getBlockHash() == rewards_votes_block.first)) {
       // CONCERN ... should we be using a period stored in peer state?
       if (peer.second->pbft_chain_size_ > vote->getPeriod() - 1) {
+        LOG(log_dg_) << " PBFT vote " << vote->getHash() << " not sent to " << peer.first
+                     << " peer chain size: " << peer.second->pbft_chain_size_;
         continue;
       }
 
       if (peer.second->pbft_round_ > vote->getRound()) {
+        LOG(log_dg_) << " PBFT vote " << vote->getHash() << " not sent to " << peer.first
+                     << " peer round: " << peer.second->pbft_round_;
         continue;
       }
     }


### PR DESCRIPTION
I have noticed while doing stress tests some propose votes are not gossiped to all nodes. My suspicion is that in ExtVotesPacketHandler::onNewPbftVote we skip sending this vote because of the state of peer.second->pbft_chain_size_ and peer.second->pbft_round_ so I added additional logging there to confirm this.

I noticed in the logs on devnet that we were logging received same votes multiple times. I moved the check for duplicate votes before the logs and before deserialization of pbft block.