### PR TITLE
fix: do not soft vote missing block

### DIFF
--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -534,14 +534,15 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   const std::optional<TwoTPlusOneSoftVotedBlockData> &getTwoTPlusOneSoftVotedBlockData(uint64_t period, uint64_t round);
 
   /**
-   * @brief Get valid proposed pbft block. It will retrieved block from proposed_blocks and then validate it
+   * @brief Get valid proposed pbft block. It will retrieve block from proposed_blocks and then validate it if not
+   *        already validated
    *
    * @param period
    * @param round
    * @param block_hash
    * @return valid proposed pbft block or nullptr
    */
-  std::shared_ptr<PbftBlock> getValidPbftProposedBlock(uint64_t period, uint64_t round, const blk_hash_t& block_hash) const;
+  std::shared_ptr<PbftBlock> getValidPbftProposedBlock(uint64_t period, uint64_t round, const blk_hash_t &block_hash);
 
   /**
    * @brief Process synced PBFT blocks if PBFT syncing queue is not empty
@@ -641,8 +642,8 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   std::chrono::milliseconds next_step_time_ms_{0};
 
   bool executed_pbft_block_ = false;
-  bool next_voted_soft_value_ = false;
-  bool next_voted_null_block_hash_ = false;
+  bool already_next_voted_value_ = false;
+  bool already_next_voted_null_block_hash_ = false;
   bool go_finish_state_ = false;
   bool loop_back_finish_state_ = false;
 

--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -485,12 +485,15 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   h256 getProposal(const std::shared_ptr<Vote> &vote) const;
 
   /**
-   * @brief Check that there are all DAG blocks with correct ordering, total gas estimation is not greater than gas
-   * limit, and PBFT block includes all reward votes.
+   * @brief Validates pbft block. It checks if:
+   *        - pbft_block's previous pbft block hash == node's latest finalized pbft block
+   *        - node has all DAG blocks with correct ordering,
+   *        - node has all reward votes
+   *        - total gas estimation is not greater than gas limit
    * @param pbft_block PBFT block
-   * @return true if pass verification
+   * @return true if pbft block is valid, otherwise false
    */
-  bool compareBlocksAndRewardVotes_(const std::shared_ptr<PbftBlock> &pbft_block);
+  bool validatePbftBlock(const std::shared_ptr<PbftBlock> &pbft_block) const;
 
   /**
    * @brief If there are enough certify votes, push the vote PBFT block in PBFT chain
@@ -570,7 +573,7 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
 
   // Multiple proposed pbft blocks could have same dag block anchor at same period so this cache improves retrieval of
   // dag block order for specific anchor
-  std::unordered_map<blk_hash_t, std::vector<DagBlock>> anchor_dag_block_order_cache_;
+  mutable std::unordered_map<blk_hash_t, std::vector<DagBlock>> anchor_dag_block_order_cache_;
 
   // Ensures that only one PBFT block per period can be proposed
   std::shared_ptr<PbftBlock> proposed_block_ = nullptr;

--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -534,6 +534,16 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   const std::optional<TwoTPlusOneSoftVotedBlockData> &getTwoTPlusOneSoftVotedBlockData(uint64_t period, uint64_t round);
 
   /**
+   * @brief Get valid proposed pbft block. It will retrieved block from proposed_blocks and then validate it
+   *
+   * @param period
+   * @param round
+   * @param block_hash
+   * @return valid proposed pbft block or nullptr
+   */
+  std::shared_ptr<PbftBlock> getValidPbftProposedBlock(uint64_t period, uint64_t round, const blk_hash_t& block_hash) const;
+
+  /**
    * @brief Process synced PBFT blocks if PBFT syncing queue is not empty
    * @return period data with cert votes for the current period
    */

