### PR TITLE
fix: transaction with same nonce

### DIFF
--- a/libraries/core_libs/consensus/src/transaction/transaction_queue.cpp
+++ b/libraries/core_libs/consensus/src/transaction/transaction_queue.cpp
@@ -122,6 +122,8 @@ bool TransactionQueue::insert(std::shared_ptr<Transaction> &&transaction, const 
             queue_transactions_.erase(nonce_it->second->getHash());
             account_nonce_transactions_[transaction->getSender()][transaction->getNonce()] = transaction;
             queue_transactions_[tx_hash] = transaction;
+          } else {
+            non_proposable_transactions_[tx_hash] = {last_block_number, transaction};
           }
         }
       }


### PR DESCRIPTION
When transaction has the same nonce as a transaction in the transaction queue, it should either replace these transaction or be inserted into non_proposable_transactions_.
Since it was not included in non_proposable_transactions_ but it was incuded in known_txs_ even if it was received later again it was ignored.

It is always possible that a DAG block might come containing this transaction.