### PR TITLE
fix: transaction sort

### DIFF
--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -121,16 +121,6 @@ void PbftManager::run() {
       validateVote(v);
     }
 
-    // Sort transactions
-    std::stable_sort(period_data.transactions.begin(), period_data.transactions.end(),
-                     [](const auto &t1, const auto &t2) {
-                       if (t1->getSender() == t2->getSender()) {
-                         return t1->getNonce() < t2->getNonce() ||
-                                (t1->getNonce() == t2->getNonce() && t1->getGasPrice() > t2->getGasPrice());
-                       }
-                       return true;
-                     });
-
     finalize_(std::move(period_data), db_->getFinalizedDagBlockHashesByPeriod(period), period == curr_period);
   }
   // Verify that last block cert votes point to the last block hash
@@ -1614,6 +1604,16 @@ void PbftManager::pushSyncedPbftBlocksIntoChain() {
 void PbftManager::finalize_(PeriodData &&period_data, std::vector<h256> &&finalized_dag_blk_hashes,
                             bool synchronous_processing) {
   const auto anchor = period_data.pbft_blk->getPivotDagBlockHash();
+
+  // Sort transactions
+  std::stable_sort(period_data.transactions.begin(), period_data.transactions.end(),
+                   [](const auto &t1, const auto &t2) {
+                     if (t1->getSender() == t2->getSender()) {
+                       return t1->getNonce() < t2->getNonce() ||
+                              (t1->getNonce() == t2->getNonce() && t1->getGasPrice() > t2->getGasPrice());
+                     }
+                     return true;
+                   });
 
   auto result = final_chain_->finalize(
       std::move(period_data), std::move(finalized_dag_blk_hashes),


### PR DESCRIPTION
Transactions sort is supposed to happen before finalizing a block. This sort is expensive operation and it should only be done when finalizing the block not to slow down the consensus.