### PR TITLE
chore: remove pbft syncing related code from pbft

### DIFF
--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -30,13 +30,6 @@ class FullNode;
 
 enum PbftStates { value_proposal_state = 1, filter_state, certify_state, finish_state, finish_polling_state };
 
-enum PbftSyncRequestReason {
-  missing_dag_blk = 1,
-  invalid_cert_voted_block,
-  invalid_soft_voted_block,
-  exceeded_max_steps
-};
-
 /**
  * @brief PbftManager class is a daemon that is used to finalize a bench of directed acyclic graph (DAG) blocks by using
  * Practical Byzantine Fault Tolerance (PBFT) protocol
@@ -494,19 +487,6 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   h256 getProposal(const std::shared_ptr<Vote> &vote) const;
 
   /**
-   * @brief Only be able to send a syncing request per each PBFT round and step
-   * @return true if the current PBFT round and step has sent a syncing request already
-   */
-  bool syncRequestedAlreadyThisStep_() const;
-
-  /**
-   * @brief Send a syncing request to peer
-   * @param reason syncing request reason
-   * @param relevant_blk_hash relevant block hash
-   */
-  void syncPbftChainFromPeers_(PbftSyncRequestReason reason, taraxa::blk_hash_t const &relevant_blk_hash);
-
-  /**
    * @brief Only be able to broadcast one time of previous round next voting votes per each PBFT round and step
    * @return true if the current PBFT round and step has broadcasted previous round next voting votes already
    */
@@ -550,12 +530,6 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
    * @brief Update PBFT 2t+1 and PBFT sortition threshold
    */
   void updateTwoTPlusOneAndThreshold_();
-
-  /**
-   * @brief Check PBFT is working on syncing or not
-   * @return true if PBFT is working on syncing
-   */
-  bool is_syncing_();
 
   /**
    * @brief Check if previous round next voting value has been changed
@@ -648,8 +622,6 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   bool loop_back_finish_state_ = false;
   bool polling_state_print_log_ = true;
 
-  uint64_t pbft_round_last_requested_sync_ = 0;
-  size_t pbft_step_last_requested_sync_ = 0;
   uint64_t pbft_round_last_broadcast_ = 0;
   size_t pbft_step_last_broadcast_ = 0;
 


### PR DESCRIPTION
## Purpose
<!-- Provide any information reviewers might need to have context on your changes. -->

It does not make sense to trigger pbft syncing from pbft after the latest changes. It was triggered when block validation failed during cert voting or pushing cert voted block but currently it is not possible that this fails due to missing previous pbft block as the current pbft period is determined based on chain_size + 1....

## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
