### PR TITLE
chore: implement nonce - gas price sorting

### DIFF
--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -240,6 +240,13 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   static blk_hash_t calculateOrderHash(const std::vector<DagBlock> &dag_blocks);
 
   /**
+   * @brief Reorder transactions data if DAG reordering caused transactions with same sender to have nonce in incorrect
+   * order. Reordering is deterministic so that same order is produced on any node on any platform
+   * @param transactions transactions to reorder
+   */
+  static void reorderTransactions(SharedTransactions &transactions);
+
+  /**
    * @brief Check a block weight of gas estimation
    * @param dag_blocks dag blocks
    * @return true if total weight of gas estimation is less or equal to gas limit. Otherwise return false

--- a/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
+++ b/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
@@ -271,7 +271,7 @@ std::pair<SharedTransactions, std::vector<uint64_t>> TransactionManager::packTrx
   const uint64_t max_transactions_in_block = weight_limit / kMinTxGas;
   {
     std::shared_lock transactions_lock(transactions_mutex_);
-    trxs = transactions_pool_.get(max_transactions_in_block);
+    trxs = transactions_pool_.getOrderedTransactions(max_transactions_in_block);
   }
   for (uint64_t i = 0; i < trxs.size(); i++) {
     uint64_t weight;
@@ -288,7 +288,7 @@ std::pair<SharedTransactions, std::vector<uint64_t>> TransactionManager::packTrx
 
 SharedTransactions TransactionManager::getAllPoolTrxs() {
   std::shared_lock transactions_lock(transactions_mutex_);
-  return transactions_pool_.get();
+  return transactions_pool_.getAllTransactions();
 }
 
 /**

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -1647,14 +1647,15 @@ TEST_F(FullNodeTest, transaction_pool_overflow) {
   // Crate transaction with lower gasprice
   auto trx = std::make_shared<Transaction>(nonce++, 0, gasprice - 1, gas, dev::fromHex("00FEDCBA9876543210000000"),
                                            node0->getSecretKey(), addr_t::random());
-  // Should fail as trx pool should be full
-  EXPECT_FALSE(node0->getTransactionManager()->insertTransaction(trx).first);
 
   // Check if they synced
   EXPECT_HAPPENS({10s, 200ms}, [&](auto &ctx) {
     // Check if transactions was propagated to node0
     WAIT_EXPECT_EQ(ctx, nodes[1]->getTransactionManager()->isTransactionPoolFull(), true)
   });
+
+  // Should fail as trx pool should be full
+  EXPECT_FALSE(node0->getTransactionManager()->insertTransaction(trx).first);
 
   // Add one valid block
   const auto proposal_level = 1;

--- a/tests/transaction_test.cpp
+++ b/tests/transaction_test.cpp
@@ -10,6 +10,7 @@
 #include "config/chain_config.hpp"
 #include "final_chain/trie_common.hpp"
 #include "logger/logger.hpp"
+#include "pbft/pbft_manager.hpp"
 #include "transaction/transaction_manager.hpp"
 #include "transaction/transaction_queue.hpp"
 #include "util_test/samples.hpp"
@@ -320,7 +321,7 @@ TEST_F(TransactionTest, priority_queue) {
     const auto trx_hash = trx->getHash();
     priority_queue.insert(std::move(trx2), TransactionStatus::Verified, 1);
     priority_queue.insert(std::move(trx), TransactionStatus::Verified, 1);
-    EXPECT_EQ(priority_queue.get(1)[0]->getHash(), trx_hash);
+    EXPECT_EQ(priority_queue.getOrderedTransactions(1)[0]->getHash(), trx_hash);
     EXPECT_EQ(priority_queue.size(), 2);
   }
 
@@ -347,8 +348,8 @@ TEST_F(TransactionTest, priority_queue) {
     auto trx_hash = trx->getHash();
     priority_queue.insert(std::move(trx2), TransactionStatus::Verified, 1);
     priority_queue.insert(std::move(trx), TransactionStatus::Verified, 1);
-    EXPECT_EQ(priority_queue.get(1)[0]->getHash(), trx_hash);
-    EXPECT_EQ(priority_queue.size(), 2);
+    EXPECT_EQ(priority_queue.getOrderedTransactions(1)[0]->getHash(), trx_hash);
+    EXPECT_EQ(priority_queue.size(), 1);
   }
 
   /*
@@ -375,68 +376,247 @@ TEST_F(TransactionTest, priority_queue) {
     priority_queue.insert(std::move(trxa2), TransactionStatus::Verified, 1);
     priority_queue.insert(std::move(trxa1), TransactionStatus::Verified, 1);
     EXPECT_EQ(priority_queue.size(), 3);
-    EXPECT_EQ(priority_queue.get(3)[0]->getHash(), trxa1_hash);
-    EXPECT_EQ(priority_queue.get(3)[1]->getHash(), trxa2_hash);
-    EXPECT_EQ(priority_queue.get(3)[2]->getHash(), trxb1_hash);
+    EXPECT_EQ(priority_queue.getOrderedTransactions(3)[0]->getHash(), trxa1_hash);
+    EXPECT_EQ(priority_queue.getOrderedTransactions(3)[1]->getHash(), trxa2_hash);
+    EXPECT_EQ(priority_queue.getOrderedTransactions(3)[2]->getHash(), trxb1_hash);
   }
 }
 
 TEST_F(TransactionTest, priority_queue_max_size) {
   // Check if insertion working as expected
   {
-    TransactionQueue priority_queue(2);
+    const uint32_t max_queue_size = 100;
+    TransactionQueue priority_queue(max_queue_size);
     uint32_t nonce = 0;
-    auto trx = std::make_shared<Transaction>(nonce++, 1, 2, 100, dev::fromHex("00FEDCBA9876543210000000"), g_secret,
-                                             addr_t::random());
-    auto trx2 = std::make_shared<Transaction>(nonce++, 1, 2, 100, dev::fromHex("00FEDCBA9876543210000000"), g_secret,
-                                              addr_t::random());
-    auto trx3 = std::make_shared<Transaction>(nonce++, 1, 1, 100, dev::fromHex("00FEDCBA9876543210000000"), g_secret,
-                                              addr_t::random());
-    const auto trx_hash = trx3->getHash();
-    EXPECT_TRUE(priority_queue.insert(std::move(trx), TransactionStatus::Verified, 1));
-    EXPECT_TRUE(priority_queue.insert(std::move(trx2), TransactionStatus::Verified, 1));
-    EXPECT_FALSE(priority_queue.insert(std::move(trx3), TransactionStatus::Verified, 1));
-    EXPECT_EQ(priority_queue.get(trx_hash), nullptr);
-    EXPECT_EQ(priority_queue.size(), 2);
+    for (uint32_t i = 0; i < max_queue_size + 1; i++) {
+      auto trx = std::make_shared<Transaction>(nonce++, 1, 2, 100, dev::fromHex("00FEDCBA9876543210000000"), g_secret,
+                                               addr_t::random());
+      if (i < max_queue_size) {
+        EXPECT_TRUE(priority_queue.insert(std::move(trx), TransactionStatus::Verified, 1));
+      } else {
+        auto trx_hash = trx->getHash();
+        EXPECT_FALSE(priority_queue.insert(std::move(trx), TransactionStatus::Verified, 1));
+        EXPECT_EQ(priority_queue.get(trx_hash), nullptr);
+      }
+    }
+    EXPECT_EQ(priority_queue.size(), max_queue_size);
   }
-  // Check if insertion working as expected when trx2 should be removed
+  // Check if insertion working as expected when trx should be replaced
   {
-    TransactionQueue priority_queue(2);
+    const uint32_t max_queue_size = 100;
+    TransactionQueue priority_queue(max_queue_size);
     uint32_t nonce = 0;
-    auto trx = std::make_shared<Transaction>(nonce++, 1, 2, 100, dev::fromHex("00FEDCBA9876543210000000"), g_secret,
-                                             addr_t::random());
-    auto trx2 = std::make_shared<Transaction>(nonce, 1, 1, 100, dev::fromHex("00FEDCBA9876543210000000"), g_secret,
-                                              addr_t::random());
-    auto trx3 = std::make_shared<Transaction>(nonce, 1, 2, 100, dev::fromHex("00FEDCBA9876543210000000"), g_secret,
-                                              addr_t::random());
-    const auto trx_hash3 = trx3->getHash();
-    const auto trx_hash2 = trx2->getHash();
-    EXPECT_TRUE(priority_queue.insert(std::move(trx), TransactionStatus::Verified, 1));
-    EXPECT_TRUE(priority_queue.insert(std::move(trx2), TransactionStatus::Verified, 1));
-    EXPECT_TRUE(priority_queue.insert(std::move(trx3), TransactionStatus::Verified, 1));
-    EXPECT_EQ(priority_queue.get(trx_hash3)->getHash(), trx_hash3);
-    EXPECT_EQ(priority_queue.get(trx_hash2), nullptr);
-    EXPECT_FALSE(priority_queue.isTransactionKnown(trx_hash2));
-    EXPECT_EQ(priority_queue.size(), 2);
+    trx_hash_t hash_to_remove;
+    for (uint32_t i = 0; i < max_queue_size + 1; i++) {
+      if (i == 3) {
+        auto trx = std::make_shared<Transaction>(nonce, 1, 1, 100, dev::fromHex("00FEDCBA9876543210000000"), g_secret,
+                                                 addr_t::random());
+        hash_to_remove = trx->getHash();
+        EXPECT_TRUE(priority_queue.insert(std::move(trx), TransactionStatus::Verified, 1));
+      } else {
+        auto trx = std::make_shared<Transaction>(nonce++, 1, 2, 100, dev::fromHex("00FEDCBA9876543210000000"), g_secret,
+                                                 addr_t::random());
+        EXPECT_TRUE(priority_queue.insert(std::move(trx), TransactionStatus::Verified, 1));
+      }
+    }
+
+    // Transaction is still part of non proposable transactions
+    EXPECT_EQ(priority_queue.get(hash_to_remove)->getHash(), hash_to_remove);
+    EXPECT_TRUE(priority_queue.isTransactionKnown(hash_to_remove));
+    EXPECT_EQ(priority_queue.size(), max_queue_size);
+
+    // Confirm that transaction is not proposable
+    auto trxs = priority_queue.getOrderedTransactions(max_queue_size * 2);
+    EXPECT_EQ(trxs.size(), max_queue_size);
+    for (const auto& t : trxs) {
+      EXPECT_TRUE(t->getHash() != hash_to_remove);
+    }
   }
   // Check if Forced insertion working as expected
   {
-    TransactionQueue priority_queue(2);
+    const uint32_t max_queue_size = 100;
+    TransactionQueue priority_queue(max_queue_size);
     uint32_t nonce = 0;
-    auto trx = std::make_shared<Transaction>(nonce++, 1, 2, 100, dev::fromHex("00FEDCBA9876543210000000"), g_secret,
-                                             addr_t::random());
-    auto trx2 = std::make_shared<Transaction>(nonce, 1, 1, 100, dev::fromHex("00FEDCBA9876543210000000"), g_secret,
-                                              addr_t::random());
-    auto trx3 = std::make_shared<Transaction>(nonce, 1, 1, 100, dev::fromHex("00FEDCBA9876543210000000"), g_secret,
-                                              addr_t::random());
-    const auto trx_hash3 = trx3->getHash();
-    const auto trx_hash2 = trx2->getHash();
-    EXPECT_TRUE(priority_queue.insert(std::move(trx), TransactionStatus::Verified, 1));
-    EXPECT_TRUE(priority_queue.insert(std::move(trx2), TransactionStatus::Verified, 1));
-    EXPECT_TRUE(priority_queue.insert(std::move(trx3), TransactionStatus::Forced, 1));
-    EXPECT_EQ(priority_queue.get(trx_hash3)->getHash(), trx_hash3);
-    EXPECT_EQ(priority_queue.get(trx_hash2)->getHash(), trx_hash2);
-    EXPECT_EQ(priority_queue.size(), 2);
+    trx_hash_t hash_to_remove;
+    for (uint32_t i = 0; i < max_queue_size + 1; i++) {
+      if (i == 3) {
+        auto trx = std::make_shared<Transaction>(nonce, 1, 1, 100, dev::fromHex("00FEDCBA9876543210000000"), g_secret,
+                                                 addr_t::random());
+        hash_to_remove = trx->getHash();
+        EXPECT_TRUE(priority_queue.insert(std::move(trx), TransactionStatus::Forced, 1));
+      } else {
+        auto trx = std::make_shared<Transaction>(nonce++, 1, 2, 100, dev::fromHex("00FEDCBA9876543210000000"), g_secret,
+                                                 addr_t::random());
+        EXPECT_TRUE(priority_queue.insert(std::move(trx), TransactionStatus::Verified, 1));
+      }
+    }
+
+    EXPECT_TRUE(priority_queue.get(hash_to_remove) != nullptr);
+    EXPECT_TRUE(priority_queue.isTransactionKnown(hash_to_remove));
+    EXPECT_EQ(priority_queue.size(), max_queue_size);
+  }
+}
+
+SharedTransactions generateRandomOrderTransactions(uint32_t size) {
+  SharedTransactions trxs;
+  std::vector<dev::KeyPair> kpv;
+  std::random_device dev;
+  std::mt19937 rng(dev());
+  std::uniform_int_distribution<std::mt19937::result_type> dist10(0, 9);
+  for (auto i = 0; i <= 10; ++i) {
+    kpv.push_back(dev::KeyPair::create());
+  }
+  for (uint32_t i = 0; i < size; ++i) {
+    trxs.emplace_back(std::make_shared<Transaction>(dist10(rng), 100, 21000 + dist10(rng), 100000, dev::bytes(),
+                                                    kpv[dist10(rng)].secret(), addr_t::random()));
+  }
+  return trxs;
+}
+
+TEST_F(TransactionTest, priority_queue_ordering) {
+  // Test generates 1000 transactions from 10 random accounts with random nonces between 1 and 10 and random gas proces
+  // and verified that transactions are properly sorted in transaction queue and that all the duplicate transactions
+  // from same account and same nonce are removed with always keeping the transaction with highest gas price
+  const uint32_t number_of_runs = 30;
+  for (uint32_t i = 0; i < number_of_runs; i++) {
+    const uint32_t max_queue_size = 1000;
+    TransactionQueue priority_queue(max_queue_size);
+    auto trxs = generateRandomOrderTransactions(max_queue_size);
+    // Calculate number of unique account nonce transactions
+    std::unordered_map<addr_t, std::map<val_t, val_t>> account_nonces_max_gas_price;
+    for (auto& t : trxs) {
+      auto it = account_nonces_max_gas_price.find(t->getSender());
+      if (it != account_nonces_max_gas_price.end()) {
+        auto it2 = it->second.find(t->getNonce());
+        if (it2 != it->second.end()) {
+          if (it2->second < t->getGasPrice()) {
+            it2->second = t->getGasPrice();
+          }
+        } else {
+          it->second[t->getNonce()] = t->getGasPrice();
+        }
+      } else {
+        account_nonces_max_gas_price[t->getSender()][t->getNonce()] = t->getGasPrice();
+      }
+      EXPECT_TRUE(priority_queue.insert(std::move(t), TransactionStatus::Verified, 1));
+    }
+    uint32_t unique_count = 0;
+    for (auto it : account_nonces_max_gas_price) {
+      for (auto it2 : it.second) {
+        unique_count++;
+      }
+    }
+
+    // Verify that only unique transactions are actually ordered in queue
+    EXPECT_EQ(priority_queue.size(), unique_count);
+    auto ordered_trxs = priority_queue.getOrderedTransactions(max_queue_size);
+    // Verify only unique nonce transactions are ordered
+    EXPECT_EQ(ordered_trxs.size(), unique_count);
+
+    // Verify nonce order
+    std::unordered_map<addr_t, val_t> account_nonces;
+    for (auto t : ordered_trxs) {
+      if (account_nonces.contains(t->getSender())) {
+        EXPECT_GT(t->getNonce(), account_nonces[t->getSender()]);
+      }
+      account_nonces[t->getSender()] = t->getNonce();
+    }
+    // Verify gasprice order up to the point where account appears for the second time
+    std::unordered_set<addr_t> accounts;
+    for (uint32_t i = 1; i < ordered_trxs.size(); i++) {
+      accounts.insert(ordered_trxs[i - 1]->getSender());
+      if (!accounts.contains(ordered_trxs[i]->getSender())) {
+        EXPECT_LE(ordered_trxs[i]->getGasPrice(), ordered_trxs[i - 1]->getGasPrice());
+      }
+    }
+  }
+}
+
+TEST_F(TransactionTest, finalization_ordering) {
+  // Test generates 1000 transactions from 10 random accounts with random nonces between 1 and 10 and random gas proces
+  // and verified that transactions are properly sorted in transaction queue and that all the duplicate transactions
+  // from same account and same nonce are removed with always keeping the transaction with highest gas price
+  const uint32_t number_of_runs = 30;
+  for (uint32_t i = 0; i < number_of_runs; i++) {
+    const uint32_t max_queue_size = 1000;
+    TransactionQueue priority_queue(max_queue_size);
+    auto trxs = generateRandomOrderTransactions(max_queue_size);
+
+    EXPECT_EQ(trxs.size(), max_queue_size);
+    PbftManager::reorderTransactions(trxs);
+    EXPECT_EQ(trxs.size(), max_queue_size);
+
+    std::unordered_map<addr_t, val_t> account_nonces;
+    for (auto& t : trxs) {
+      auto it = account_nonces.find(t->getSender());
+      if (it != account_nonces.end()) {
+        EXPECT_GE(t->getNonce(), it->second);
+        it->second = t->getNonce();
+      } else {
+        account_nonces[t->getSender()] = t->getNonce();
+      }
+    }
+  }
+}
+
+TEST_F(TransactionTest, priority_queue_ordering_eth_test) {
+  SharedTransactions trxs;
+  std::vector<dev::KeyPair> kpv;
+  std::random_device dev;
+  std::mt19937 rng(dev());
+  std::uniform_int_distribution<std::mt19937::result_type> dist10(0, 9);
+  for (auto i = 0; i <= 25; ++i) {
+    kpv.push_back(dev::KeyPair::create());
+  }
+
+  for (auto start = 0; start < 25; start++) {
+    for (auto i = 0; i <= 25; ++i) {
+      trxs.emplace_back(std::make_shared<Transaction>((val_t)(start + i), 100, 21000 + start + i, 100000, dev::bytes(),
+                                                      kpv[start].secret(), addr_t::random()));
+    }
+  }
+
+  TransactionQueue priority_queue(1000);
+  for (auto& t : trxs) {
+    EXPECT_TRUE(priority_queue.insert(std::move(t), TransactionStatus::Verified, 1));
+  }
+
+  trxs = priority_queue.getOrderedTransactions(1000);
+  for (auto i = 0; i < (int32_t)trxs.size(); ++i) {
+    // Make sure the nonce order is valid
+    for (auto j = i + 1; j < (int32_t)trxs.size(); ++j) {
+      if (trxs[i]->getSender() == trxs[j]->getSender()) {
+        EXPECT_LT(trxs[i]->getNonce(), trxs[j]->getNonce());
+      }
+    }
+
+    // Find the previous and next nonce of this account
+    auto prev = i - 1;
+    auto next = i + 1;
+
+    for (auto j = i - 1; j >= 0; j--) {
+      if (trxs[i]->getSender() == trxs[j]->getSender()) {
+        prev = j;
+        break;
+      }
+    }
+
+    for (auto j = i + 1; j < (int32_t)trxs.size(); j++) {
+      if (trxs[i]->getSender() == trxs[j]->getSender()) {
+        next = j;
+        break;
+      }
+    }
+
+    // Make sure that in between the neighbor nonces, the transaction is correctly positioned price wise
+    for (auto j = prev + 1; j < next; j++) {
+      if (j < i) {
+        EXPECT_GE(trxs[j]->getGasPrice(), trxs[i]->getGasPrice());
+      }
+      if (j > i) {
+        EXPECT_GE(trxs[i]->getGasPrice(), trxs[j]->getGasPrice());
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Since sorting transactions for block proposal is an expensive operation, it is now only done when we propose a dag block and not on ever transaction insertion/removal. Algorithm for sorting is:
1. Order by gas price all the unique sender transactions with minimal nonce per account
2. Remove already ordered transactions from the set and move back to step 1 if there are still transactions remaining

On execution preserve the order of all the transactions that have correct nonce order. Any transactions with nonce order is reversed are moved to the back of the order and sorted by nonce.