### PR TITLE
chore: step end time

### DIFF
--- a/libraries/cli/include/cli/config_jsons/default.json
+++ b/libraries/cli/include/cli/config_jsons/default.json
@@ -15,7 +15,7 @@
   "deep_syncing_threshold": 10,
   "vote_accepting_periods": 5,
   "vote_accepting_rounds": 5,
-  "vote_accepting_steps": 25,
+  "vote_accepting_steps": 100,
   "final_chain_cache_in_blocks": 5,
   "network_boot_nodes": [
   ],

--- a/libraries/cli/include/cli/config_jsons/devnet.json
+++ b/libraries/cli/include/cli/config_jsons/devnet.json
@@ -15,7 +15,7 @@
   "deep_syncing_threshold": 10,
   "vote_accepting_periods": 5,
   "vote_accepting_rounds": 5,
-  "vote_accepting_steps": 25,
+  "vote_accepting_steps": 100,
   "final_chain_cache_in_blocks": 5,
   "network_boot_nodes": [
     {

--- a/libraries/cli/include/cli/config_jsons/mainnet.json
+++ b/libraries/cli/include/cli/config_jsons/mainnet.json
@@ -15,7 +15,7 @@
   "deep_syncing_threshold": 10,
   "vote_accepting_periods": 5,
   "vote_accepting_rounds": 5,
-  "vote_accepting_steps": 25,
+  "vote_accepting_steps": 100,
   "final_chain_cache_in_blocks": 5,
   "network_boot_nodes": [
     {

--- a/libraries/cli/include/cli/config_jsons/testnet.json
+++ b/libraries/cli/include/cli/config_jsons/testnet.json
@@ -15,7 +15,7 @@
   "deep_syncing_threshold": 10,
   "vote_accepting_periods": 5,
   "vote_accepting_rounds": 5,
-  "vote_accepting_steps": 25,
+  "vote_accepting_steps": 100,
   "final_chain_cache_in_blocks": 5,
   "network_boot_nodes": [
     {

--- a/libraries/config/include/config/config.hpp
+++ b/libraries/config/include/config/config.hpp
@@ -48,7 +48,7 @@ struct NetworkConfig {
   uint16_t deep_syncing_threshold = 10;
   uint16_t vote_accepting_periods = 5;
   uint16_t vote_accepting_rounds = 5;
-  uint16_t vote_accepting_steps = 25;
+  uint16_t vote_accepting_steps = 100;
 
   void validate() const;
 };

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1043,8 +1043,10 @@ void PbftManager::secondFinish_() {
   LOG(log_dg_) << "PBFT second finishing state in round: " << round << ", period: " << period;
 
   assert(step_ >= startingStepInRound_);
-  auto end_time_for_step = (2 + step_ - startingStepInRound_) * LAMBDA_ms - POLLING_INTERVAL_ms;
-  LOG(log_tr_) << "Step " << step_ << " end time " << end_time_for_step;
+
+  auto elapsed_time_in_step = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                  std::chrono::system_clock::now() - current_step_clock_initial_datetime_)
+                                  .count();
 
   if (const auto soft_voted_block = getSoftVotedBlockForThisRound_(); soft_voted_block.has_value()) {
     // TODO: this same call is performed also inside getSoftVotedBlockForThisRound_() -> refactor this
@@ -1094,7 +1096,7 @@ void PbftManager::secondFinish_() {
     pbft_step_last_broadcast_ = step_;
   }
 
-  loop_back_finish_state_ = elapsed_time_in_round_ms_ > end_time_for_step;
+  loop_back_finish_state_ = elapsed_time_in_step > (int64_t)(2 * (LAMBDA_ms - POLLING_INTERVAL_ms));
 }
 
 std::shared_ptr<PbftBlock> PbftManager::generatePbftBlock(uint64_t propose_period, const blk_hash_t &prev_blk_hash,


### PR DESCRIPTION
Original calculation for end_time_for_step was not good because LAMBDA_ms is not constant which could make several steps move very quickly and then some steps taking a very long time. 

New calculation only uses current LAMBDA to increase the time spent in the current step.

Reason for this:
loop_back_finish_state_ = elapsed_time_in_step > (int64_t)(2 * (LAMBDA_ms - POLLING_INTERVAL_ms));
being two times lambda is because this covers two steps since the delay is only added in second finish.

Besides this vote_accepting_steps is increased to 100 to prevent issues when nodes are down for a while and steps are not synchronized.