### PR TITLE
chore: change log level

### DIFF
--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -959,7 +959,7 @@ void PbftManager::certifyBlock_() {
   auto vote = generateVoteWithWeight(current_round_soft_voted_block->getBlockHash(), cert_vote_type,
                                      current_round_soft_voted_block->getPeriod(), round, step_);
   if (!vote) {
-    LOG(log_er_) << "Failed to generate cert vote for " << current_round_soft_voted_block->getBlockHash();
+    LOG(log_dg_) << "Failed to generate cert vote for " << current_round_soft_voted_block->getBlockHash();
     return;
   }
 


### PR DESCRIPTION
Change to debug level since this is logged all the time on rpc nodes which have no voting weight. On develop this should be fixed once non-voting nodes will not go into the voting code.