### PR TITLE
fix: pbft syncing

### DIFF
--- a/libraries/core_libs/network/src/tarcap/packets_handlers/dag_block_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/dag_block_packet_handler.cpp
@@ -110,7 +110,7 @@ void DagBlockPacketHandler::onNewBlockReceived(DagBlock &&block, const std::shar
         throw MaliciousPeerException(err_msg.str());
       }
       case DagManager::VerifyBlockReturnType::MissingTransaction:
-        if (trx_mgr_->isTransactionPoolFull(90)) [[unlikely]] {
+        if (trx_mgr_->isTransactionPoolFull(50)) [[unlikely]] {
           LOG(log_wr_) << "NewBlock " << block_hash.toString() << " from peer " << peer->getId()
                        << " is missing transaction, but our pool is full so we are requesting it again";
           peer->peer_dag_synced_ = false;

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/get_dag_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/get_dag_sync_packet_handler.cpp
@@ -25,7 +25,7 @@ void GetDagSyncPacketHandler::process(const PacketData &packet_data,
                                       [[maybe_unused]] const std::shared_ptr<TaraxaPeer> &peer) {
   if (peer->peer_requested_dag_syncing_) {
     // If transaction pool is full we need to send missing transactions back to peer
-    if (!trx_mgr_->isTransactionPoolFull(90)) {
+    if (!trx_mgr_->isTransactionPoolFull(50)) {
       // This should not be possible for honest node
       // Each node should perform dag syncing only once
       std::ostringstream err_msg;


### PR DESCRIPTION
It is a valid possibility that block we receive in syncing could have already been pushed to the chain by consensus or by syncing that was interrupted so there is no need to restart syncing.
Calling restartSyncingPbft(true) unnecessarily restarts syncing and asks for the same data again. Since pbft sync packets come in series of ""network_sync_level_size": 25" same packets will be received multiple times which will lead to an infinite loop of calling restartSyncingPbft. This happened on devnet causing queue to be overfilled with these packets:
Low priority queue size: 137557

If synced block already in queue node now simply proceeds with syncing as if the block has been pushed to queue
 