### PR TITLE
fix: save 2t+1 soft voted block also into db in case it is present + …

### DIFF
--- a/libraries/core_libs/consensus/include/pbft/pbft_chain.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_chain.hpp
@@ -98,7 +98,7 @@ class PbftChain {
    * @param pbft_block PBFT block
    * @return true if passed verification
    */
-  bool checkPbftBlockValidation(taraxa::PbftBlock const& pbft_block) const;
+  bool checkPbftBlockValidation(const std::shared_ptr<PbftBlock>& pbft_block) const;
 
  private:
   using UniqueLock = boost::unique_lock<boost::shared_mutex>;

--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -13,12 +13,11 @@
 #include "network/tarcap/taraxa_capability.hpp"
 #include "pbft/period_data_queue.hpp"
 #include "pbft/proposed_blocks.hpp"
+#include "pbft/soft_voted_block_data.hpp"
 
 #define NULL_BLOCK_HASH blk_hash_t(0)
 #define POLLING_INTERVAL_ms 100  // milliseconds...
 #define MAX_STEPS 13             // Need to be a odd number
-#define MAX_WAIT_FOR_SOFT_VOTED_BLOCK_STEPS 20
-#define MAX_WAIT_FOR_NEXT_VOTED_BLOCK_STEPS 20
 
 namespace taraxa {
 
@@ -537,9 +536,11 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   void checkPreviousRoundNextVotedValueChange_();
 
   /**
-   * @return soft voted PBFT block if there is enough (2t+1) soft votes + it's period, otherwise returns empty optional
+   * @param period
+   * @param round
+   * @return Soft voted block data if there is enough (2t+1) soft votes, otherwise returns empty optional
    */
-  std::optional<std::pair<blk_hash_t, std::shared_ptr<PbftBlock>>> getSoftVotedBlockForThisRound_();
+  std::optional<TwoTPlusOneSoftVotedBlockData> getTwoTPlusOneSoftVotedBlockData(uint64_t period, uint64_t round);
 
   /**
    * @brief Process synced PBFT blocks if PBFT syncing queue is not empty
@@ -597,8 +598,8 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   size_t step_ = 1;
   size_t startingStepInRound_ = 1;
 
-  // Block that node saw 2t+1 soft votes for
-  std::optional<std::pair<blk_hash_t, std::shared_ptr<PbftBlock>>> soft_voted_block_for_round_{};
+  // 2t+1 soft voted block related data
+  std::optional<TwoTPlusOneSoftVotedBlockData> soft_voted_block_for_round_{};
 
   // Block that node cert voted
   std::optional<std::shared_ptr<PbftBlock>> cert_voted_block_for_round_{};
@@ -618,7 +619,6 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   bool next_voted_null_block_hash_ = false;
   bool go_finish_state_ = false;
   bool loop_back_finish_state_ = false;
-  bool polling_state_print_log_ = true;
 
   uint64_t pbft_round_last_broadcast_ = 0;
   size_t pbft_step_last_broadcast_ = 0;

--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -540,7 +540,7 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
    * @param round
    * @return Soft voted block data if there is enough (2t+1) soft votes, otherwise returns empty optional
    */
-  std::optional<TwoTPlusOneSoftVotedBlockData> getTwoTPlusOneSoftVotedBlockData(uint64_t period, uint64_t round);
+  const std::optional<TwoTPlusOneSoftVotedBlockData> &getTwoTPlusOneSoftVotedBlockData(uint64_t period, uint64_t round);
 
   /**
    * @brief Process synced PBFT blocks if PBFT syncing queue is not empty

--- a/libraries/core_libs/consensus/include/pbft/soft_voted_block_data.hpp
+++ b/libraries/core_libs/consensus/include/pbft/soft_voted_block_data.hpp
@@ -1,7 +1,11 @@
 #pragma once
 
+#include <libdevcore/RLP.h>
+
 #include <memory>
 #include <vector>
+
+#include "common/types.hpp"
 
 namespace taraxa {
 
@@ -11,12 +15,22 @@ class Vote;
 /**
  * @brief TwoTPlusOneSoftVotedBlockData holds data related to observed 2t+1 soft voted block
  */
-struct TwoTPlusOneSoftVotedBlockData {
-  uint64_t round;
-  blk_hash_t block_hash;
-  std::vector<std::shared_ptr<Vote>> soft_votes;
+class TwoTPlusOneSoftVotedBlockData {
+ public:
+  TwoTPlusOneSoftVotedBlockData() = default;
+  TwoTPlusOneSoftVotedBlockData(const TwoTPlusOneSoftVotedBlockData&) = default;
+  TwoTPlusOneSoftVotedBlockData& operator=(const TwoTPlusOneSoftVotedBlockData&) = default;
+  TwoTPlusOneSoftVotedBlockData(TwoTPlusOneSoftVotedBlockData&&) = default;
+  TwoTPlusOneSoftVotedBlockData& operator=(TwoTPlusOneSoftVotedBlockData&&) = default;
+
+  TwoTPlusOneSoftVotedBlockData(dev::RLP const& rlp);
+  bytes rlp() const;
+
+  uint64_t round_;
+  blk_hash_t block_hash_;
+  std::vector<std::shared_ptr<Vote>> soft_votes_;
   // can be nullptr as node might not have the actual block even though it saw 2t+1 soft votes
-  std::shared_ptr<PbftBlock> block;
+  std::shared_ptr<PbftBlock> block_;
 
   static constexpr size_t kStandardDataItemCount{3};
   static constexpr size_t kExtendedDataItemCount{4};  // with block

--- a/libraries/core_libs/consensus/include/pbft/soft_voted_block_data.hpp
+++ b/libraries/core_libs/consensus/include/pbft/soft_voted_block_data.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+namespace taraxa {
+
+class PbftBlock;
+class Vote;
+
+/**
+ * @brief TwoTPlusOneSoftVotedBlockData holds data related to observed 2t+1 soft voted block
+ */
+struct TwoTPlusOneSoftVotedBlockData {
+  uint64_t round;
+  blk_hash_t block_hash;
+  std::vector<std::shared_ptr<Vote>> soft_votes;
+  // can be nullptr as node might not have the actual block even though it saw 2t+1 soft votes
+  std::shared_ptr<PbftBlock> block;
+
+  static constexpr size_t kStandardDataItemCount{3};
+  static constexpr size_t kExtendedDataItemCount{4};  // with block
+};
+
+}  // namespace taraxa

--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -220,7 +220,8 @@ class VoteManager {
    * @param two_t_plus_one PBFT 2t+1 is 2/3 of PBFT sortition threshold and plus 1
    * @return VotesBundle a bunch of votes that vote on the same voting value in the specific PBFT round and step
    */
-  std::optional<VotesBundle> getVotesBundle(uint64_t round, uint64_t period, size_t step, size_t two_t_plus_one) const;
+  std::optional<VotesBundle> getTwoTPlusOneVotesBundle(uint64_t round, uint64_t period, size_t step,
+                                                       size_t two_t_plus_one) const;
 
   /**
    * @brief Check if there are enough next voting type votes to set PBFT to a forward round within period

--- a/libraries/core_libs/consensus/src/pbft/pbft_chain.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_chain.cpp
@@ -91,17 +91,17 @@ void PbftChain::updatePbftChain(blk_hash_t const& pbft_block_hash, blk_hash_t co
   last_pbft_block_hash_ = pbft_block_hash;
 }
 
-bool PbftChain::checkPbftBlockValidation(taraxa::PbftBlock const& pbft_block) const {
-  if (getPbftChainSize() + 1 != pbft_block.getPeriod()) {
+bool PbftChain::checkPbftBlockValidation(const std::shared_ptr<PbftBlock>& pbft_block) const {
+  if (getPbftChainSize() + 1 != pbft_block->getPeriod()) {
     LOG(log_er_) << "Pbft validation failed. PBFT chain size " << getPbftChainSize()
-                 << ". Pbft block period: " << pbft_block.getPeriod() << " for block " << pbft_block.getBlockHash();
+                 << ". Pbft block period: " << pbft_block->getPeriod() << " for block " << pbft_block->getBlockHash();
     return false;
   }
 
   auto last_pbft_block_hash = getLastPbftBlockHash();
-  if (pbft_block.getPrevBlockHash() != last_pbft_block_hash) {
+  if (pbft_block->getPrevBlockHash() != last_pbft_block_hash) {
     LOG(log_er_) << "PBFT chain last block hash " << last_pbft_block_hash << " Invalid PBFT prev block hash "
-                 << pbft_block.getPrevBlockHash() << " in block " << pbft_block.getBlockHash();
+                 << pbft_block->getPrevBlockHash() << " in block " << pbft_block->getBlockHash();
     return false;
   }
 

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -532,7 +532,7 @@ void PbftManager::initialState() {
     }
 
     // Use period from votes as soft_voted_block_data->block is optional
-    auto votes_period = soft_voted_block_data->soft_votes[0]->getPeriod();
+    const auto votes_period = soft_voted_block_data->soft_votes[0]->getPeriod();
 
     // Set soft_voted_block_for_round_ only if round and period match. Note: could differ in edge case when node crashed,
     // new period/round was already saved in db but soft voted block data was not cleared yet
@@ -735,7 +735,7 @@ std::optional<TwoTPlusOneSoftVotedBlockData> PbftManager::getTwoTPlusOneSoftVote
     if (!soft_voted_block_for_round_->block) {
       auto block = proposed_blocks_.getPbftProposedBlock(period, round, soft_voted_block_for_round_->block_hash);
       if (block) {
-        soft_voted_block_for_round_->block = block;
+        soft_voted_block_for_round_->block = std::move(block);
         db_->saveSoftVotedBlockDataInRound(*soft_voted_block_for_round_);
       }
     }
@@ -753,8 +753,8 @@ std::optional<TwoTPlusOneSoftVotedBlockData> PbftManager::getTwoTPlusOneSoftVote
     soft_voted_block_data.block =
         proposed_blocks_.getPbftProposedBlock(period, round, soft_votes_bundle->voted_block_hash);
 
-    soft_voted_block_for_round_ = soft_voted_block_data;
     db_->saveSoftVotedBlockDataInRound(soft_voted_block_data);
+    soft_voted_block_for_round_ = std::move(soft_voted_block_data);
 
     return soft_voted_block_for_round_;
   }

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -338,7 +338,7 @@ bool PbftManager::tryPushCertVotesBlock() {
   const auto [current_pbft_round, current_pbft_period] = getPbftRoundAndPeriod();
 
   auto certified_block =
-      vote_mgr_->getVotesBundle(current_pbft_round, current_pbft_period, certify_state, two_t_plus_one_);
+      vote_mgr_->getTwoTPlusOneVotesBundle(current_pbft_round, current_pbft_period, certify_state, two_t_plus_one_);
   // Not enough cert votes found yet
   if (!certified_block.has_value()) {
     return false;
@@ -417,7 +417,7 @@ bool PbftManager::advanceRound() {
 }
 
 void PbftManager::resetPbftConsensus(uint64_t round) {
-  LOG(log_dg_) << "Reset PBFT consensus to: round " << round << ", period " << getPbftPeriod()
+  LOG(log_dg_) << "Reset PBFT consensus to: period " << getPbftPeriod() << ", round " << round
                << ", step 1, and resetting clock.";
   round_clock_initial_datetime_ = now_;
 
@@ -435,18 +435,16 @@ void PbftManager::resetPbftConsensus(uint64_t round) {
 
   // Reset cert voted block in the new upcoming round
   if (cert_voted_block_for_round_.has_value()) {
-    db_->removePbftMgrVotedValueToBatch(PbftMgrVotedValue::CertVotedBlockInRound, batch);
+    db_->removeCertVotedBlockInRound(batch);
     cert_voted_block_for_round_.reset();
   }
 
   // Reset soft voted block in the new upcoming round
   if (soft_voted_block_for_round_.has_value()) {
-    // Cleanup soft votes for previous round
-    db_->removeSoftVotesToBatch(round, batch);
-    db_->removePbftMgrVotedValueToBatch(PbftMgrVotedValue::SoftVotedBlockInRound, batch);
-
+    db_->removeSoftVotedBlockDataInRound(batch);
     soft_voted_block_for_round_.reset();
   }
+
   db_->commitWriteBatch(batch);
 
   // reset next voted value since start a new round
@@ -455,8 +453,6 @@ void PbftManager::resetPbftConsensus(uint64_t round) {
   // TODO: Get rid of this way of doing it!
   next_voted_null_block_hash_ = false;
   next_voted_soft_value_ = false;
-
-  polling_state_print_log_ = true;
 
   if (executed_pbft_block_) {
     waitForPeriodFinalization();
@@ -493,7 +489,8 @@ void PbftManager::initialState() {
   // Time constants...
   LAMBDA_ms = LAMBDA_ms_MIN;
 
-  auto round = db_->getPbftMgrField(PbftMgrRoundStep::PbftRound);
+  const auto period = getPbftPeriod();
+  const auto round = db_->getPbftMgrField(PbftMgrRoundStep::PbftRound);
   auto step = db_->getPbftMgrField(PbftMgrRoundStep::PbftStep);
 
   if (round == 1 && step == 1) {
@@ -519,29 +516,49 @@ void PbftManager::initialState() {
   setPbftStep(step);
   round_ = round;
 
-  auto soft_voted_block = db_->getPbftMgrVotedValue(PbftMgrVotedValue::SoftVotedBlockInRound);
-  if (soft_voted_block.has_value()) {
-    // From DB
-    soft_voted_block_for_round_ = std::make_pair(soft_voted_block->first, nullptr);
-    for (const auto &vote : db_->getSoftVotes(round)) {
-      if (vote->getBlockHash() != soft_voted_block->first) {
-        LOG(log_er_) << "The soft vote should have voting value " << soft_voted_block->first << ". Vote" << vote;
-        continue;
-      }
+  // Process saved soft voted block + votes from db
+  if (auto soft_voted_block_data = db_->getSoftVotedBlockDataInRound(); soft_voted_block_data.has_value()) {
+    for (const auto &vote : soft_voted_block_data->soft_votes) {
       vote_mgr_->addVerifiedVote(vote);
     }
-  } else {
-    // Default value
-    soft_voted_block_for_round_.reset();
+
+    // If there is also actual block, push it into the proposed blocks
+    if (soft_voted_block_data->block) {
+      if (proposed_blocks_.pushProposedPbftBlock(soft_voted_block_data->round, soft_voted_block_data->block)) {
+        LOG(log_nf_) << "Last soft voted block " << soft_voted_block_data->block->getBlockHash() << " with period "
+                     << soft_voted_block_data->block->getPeriod() << ", round " << soft_voted_block_data->round
+                     << " pushed into proposed blocks";
+      }
+    }
+
+    // Use period from votes as soft_voted_block_data->block is optional
+    auto votes_period = soft_voted_block_data->soft_votes[0]->getPeriod();
+
+    // Set soft_voted_block_for_round_ only if round and period match. Note: could differ in edge case when node crashed,
+    // new period/round was already saved in db but soft voted block data was not cleared yet
+    if (period == votes_period && round == soft_voted_block_data->round) {
+      soft_voted_block_for_round_ = *soft_voted_block_data;
+      LOG(log_nf_) << "Init last observed 2t+1 soft voted block to " << soft_voted_block_data->block_hash << ", period "
+                   << period << ", round " << round;
+    }
   }
 
-  if (auto cert_voted_block = db_->getPbftMgrVotedValue(PbftMgrVotedValue::CertVotedBlockInRound);
-      cert_voted_block.has_value()) {
-    auto block = db_->getPbftCertVotedBlock((*cert_voted_block).first);
-    assert(block);
-    cert_voted_block_for_round_ = block;
-    proposed_blocks_.pushProposedPbftBlock(round, block);
-    LOG(log_nf_) << "Initialize last cert voted value " << (*cert_voted_block_for_round_)->getBlockHash();
+  // Process saved cert voted block from db
+  if (auto cert_voted_block_data = db_->getCertVotedBlockInRound(); cert_voted_block_data.has_value()) {
+    const auto &[cert_voted_block_round, cert_voted_block] = *cert_voted_block_data;
+    if (proposed_blocks_.pushProposedPbftBlock(cert_voted_block_round, cert_voted_block)) {
+      LOG(log_nf_) << "Last cert voted block " << cert_voted_block->getBlockHash() << " with period "
+                   << cert_voted_block->getPeriod() << ", round " << cert_voted_block_round
+                   << " pushed into proposed blocks";
+    }
+
+    // Set cert_voted_block_for_round_ only if round and period match. Note: could differ in edge case when node crashed,
+    // new period/round was already saved in db but cert voted block was not cleared yet
+    if (period == cert_voted_block->getPeriod() && round == cert_voted_block_round) {
+      cert_voted_block_for_round_ = cert_voted_block;
+      LOG(log_nf_) << "Init last cert voted block in round to " << cert_voted_block->getBlockHash() << ", period "
+                   << period << ", round " << round;
+    }
   }
 
   executed_pbft_block_ = db_->getPbftMgrStatus(PbftMgrStatus::ExecutedBlock);
@@ -620,7 +637,6 @@ void PbftManager::setFilterState_() {
   next_step_time_ms_ = 2 * LAMBDA_ms;
   last_step_clock_initial_datetime_ = current_step_clock_initial_datetime_;
   current_step_clock_initial_datetime_ = std::chrono::system_clock::now();
-  polling_state_print_log_ = true;
 }
 
 void PbftManager::setCertifyState_() {
@@ -629,7 +645,6 @@ void PbftManager::setCertifyState_() {
   next_step_time_ms_ = 2 * LAMBDA_ms;
   last_step_clock_initial_datetime_ = current_step_clock_initial_datetime_;
   current_step_clock_initial_datetime_ = std::chrono::system_clock::now();
-  polling_state_print_log_ = true;
 }
 
 void PbftManager::setFinishState_() {
@@ -639,7 +654,6 @@ void PbftManager::setFinishState_() {
   next_step_time_ms_ = 4 * LAMBDA_ms;
   last_step_clock_initial_datetime_ = current_step_clock_initial_datetime_;
   current_step_clock_initial_datetime_ = std::chrono::system_clock::now();
-  polling_state_print_log_ = true;
 }
 
 void PbftManager::setFinishPollingState_() {
@@ -651,7 +665,6 @@ void PbftManager::setFinishPollingState_() {
   db_->commitWriteBatch(batch);
   next_voted_soft_value_ = false;
   next_voted_null_block_hash_ = false;
-  polling_state_print_log_ = true;
   last_step_clock_initial_datetime_ = current_step_clock_initial_datetime_;
   current_step_clock_initial_datetime_ = std::chrono::system_clock::now();
 }
@@ -660,7 +673,8 @@ void PbftManager::loopBackFinishState_() {
   auto round = getPbftRound();
   LOG(log_dg_) << "CONSENSUS debug round " << round << " , step " << step_
                << " | next_voted_soft_value_ = " << next_voted_soft_value_ << " soft_voted_value_for_round = "
-               << (soft_voted_block_for_round_.has_value() ? soft_voted_block_for_round_->first.abridged() : "no value")
+               << (soft_voted_block_for_round_.has_value() ? soft_voted_block_for_round_->block_hash.abridged()
+                                                           : "no value")
                << " next_voted_null_block_hash_ = " << next_voted_null_block_hash_ << " cert_voted_value_for_round = "
                << (cert_voted_block_for_round_.has_value() ? (*cert_voted_block_for_round_)->getBlockHash().abridged()
                                                            : "no value")
@@ -676,7 +690,6 @@ void PbftManager::loopBackFinishState_() {
   db_->commitWriteBatch(batch);
   next_voted_soft_value_ = false;
   next_voted_null_block_hash_ = false;
-  polling_state_print_log_ = true;
   assert(step_ >= startingStepInRound_);
   next_step_time_ms_ += POLLING_INTERVAL_ms;
   last_step_clock_initial_datetime_ = current_step_clock_initial_datetime_;
@@ -708,37 +721,40 @@ bool PbftManager::stateOperations_() {
   return false;
 }
 
-std::optional<std::pair<blk_hash_t, std::shared_ptr<PbftBlock>>> PbftManager::getSoftVotedBlockForThisRound_() {
-  auto [round, period] = getPbftRoundAndPeriod();
-
-  // Check current round cache
+std::optional<TwoTPlusOneSoftVotedBlockData> PbftManager::getTwoTPlusOneSoftVotedBlockData(uint64_t period,
+                                                                                           uint64_t round) {
+  // Have 2t+1 soft votes for some block for current round already
   if (soft_voted_block_for_round_.has_value()) {
-    // Have enough soft votes for current round already
+    // soft_voted_block_for_round_ should be reset every time period or round is incremented and we should never request
+    // it with different period or round than what is already saved in cache.
+    // If this happens, it is code bug that should be fixed
+    assert(period == soft_voted_block_for_round_->soft_votes[0]->getPeriod());
+    assert(round == soft_voted_block_for_round_->round);
 
-    // In case we dont have full block object, try to get it
-    if ((*soft_voted_block_for_round_).second == nullptr) {
-      (*soft_voted_block_for_round_).second =
-          proposed_blocks_.getPbftProposedBlock(period, round, (*soft_voted_block_for_round_).first);
+    // In case we dont have full block object yet, try to get it and save into db
+    if (!soft_voted_block_for_round_->block) {
+      auto block = proposed_blocks_.getPbftProposedBlock(period, round, soft_voted_block_for_round_->block_hash);
+      if (block) {
+        soft_voted_block_for_round_->block = block;
+        db_->saveSoftVotedBlockDataInRound(*soft_voted_block_for_round_);
+      }
     }
 
     return soft_voted_block_for_round_;
   }
 
-  const auto voted_block_hash_with_soft_votes = vote_mgr_->getVotesBundle(round, period, filter_state, two_t_plus_one_);
-  if (voted_block_hash_with_soft_votes.has_value()) {
-    // Have enough soft votes for a voted value
-    auto block =
-        proposed_blocks_.getPbftProposedBlock(period, round, voted_block_hash_with_soft_votes->voted_block_hash);
-    soft_voted_block_for_round_ = {
-        std::make_pair(voted_block_hash_with_soft_votes->voted_block_hash, std::move(block))};
+  const auto soft_votes_bundle = vote_mgr_->getTwoTPlusOneVotesBundle(round, period, filter_state, two_t_plus_one_);
+  // Have 2t+1 soft votes for some block
+  if (soft_votes_bundle.has_value()) {
+    TwoTPlusOneSoftVotedBlockData soft_voted_block_data;
+    soft_voted_block_data.round = round;
+    soft_voted_block_data.block_hash = soft_votes_bundle->voted_block_hash;
+    soft_voted_block_data.soft_votes = std::move(soft_votes_bundle->votes);
+    soft_voted_block_data.block =
+        proposed_blocks_.getPbftProposedBlock(period, round, soft_votes_bundle->voted_block_hash);
 
-    auto batch = db_->createWriteBatch();
-    db_->addPbftMgrVotedValueToBatch(PbftMgrVotedValue::SoftVotedBlockInRound,
-                                     std::make_pair(voted_block_hash_with_soft_votes->voted_block_hash,
-                                                    voted_block_hash_with_soft_votes->votes_period),
-                                     batch);
-    db_->addSoftVotesToBatch(round, voted_block_hash_with_soft_votes->votes, batch);
-    db_->commitWriteBatch(batch);
+    soft_voted_block_for_round_ = soft_voted_block_data;
+    db_->saveSoftVotedBlockDataInRound(soft_voted_block_data);
 
     return soft_voted_block_for_round_;
   }
@@ -907,57 +923,49 @@ void PbftManager::certifyBlock_() {
   }
 
   // Get soft voted bock with 2t+1 soft votes
-  const auto soft_voted_block = getSoftVotedBlockForThisRound_();
-  if (soft_voted_block.has_value() == false) {
-    LOG(log_dg_) << "Certify: Not enough soft votes for current round yet. Round " << round << ", period " << period;
+  const auto soft_voted_block_data = getTwoTPlusOneSoftVotedBlockData(period, round);
+  if (soft_voted_block_data.has_value() == false) {
+    LOG(log_dg_) << "Certify: Not enough soft votes for current round yet. Period " << period << ",  round" << round;
     return;
   }
 
-  auto current_round_soft_voted_block = soft_voted_block->second;
-  if (!current_round_soft_voted_block) {
-    LOG(log_er_) << "Unable to get proposed block " << soft_voted_block->first << ", period " << period << ", round "
-                 << round;
+  if (!soft_voted_block_data->block) {
+    LOG(log_er_) << "Unable to get proposed block " << soft_voted_block_data->block_hash << ", period " << period
+                 << ", round " << round;
     return;
   }
 
-  if (!pbft_chain_->checkPbftBlockValidation(*current_round_soft_voted_block)) {
+  if (!pbft_chain_->checkPbftBlockValidation(soft_voted_block_data->block)) {
     return;
   }
 
-  if (!compareBlocksAndRewardVotes_(current_round_soft_voted_block)) {
-    LOG(log_dg_) << "Incomplete or invalid soft voted block " << soft_voted_block->first << ", round " << round
-                 << ", period " << period;
+  if (!compareBlocksAndRewardVotes_(soft_voted_block_data->block)) {
+    LOG(log_dg_) << "Incomplete or invalid soft voted block " << soft_voted_block_data->block->getBlockHash()
+                 << ", period " << period << ", round " << round;
     return;
   }
 
   // generate cert vote
-  auto vote = generateVoteWithWeight(current_round_soft_voted_block->getBlockHash(), cert_vote_type,
-                                     current_round_soft_voted_block->getPeriod(), round, step_);
+  auto vote = generateVoteWithWeight(soft_voted_block_data->block->getBlockHash(), cert_vote_type,
+                                     soft_voted_block_data->block->getPeriod(), round, step_);
   if (!vote) {
-    LOG(log_dg_) << "Failed to generate cert vote for " << current_round_soft_voted_block->getBlockHash();
+    LOG(log_dg_) << "Failed to generate cert vote for " << soft_voted_block_data->block->getBlockHash();
     return;
   }
 
-  if (!placeVote(vote, "cert vote", current_round_soft_voted_block)) {
-    LOG(log_er_) << "Failed to place cert vote for " << current_round_soft_voted_block->getBlockHash();
+  if (!placeVote(vote, "cert vote", soft_voted_block_data->block)) {
+    LOG(log_er_) << "Failed to place cert vote for " << soft_voted_block_data->block->getBlockHash();
     return;
   }
 
-  cert_voted_block_for_round_ = current_round_soft_voted_block;
-
-  auto batch = db_->createWriteBatch();
-  // TODO: most probably we dont need to save cert voted block through addPbftMgrVotedValueToBatch anymore...
-  db_->addPbftMgrVotedValueToBatch(
-      PbftMgrVotedValue::CertVotedBlockInRound,
-      {current_round_soft_voted_block->getBlockHash(), current_round_soft_voted_block->getPeriod()}, batch);
-  db_->addPbftCertVotedBlockToBatch(*current_round_soft_voted_block, batch);
-  db_->commitWriteBatch(batch);
+  cert_voted_block_for_round_ = soft_voted_block_data->block;
+  db_->saveCertVotedBlockInRound(round, soft_voted_block_data->block);
 }
 
 void PbftManager::firstFinish_() {
   // Even number steps from 4 are in first finish
   auto [round, period] = getPbftRoundAndPeriod();
-  LOG(log_dg_) << "PBFT first finishing state in round: " << round << ", period: " << period;
+  LOG(log_dg_) << "PBFT first finishing state in period " << period << ", round " << round << ", step " << step_;
 
   if (cert_voted_block_for_round_.has_value()) {
     const auto &cert_voted_block = *cert_voted_block_for_round_;
@@ -1000,7 +1008,7 @@ void PbftManager::firstFinish_() {
 void PbftManager::secondFinish_() {
   // Odd number steps from 5 are in second finish
   auto [round, period] = getPbftRoundAndPeriod();
-  LOG(log_dg_) << "PBFT second finishing state in round: " << round << ", period: " << period;
+  LOG(log_dg_) << "PBFT second finishing state in period " << period << ", round " << round << ", step " << step_;
 
   assert(step_ >= startingStepInRound_);
 
@@ -1008,23 +1016,20 @@ void PbftManager::secondFinish_() {
                                   std::chrono::system_clock::now() - current_step_clock_initial_datetime_)
                                   .count();
 
-  if (const auto soft_voted_block = getSoftVotedBlockForThisRound_(); soft_voted_block.has_value()) {
-    // TODO: this same call is performed also inside getSoftVotedBlockForThisRound_() -> refactor this
-    auto soft_voted_block_votes = vote_mgr_->getVotesBundle(round, period, filter_state, two_t_plus_one_);
-    if (soft_voted_block_votes.has_value()) {
-      // Have enough soft votes for a voting value
-      auto net = network_.lock();
-      assert(net);  // Should never happen
-      net->getSpecificHandler<network::tarcap::VotePacketHandler>()->onNewPbftVotes(
-          std::move(soft_voted_block_votes->votes));
-      vote_mgr_->sendRewardVotes(getLastPbftBlockHash());
-      LOG(log_dg_) << "Node has seen enough soft votes for " << soft_voted_block_votes->voted_block_hash
-                   << ", regossip soft votes. Period " << period << ", round " << round << " step " << step_;
-    }
+  // Have 2t+1 soft votes for some block
+  if (auto soft_voted_block_data = getTwoTPlusOneSoftVotedBlockData(period, round); soft_voted_block_data.has_value()) {
+    auto net = network_.lock();
+    assert(net);  // Should never happen
+    net->getSpecificHandler<network::tarcap::VotePacketHandler>()->onNewPbftVotes(
+        std::move(soft_voted_block_data->soft_votes));
+    vote_mgr_->sendRewardVotes(getLastPbftBlockHash());
+    LOG(log_dg_) << "Regossip 2t+1 soft votes for " << soft_voted_block_data->block_hash;
 
     if (!next_voted_soft_value_) {
-      if (auto vote = generateVoteWithWeight(soft_voted_block->first, next_vote_type, period, round, step_); vote) {
-        if (placeVote(vote, "second finish vote", soft_voted_block->second)) {
+      if (auto vote = generateVoteWithWeight(soft_voted_block_data->block_hash, next_vote_type, period, round, step_);
+          vote) {
+        // It is ok even if soft_voted_block_data->block == nullptr
+        if (placeVote(vote, "second finish vote", soft_voted_block_data->block)) {
           db_->savePbftMgrStatus(PbftMgrStatus::NextVotedSoftValue, true);
           next_voted_soft_value_ = true;
         }
@@ -1377,7 +1382,7 @@ std::shared_ptr<PbftBlock> PbftManager::identifyLeaderBlock_(uint64_t round, uin
       continue;
     }
 
-    if (!pbft_chain_->checkPbftBlockValidation(*leader_block)) {
+    if (!pbft_chain_->checkPbftBlockValidation(leader_block)) {
       LOG(log_er_) << "Proposed block " << leader_block->getBlockHash() << " failed validation, period " << period
                    << ", round " << round;
       continue;
@@ -1454,7 +1459,7 @@ bool PbftManager::compareBlocksAndRewardVotes_(const std::shared_ptr<PbftBlock> 
 
 bool PbftManager::pushCertVotedPbftBlockIntoChain_(const std::shared_ptr<PbftBlock> &pbft_block,
                                                    std::vector<std::shared_ptr<Vote>> &&current_round_cert_votes) {
-  if (!pbft_chain_->checkPbftBlockValidation(*pbft_block)) {
+  if (!pbft_chain_->checkPbftBlockValidation(pbft_block)) {
     LOG(log_er_) << "Failed pbft chain validation for cert voted block " << pbft_block->getBlockHash()
                  << ", will call sync pbft chain from peers";
     return false;

--- a/libraries/core_libs/consensus/src/pbft/soft_voted_block_data.cpp
+++ b/libraries/core_libs/consensus/src/pbft/soft_voted_block_data.cpp
@@ -1,0 +1,75 @@
+#include "pbft/soft_voted_block_data.hpp"
+
+#include "pbft/pbft_block.hpp"
+#include "vote/vote.hpp"
+
+namespace taraxa {
+
+TwoTPlusOneSoftVotedBlockData::TwoTPlusOneSoftVotedBlockData(dev::RLP const& rlp) {
+  assert(rlp.itemCount() == TwoTPlusOneSoftVotedBlockData::kStandardDataItemCount ||
+         rlp.itemCount() == TwoTPlusOneSoftVotedBlockData::kExtendedDataItemCount);
+
+  auto it = rlp.begin();
+
+  // Parse block if present
+  block_ = nullptr;
+  // block is optional as node might not had the actual block when it observed 2t+1 soft votes and saved it
+  if (rlp.itemCount() == TwoTPlusOneSoftVotedBlockData::kExtendedDataItemCount) {
+    block_ = std::make_shared<PbftBlock>(*it++);
+  }
+
+  // Parse round
+  round_ = (*it++).toInt<uint64_t>();
+
+  // Parse block hash
+  block_hash_ = (*it++).toHash<blk_hash_t>();
+  if (block_) {
+    assert(block_->getBlockHash() == block_hash_);
+  }
+
+  // Parse votes
+  soft_votes_.reserve((*it).itemCount());
+  for (auto const vote_rlp : *it) {
+    auto vote = std::make_shared<Vote>(vote_rlp);
+    assert(vote->getType() == PbftVoteTypes::soft_vote_type);
+    assert(vote->getRound() == round_);
+    assert(vote->getBlockHash() == block_hash_);
+    if (block_) {
+      assert(vote->getPeriod() == block_->getPeriod());
+    }
+
+    soft_votes_.push_back(std::move(vote));
+  }
+
+  assert(!soft_votes_.empty());
+}
+
+bytes TwoTPlusOneSoftVotedBlockData::rlp() const {
+  dev::RLPStream s;
+  // block is optional as node might not had the actual block when it observed 2t+1 soft votes and saved it
+  if (block_) {
+    assert(block_->getBlockHash() == block_hash_);
+    s.appendList(TwoTPlusOneSoftVotedBlockData::kExtendedDataItemCount);  // block + round + block_hash + votes
+    s.appendRaw(block_->rlp(true));
+  } else {
+    s.appendList(TwoTPlusOneSoftVotedBlockData::kStandardDataItemCount);  // round + block_hash + votes
+  }
+
+  s.append(round_);
+  s.append(block_hash_);
+  s.appendList(soft_votes_.size());
+  for (auto const& vote : soft_votes_) {
+    assert(vote->getType() == PbftVoteTypes::soft_vote_type);
+    assert(vote->getRound() == round_);
+    assert(vote->getBlockHash() == block_hash_);
+    if (block_) {
+      assert(vote->getPeriod() == block_->getPeriod());
+    }
+
+    s.appendRaw(vote->rlp(true, true));
+  }
+
+  return s.invalidate();
+}
+
+}  // namespace taraxa

--- a/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
+++ b/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
@@ -472,8 +472,8 @@ std::vector<std::shared_ptr<Vote>> VoteManager::getProposalVotes(uint64_t period
 }
 
 // TODO: Refactor call to put period before round
-std::optional<VotesBundle> VoteManager::getVotesBundle(uint64_t round, uint64_t period, size_t step,
-                                                       size_t two_t_plus_one) const {
+std::optional<VotesBundle> VoteManager::getTwoTPlusOneVotesBundle(uint64_t round, uint64_t period, size_t step,
+                                                                  size_t two_t_plus_one) const {
   SharedLock lock(verified_votes_access_);
 
   const auto found_period_it = verified_votes_.find(period);

--- a/libraries/core_libs/storage/src/storage.cpp
+++ b/libraries/core_libs/storage/src/storage.cpp
@@ -680,27 +680,17 @@ void DbStorage::addPbftMgrStatusToBatch(PbftMgrStatus field, bool const& value, 
   insert(write_batch, DbStorage::Columns::pbft_mgr_status, toSlice(field), toSlice(value));
 }
 
-void DbStorage::savePbftMgrVotedValue(PbftMgrVotedValue field, const std::pair<blk_hash_t, uint64_t>& value) {
+void DbStorage::saveCertVotedBlockInRound(uint64_t round, const std::shared_ptr<PbftBlock>& block) {
+  assert(block);
+
   dev::RLPStream s(2);
-  s.append(value.first);
-  s.append(value.second);
-  insert(Columns::pbft_mgr_voted_value, toSlice(field), toSlice(s.out()));
+  s.append(round);
+  s.appendRaw(block->rlp(true));
+  insert(Columns::cert_voted_block_in_round, 0, toSlice(s.out()));
 }
 
-void DbStorage::addPbftMgrVotedValueToBatch(PbftMgrVotedValue field, const std::pair<blk_hash_t, uint64_t>& value,
-                                            Batch& write_batch) {
-  dev::RLPStream s(2);
-  s.append(value.first);
-  s.append(value.second);
-
-  insert(write_batch, Columns::pbft_mgr_voted_value, toSlice(field), toSlice(s.out()));
-}
-
-void DbStorage::removePbftMgrVotedValueToBatch(PbftMgrVotedValue field, Batch& write_batch) {
-  remove(write_batch, Columns::pbft_mgr_voted_value, toSlice(field));
-}
-std::optional<std::pair<blk_hash_t, uint64_t>> DbStorage::getPbftMgrVotedValue(PbftMgrVotedValue field) {
-  auto value = asBytes(lookup(toSlice(field), Columns::pbft_mgr_voted_value));
+std::optional<std::pair<uint64_t /* round */, std::shared_ptr<PbftBlock>>> DbStorage::getCertVotedBlockInRound() const {
+  auto value = asBytes(lookup(0, Columns::cert_voted_block_in_round));
   if (value.empty()) {
     return {};
   }
@@ -708,25 +698,94 @@ std::optional<std::pair<blk_hash_t, uint64_t>> DbStorage::getPbftMgrVotedValue(P
   auto value_rlp = dev::RLP(value);
   assert(value_rlp.itemCount() == 2);
 
-  return std::make_pair(value_rlp[0].toHash<blk_hash_t>(), value_rlp[1].toInt<uint64_t>());
+  std::pair<uint64_t /* round */, std::shared_ptr<PbftBlock>> ret;
+  ret.first = value_rlp[0].toInt<uint64_t>();
+  ret.second = std::make_shared<PbftBlock>(value_rlp[1]);
+
+  return ret;
 }
 
-std::shared_ptr<PbftBlock> DbStorage::getPbftCertVotedBlock(blk_hash_t const& block_hash) {
-  auto block = lookup(toSlice(block_hash.asBytes()), Columns::pbft_cert_voted_block);
-  if (!block.empty()) {
-    return std::make_shared<PbftBlock>(dev::RLP(block));
+void DbStorage::removeCertVotedBlockInRound(Batch& write_batch) {
+  remove(write_batch, Columns::cert_voted_block_in_round, 0);
+}
+
+void DbStorage::saveSoftVotedBlockDataInRound(const TwoTPlusOneSoftVotedBlockData& soft_voted_block_data) {
+  dev::RLPStream s;
+  // block is optional as node might not had the actual block when it observed 2t+1 soft votes and saved it
+  if (soft_voted_block_data.block) {
+    assert(soft_voted_block_data.block->getBlockHash() == soft_voted_block_data.block_hash);
+    s.appendList(TwoTPlusOneSoftVotedBlockData::kExtendedDataItemCount);  // block + round + block_hash + votes
+    s.appendRaw(soft_voted_block_data.block->rlp(true));
+  } else {
+    s.appendList(TwoTPlusOneSoftVotedBlockData::kStandardDataItemCount);  // round + block_hash + votes
   }
-  return nullptr;
+
+  s.append(soft_voted_block_data.round);
+  s.append(soft_voted_block_data.block_hash);
+  s.appendList(soft_voted_block_data.soft_votes.size());
+  for (auto const& vote : soft_voted_block_data.soft_votes) {
+    assert(vote->getType() == PbftVoteTypes::soft_vote_type);
+    assert(vote->getRound() == soft_voted_block_data.round);
+    assert(vote->getBlockHash() == soft_voted_block_data.block_hash);
+    if (soft_voted_block_data.block) {
+      assert(vote->getPeriod() == soft_voted_block_data.block->getPeriod());
+    }
+
+    s.appendRaw(vote->rlp(true, true));
+  }
+
+  insert(Columns::soft_voted_block_in_round, 0, toSlice(s.out()));
 }
 
-// Only for test
-void DbStorage::savePbftCertVotedBlock(PbftBlock const& pbft_block) {
-  insert(Columns::pbft_cert_voted_block, toSlice(pbft_block.getBlockHash().asBytes()), toSlice(pbft_block.rlp(true)));
+std::optional<TwoTPlusOneSoftVotedBlockData> DbStorage::getSoftVotedBlockDataInRound() const {
+  auto value = asBytes(lookup(0, Columns::soft_voted_block_in_round));
+  if (value.empty()) {
+    return {};
+  }
+  auto value_rlp = dev::RLP(value);
+  assert(value_rlp.itemCount() == TwoTPlusOneSoftVotedBlockData::kStandardDataItemCount ||
+         value_rlp.itemCount() == TwoTPlusOneSoftVotedBlockData::kExtendedDataItemCount);
+
+  auto it = value_rlp.begin();
+
+  TwoTPlusOneSoftVotedBlockData ret;
+
+  // Parse block if present
+  ret.block = nullptr;
+  // block is optional as node might not had the actual block when it observed 2t+1 soft votes and saved it
+  if (value_rlp.itemCount() == TwoTPlusOneSoftVotedBlockData::kExtendedDataItemCount) {
+    ret.block = std::make_shared<PbftBlock>(*it++);
+  }
+
+  // Parse round
+  ret.round = (*it++).toInt<uint64_t>();
+
+  // Parse block hash
+  ret.block_hash = (*it++).toHash<blk_hash_t>();
+  if (ret.block) {
+    assert(ret.block->getBlockHash() == ret.block_hash);
+  }
+
+  // Parse votes
+  ret.soft_votes.reserve((*it).itemCount());
+  for (auto const vote_rlp : *it) {
+    auto vote = std::make_shared<Vote>(vote_rlp);
+    assert(vote->getType() == PbftVoteTypes::soft_vote_type);
+    assert(vote->getRound() == ret.round);
+    assert(vote->getBlockHash() == ret.block_hash);
+    if (ret.block) {
+      assert(vote->getPeriod() == ret.block->getPeriod());
+    }
+
+    ret.soft_votes.push_back(std::move(vote));
+  }
+
+  assert(!ret.soft_votes.empty());
+  return ret;
 }
 
-void DbStorage::addPbftCertVotedBlockToBatch(PbftBlock const& pbft_block, Batch& write_batch) {
-  insert(write_batch, Columns::pbft_cert_voted_block, toSlice(pbft_block.getBlockHash().asBytes()),
-         toSlice(pbft_block.rlp(true)));
+void DbStorage::removeSoftVotedBlockDataInRound(Batch& write_batch) {
+  remove(write_batch, Columns::soft_voted_block_in_round, 0);
 }
 
 std::optional<PbftBlock> DbStorage::getPbftBlock(blk_hash_t const& hash) {
@@ -782,41 +841,6 @@ void DbStorage::addVerifiedVoteToBatch(std::shared_ptr<Vote> const& vote, Batch&
 
 void DbStorage::removeVerifiedVoteToBatch(vote_hash_t const& vote_hash, Batch& write_batch) {
   remove(write_batch, Columns::verified_votes, toSlice(vote_hash.asBytes()));
-}
-
-std::vector<std::shared_ptr<Vote>> DbStorage::getSoftVotes(uint64_t pbft_round) {
-  std::vector<std::shared_ptr<Vote>> soft_votes;
-  auto soft_votes_raw = asBytes(lookup(toSlice(pbft_round), Columns::soft_votes));
-  auto soft_votes_rlp = dev::RLP(soft_votes_raw);
-  soft_votes.reserve(soft_votes_rlp.size());
-
-  for (auto const soft_vote : soft_votes_rlp) {
-    soft_votes.emplace_back(std::make_shared<Vote>(soft_vote));
-  }
-
-  return soft_votes;
-}
-
-// Only for test
-void DbStorage::saveSoftVotes(uint64_t pbft_round, std::vector<std::shared_ptr<Vote>> const& soft_votes) {
-  dev::RLPStream s(soft_votes.size());
-  for (auto const& v : soft_votes) {
-    s.appendRaw(v->rlp(true, true));
-  }
-  insert(Columns::soft_votes, toSlice(pbft_round), toSlice(s.out()));
-}
-
-void DbStorage::addSoftVotesToBatch(uint64_t pbft_round, std::vector<std::shared_ptr<Vote>> const& soft_votes,
-                                    Batch& write_batch) {
-  dev::RLPStream s(soft_votes.size());
-  for (auto const& v : soft_votes) {
-    s.appendRaw(v->rlp(true, true));
-  }
-  insert(write_batch, Columns::soft_votes, toSlice(pbft_round), toSlice(s.out()));
-}
-
-void DbStorage::removeSoftVotesToBatch(uint64_t pbft_round, Batch& write_batch) {
-  remove(write_batch, Columns::soft_votes, toSlice(pbft_round));
 }
 
 std::vector<std::shared_ptr<Vote>> DbStorage::getCertVotes(uint64_t period) {

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -138,10 +138,10 @@ TEST_F(FullNodeTest, db_test) {
   EXPECT_EQ(db.getSoftVotedBlockDataInRound(), std::nullopt);
   uint64_t soft_voted_block_period_and_round = 123;
   TwoTPlusOneSoftVotedBlockData soft_voted_block_data_with_block;
-  soft_voted_block_data_with_block.round = soft_voted_block_period_and_round;
-  soft_voted_block_data_with_block.block =
-      make_simple_pbft_block(soft_voted_block_data_with_block.block_hash, soft_voted_block_period_and_round);
-  soft_voted_block_data_with_block.block_hash = soft_voted_block_data_with_block.block->getBlockHash();
+  soft_voted_block_data_with_block.round_ = soft_voted_block_period_and_round;
+  soft_voted_block_data_with_block.block_ =
+      make_simple_pbft_block(soft_voted_block_data_with_block.block_hash_, soft_voted_block_period_and_round);
+  soft_voted_block_data_with_block.block_hash_ = soft_voted_block_data_with_block.block_->getBlockHash();
   std::vector<std::shared_ptr<Vote>> soft_votes;
   for (auto i = 0; i < 3; i++) {
     blk_hash_t voted_pbft_block_hash(i);
@@ -150,22 +150,23 @@ TEST_F(FullNodeTest, db_test) {
         "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
         "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
     VrfPbftSortition vrf_sortition(vrf_sk, msg);
-    Vote vote(g_secret, vrf_sortition, soft_voted_block_data_with_block.block_hash);
+    Vote vote(g_secret, vrf_sortition, soft_voted_block_data_with_block.block_hash_);
     soft_votes.emplace_back(std::make_shared<Vote>(vote));
   }
-  soft_voted_block_data_with_block.soft_votes = soft_votes;
+  soft_voted_block_data_with_block.soft_votes_ = soft_votes;
 
   db.saveSoftVotedBlockDataInRound(soft_voted_block_data_with_block);
   auto soft_voted_block_data_with_block_db = db.getSoftVotedBlockDataInRound();
-  EXPECT_EQ(soft_voted_block_data_with_block_db->round, soft_voted_block_data_with_block.round);
-  EXPECT_EQ(soft_voted_block_data_with_block_db->block_hash, soft_voted_block_data_with_block.block_hash);
-  EXPECT_EQ(soft_voted_block_data_with_block_db->soft_votes.size(), soft_voted_block_data_with_block.soft_votes.size());
-  for (size_t idx = 0; idx < soft_voted_block_data_with_block.soft_votes.size(); idx++) {
-    const auto &db_vote = soft_voted_block_data_with_block_db->soft_votes[idx];
-    const auto &orig_vote = soft_voted_block_data_with_block.soft_votes[idx];
+  EXPECT_EQ(soft_voted_block_data_with_block_db->round_, soft_voted_block_data_with_block.round_);
+  EXPECT_EQ(soft_voted_block_data_with_block_db->block_hash_, soft_voted_block_data_with_block.block_hash_);
+  EXPECT_EQ(soft_voted_block_data_with_block_db->soft_votes_.size(),
+            soft_voted_block_data_with_block.soft_votes_.size());
+  for (size_t idx = 0; idx < soft_voted_block_data_with_block.soft_votes_.size(); idx++) {
+    const auto &db_vote = soft_voted_block_data_with_block_db->soft_votes_[idx];
+    const auto &orig_vote = soft_voted_block_data_with_block.soft_votes_[idx];
     EXPECT_EQ(db_vote->rlp(true, true), orig_vote->rlp(true, true));
   }
-  EXPECT_EQ(soft_voted_block_data_with_block_db->block->rlp(true), soft_voted_block_data_with_block.block->rlp(true));
+  EXPECT_EQ(soft_voted_block_data_with_block_db->block_->rlp(true), soft_voted_block_data_with_block.block_->rlp(true));
 
   batch = db.createWriteBatch();
   db.removeSoftVotedBlockDataInRound(batch);
@@ -173,18 +174,18 @@ TEST_F(FullNodeTest, db_test) {
   EXPECT_EQ(db.getSoftVotedBlockDataInRound(), std::nullopt);
 
   TwoTPlusOneSoftVotedBlockData soft_voted_block_data_no_block = soft_voted_block_data_with_block;
-  soft_voted_block_data_no_block.block = nullptr;
+  soft_voted_block_data_no_block.block_ = nullptr;
   db.saveSoftVotedBlockDataInRound(soft_voted_block_data_no_block);
   auto soft_voted_block_data_no_block_db = db.getSoftVotedBlockDataInRound();
-  EXPECT_EQ(soft_voted_block_data_no_block_db->round, soft_voted_block_data_no_block.round);
-  EXPECT_EQ(soft_voted_block_data_no_block_db->block_hash, soft_voted_block_data_no_block.block_hash);
-  EXPECT_EQ(soft_voted_block_data_no_block_db->soft_votes.size(), soft_voted_block_data_no_block.soft_votes.size());
-  for (size_t idx = 0; idx < soft_voted_block_data_with_block.soft_votes.size(); idx++) {
-    const auto &db_vote = soft_voted_block_data_with_block_db->soft_votes[idx];
-    const auto &orig_vote = soft_voted_block_data_with_block.soft_votes[idx];
+  EXPECT_EQ(soft_voted_block_data_no_block_db->round_, soft_voted_block_data_no_block.round_);
+  EXPECT_EQ(soft_voted_block_data_no_block_db->block_hash_, soft_voted_block_data_no_block.block_hash_);
+  EXPECT_EQ(soft_voted_block_data_no_block_db->soft_votes_.size(), soft_voted_block_data_no_block.soft_votes_.size());
+  for (size_t idx = 0; idx < soft_voted_block_data_with_block.soft_votes_.size(); idx++) {
+    const auto &db_vote = soft_voted_block_data_with_block_db->soft_votes_[idx];
+    const auto &orig_vote = soft_voted_block_data_with_block.soft_votes_[idx];
     EXPECT_EQ(db_vote->rlp(true, true), orig_vote->rlp(true, true));
   }
-  EXPECT_EQ(soft_voted_block_data_no_block_db->block, soft_voted_block_data_no_block.block);
+  EXPECT_EQ(soft_voted_block_data_no_block_db->block_, soft_voted_block_data_no_block.block_);
 
   // PBFT cert voted block in round
   EXPECT_EQ(db.getCertVotedBlockInRound(), std::nullopt);

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -134,50 +134,79 @@ TEST_F(FullNodeTest, db_test) {
   EXPECT_FALSE(db.getPbftMgrStatus(PbftMgrStatus::NextVotedSoftValue));
   EXPECT_FALSE(db.getPbftMgrStatus(PbftMgrStatus::NextVotedNullBlockHash));
 
-  // PBFT manager voted value
-  EXPECT_EQ(db.getPbftMgrVotedValue(PbftMgrVotedValue::SoftVotedBlockInRound), std::nullopt);
-  EXPECT_EQ(db.getPbftMgrVotedValue(PbftMgrVotedValue::CertVotedBlockInRound), std::nullopt);
-  db.savePbftMgrVotedValue(PbftMgrVotedValue::SoftVotedBlockInRound, {blk_hash_t(2), uint64_t(0)});
-  db.savePbftMgrVotedValue(PbftMgrVotedValue::CertVotedBlockInRound, {blk_hash_t(3), uint64_t(0)});
-  EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::SoftVotedBlockInRound),
-            std::make_pair(blk_hash_t(2), uint64_t(0)));
-  EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::CertVotedBlockInRound),
-            std::make_pair(blk_hash_t(3), uint64_t(0)));
-  batch = db.createWriteBatch();
-  db.addPbftMgrVotedValueToBatch(PbftMgrVotedValue::SoftVotedBlockInRound, std::make_pair(blk_hash_t(5), uint64_t(0)),
-                                 batch);
-  db.addPbftMgrVotedValueToBatch(PbftMgrVotedValue::CertVotedBlockInRound, std::make_pair(blk_hash_t(6), uint64_t(0)),
-                                 batch);
-  db.commitWriteBatch(batch);
-  EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::SoftVotedBlockInRound),
-            std::make_pair(blk_hash_t(5), uint64_t(0)));
-  EXPECT_EQ(*db.getPbftMgrVotedValue(PbftMgrVotedValue::CertVotedBlockInRound),
-            std::make_pair(blk_hash_t(6), uint64_t(0)));
+  // PBFT soft voted block data in round
+  EXPECT_EQ(db.getSoftVotedBlockDataInRound(), std::nullopt);
+  uint64_t soft_voted_block_period_and_round = 123;
+  TwoTPlusOneSoftVotedBlockData soft_voted_block_data_with_block;
+  soft_voted_block_data_with_block.round = soft_voted_block_period_and_round;
+  soft_voted_block_data_with_block.block =
+      make_simple_pbft_block(soft_voted_block_data_with_block.block_hash, soft_voted_block_period_and_round);
+  soft_voted_block_data_with_block.block_hash = soft_voted_block_data_with_block.block->getBlockHash();
+  std::vector<std::shared_ptr<Vote>> soft_votes;
+  for (auto i = 0; i < 3; i++) {
+    blk_hash_t voted_pbft_block_hash(i);
+    VrfPbftMsg msg(soft_vote_type, soft_voted_block_period_and_round, soft_voted_block_period_and_round, filter_state);
+    vrf_wrapper::vrf_sk_t vrf_sk(
+        "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
+        "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
+    VrfPbftSortition vrf_sortition(vrf_sk, msg);
+    Vote vote(g_secret, vrf_sortition, soft_voted_block_data_with_block.block_hash);
+    soft_votes.emplace_back(std::make_shared<Vote>(vote));
+  }
+  soft_voted_block_data_with_block.soft_votes = soft_votes;
 
-  // PBFT cert voted block
-  auto pbft_block1 = make_simple_pbft_block(blk_hash_t(1), 1);
-  auto pbft_block2 = make_simple_pbft_block(blk_hash_t(2), 2);
-  auto pbft_block3 = make_simple_pbft_block(blk_hash_t(3), 3);
-  auto pbft_block4 = make_simple_pbft_block(blk_hash_t(4), 4);
-  EXPECT_EQ(db.getPbftCertVotedBlock(blk_hash_t(1)), nullptr);
-  db.savePbftCertVotedBlock(*pbft_block1);
-  EXPECT_EQ(db.getPbftCertVotedBlock(pbft_block1->getBlockHash())->rlp(false), pbft_block1->rlp(false));
+  db.saveSoftVotedBlockDataInRound(soft_voted_block_data_with_block);
+  auto soft_voted_block_data_with_block_db = db.getSoftVotedBlockDataInRound();
+  EXPECT_EQ(soft_voted_block_data_with_block_db->round, soft_voted_block_data_with_block.round);
+  EXPECT_EQ(soft_voted_block_data_with_block_db->block_hash, soft_voted_block_data_with_block.block_hash);
+  EXPECT_EQ(soft_voted_block_data_with_block_db->soft_votes.size(), soft_voted_block_data_with_block.soft_votes.size());
+  for (size_t idx = 0; idx < soft_voted_block_data_with_block.soft_votes.size(); idx++) {
+    const auto &db_vote = soft_voted_block_data_with_block_db->soft_votes[idx];
+    const auto &orig_vote = soft_voted_block_data_with_block.soft_votes[idx];
+    EXPECT_EQ(db_vote->rlp(true, true), orig_vote->rlp(true, true));
+  }
+  EXPECT_EQ(soft_voted_block_data_with_block_db->block->rlp(true), soft_voted_block_data_with_block.block->rlp(true));
+
   batch = db.createWriteBatch();
-  db.addPbftCertVotedBlockToBatch(*pbft_block2, batch);
-  db.addPbftCertVotedBlockToBatch(*pbft_block3, batch);
-  db.addPbftCertVotedBlockToBatch(*pbft_block4, batch);
+  db.removeSoftVotedBlockDataInRound(batch);
   db.commitWriteBatch(batch);
-  EXPECT_EQ(db.getPbftCertVotedBlock(pbft_block2->getBlockHash())->rlp(false), pbft_block2->rlp(false));
-  EXPECT_EQ(db.getPbftCertVotedBlock(pbft_block3->getBlockHash())->rlp(false), pbft_block3->rlp(false));
-  EXPECT_EQ(db.getPbftCertVotedBlock(pbft_block4->getBlockHash())->rlp(false), pbft_block4->rlp(false));
+  EXPECT_EQ(db.getSoftVotedBlockDataInRound(), std::nullopt);
+
+  TwoTPlusOneSoftVotedBlockData soft_voted_block_data_no_block = soft_voted_block_data_with_block;
+  soft_voted_block_data_no_block.block = nullptr;
+  db.saveSoftVotedBlockDataInRound(soft_voted_block_data_no_block);
+  auto soft_voted_block_data_no_block_db = db.getSoftVotedBlockDataInRound();
+  EXPECT_EQ(soft_voted_block_data_no_block_db->round, soft_voted_block_data_no_block.round);
+  EXPECT_EQ(soft_voted_block_data_no_block_db->block_hash, soft_voted_block_data_no_block.block_hash);
+  EXPECT_EQ(soft_voted_block_data_no_block_db->soft_votes.size(), soft_voted_block_data_no_block.soft_votes.size());
+  for (size_t idx = 0; idx < soft_voted_block_data_with_block.soft_votes.size(); idx++) {
+    const auto &db_vote = soft_voted_block_data_with_block_db->soft_votes[idx];
+    const auto &orig_vote = soft_voted_block_data_with_block.soft_votes[idx];
+    EXPECT_EQ(db_vote->rlp(true, true), orig_vote->rlp(true, true));
+  }
+  EXPECT_EQ(soft_voted_block_data_no_block_db->block, soft_voted_block_data_no_block.block);
+
+  // PBFT cert voted block in round
+  EXPECT_EQ(db.getCertVotedBlockInRound(), std::nullopt);
+
+  auto cert_voted_block_in_round = make_simple_pbft_block(blk_hash_t(1), 1);
+  db.saveCertVotedBlockInRound(1, cert_voted_block_in_round);
+  auto cert_voted_block_in_round_db = db.getCertVotedBlockInRound();
+  EXPECT_EQ(cert_voted_block_in_round_db->second->rlp(true), cert_voted_block_in_round->rlp(true));
+  EXPECT_EQ(cert_voted_block_in_round_db->first, 1);
+
+  batch = db.createWriteBatch();
+  db.removeCertVotedBlockInRound(batch);
+  db.commitWriteBatch(batch);
+  EXPECT_EQ(db.getCertVotedBlockInRound(), std::nullopt);
 
   // pbft_blocks and cert votes
   EXPECT_FALSE(db.pbftBlockInDb(blk_hash_t(0)));
   EXPECT_FALSE(db.pbftBlockInDb(blk_hash_t(1)));
-  pbft_block1 = make_simple_pbft_block(blk_hash_t(1), 2);
-  pbft_block2 = make_simple_pbft_block(blk_hash_t(2), 3);
-  pbft_block3 = make_simple_pbft_block(blk_hash_t(3), 4);
-  pbft_block4 = make_simple_pbft_block(blk_hash_t(4), 5);
+  auto pbft_block1 = make_simple_pbft_block(blk_hash_t(1), 2);
+  auto pbft_block2 = make_simple_pbft_block(blk_hash_t(2), 3);
+  auto pbft_block3 = make_simple_pbft_block(blk_hash_t(3), 4);
+  auto pbft_block4 = make_simple_pbft_block(blk_hash_t(4), 5);
 
   // Certified votes
   std::vector<std::shared_ptr<Vote>> cert_votes;
@@ -275,48 +304,8 @@ TEST_F(FullNodeTest, db_test) {
   db.commitWriteBatch(batch);
   EXPECT_TRUE(db.getVerifiedVotes().empty());
 
-  // Soft votes
-  auto period = 1, round = 1, step = 2;
-  auto soft_votes = db.getSoftVotes(round);
-  EXPECT_TRUE(soft_votes.empty());
-  for (auto i = 0; i < 3; i++) {
-    blk_hash_t voted_pbft_block_hash(i);
-    VrfPbftMsg msg(soft_vote_type, period, round, step);
-    vrf_wrapper::vrf_sk_t vrf_sk(
-        "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
-        "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
-    VrfPbftSortition vrf_sortition(vrf_sk, msg);
-    Vote vote(g_secret, vrf_sortition, voted_pbft_block_hash);
-    soft_votes.emplace_back(std::make_shared<Vote>(vote));
-  }
-  db.saveSoftVotes(round, soft_votes);
-  auto soft_votes_from_db = db.getSoftVotes(round);
-  EXPECT_EQ(soft_votes.size(), soft_votes_from_db.size());
-  EXPECT_EQ(soft_votes_from_db.size(), 3);
-  for (auto i = 3; i < 5; i++) {
-    blk_hash_t voted_pbft_block_hash(i);
-    VrfPbftMsg msg(soft_vote_type, period, round, step);
-    vrf_wrapper::vrf_sk_t vrf_sk(
-        "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
-        "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
-    VrfPbftSortition vrf_sortition(vrf_sk, msg);
-    Vote vote(g_secret, vrf_sortition, voted_pbft_block_hash);
-    soft_votes.emplace_back(std::make_shared<Vote>(vote));
-  }
-  batch = db.createWriteBatch();
-  db.addSoftVotesToBatch(round, soft_votes, batch);
-  db.commitWriteBatch(batch);
-  soft_votes_from_db = db.getSoftVotes(round);
-  EXPECT_EQ(soft_votes.size(), soft_votes_from_db.size());
-  EXPECT_EQ(soft_votes_from_db.size(), 5);
-  batch = db.createWriteBatch();
-  db.removeSoftVotesToBatch(round, batch);
-  db.commitWriteBatch(batch);
-  soft_votes_from_db = db.getSoftVotes(round);
-  EXPECT_TRUE(soft_votes_from_db.empty());
-
   // Next votes
-  period = 3, round = 3, step = 5;
+  uint64_t period = 3, round = 3, step = 5;
   auto next_votes = db.getPreviousRoundNextVotes();
   EXPECT_TRUE(next_votes.empty());
   for (auto i = 0; i < 3; i++) {


### PR DESCRIPTION
## Purpose
<!-- Provide any information reviewers might need to have context on your changes. -->

This PR fixes the bug, when we saved 2t+1 soft votes but not the block itself in db.

Remove db columns:
    COLUMN(pbft_mgr_voted_value);
    COLUMN(pbft_cert_voted_block);

, which were replaced by:
    COLUMN(soft_voted_block_in_round);  // Soft voted block + votes + round -> node saw 2t+1 soft votes for this block
    COLUMN(cert_voted_block_in_round);  // Cert voted block + round -> node voted for this block

+ overall refactor of which data are stored in those columns now, etc...

## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