--- a/libraries/core_libs/consensus/include/pbft/proposed_blocks.hpp
+++ b/libraries/core_libs/consensus/include/pbft/proposed_blocks.hpp
@@ -38,13 +38,22 @@ class ProposedBlocks {
   bool pushProposedPbftBlock(uint64_t round, const std::shared_ptr<PbftBlock>& proposed_block, bool save_to_db = true);
 
   /**
-   * @brief Get a proposed PBFT block and vote based on specified period, round and block hash
+   * @brief Mark block as valid - no need to validate it again
+   *
+   * @param round
+   * @param proposed_block
+   */
+  void markBlockAsValid(uint64_t round, const std::shared_ptr<PbftBlock>& proposed_block);
+
+  /**
+   * @brief Get a proposed PBFT block based on specified period, round and block hash
    * @param period
    * @param round
    * @param block_hash
-   * @return proposed PBFT block
+   * @return optional<pair<block, is_valid flag>>
    */
-  std::shared_ptr<PbftBlock> getPbftProposedBlock(uint64_t period, uint64_t round, const blk_hash_t& block_hash) const;
+  std::optional<std::pair<std::shared_ptr<PbftBlock>, bool>> getPbftProposedBlock(uint64_t period, uint64_t round,
+                                                                                  const blk_hash_t& block_hash) const;
 
   /**
    * @brief Check if specified block is already in proposed blocks
@@ -70,8 +79,9 @@ class ProposedBlocks {
   void cleanupProposedPbftBlocksByRound(uint64_t period, uint64_t round);
 
  private:
-  // <PBFT period, <PBFT round, <block hash, block>>>
-  std::map<uint64_t, std::map<uint64_t, std::unordered_map<blk_hash_t, std::shared_ptr<PbftBlock>>>> proposed_blocks_;
+  // <PBFT period, <PBFT round, <block hash, [block, is_valid_flag]>>>
+  std::map<uint64_t, std::map<uint64_t, std::unordered_map<blk_hash_t, std::pair<std::shared_ptr<PbftBlock>, bool>>>>
+      proposed_blocks_;
   mutable std::shared_mutex proposed_blocks_mutex_;
   std::shared_ptr<DbStorage> db_;
 };

--- a/libraries/core_libs/consensus/include/pbft/soft_voted_block_data.hpp
+++ b/libraries/core_libs/consensus/include/pbft/soft_voted_block_data.hpp
@@ -29,8 +29,8 @@ class TwoTPlusOneSoftVotedBlockData {
   uint64_t round_;
   blk_hash_t block_hash_;
   std::vector<std::shared_ptr<Vote>> soft_votes_;
-  // can be nullptr as node might not have the actual block even though it saw 2t+1 soft votes
-  std::shared_ptr<PbftBlock> block_;
+  // node might not have the actual block even though it saw 2t+1 soft votes
+  std::optional<std::pair<std::shared_ptr<PbftBlock>, bool /* is valid flag */>> block_data_;
 
   static constexpr size_t kStandardDataItemCount{3};
   static constexpr size_t kExtendedDataItemCount{4};  // with block

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -800,6 +800,24 @@ const std::optional<TwoTPlusOneSoftVotedBlockData> &PbftManager::getTwoTPlusOneS
   return soft_voted_block_for_round_;
 }
 
