### PR TITLE
chore: rpc for creating large number of transactions

### DIFF
--- a/doc/RPC.md
+++ b/doc/RPC.md
@@ -544,6 +544,26 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"send_coin_transaction","params":
   "result": null
 }
 ```
+### send_coin_transactions
+
+Method to create and send multiple transaction. Used to create high transactions load in tests
+
+#### Parameters
+
+`OBJECT` - block json to insert
+* `secret`: `DATA`, 32 Bytes - Secret key for account to send transactions from
+* `nonce`: `QUANTITY` - Nonce to start sending transaction with
+* `value`: `QUANTITY` - Value to specify in created transaction
+* `gas_price`: `QUANTITY` - Gas price to specify in created transaction
+* `gas`: `QUANTITY` - Amount of gas transaction can use
+* `receiver`: `DATA`, 20 Bytes - Array of Addresses of receiver account
+* `transaction_count`: `QUANTITY`, - Number of transactions to create
+
+#### Returns
+
+Number of transactions inserted successfuly, in case of transaction insertion failure, error message is returned
+
+
 
 ### get_account_address
 

--- a/libraries/core_libs/network/rpc/Test.h
+++ b/libraries/core_libs/network/rpc/Test.h
@@ -19,6 +19,7 @@ class Test : public TestFace {
 
   virtual Json::Value get_sortition_change(const Json::Value& param1) override;
   virtual Json::Value send_coin_transaction(const Json::Value& param1) override;
+  virtual Json::Value send_coin_transactions(const Json::Value& param1) override;
   virtual Json::Value get_account_address() override;
   virtual Json::Value get_peer_count() override;
   virtual Json::Value get_node_status() override;

--- a/libraries/core_libs/network/rpc/Test.jsonrpc.json
+++ b/libraries/core_libs/network/rpc/Test.jsonrpc.json
@@ -14,6 +14,13 @@
     "returns": {}
   },
   {
+    "name": "send_coin_transactions",
+    "params": [
+      {}
+    ],
+    "returns": {}
+  },
+  {
     "name": "get_account_address",
     "params": [],
     "returns": {}

--- a/libraries/core_libs/network/rpc/TestClient.h
+++ b/libraries/core_libs/network/rpc/TestClient.h
@@ -32,6 +32,15 @@ class TestClient : public jsonrpc::Client {
     else
       throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
   }
+  Json::Value send_coin_transactions(const Json::Value& param1) throw(jsonrpc::JsonRpcException) {
+    Json::Value p;
+    p.append(param1);
+    Json::Value result = this->CallMethod("send_coin_transactions", p);
+    if (result.isObject())
+      return result;
+    else
+      throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
+  }
   Json::Value get_account_address() throw(jsonrpc::JsonRpcException) {
     Json::Value p;
     p = Json::nullValue;

--- a/libraries/core_libs/network/rpc/TestFace.h
+++ b/libraries/core_libs/network/rpc/TestFace.h
@@ -18,6 +18,9 @@ class TestFace : public ServerInterface<TestFace> {
     this->bindAndAddMethod(jsonrpc::Procedure("send_coin_transaction", jsonrpc::PARAMS_BY_POSITION,
                                               jsonrpc::JSON_OBJECT, "param1", jsonrpc::JSON_OBJECT, NULL),
                            &taraxa::net::TestFace::send_coin_transactionI);
+    this->bindAndAddMethod(jsonrpc::Procedure("send_coin_transactions", jsonrpc::PARAMS_BY_POSITION,
+                                              jsonrpc::JSON_OBJECT, "param1", jsonrpc::JSON_OBJECT, NULL),
+                           &taraxa::net::TestFace::send_coin_transactionsI);
     this->bindAndAddMethod(
         jsonrpc::Procedure("get_account_address", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, NULL),
         &taraxa::net::TestFace::get_account_addressI);
@@ -39,6 +42,9 @@ class TestFace : public ServerInterface<TestFace> {
   }
   inline virtual void send_coin_transactionI(const Json::Value &request, Json::Value &response) {
     response = this->send_coin_transaction(request[0u]);
+  }
+  inline virtual void send_coin_transactionsI(const Json::Value &request, Json::Value &response) {
+    response = this->send_coin_transactions(request[0u]);
   }
   inline virtual void get_account_addressI(const Json::Value &request, Json::Value &response) {
     (void)request;
@@ -62,6 +68,7 @@ class TestFace : public ServerInterface<TestFace> {
   }
   virtual Json::Value get_sortition_change(const Json::Value &param1) = 0;
   virtual Json::Value send_coin_transaction(const Json::Value &param1) = 0;
+  virtual Json::Value send_coin_transactions(const Json::Value &param1) = 0;
   virtual Json::Value get_account_address() = 0;
   virtual Json::Value get_peer_count() = 0;
   virtual Json::Value get_node_status() = 0;


### PR DESCRIPTION
send_coin_transactions can create about 5000 transactions per second.

Transactions created will have most of the data the same other than:
nonce - specified nonce is increased for each transaction
receiver - is an array of receivers, if transaction count is greater than receiver, receivers are simply repeated
transaction_count - specifies number of transactions to create 