### PR TITLE
fix: fix potential spurious wakeup during sleep_(), which could lead …

### DIFF
--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -481,7 +481,7 @@ std::chrono::milliseconds PbftManager::elapsedTimeInMs(const time_point &start_t
 
 void PbftManager::sleep_() {
   // Run "wait_for" sleep in loop due to potential spurious wakeup on lock
-  while (true) {
+  while (!stopped_) {
     const auto round_elapsed_time = elapsedTimeInMs(current_round_start_datetime_);
     if (next_step_time_ms_ <= round_elapsed_time) {
       return;

--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -126,7 +126,7 @@ void TaraxaCapability::initPeriodicEvents(const std::shared_ptr<PbftManager> &pb
   //       1. Most of time is this single threaded thread pool doing nothing...
   //       2. These periodic events are sending packets - that might be processed by main thread_pool ???
   // Creates periodic events
-  const auto lambda_ms_min = pbft_mgr ? pbft_mgr->getPbftInitialLambda() : 2000;
+  uint64_t lambda_ms_min = pbft_mgr ? pbft_mgr->getPbftInitialLambda().count() : 2000;
 
   // Send new txs periodic event
   auto tx_packet_handler = packets_handlers_->getSpecificHandler<TransactionPacketHandler>();

--- a/tests/pbft_manager_test.cpp
+++ b/tests/pbft_manager_test.cpp
@@ -396,7 +396,7 @@ TEST_F(PbftManagerTest, full_node_lambda_input_test) {
   node->start();
 
   auto pbft_mgr = node->getPbftManager();
-  EXPECT_EQ(pbft_mgr->getPbftInitialLambda(), 2000);
+  EXPECT_EQ(pbft_mgr->getPbftInitialLambda().count(), 2000);
 }
 
 TEST_F(PbftManagerTest, check_get_eligible_vote_count) {


### PR DESCRIPTION
## Purpose
<!-- Provide any information reviewers might need to have context on your changes. -->

This PR mainly fixes a potential bug:

In sleep mechanism
`stop_cv_.wait_for(lock, std::chrono::milliseconds(time_to_sleep_for_ms));`
could spuriously wake up and in such case, wait_for exits, which would case this waiting mechanism to fail and we would start next step sooner than we are supposed to - not good.

Solution is to put this waiting mechanism into loop


As a byproduct this PR also cleans up the code around these timeouts:

- multiple unnecessary class members were removed
- u_long was replace by std::chrono::milliseconds

## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