+std::shared_ptr<PbftBlock> PbftManager::getValidPbftProposedBlock(uint64_t period, uint64_t round,
+                                                                  const blk_hash_t& block_hash) const {
+  auto block = proposed_blocks_.getPbftProposedBlock(period, round, block_hash);
+  if (!block) {
+    LOG(log_er_) << "Unable to find proposed block " << block_hash << ", period " << period << ", round " << round;
+    return nullptr;
+  }
+
+  if (!validatePbftBlock(block)) {
+    LOG(log_er_) << "Proposed block " << block_hash << " failed validation, period " << period << ", round " << round;
+    return nullptr;
+  }
+
+  // TODO: save validation flag in proposed_blocks_
+
+  return block;
+}
+
 void PbftManager::checkPreviousRoundNextVotedValueChange_() {
   previous_round_next_voted_value_ = next_votes_manager_->getVotedValue();
   previous_round_next_voted_null_block_hash_ = next_votes_manager_->haveEnoughVotesForNullBlockHash();

--- a/tests/pbft_manager_test.cpp
+++ b/tests/pbft_manager_test.cpp
@@ -654,13 +654,13 @@ TEST_F(PbftManagerTest, propose_block_and_vote_broadcast) {
   auto block1_from_node1 = pbft_mgr1->getProposedBlocksSt().getPbftProposedBlock(
       propose_vote->getPeriod(), propose_vote->getRound(), propose_vote->getBlockHash());
   ASSERT_TRUE(block1_from_node1);
-  EXPECT_EQ(block1_from_node1->getJsonStr(), proposed_pbft_block->getJsonStr());
+  EXPECT_EQ(block1_from_node1->first->getJsonStr(), proposed_pbft_block->getJsonStr());
 
   nw1->getSpecificHandler<network::tarcap::VotePacketHandler>()->onNewPbftVote(propose_vote, proposed_pbft_block);
 
   // Check node2 and node3 receive the PBFT block
-  std::shared_ptr<PbftBlock> node2_synced_proposed_block_and_vote = nullptr;
-  std::shared_ptr<PbftBlock> node3_synced_proposed_block_and_vote = nullptr;
+  std::optional<std::pair<std::shared_ptr<PbftBlock>, bool>> node2_synced_proposed_block_and_vote = std::nullopt;
+  std::optional<std::pair<std::shared_ptr<PbftBlock>, bool>> node3_synced_proposed_block_and_vote = std::nullopt;
 
   EXPECT_HAPPENS({20s, 200ms}, [&](auto &ctx) {
     node2_synced_proposed_block_and_vote = pbft_mgr2->getProposedBlocksSt().getPbftProposedBlock(
@@ -671,8 +671,8 @@ TEST_F(PbftManagerTest, propose_block_and_vote_broadcast) {
     WAIT_EXPECT_TRUE(ctx, node2_synced_proposed_block_and_vote)
     WAIT_EXPECT_TRUE(ctx, node3_synced_proposed_block_and_vote)
   });
-  EXPECT_EQ(node2_synced_proposed_block_and_vote->getJsonStr(), proposed_pbft_block->getJsonStr());
-  EXPECT_EQ(node3_synced_proposed_block_and_vote->getJsonStr(), proposed_pbft_block->getJsonStr());
+  EXPECT_EQ(node2_synced_proposed_block_and_vote->first->getJsonStr(), proposed_pbft_block->getJsonStr());
+  EXPECT_EQ(node3_synced_proposed_block_and_vote->first->getJsonStr(), proposed_pbft_block->getJsonStr());
 }
 
 TEST_F(PbftManagerTest, check_committeeSize_less_or_equal_to_activePlayers) {


### PR DESCRIPTION
## Purpose
<!-- Provide any information reviewers might need to have context on your changes. -->

If (for any reason/bug) we lose block, there is an infinite loop in our pbft when:
1. nodes soft vote missing previous round next voted block
2. nodes next vote 2t+1 soft-voted block (from previous step)
3. in new round propose step is skipped as nodes are supposed to re-propose previous round next voted block but they cant as they dont have it
4. repeat the loop from step 1.

This is a state, from which we cant recover + we are saving proposed block in memory as well as db per period & round. So even if the block is actually saved on some node(e.g. period 1, round 2), we already moved forward multiple rounds so we are not able to get it due to that infinite loop I mentioned above - we might be trying to get some block hash for current period 1, round 10 but the block is saved for period 1, round 2

## How does the solution address the problem
<!-- Describe your solution. -->

Vote only for block that node has and it is valid

Reason:
- Voting for missing blocks means we have no idea if the block is valid, etc... If we do not allow this for newly proposed blocks it does not make sense to allow it for previous round next voted blocks

This PR does not change current pbft behaviour - it would not start proposing new blocks, but rather get stalled on soft/next voting steps with error message - "Unable to soft/next vte for missing XYZ block", which would be printed repeatedly. It should be easier to spot and later debug without increasing round


## Changes made
<!-- Summary or changes that have been made. -->
