### PR TITLE
chore: remove unsued db column, which became obsolete after latest pb…

### DIFF
--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -436,20 +436,10 @@ void PbftManager::resetPbftConsensus(uint64_t round) {
   resetStep();
   state_ = value_proposal_state;
 
-  auto batch = db_->createWriteBatch();
-
   // Update in DB first
+  auto batch = db_->createWriteBatch();
   db_->addPbftMgrFieldToBatch(PbftMgrRoundStep::PbftRound, round, batch);
   db_->addPbftMgrFieldToBatch(PbftMgrRoundStep::PbftStep, 1, batch);
-
-  // TODO[2032]: PreviousRound... values probably dont make sense anymore as votes count, threshold, etc... change only
-  // with periods
-  db_->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundSortitionThreshold, sortition_threshold_,
-                                     batch);
-  db_->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposPeriod, dpos_period_, batch);
-  db_->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposTotalVotesCount,
-                                     currentTotalVotesCount(), batch);
-
   db_->addPbftMgrStatusToBatch(PbftMgrStatus::NextVotedNullBlockHash, false, batch);
   db_->addPbftMgrStatusToBatch(PbftMgrStatus::NextVotedSoftValue, false, batch);
 

--- a/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
+++ b/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
@@ -993,16 +993,6 @@ void NextVotesManager::updateWithSyncedVotes(std::vector<std::shared_ptr<Vote>>&
     return;
   }
 
-  size_t previous_round_sortition_threshold =
-      db_->getPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundSortitionThreshold);
-  uint64_t previous_round_dpos_period =
-      db_->getPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposPeriod);
-  size_t previous_round_dpos_total_votes_count =
-      db_->getPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposTotalVotesCount);
-  LOG(log_nf_) << "Previous round sortition threshold " << previous_round_sortition_threshold
-               << ", previous round DPOS period " << previous_round_dpos_period
-               << ", previous round DPOS total votes count " << previous_round_dpos_total_votes_count;
-
   std::unordered_map<blk_hash_t, std::vector<std::shared_ptr<Vote>>> synced_next_votes;
   std::unordered_map<blk_hash_t, uint64_t> synced_next_votes_weight;
   for (auto& vote : next_votes) {

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -31,12 +31,6 @@ enum StatusDbField : uint8_t {
   DbMinorVersion
 };
 
-enum PbftMgrPreviousRoundStatus : uint8_t {
-  PreviousRoundSortitionThreshold = 0,
-  PreviousRoundDposPeriod,
-  PreviousRoundDposTotalVotesCount
-};
-
 enum PbftMgrRoundStep : uint8_t { PbftRound = 0, PbftStep };
 
 enum PbftMgrStatus : uint8_t {
@@ -103,7 +97,6 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
     COLUMN(transactions);
     COLUMN(trx_period);
     COLUMN(status);
-    COLUMN(pbft_mgr_previous_round_status);
     COLUMN(pbft_mgr_round_step);
     COLUMN(pbft_period_2t_plus_1);
     COLUMN(pbft_mgr_status);
@@ -238,10 +231,6 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   std::unordered_map<trx_hash_t, uint32_t> getAllTransactionPeriod();
 
   // PBFT manager
-  uint64_t getPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus field);
-  void savePbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus field, uint64_t value);
-  void addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus field, uint64_t value, Batch& write_batch);
-
   uint64_t getPbftMgrField(PbftMgrRoundStep field);
   void savePbftMgrField(PbftMgrRoundStep field, uint64_t value);
   void addPbftMgrFieldToBatch(PbftMgrRoundStep field, uint64_t value, Batch& write_batch);

--- a/libraries/core_libs/storage/src/storage.cpp
+++ b/libraries/core_libs/storage/src/storage.cpp
@@ -643,24 +643,6 @@ void DbStorage::addStatusFieldToBatch(StatusDbField const& field, uint64_t value
 }
 
 // PBFT
