### PR TITLE
fix: reset cert_voted_block_for_round_ for each round as it affects f…

### DIFF
--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -641,7 +641,6 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   u_long elapsed_time_in_round_ms_ = 0;
 
   bool executed_pbft_block_ = false;
-  bool should_have_cert_voted_in_this_round_ = false;
   bool next_voted_soft_value_ = false;
   bool next_voted_null_block_hash_ = false;
   bool go_finish_state_ = false;

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -454,10 +454,8 @@ void PbftManager::resetPbftConsensus(uint64_t round) {
   db_->addPbftMgrStatusToBatch(PbftMgrStatus::NextVotedSoftValue, false, batch);
 
   // Reset cert voted block in the new upcoming round
-  if (cert_voted_block_for_round_.has_value() &&
-      (*cert_voted_block_for_round_)->getPeriod() <= pbft_chain_->getPbftChainSize()) {
+  if (cert_voted_block_for_round_.has_value()) {
     db_->removePbftMgrVotedValueToBatch(PbftMgrVotedValue::CertVotedBlockInRound, batch);
-
     cert_voted_block_for_round_.reset();
   }
 
@@ -470,8 +468,6 @@ void PbftManager::resetPbftConsensus(uint64_t round) {
     soft_voted_block_for_round_.reset();
   }
   db_->commitWriteBatch(batch);
-
-  should_have_cert_voted_in_this_round_ = false;
 
   // reset next voted value since start a new round
   // these are used to prevent voting multiple times while polling through the step
@@ -937,9 +933,9 @@ void PbftManager::certifyBlock_() {
     return;
   }
 
-  // Already sent (or should have) cert voted in this round
-  if (should_have_cert_voted_in_this_round_) {
-    LOG(log_dg_) << "Already did (or should have) cert vote in this round " << round;
+  // Already sent cert voted in this round
+  if (cert_voted_block_for_round_.has_value()) {
+    LOG(log_dg_) << "Already did cert vote in this round " << round;
     return;
   }
 
@@ -990,8 +986,6 @@ void PbftManager::certifyBlock_() {
       {current_round_soft_voted_block->getBlockHash(), current_round_soft_voted_block->getPeriod()}, batch);
   db_->addPbftCertVotedBlockToBatch(*current_round_soft_voted_block, batch);
   db_->commitWriteBatch(batch);
-
-  should_have_cert_voted_in_this_round_ = true;
 }
 
 void PbftManager::firstFinish_() {


### PR DESCRIPTION
## Purpose
<!-- Provide any information reviewers might need to have context on your changes. -->

- we has `should_have_cert_voted_in_this_round_` bool flag, which was used to decide if we should cert vote in the current round or not. This variable was cleaned without any condition each round, so we would cert-vote each round if we saw 2t+1 cert votes

- then we have `cert_voted_block_for_round_` variable into which we saved full cert-voted block. This variable was cleaned under a condition that its cert_voted_block_for_round_->period <= chain_size, which basically means it was pushed into the chain

Now the problem is that based on `cert_voted_block_for_round_` we decide in first and second finishing steps what value to vote for. 

Example:
node cert-voted some block in round 1 -> is is saved in cert_voted_block_for_round_. It was not pushed into chain as node did not see 2t+1 cert votes. Then node moves to the round 2 and because this variable was not cleaned, it wrongly decides on what value to next vote. See defitinitons(their period is our round):

```
Step 4: [The Period's First Finishing Step] User i does the following when clocki = 4λ.
– If i has certified some value v for period p, he next-votes v;
– Else if p ≥ 2 AND i has seen 2t+1 next-votes for ⊥ for period p−1 , he next-votes ⊥.
– Else he next-votes his starting value stpi .

Step 5: [The Period's Second Finishing Step] User i does the following when clocki ∈ (4λ, +∞),
until he is able to finish period p.
– If i sees 2t + 1 soft-votes for some value v 6= ⊥ for period p, then i next-votes v.
– If p ≥ 2 AND i sees 2t + 1 next-votes for ⊥ for period p − 1 AND i has not certified
in period p , then i next-votes ⊥.

```
In step 4, node pass the first if, even though it probably should not because it did not cert-vote in this round(period from definition), it cert-voted in previous round
In step 5, this affect second if

!!! Important: but this seems that we theoretically enable node to cert vote for different blocks in different round & same period ? Maybe not possible due to new pbft design -> something to think about ? 

## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
