### PR TITLE
chore: save proposed pbft blocks to db

### DIFF
--- a/libraries/core_libs/consensus/include/pbft/proposed_blocks.hpp
+++ b/libraries/core_libs/consensus/include/pbft/proposed_blocks.hpp
@@ -5,6 +5,7 @@
 #include <shared_mutex>
 
 #include "common/types.hpp"
+#include "storage/storage.hpp"
 
 namespace taraxa {
 
@@ -16,6 +17,8 @@ class Vote;
  */
 class ProposedBlocks {
  public:
+  ProposedBlocks(std::shared_ptr<DbStorage> db) : db_(db) {}
+
   /**
    * @brief Push proposed PBFT block into the proposed blocks
    * @param proposed_block proposed PBFT block
@@ -29,9 +32,10 @@ class ProposedBlocks {
    * @brief Push proposed PBFT block into the proposed blocks
    * @param round
    * @param proposed_block
+   * @param save_to_db if true save to db
    * @return true if block was successfully pushed, otherwise false
    */
-  bool pushProposedPbftBlock(uint64_t round, const std::shared_ptr<PbftBlock>& proposed_block);
+  bool pushProposedPbftBlock(uint64_t round, const std::shared_ptr<PbftBlock>& proposed_block, bool save_to_db = true);
 
   /**
    * @brief Get a proposed PBFT block and vote based on specified period, round and block hash
@@ -69,6 +73,7 @@ class ProposedBlocks {
   // <PBFT period, <PBFT round, <block hash, block>>>
   std::map<uint64_t, std::map<uint64_t, std::unordered_map<blk_hash_t, std::shared_ptr<PbftBlock>>>> proposed_blocks_;
   mutable std::shared_mutex proposed_blocks_mutex_;
+  std::shared_ptr<DbStorage> db_;
 };
 
 }  // namespace taraxa

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -53,6 +53,7 @@ PbftManager::PbftManager(const PbftConfig &conf, const blk_hash_t &dag_genesis_b
       GHOST_PATH_MOVE_BACK(conf.ghost_path_move_back),
       dag_genesis_block_hash_(dag_genesis_block_hash),
       config_(conf),
+      proposed_blocks_(db_),
       max_levels_per_period_(max_levels_per_period) {
   LOG_OBJECTS_CREATE("PBFT_MGR");
 }
@@ -524,6 +525,10 @@ void PbftManager::initialState() {
   } else {
     LOG(log_er_) << "Unexpected condition at round " << current_pbft_round << " step " << current_pbft_step;
     assert(false);
+  }
+
+  for (const auto &block : db_->getProposedPbftBlocks()) {
+    proposed_blocks_.pushProposedPbftBlock(block.first, block.second, false);
   }
 
   // This is used to offset endtime for second finishing step...

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -101,6 +101,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
     COLUMN(pbft_mgr_status);
     COLUMN(soft_voted_block_in_round);  // Soft voted block + votes + round -> node saw 2t+1 soft votes for this block
     COLUMN(cert_voted_block_in_round);  // Cert voted block + round -> node voted for this block
+    COLUMN(proposed_pbft_blocks);       // Proposed pbft blocks
     COLUMN(pbft_head);
     COLUMN(verified_votes);
     COLUMN(next_votes);             // only for previous PBFT round
@@ -248,6 +249,11 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   // pbft_blocks
   std::optional<PbftBlock> getPbftBlock(blk_hash_t const& hash);
   bool pbftBlockInDb(blk_hash_t const& hash);
+
+  // Proposed pbft blocks
+  void saveProposedPbftBlock(const std::shared_ptr<PbftBlock>& block, uint64_t round);
+  void removeProposedPbftBlock(const blk_hash_t& block_hash, Batch& write_batch);
+  std::vector<std::pair<uint64_t, std::shared_ptr<PbftBlock>>> getProposedPbftBlocks();
 
   // pbft_blocks (head)
   string getPbftHead(blk_hash_t const& hash);


### PR DESCRIPTION
Saving proposed blocks to db so that on restart all the proposed blocks from the last period/round can be reloaded.
I understand that there could be performance concerns about this change. I have added measuring pushing and erasing 100 blocks to db in the unit test. Results are:
Time to push 100 blocks: 927 microseconds
Time to erase 100 blocks: 132 microseconds

Rocksdb is very fast when dealing with columns that have small size by using its internal memory cache and delayed writes. So I do not believe speed should be an issue.

