### PR TITLE
chore: verify vrf and node keys

### DIFF
--- a/libraries/core_libs/node/src/node.cpp
+++ b/libraries/core_libs/node/src/node.cpp
@@ -111,7 +111,7 @@ void FullNode::init() {
                                             vote_mgr_, next_votes_mgr_, dag_mgr_, trx_mgr_, final_chain_, key_manager_,
                                             kp_.secret(), conf_.vrf_secret, conf_.max_levels_per_period);
   blk_proposer_ = std::make_shared<BlockProposer>(conf_.chain.dag.block_proposer, dag_mgr_, trx_mgr_, final_chain_, db_,
-                                                  node_addr, getSecretKey(), getVrfSecretKey());
+                                                  key_manager_, node_addr, getSecretKey(), getVrfSecretKey());
   network_ = std::make_shared<Network>(conf_, genesis_hash, dev::p2p::Host::CapabilitiesFactory(),
                                        conf_.net_file_path().string(), kp_, db_, pbft_mgr_, pbft_chain_, vote_mgr_,
                                        next_votes_mgr_, dag_mgr_, trx_mgr_);


### PR DESCRIPTION
On proposing dag blocks, verify the vrf secret key that was retrieved from wallet file on startup matches the public vrf key used when registering a validator. Do not propose a block if they are not matching.

Verify public keys and addresses from wallet file to match the secret keys in the wallet file.