-uint64_t DbStorage::getPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus field) {
-  auto status = lookup(toSlice(field), Columns::pbft_mgr_previous_round_status);
-  if (!status.empty()) {
-    size_t value;
-    memcpy(&value, status.data(), sizeof(uint64_t));
-    return value;
-  }
-
-  return 0;
-}
-
-void DbStorage::savePbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus field, uint64_t value) {
-  insert(Columns::pbft_mgr_previous_round_status, toSlice(field), toSlice(value));
-}
-
-void DbStorage::addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus field, uint64_t value, Batch& write_batch) {
-  insert(write_batch, Columns::pbft_mgr_previous_round_status, toSlice(field), toSlice(value));
-}
 
 uint64_t DbStorage::getPbftMgrField(PbftMgrRoundStep field) {
   auto status = lookup(toSlice(field), Columns::pbft_mgr_round_step);

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -94,42 +94,6 @@ TEST_F(FullNodeTest, db_test) {
   ASSERT_EQ(*g_trx_signed_samples[2], *db.getTransaction(g_trx_signed_samples[2]->getHash()));
   ASSERT_EQ(*g_trx_signed_samples[3], *db.getTransaction(g_trx_signed_samples[3]->getHash()));
 
-  // PBFT manager previous round status
-  EXPECT_EQ(db.getPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundSortitionThreshold), 0);
-  EXPECT_EQ(db.getPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposPeriod), 0);
-  EXPECT_EQ(db.getPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposTotalVotesCount), 0);
-  size_t previous_round_sortition_threshold = 2;
-  db.savePbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundSortitionThreshold,
-                                    previous_round_sortition_threshold);
-  EXPECT_EQ(db.getPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundSortitionThreshold),
-            previous_round_sortition_threshold);
-  uint64_t previous_round_dpos_period = 3;
-  db.savePbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposPeriod, previous_round_dpos_period);
-  EXPECT_EQ(db.getPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposPeriod),
-            previous_round_dpos_period);
-  size_t previous_round_dpos_total_votes_count = 4;
-  db.savePbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposTotalVotesCount,
-                                    previous_round_dpos_total_votes_count);
-  EXPECT_EQ(db.getPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposTotalVotesCount),
-            previous_round_dpos_total_votes_count);
-  previous_round_sortition_threshold = 6;
-  previous_round_dpos_period = 7;
-  previous_round_dpos_total_votes_count = 8;
-  batch = db.createWriteBatch();
-  db.addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundSortitionThreshold,
-                                   previous_round_sortition_threshold, batch);
-  db.addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposPeriod, previous_round_dpos_period,
-                                   batch);
-  db.addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposTotalVotesCount,
-                                   previous_round_dpos_total_votes_count, batch);
-  db.commitWriteBatch(batch);
-  EXPECT_EQ(db.getPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundSortitionThreshold),
-            previous_round_sortition_threshold);
-  EXPECT_EQ(db.getPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposPeriod),
-            previous_round_dpos_period);
-  EXPECT_EQ(db.getPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposTotalVotesCount),
-            previous_round_dpos_total_votes_count);
-
   // PBFT manager round and step
   EXPECT_EQ(db.getPbftMgrField(PbftMgrRoundStep::PbftRound), 1);
   EXPECT_EQ(db.getPbftMgrField(PbftMgrRoundStep::PbftStep), 1);

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -892,14 +892,6 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_1) {
   pbft_mgr1->setPbftRound(2);
   pbft_mgr2->setPbftRound(2);
 
-  // Set PBFT previous round 2t+1, sortition threshold, DPOS period and DPOS total votes count for syncing
-  auto db = node2->getDB();
-  auto batch = db->createWriteBatch();
-  db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundSortitionThreshold, 1, batch);
-  db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposPeriod, 0, batch);
-  db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposTotalVotesCount, 1, batch);
-  db->commitWriteBatch(batch);
-
   auto expect_size = next_votes1.size();
   EXPECT_HAPPENS({30s, 500ms},
                  [&](auto& ctx) { WAIT_EXPECT_EQ(ctx, node2_next_votes_mgr->getNextVotesWeight(), expect_size); });
@@ -962,14 +954,6 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_2) {
   pbft_mgr1->setPbftRound(2);
   pbft_mgr2->setPbftRound(2);
 
-  // Set node2 PBFT previous round 2t+1, sortition threshold, DPOS period and DPOS total votes count for syncing
-  auto node2_db = node2->getDB();
-  auto batch = node2_db->createWriteBatch();
-  node2_db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundSortitionThreshold, 1, batch);
-  node2_db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposPeriod, 0, batch);
-  node2_db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposTotalVotesCount, 1, batch);
-  node2_db->commitWriteBatch(batch);
-
   std::shared_ptr<Network> nw1 = node1->getNetwork();
   std::shared_ptr<Network> nw2 = node2->getNetwork();
 
@@ -982,14 +966,6 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_2) {
 
   // Expect node1 print out "ERROR: Cannot get PBFT 2t+1 in PBFT round 0"
   EXPECT_EQ(node1_next_votes_mgr->getNextVotesWeight(), next_votes1.size());
-
-  // Set node1 PBFT previous round 2t+1, sortition threshold, DPOS period and DPOS total votes count for syncing
-  auto node1_db = node1->getDB();
-  batch = node1_db->createWriteBatch();
-  node1_db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundSortitionThreshold, 1, batch);
-  node1_db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposPeriod, 0, batch);
-  node1_db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposTotalVotesCount, 1, batch);
-  node1_db->commitWriteBatch(batch);
 
   // Node2 broadcast updated next votes to node1
   nw2->getSpecificHandler<network::tarcap::VotesSyncPacketHandler>()->broadcastPreviousRoundNextVotesBundle();

--- a/tests/vote_test.cpp
+++ b/tests/vote_test.cpp
@@ -302,12 +302,6 @@ TEST_F(VoteTest, previous_round_next_votes) {
   std::vector<std::shared_ptr<Vote>> next_votes_2{vote2};
 
   // Enough votes for blk_hash_t(1)
-  auto db = node->getDB();
-  auto batch = db->createWriteBatch();
-  db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundSortitionThreshold, 1, batch);
-  db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposPeriod, 0, batch);
-  db->addPbftMgrPreviousRoundStatus(PbftMgrPreviousRoundStatus::PreviousRoundDposTotalVotesCount, 1, batch);
-  db->commitWriteBatch(batch);
   next_votes_mgr->updateWithSyncedVotes(next_votes_2, pbft_2t_plus_1);
   EXPECT_EQ(next_votes_mgr->getVotedValue(), voted_pbft_block_hash);
   EXPECT_TRUE(next_votes_mgr->enoughNextVotes());


### PR DESCRIPTION
## Purpose
<!-- Provide any information reviewers might need to have context on your changes. -->

Remove pbft_mgr_previous_round_status db columns as we were no longer using it

## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
