### PR TITLE
chore: optimize vote structure by removing type and using uint32 for …

### DIFF
--- a/libraries/common/include/common/types.hpp
+++ b/libraries/common/include/common/types.hpp
@@ -27,21 +27,14 @@ using dev::Secret;
 using dev::u256;
 
 using EthBlockNumber = uint64_t;
+using PbftPeriod = EthBlockNumber;
+using PbftRound = uint32_t;
+using PbftStep = uint32_t;
 
 // time related
-using time_point_t = std::chrono::system_clock::time_point;
-using time_stamp_t = unsigned long;
-
-using uint128_t = boost::multiprecision::uint128_t;
 using uint256_t = boost::multiprecision::uint256_t;
-using uint512_t = boost::multiprecision::uint512_t;
-using uint1024_t = boost::multiprecision::uint1024_t;
 
-// newtork related
-using end_point_udp_t = boost::asio::ip::udp::endpoint;
-using socket_udp_t = boost::asio::ip::udp::socket;
-using resolver_udp_t = boost::asio::ip::udp::resolver;
-
+// network related
 using uint256_hash_t = dev::FixedHash<32>;
 using uint512_hash_t = dev::FixedHash<64>;
 using uint520_hash_t = dev::FixedHash<65>;
@@ -54,26 +47,21 @@ using sig_t = uint520_hash_t;
 using vote_hash_t = uint256_hash_t;
 using blk_hash_t = uint256_hash_t;
 using trx_hash_t = uint256_hash_t;
-using sig_hash_t = uint256_hash_t;
 
 using gas_t = uint64_t;
-using key_t = std::string;
 using level_t = uint64_t;
 using val_t = dev::u256;
 using root_t = dev::h256;
-using dag_blk_num_t = uint64_t;
 
 using vec_blk_t = std::vector<blk_hash_t>;
 using vec_trx_t = std::vector<trx_hash_t>;
-using trx_num_t = vec_trx_t::size_type;
 using byte = uint8_t;
 using bytes = std::vector<byte>;
-using node_id_t = uint512_hash_t;
 using trx_nonce_t = val_t;
 
 // val_t type related helper functions
-inline val_t operator+=(val_t const &val, val_t const &other) { return val + other; }
-inline std::string toString(val_t const &val) {
+inline val_t operator+=(const val_t &val, const val_t &other) { return val + other; }
+inline std::string toString(const val_t &val) {
   std::stringstream strm;
   strm << val;
   return strm.str();

--- a/libraries/config/include/config/config.hpp
+++ b/libraries/config/include/config/config.hpp
@@ -46,9 +46,9 @@ struct NetworkConfig {
   uint16_t network_peer_blacklist_timeout = kBlacklistTimeoutDefaultInSeconds;
   bool disable_peer_blacklist = false;
   uint16_t deep_syncing_threshold = 10;
-  uint16_t vote_accepting_periods = 5;
-  uint16_t vote_accepting_rounds = 5;
-  uint16_t vote_accepting_steps = 0;
+  PbftPeriod vote_accepting_periods = 5;
+  PbftRound vote_accepting_rounds = 5;
+  PbftStep vote_accepting_steps = 0;
 
   void validate() const;
 };
@@ -57,9 +57,9 @@ struct DBConfig {
   uint32_t db_snapshot_each_n_pbft_block = 0;
   uint32_t db_max_snapshots = 0;
   uint32_t db_max_open_files = 0;
-  uint32_t db_revert_to_period = 0;
+  PbftPeriod db_revert_to_period = 0;
   bool rebuild_db = false;
-  uint64_t rebuild_db_period = 0;
+  PbftPeriod rebuild_db_period = 0;
   bool rebuild_db_columns = false;
 };
 

--- a/libraries/core_libs/consensus/include/dag/block_proposer.hpp
+++ b/libraries/core_libs/consensus/include/dag/block_proposer.hpp
@@ -149,7 +149,8 @@ class BlockProposer : public std::enable_shared_from_this<BlockProposer> {
    * @param weight_limit weight limit
    * @return transactions and weight estimations
    */
-  std::pair<SharedTransactions, std::vector<uint64_t>> getShardedTrxs(uint64_t proposal_period, uint64_t weight_limit);
+  std::pair<SharedTransactions, std::vector<uint64_t>> getShardedTrxs(PbftPeriod proposal_period,
+                                                                      uint64_t weight_limit);
 
   /**
    * @brief Gets current propose level for provided pivot and tips

--- a/libraries/core_libs/consensus/include/dag/dag_manager.hpp
+++ b/libraries/core_libs/consensus/include/dag/dag_manager.hpp
@@ -108,7 +108,7 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
    * @param period period
    * @return ordered blocks
    */
-  vec_blk_t getDagBlockOrder(blk_hash_t const &anchor, uint64_t period);
+  vec_blk_t getDagBlockOrder(blk_hash_t const &anchor, PbftPeriod period);
 
   /**
    * @brief Sets the dag block order on finalizing PBFT block
@@ -121,7 +121,7 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
    *
    * @return number of dag blocks finalized
    */
-  uint setDagBlockOrder(blk_hash_t const &anchor, uint64_t period, vec_blk_t const &dag_order);
+  uint setDagBlockOrder(blk_hash_t const &anchor, PbftPeriod period, vec_blk_t const &dag_order);
 
   uint64_t getLightNodeHistory() const { return light_node_history_; }
   bool isLightNode() const { return is_light_node_; }
@@ -154,7 +154,7 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
   level_t getMaxLevel() const { return max_level_; }
 
   // DAG anchors
-  uint64_t getLatestPeriod() const {
+  PbftPeriod getLatestPeriod() const {
     SharedLock lock(mutex_);
     return period_;
   }
@@ -170,7 +170,7 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
    */
   uint32_t getDagExpiryLimit() const { return dag_expiry_limit_; }
 
-  const std::pair<uint64_t, std::map<uint64_t, std::unordered_set<blk_hash_t>>> getNonFinalizedBlocks() const;
+  const std::pair<PbftPeriod, std::map<uint64_t, std::unordered_set<blk_hash_t>>> getNonFinalizedBlocks() const;
 
   /**
    * @brief Retrieves current period together with non finalized blocks with the unique list of non finalized
@@ -179,7 +179,7 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
    * @param known_hashes excludes known hashes from result
    * @return Period, blocks and transactions
    */
-  const std::tuple<uint64_t, std::vector<std::shared_ptr<DagBlock>>, SharedTransactions>
+  const std::tuple<PbftPeriod, std::vector<std::shared_ptr<DagBlock>>, SharedTransactions>
   getNonFinalizedBlocksWithTransactions(const std::unordered_set<blk_hash_t> &known_hashes) const;
 
   DagFrontier getDagFrontier();
@@ -242,7 +242,7 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
   std::shared_ptr<KeyManager> key_manager_;
   blk_hash_t anchor_;      // anchor of the last period
   blk_hash_t old_anchor_;  // anchor of the second to last period
-  uint64_t period_;        // last period
+  PbftPeriod period_;      // last period
   std::map<uint64_t, std::unordered_set<blk_hash_t>> non_finalized_blks_;
   DagFrontier frontier_;
   SortitionParamsManager sortition_params_manager_;

--- a/libraries/core_libs/consensus/include/dag/sortition_params_manager.hpp
+++ b/libraries/core_libs/consensus/include/dag/sortition_params_manager.hpp
@@ -16,12 +16,12 @@ using EfficienciesMap = std::map<uint16_t, int32_t>;
  * @brief Changing vrf params for DAG blocks generation
  */
 struct SortitionParamsChange {
-  uint64_t period = 0;
+  PbftPeriod period = 0;
   VrfParams vrf_params;
   uint16_t interval_efficiency = 0;
 
   SortitionParamsChange() = default;
-  SortitionParamsChange(uint64_t period, uint16_t efficiency, const VrfParams& vrf);
+  SortitionParamsChange(PbftPeriod period, uint16_t efficiency, const VrfParams& vrf);
   static SortitionParamsChange from_rlp(const dev::RLP& rlp);
   bytes rlp() const;
 };
@@ -36,7 +36,7 @@ struct SortitionParamsChange {
 class SortitionParamsManager {
  public:
   SortitionParamsManager(const addr_t& node_addr, SortitionConfig sort_conf, std::shared_ptr<DbStorage> db);
-  SortitionParams getSortitionParams(std::optional<uint64_t> for_period = {}) const;
+  SortitionParams getSortitionParams(std::optional<PbftPeriod> for_period = {}) const;
 
   /**
    * Calculating DAG efficiency in passed PeriodData(PBFT)
@@ -55,7 +55,7 @@ class SortitionParamsManager {
    * @param batch DB batch in which all changes  will be added
    * @param non_empty_pbft_chain_size PBFT chain size excluding pbft blocks with null anchor
    */
-  void pbftBlockPushed(const PeriodData& block, DbStorage::Batch& batch, size_t non_empty_pbft_chain_size);
+  void pbftBlockPushed(const PeriodData& block, DbStorage::Batch& batch, PbftPeriod non_empty_pbft_chain_size);
 
   /**
    * Calculate average DAG efficiency from dag_efficiencies_. Used at the end of interval.
@@ -75,7 +75,7 @@ class SortitionParamsManager {
   std::deque<uint16_t> dag_efficiencies_;
   uint32_t ignored_efficiency_counter_ = 0;
   std::deque<SortitionParamsChange> params_changes_;
-  SortitionParamsChange calculateChange(uint64_t period);
+  SortitionParamsChange calculateChange(PbftPeriod period);
   EfficienciesMap getEfficienciesToUpperRange(uint16_t efficiency, int32_t threshold) const;
   int32_t getNewUpperRange(uint16_t efficiency) const;
   void cleanup();

--- a/libraries/core_libs/consensus/include/final_chain/final_chain.hpp
+++ b/libraries/core_libs/consensus/include/final_chain/final_chain.hpp
@@ -46,7 +46,7 @@ class FinalChain {
 
   virtual void stop() = 0;
 
-  virtual uint64_t delegation_delay() const = 0;
+  virtual EthBlockNumber delegation_delay() const = 0;
 
   /**
    * @brief Method which finalizes a block and executes it in EVM

--- a/libraries/core_libs/consensus/include/final_chain/replay_protection_service.hpp
+++ b/libraries/core_libs/consensus/include/final_chain/replay_protection_service.hpp
@@ -30,7 +30,7 @@ class ReplayProtectionService {
     addr_t sender;
     trx_nonce_t nonce = 0;
   };
-  virtual void update(DB::Batch &, uint64_t, util::RangeView<TransactionInfo> const &) = 0;
+  virtual void update(DB::Batch &, PbftPeriod, util::RangeView<TransactionInfo> const &) = 0;
 };
 
 std::unique_ptr<ReplayProtectionService> NewReplayProtectionService(ReplayProtectionService::Config,

--- a/libraries/core_libs/consensus/include/final_chain/state_api.hpp
+++ b/libraries/core_libs/consensus/include/final_chain/state_api.hpp
@@ -47,7 +47,7 @@ class StateAPI {
                                                 const util::RangeView<UncleBlock>& uncles = {},
                                                 const RewardsStats& rewards_stats = {});
   void transition_state_commit();
-  void create_snapshot(uint64_t period);
+  void create_snapshot(PbftPeriod period);
 
   // DPOS
   uint64_t dpos_eligible_total_vote_count(EthBlockNumber blk_num) const;

--- a/libraries/core_libs/consensus/include/pbft/pbft_chain.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_chain.hpp
@@ -38,13 +38,13 @@ class PbftChain {
    * @brief Get PBFT chain size
    * @return PBFT chain size
    */
-  uint64_t getPbftChainSize() const;
+  PbftPeriod getPbftChainSize() const;
 
   /**
    * @brief Get PBFT chain size excluding empty PBFT blocks
    * @return PBFT chain size excluding empty PBFT blocks
    */
-  uint64_t getPbftChainSizeExcludingEmptyPbftBlocks() const;
+  PbftPeriod getPbftChainSizeExcludingEmptyPbftBlocks() const;
 
   /**
    * @brief Get last PBFT block hash
@@ -108,11 +108,11 @@ class PbftChain {
 
   mutable boost::shared_mutex chain_head_access_;
 
-  blk_hash_t head_hash_;     // PBFT head hash
-  uint64_t size_;            // PBFT chain size, includes both executed and unexecuted PBFT blocks
-  uint64_t non_empty_size_;  // PBFT chain size excluding blocks with null anchor, includes both executed and unexecuted
-                             // PBFT blocks
-  blk_hash_t last_pbft_block_hash_;                // last PBFT block hash in PBFT chain, may not execute yet
+  blk_hash_t head_hash_;             // PBFT head hash
+  PbftPeriod size_;                  // PBFT chain size, includes both executed and unexecuted PBFT blocks
+  PbftPeriod non_empty_size_;        // PBFT chain size excluding blocks with null anchor, includes both executed and
+                                     // unexecuted PBFT blocks
+  blk_hash_t last_pbft_block_hash_;  // last PBFT block hash in PBFT chain, may not execute yet
   blk_hash_t last_non_null_pbft_dag_anchor_hash_;  // last dag block anchor which is not null
 
   std::shared_ptr<DbStorage> db_ = nullptr;

--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -109,43 +109,44 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
    * @param hash DAG block hash
    * @return true with DAG block period number if the DAG block has been finalized. Otherwise return false
    */
-  std::pair<bool, uint64_t> getDagBlockPeriod(blk_hash_t const &hash);
+  std::pair<bool, PbftPeriod> getDagBlockPeriod(const blk_hash_t &hash);
 
   /**
    * @brief Get current PBFT period number
    * @return current PBFT period
    */
-  uint64_t getPbftPeriod() const;
+  PbftPeriod getPbftPeriod() const;
 
   /**
    * @brief Get current PBFT round number
    * @return current PBFT round
    */
-  uint32_t getPbftRound() const;
+  PbftRound getPbftRound() const;
 
   /**
    * @brief Get PBFT round & period number
    * @return <PBFT round, PBFT period>
    */
-  std::pair<uint32_t, uint64_t> getPbftRoundAndPeriod() const;
+  // TODO: exchange round <-> period
+  std::pair<PbftRound, PbftPeriod> getPbftRoundAndPeriod() const;
 
   /**
    * @brief Get PBFT step number
    * @return PBFT step
    */
-  uint32_t getPbftStep() const;
+  PbftStep getPbftStep() const;
 
   /**
    * @brief Set PBFT round number
    * @param round PBFT round
    */
-  void setPbftRound(uint32_t round);
+  void setPbftRound(PbftRound round);
 
   /**
    * @brief Set PBFT step
    * @param pbft_step PBFT step
    */
-  void setPbftStep(uint32_t pbft_step);
+  void setPbftStep(PbftStep pbft_step);
 
   /**
    * @brief Generate PBFT block, push into unverified queue, and broadcast to peers
@@ -155,7 +156,7 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
    * @param order_hash the hash of all DAG blocks include in the PBFT block
    * @return PBFT block
    */
-  std::shared_ptr<PbftBlock> generatePbftBlock(uint64_t propose_period, const blk_hash_t &prev_blk_hash,
+  std::shared_ptr<PbftBlock> generatePbftBlock(PbftPeriod propose_period, const blk_hash_t &prev_blk_hash,
                                                const blk_hash_t &anchor_hash, const blk_hash_t &order_hash);
 
   /**
@@ -167,8 +168,8 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
    * @param step PBFT step
    * @return vote
    */
-  std::shared_ptr<Vote> generateVote(blk_hash_t const &blockhash, PbftVoteTypes type, uint64_t period, uint32_t round,
-                                     uint32_t step);
+  std::shared_ptr<Vote> generateVote(const blk_hash_t &blockhash, PbftVoteTypes type, PbftPeriod period,
+                                     PbftRound round, PbftStep step);
 
   /**
    * @brief Get current total DPOS votes count
@@ -188,7 +189,7 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
    * @brief Get PBFT blocks synced period
    * @return PBFT blocks synced period
    */
-  uint64_t pbftSyncingPeriod() const;
+  PbftPeriod pbftSyncingPeriod() const;
 
   /**
    * @brief Get PBFT blocks syncing queue size
@@ -298,7 +299,7 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
    * @param pbft_period pbft period
    * @return PBFT 2T + 1 if successful, otherwise (due to non-existent data for pbft_period) empty optional
    */
-  std::optional<uint64_t> getPbftTwoTPlusOne(uint64_t pbft_period) const;
+  std::optional<uint64_t> getPbftTwoTPlusOne(PbftPeriod pbft_period) const;
 
  private:
   // DPOS
@@ -334,7 +335,7 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
    * @brief Resets pbft consensus: current pbft round is set to round, step is set to the beginning value
    * @param round
    */
-  void resetPbftConsensus(uint64_t round);
+  void resetPbftConsensus(PbftRound round);
 
   /**
    * @param start_time
@@ -432,8 +433,8 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
    * @param step PBFT step
    * @param step PBFT step
    */
-  std::shared_ptr<Vote> generateVoteWithWeight(blk_hash_t const &blockhash, PbftVoteTypes vote_type, uint64_t period,
-                                               uint32_t round, uint32_t step);
+  std::shared_ptr<Vote> generateVoteWithWeight(blk_hash_t const &blockhash, PbftVoteTypes vote_type, PbftPeriod period,
+                                               PbftRound round, PbftStep step);
 
   /**
    * @brief Place (gossip) vote
@@ -442,7 +443,7 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
    * @param voted_block voted block object - should be == vote->voted_block. In case we dont have block object, nullptr
    *                    is provided
    */
-  bool placeVote(const std::shared_ptr<Vote> &, std::string_view log_vote_id,
+  bool placeVote(const std::shared_ptr<Vote> &vote, std::string_view log_vote_id,
                  const std::shared_ptr<PbftBlock> &voted_block);
 
   /**
@@ -475,7 +476,8 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
    * @param period new pbft period (perriod == chain_size + 1)
    * @return shared_ptr to leader identified leader block
    */
-  std::shared_ptr<PbftBlock> identifyLeaderBlock_(uint64_t round, uint64_t period);
+  // TODO: exchange round <-> period
+  std::shared_ptr<PbftBlock> identifyLeaderBlock_(PbftRound round, PbftPeriod period);
 
   /**
    * @brief Calculate the lowest hash of a vote by vote weight
@@ -531,7 +533,8 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
    * @param round
    * @return Soft voted block data if there is enough (2t+1) soft votes, otherwise returns empty optional
    */
-  const std::optional<TwoTPlusOneSoftVotedBlockData> &getTwoTPlusOneSoftVotedBlockData(uint64_t period, uint64_t round);
+  const std::optional<TwoTPlusOneSoftVotedBlockData> &getTwoTPlusOneSoftVotedBlockData(PbftPeriod period,
+                                                                                       PbftRound round);
 
   /**
    * @brief Get valid proposed pbft block. It will retrieve block from proposed_blocks and then validate it if not
@@ -542,7 +545,8 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
    * @param block_hash
    * @return valid proposed pbft block or nullptr
    */
-  std::shared_ptr<PbftBlock> getValidPbftProposedBlock(uint64_t period, uint64_t round, const blk_hash_t &block_hash);
+  std::shared_ptr<PbftBlock> getValidPbftProposedBlock(PbftPeriod period, PbftRound round,
+                                                       const blk_hash_t &block_hash);
 
   /**
    * @brief Process synced PBFT blocks if PBFT syncing queue is not empty
@@ -564,7 +568,7 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
    * @param period
    * @return true if node can participate in consensus - is dpos eligible to vote and create blocks for specified period
    */
-  bool canParticipateInConsensus(uint64_t period) const;
+  bool canParticipateInConsensus(PbftPeriod period) const;
 
   /**
    * @brief Get PBFT sortition threshold for specific period
@@ -624,9 +628,9 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
 
   PbftStates state_ = value_proposal_state;
 
-  std::atomic<uint32_t> round_ = 1;
-  uint32_t step_ = 1;
-  size_t startingStepInRound_ = 1;
+  std::atomic<PbftRound> round_ = 1;
+  PbftStep step_ = 1;
+  PbftStep startingStepInRound_ = 1;
 
   // 2t+1 soft voted block related data
   std::optional<TwoTPlusOneSoftVotedBlockData> soft_voted_block_for_round_{};
@@ -649,7 +653,7 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
 
   // Cache for current 2T+1 - do not access it directly as it is not updated automatically,
   // always call getPbftTwoTPlusOne instead !!!
-  mutable std::pair<uint64_t /* period */, uint64_t /* two_t_plus_one for period */> current_two_t_plus_one_;
+  mutable std::pair<PbftPeriod, uint64_t /* two_t_plus_one for period */> current_two_t_plus_one_;
   mutable std::shared_mutex current_two_t_plus_one_mutex_;
 
   const blk_hash_t dag_genesis_block_hash_;

--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -121,31 +121,31 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
    * @brief Get current PBFT round number
    * @return current PBFT round
    */
-  uint64_t getPbftRound() const;
+  uint32_t getPbftRound() const;
 
   /**
    * @brief Get PBFT round & period number
    * @return <PBFT round, PBFT period>
    */
-  std::pair<uint64_t, uint64_t> getPbftRoundAndPeriod() const;
+  std::pair<uint32_t, uint64_t> getPbftRoundAndPeriod() const;
 
   /**
    * @brief Get PBFT step number
    * @return PBFT step
    */
-  uint64_t getPbftStep() const;
+  uint32_t getPbftStep() const;
 
   /**
    * @brief Set PBFT round number
    * @param round PBFT round
    */
-  void setPbftRound(uint64_t const round);
+  void setPbftRound(uint32_t round);
 
   /**
    * @brief Set PBFT step
    * @param pbft_step PBFT step
    */
-  void setPbftStep(size_t const pbft_step);
+  void setPbftStep(uint32_t pbft_step);
 
   /**
    * @brief Generate PBFT block, push into unverified queue, and broadcast to peers
@@ -167,8 +167,8 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
    * @param step PBFT step
    * @return vote
    */
-  std::shared_ptr<Vote> generateVote(blk_hash_t const &blockhash, PbftVoteTypes type, uint64_t period, uint64_t round,
-                                     size_t step);
+  std::shared_ptr<Vote> generateVote(blk_hash_t const &blockhash, PbftVoteTypes type, uint64_t period, uint32_t round,
+                                     uint32_t step);
 
   /**
    * @brief Get current total DPOS votes count
@@ -433,7 +433,7 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
    * @param step PBFT step
    */
   std::shared_ptr<Vote> generateVoteWithWeight(blk_hash_t const &blockhash, PbftVoteTypes vote_type, uint64_t period,
-                                               uint64_t round, size_t step);
+                                               uint32_t round, uint32_t step);
 
   /**
    * @brief Place (gossip) vote
@@ -624,8 +624,8 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
 
   PbftStates state_ = value_proposal_state;
 
-  std::atomic<uint64_t> round_ = 1;
-  size_t step_ = 1;
+  std::atomic<uint32_t> round_ = 1;
+  uint32_t step_ = 1;
   size_t startingStepInRound_ = 1;
 
   // 2t+1 soft voted block related data

--- a/libraries/core_libs/consensus/include/pbft/proposed_blocks.hpp
+++ b/libraries/core_libs/consensus/include/pbft/proposed_blocks.hpp
@@ -35,7 +35,7 @@ class ProposedBlocks {
    * @param save_to_db if true save to db
    * @return true if block was successfully pushed, otherwise false
    */
-  bool pushProposedPbftBlock(uint32_t round, const std::shared_ptr<PbftBlock>& proposed_block, bool save_to_db = true);
+  bool pushProposedPbftBlock(PbftRound round, const std::shared_ptr<PbftBlock>& proposed_block, bool save_to_db = true);
 
   /**
    * @brief Mark block as valid - no need to validate it again
@@ -43,7 +43,7 @@ class ProposedBlocks {
    * @param round
    * @param proposed_block
    */
-  void markBlockAsValid(uint32_t round, const std::shared_ptr<PbftBlock>& proposed_block);
+  void markBlockAsValid(PbftRound round, const std::shared_ptr<PbftBlock>& proposed_block);
 
   /**
    * @brief Get a proposed PBFT block based on specified period, round and block hash
@@ -52,7 +52,7 @@ class ProposedBlocks {
    * @param block_hash
    * @return optional<pair<block, is_valid flag>>
    */
-  std::optional<std::pair<std::shared_ptr<PbftBlock>, bool>> getPbftProposedBlock(uint64_t period, uint32_t round,
+  std::optional<std::pair<std::shared_ptr<PbftBlock>, bool>> getPbftProposedBlock(PbftPeriod period, PbftRound round,
                                                                                   const blk_hash_t& block_hash) const;
 
   /**
@@ -62,13 +62,13 @@ class ProposedBlocks {
    * @param block_hash
    * @return true if block is present, otherwise false
    */
-  bool isInProposedBlocks(uint64_t period, uint32_t round, const blk_hash_t& block_hash) const;
+  bool isInProposedBlocks(PbftPeriod period, PbftRound round, const blk_hash_t& block_hash) const;
 
   /**
    * @brief Cleanup all proposed PBFT blocks for the finalized period
    * @param period
    */
-  void cleanupProposedPbftBlocksByPeriod(uint64_t period);
+  void cleanupProposedPbftBlocksByPeriod(PbftPeriod period);
 
   /**
    * @brief Cleanup all proposed PBFT blocks for the finalized round - 1. We must keep previous round proposed blocks
@@ -76,11 +76,11 @@ class ProposedBlocks {
    * @param period
    * @param round
    */
-  void cleanupProposedPbftBlocksByRound(uint64_t period, uint32_t round);
+  void cleanupProposedPbftBlocksByRound(PbftPeriod period, PbftRound round);
 
  private:
   // <PBFT period, <PBFT round, <block hash, [block, is_valid_flag]>>>
-  std::map<uint64_t, std::map<uint32_t, std::unordered_map<blk_hash_t, std::pair<std::shared_ptr<PbftBlock>, bool>>>>
+  std::map<PbftPeriod, std::map<PbftRound, std::unordered_map<blk_hash_t, std::pair<std::shared_ptr<PbftBlock>, bool>>>>
       proposed_blocks_;
   mutable std::shared_mutex proposed_blocks_mutex_;
   std::shared_ptr<DbStorage> db_;

--- a/libraries/core_libs/consensus/include/pbft/proposed_blocks.hpp
+++ b/libraries/core_libs/consensus/include/pbft/proposed_blocks.hpp
@@ -35,7 +35,7 @@ class ProposedBlocks {
    * @param save_to_db if true save to db
    * @return true if block was successfully pushed, otherwise false
    */
-  bool pushProposedPbftBlock(uint64_t round, const std::shared_ptr<PbftBlock>& proposed_block, bool save_to_db = true);
+  bool pushProposedPbftBlock(uint32_t round, const std::shared_ptr<PbftBlock>& proposed_block, bool save_to_db = true);
 
   /**
    * @brief Mark block as valid - no need to validate it again
@@ -43,7 +43,7 @@ class ProposedBlocks {
    * @param round
    * @param proposed_block
    */
-  void markBlockAsValid(uint64_t round, const std::shared_ptr<PbftBlock>& proposed_block);
+  void markBlockAsValid(uint32_t round, const std::shared_ptr<PbftBlock>& proposed_block);
 
   /**
    * @brief Get a proposed PBFT block based on specified period, round and block hash
@@ -52,7 +52,7 @@ class ProposedBlocks {
    * @param block_hash
    * @return optional<pair<block, is_valid flag>>
    */
-  std::optional<std::pair<std::shared_ptr<PbftBlock>, bool>> getPbftProposedBlock(uint64_t period, uint64_t round,
+  std::optional<std::pair<std::shared_ptr<PbftBlock>, bool>> getPbftProposedBlock(uint64_t period, uint32_t round,
                                                                                   const blk_hash_t& block_hash) const;
 
   /**
@@ -62,7 +62,7 @@ class ProposedBlocks {
    * @param block_hash
    * @return true if block is present, otherwise false
    */
-  bool isInProposedBlocks(uint64_t period, uint64_t round, const blk_hash_t& block_hash) const;
+  bool isInProposedBlocks(uint64_t period, uint32_t round, const blk_hash_t& block_hash) const;
 
   /**
    * @brief Cleanup all proposed PBFT blocks for the finalized period
@@ -76,11 +76,11 @@ class ProposedBlocks {
    * @param period
    * @param round
    */
-  void cleanupProposedPbftBlocksByRound(uint64_t period, uint64_t round);
+  void cleanupProposedPbftBlocksByRound(uint64_t period, uint32_t round);
 
  private:
   // <PBFT period, <PBFT round, <block hash, [block, is_valid_flag]>>>
-  std::map<uint64_t, std::map<uint64_t, std::unordered_map<blk_hash_t, std::pair<std::shared_ptr<PbftBlock>, bool>>>>
+  std::map<uint64_t, std::map<uint32_t, std::unordered_map<blk_hash_t, std::pair<std::shared_ptr<PbftBlock>, bool>>>>
       proposed_blocks_;
   mutable std::shared_mutex proposed_blocks_mutex_;
   std::shared_ptr<DbStorage> db_;

--- a/libraries/core_libs/consensus/include/pbft/soft_voted_block_data.hpp
+++ b/libraries/core_libs/consensus/include/pbft/soft_voted_block_data.hpp
@@ -26,7 +26,7 @@ class TwoTPlusOneSoftVotedBlockData {
   TwoTPlusOneSoftVotedBlockData(dev::RLP const& rlp);
   bytes rlp() const;
 
-  uint64_t round_;
+  PbftRound round_;
   blk_hash_t block_hash_;
   std::vector<std::shared_ptr<Vote>> soft_votes_;
   // node might not have the actual block even though it saw 2t+1 soft votes

--- a/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
+++ b/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
@@ -61,7 +61,7 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
    * @param proposal_period proposal period
    * @return estimated gas value for transaction
    */
-  uint64_t estimateTransactionGas(std::shared_ptr<Transaction> trx, std::optional<uint64_t> proposal_period) const;
+  uint64_t estimateTransactionGas(std::shared_ptr<Transaction> trx, std::optional<PbftPeriod> proposal_period) const;
 
   /**
    * @brief Gets transactions from pool to include in the block with specified weight limit
@@ -69,7 +69,7 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
    * @param weight_limit weight limit
    * @return transactions and weight estimations
    */
-  std::pair<SharedTransactions, std::vector<uint64_t>> packTrxs(uint64_t proposal_period, uint64_t weight_limit);
+  std::pair<SharedTransactions, std::vector<uint64_t>> packTrxs(PbftPeriod proposal_period, uint64_t weight_limit);
 
   /**
    * @brief Gets all transactions from pool
@@ -95,7 +95,7 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
    *
    * @param block_number block number finalized
    */
-  void blockFinalized(uint64_t block_number);
+  void blockFinalized(EthBlockNumber block_number);
 
   /**
    * @brief Inserts verified transaction to transaction pool

--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -186,13 +186,13 @@ class VoteManager {
    * @param pbft_period current PBFT period
    * @param pbft_round current PBFT round
    */
-  void cleanupVotesByRound(uint64_t pbft_period, uint32_t pbft_round);
+  void cleanupVotesByRound(PbftPeriod pbft_period, PbftRound pbft_round);
 
   /**
    * @brief Cleanup votes for previous PBFT periods
    * @param pbft_period current PBFT period
    */
-  void cleanupVotesByPeriod(uint64_t pbft_period);
+  void cleanupVotesByPeriod(PbftPeriod pbft_period);
 
   /**
    * @brief Get single propose vote for specified voted block
@@ -201,7 +201,7 @@ class VoteManager {
    * @param voted_block_hash
    * @return single propose vote for specified voted block
    */
-  std::shared_ptr<Vote> getProposalVote(uint64_t period, uint32_t round, const blk_hash_t& voted_block_hash) const;
+  std::shared_ptr<Vote> getProposalVote(PbftPeriod period, PbftRound round, const blk_hash_t& voted_block_hash) const;
 
   /**
    * @brief Get all verified votes in proposal vote type for the current PBFT round
@@ -209,7 +209,7 @@ class VoteManager {
    * @param round current PBFT round
    * @return all verified votes in proposal vote type for the current PBFT round
    */
-  std::vector<std::shared_ptr<Vote>> getProposalVotes(uint64_t period, uint32_t round) const;
+  std::vector<std::shared_ptr<Vote>> getProposalVotes(PbftPeriod period, PbftRound round) const;
 
   /**
    * @brief Get a bunch of votes that vote on the same voting value in the specific PBFT round and step, the total votes
@@ -220,7 +220,7 @@ class VoteManager {
    * @param two_t_plus_one PBFT 2t+1 is 2/3 of PBFT sortition threshold and plus 1
    * @return VotesBundle a bunch of votes that vote on the same voting value in the specific PBFT round and step
    */
-  std::optional<VotesBundle> getTwoTPlusOneVotesBundle(uint64_t period, uint32_t round, uint32_t step,
+  std::optional<VotesBundle> getTwoTPlusOneVotesBundle(PbftPeriod period, PbftRound round, PbftStep step,
                                                        uint64_t two_t_plus_one) const;
 
   /**
@@ -230,14 +230,14 @@ class VoteManager {
    * @return optional<pair<new round, 2t+1 next votes>> if there is enough next votes from prior round, otherwise
    * returns empty optional
    */
-  std::optional<std::pair<uint32_t, std::vector<std::shared_ptr<Vote>>>> determineRoundFromPeriodAndVotes(
-      uint64_t period, uint64_t two_t_plus_one);
+  std::optional<std::pair<PbftRound, std::vector<std::shared_ptr<Vote>>>> determineRoundFromPeriodAndVotes(
+      PbftPeriod period, uint64_t two_t_plus_one);
 
   // reward votes
   /**
    * @return current rewards votes <pbft block hash, pbft block period>
    */
-  std::pair<blk_hash_t, uint64_t> getCurrentRewardsVotesBlock() const;
+  std::pair<blk_hash_t, PbftPeriod> getCurrentRewardsVotesBlock() const;
 
   /**
    * @brief Add last period cert vote to reward_votes_ after the cert vote voted block finalized
@@ -330,29 +330,29 @@ class VoteManager {
   // TODO[1907]: this will be part of VerifiedVotes class
   // <PBFT period, <PBFT round, <PBFT step, <voted value, pair<voted weight, <vote hash, vote>>>>>
   std::map<
-      uint64_t,
-      std::map<uint32_t,
-               std::map<uint32_t,
+      PbftPeriod,
+      std::map<PbftRound,
+               std::map<PbftStep,
                         std::unordered_map<
                             blk_hash_t, std::pair<uint64_t, std::unordered_map<vote_hash_t, std::shared_ptr<Vote>>>>>>>
       verified_votes_;
   // Current period, it should only be used under verified_votes_access_ mutex
-  uint64_t verified_votes_last_period_;
+  PbftPeriod verified_votes_last_period_;
   mutable boost::shared_mutex verified_votes_access_;
 
   // <PBFT period, <PBFT round, <PBFT step, <voter address, pair<vote 1, vote 2>>><>
   // For next votes we enable 2 votes per round & step, one of which must be vote for NULL_BLOCK_HASH
-  std::map<uint64_t,
-           std::map<uint32_t,
+  std::map<PbftPeriod,
+           std::map<PbftRound,
                     std::unordered_map<
-                        uint32_t, std::unordered_map<addr_t, std::pair<std::shared_ptr<Vote>, std::shared_ptr<Vote>>>>>>
+                        PbftStep, std::unordered_map<addr_t, std::pair<std::shared_ptr<Vote>, std::shared_ptr<Vote>>>>>>
       voters_unique_votes_;
   mutable std::shared_mutex voters_unique_votes_mutex_;
   // TODO[1907]: end of VerifiedVotes class
 
   // TODO[1907]: this will be part of RewardVotes class
-  std::pair<blk_hash_t, uint64_t /* period */> reward_votes_pbft_block_;
-  uint64_t reward_votes_round_;  // round, during which was the block pushed into the chain
+  std::pair<blk_hash_t, PbftPeriod> reward_votes_pbft_block_;
+  PbftRound reward_votes_round_;  // round, during which was the block pushed into the chain
   std::unordered_map<vote_hash_t, std::shared_ptr<Vote>> reward_votes_;
   mutable std::shared_mutex reward_votes_mutex_;
   // TODO[1907]: end of RewardVotes class

--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -186,7 +186,7 @@ class VoteManager {
    * @param pbft_period current PBFT period
    * @param pbft_round current PBFT round
    */
-  void cleanupVotesByRound(uint64_t pbft_period, uint64_t pbft_round);
+  void cleanupVotesByRound(uint64_t pbft_period, uint32_t pbft_round);
 
   /**
    * @brief Cleanup votes for previous PBFT periods
@@ -201,7 +201,7 @@ class VoteManager {
    * @param voted_block_hash
    * @return single propose vote for specified voted block
    */
-  std::shared_ptr<Vote> getProposalVote(uint64_t period, uint64_t round, const blk_hash_t& voted_block_hash) const;
+  std::shared_ptr<Vote> getProposalVote(uint64_t period, uint32_t round, const blk_hash_t& voted_block_hash) const;
 
   /**
    * @brief Get all verified votes in proposal vote type for the current PBFT round
@@ -209,19 +209,19 @@ class VoteManager {
    * @param round current PBFT round
    * @return all verified votes in proposal vote type for the current PBFT round
    */
-  std::vector<std::shared_ptr<Vote>> getProposalVotes(uint64_t period, uint64_t round) const;
+  std::vector<std::shared_ptr<Vote>> getProposalVotes(uint64_t period, uint32_t round) const;
 
   /**
    * @brief Get a bunch of votes that vote on the same voting value in the specific PBFT round and step, the total votes
    * weights must be greater or equal to PBFT 2t+1
-   * @param round PBFT round
    * @param period PBFT period
+   * @param round PBFT round
    * @param step PBFT step
    * @param two_t_plus_one PBFT 2t+1 is 2/3 of PBFT sortition threshold and plus 1
    * @return VotesBundle a bunch of votes that vote on the same voting value in the specific PBFT round and step
    */
-  std::optional<VotesBundle> getTwoTPlusOneVotesBundle(uint64_t round, uint64_t period, size_t step,
-                                                       size_t two_t_plus_one) const;
+  std::optional<VotesBundle> getTwoTPlusOneVotesBundle(uint64_t period, uint32_t round, uint32_t step,
+                                                       uint64_t two_t_plus_one) const;
 
   /**
    * @brief Check if there are enough next voting type votes to set PBFT to a forward round within period
@@ -230,8 +230,8 @@ class VoteManager {
    * @return optional<pair<new round, 2t+1 next votes>> if there is enough next votes from prior round, otherwise
    * returns empty optional
    */
-  std::optional<std::pair<uint64_t, std::vector<std::shared_ptr<Vote>>>> determineRoundFromPeriodAndVotes(
-      uint64_t period, size_t two_t_plus_one);
+  std::optional<std::pair<uint32_t, std::vector<std::shared_ptr<Vote>>>> determineRoundFromPeriodAndVotes(
+      uint64_t period, uint64_t two_t_plus_one);
 
   // reward votes
   /**
@@ -329,11 +329,12 @@ class VoteManager {
 
   // TODO[1907]: this will be part of VerifiedVotes class
   // <PBFT period, <PBFT round, <PBFT step, <voted value, pair<voted weight, <vote hash, vote>>>>>
-  std::map<uint64_t,
-           std::map<uint64_t,
-                    std::map<size_t, std::unordered_map<
-                                         blk_hash_t,
-                                         std::pair<uint64_t, std::unordered_map<vote_hash_t, std::shared_ptr<Vote>>>>>>>
+  std::map<
+      uint64_t,
+      std::map<uint32_t,
+               std::map<uint32_t,
+                        std::unordered_map<
+                            blk_hash_t, std::pair<uint64_t, std::unordered_map<vote_hash_t, std::shared_ptr<Vote>>>>>>>
       verified_votes_;
   // Current period, it should only be used under verified_votes_access_ mutex
   uint64_t verified_votes_last_period_;
@@ -342,8 +343,9 @@ class VoteManager {
   // <PBFT period, <PBFT round, <PBFT step, <voter address, pair<vote 1, vote 2>>><>
   // For next votes we enable 2 votes per round & step, one of which must be vote for NULL_BLOCK_HASH
   std::map<uint64_t,
-           std::map<uint64_t, std::unordered_map<size_t, std::unordered_map<addr_t, std::pair<std::shared_ptr<Vote>,
-                                                                                              std::shared_ptr<Vote>>>>>>
+           std::map<uint32_t,
+                    std::unordered_map<
+                        uint32_t, std::unordered_map<addr_t, std::pair<std::shared_ptr<Vote>, std::shared_ptr<Vote>>>>>>
       voters_unique_votes_;
   mutable std::shared_mutex voters_unique_votes_mutex_;
   // TODO[1907]: end of VerifiedVotes class

--- a/libraries/core_libs/consensus/src/dag/block_proposer.cpp
+++ b/libraries/core_libs/consensus/src/dag/block_proposer.cpp
@@ -163,7 +163,7 @@ void BlockProposer::stop() {
   proposer_worker_->join();
 }
 
-std::pair<SharedTransactions, std::vector<uint64_t>> BlockProposer::getShardedTrxs(uint64_t proposal_period,
+std::pair<SharedTransactions, std::vector<uint64_t>> BlockProposer::getShardedTrxs(PbftPeriod proposal_period,
                                                                                    uint64_t weight_limit) {
   // If syncing return empty list
   auto syncing = false;

--- a/libraries/core_libs/consensus/src/dag/dag_manager.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_manager.cpp
@@ -254,7 +254,7 @@ std::vector<blk_hash_t> DagManager::getGhostPath() const {
 }
 
 // return {block order}, for pbft-pivot-blk proposing
-std::vector<blk_hash_t> DagManager::getDagBlockOrder(blk_hash_t const &anchor, uint64_t period) {
+std::vector<blk_hash_t> DagManager::getDagBlockOrder(blk_hash_t const &anchor, PbftPeriod period) {
   SharedLock lock(mutex_);
   std::vector<blk_hash_t> blk_orders;
 
@@ -301,7 +301,7 @@ void DagManager::clearLightNodeHistory() {
   }
 }
 
-uint DagManager::setDagBlockOrder(blk_hash_t const &new_anchor, uint64_t period, vec_blk_t const &dag_order) {
+uint DagManager::setDagBlockOrder(blk_hash_t const &new_anchor, PbftPeriod period, vec_blk_t const &dag_order) {
   LOG(log_dg_) << "setDagBlockOrder called with anchor " << new_anchor << " and period " << period;
   if (period != period_ + 1) {
     LOG(log_er_) << " Inserting period (" << period << ") anchor " << new_anchor
@@ -516,13 +516,13 @@ void DagManager::recoverDag() {
   trx_mgr_->recoverNonfinalizedTransactions();
 }
 
-const std::pair<uint64_t, std::map<uint64_t, std::unordered_set<blk_hash_t>>> DagManager::getNonFinalizedBlocks()
+const std::pair<PbftPeriod, std::map<uint64_t, std::unordered_set<blk_hash_t>>> DagManager::getNonFinalizedBlocks()
     const {
   SharedLock lock(mutex_);
   return {period_, non_finalized_blks_};
 }
 
-const std::tuple<uint64_t, std::vector<std::shared_ptr<DagBlock>>, SharedTransactions>
+const std::tuple<PbftPeriod, std::vector<std::shared_ptr<DagBlock>>, SharedTransactions>
 DagManager::getNonFinalizedBlocksWithTransactions(const std::unordered_set<blk_hash_t> &known_hashes) const {
   SharedLock lock(mutex_);
   std::vector<std::shared_ptr<DagBlock>> dag_blocks;

--- a/libraries/core_libs/consensus/src/dag/sortition_params_manager.cpp
+++ b/libraries/core_libs/consensus/src/dag/sortition_params_manager.cpp
@@ -4,7 +4,7 @@
 
 namespace taraxa {
 
-SortitionParamsChange::SortitionParamsChange(uint64_t period, uint16_t efficiency, const VrfParams& vrf)
+SortitionParamsChange::SortitionParamsChange(PbftPeriod period, uint16_t efficiency, const VrfParams& vrf)
     : period(period), vrf_params(vrf), interval_efficiency(efficiency) {}
 
 bytes SortitionParamsChange::rlp() const {
@@ -23,7 +23,7 @@ SortitionParamsChange SortitionParamsChange::from_rlp(const dev::RLP& rlp) {
 
   p.vrf_params.threshold_range = rlp[0].toInt<uint16_t>();
   p.vrf_params.threshold_upper = rlp[1].toInt<uint16_t>();
-  p.period = rlp[2].toInt<uint64_t>();
+  p.period = rlp[2].toInt<PbftPeriod>();
   p.interval_efficiency = rlp[3].toInt<uint16_t>();
 
   return p;
@@ -65,7 +65,7 @@ SortitionParamsManager::SortitionParamsManager(const addr_t& node_addr, Sortitio
   }
 }
 
-SortitionParams SortitionParamsManager::getSortitionParams(std::optional<uint64_t> period) const {
+SortitionParams SortitionParamsManager::getSortitionParams(std::optional<PbftPeriod> period) const {
   if (!period || (config_.changing_interval == 0)) {
     return config_;
   }
@@ -220,7 +220,7 @@ int32_t SortitionParamsManager::getNewUpperRange(uint16_t efficiency) const {
   assert(false);
 }
 
-SortitionParamsChange SortitionParamsManager::calculateChange(uint64_t period) {
+SortitionParamsChange SortitionParamsManager::calculateChange(PbftPeriod period) {
   const auto average_dag_efficiency = averageDagEfficiency();
 
   int32_t new_upper_range = getNewUpperRange(average_dag_efficiency);

--- a/libraries/core_libs/consensus/src/final_chain/final_chain.cpp
+++ b/libraries/core_libs/consensus/src/final_chain/final_chain.cpp
@@ -133,7 +133,7 @@ class FinalChainImpl final : public FinalChain {
     return p->get_future();
   }
 
-  uint64_t delegation_delay() const override { return delegation_delay_; }
+  EthBlockNumber delegation_delay() const override { return delegation_delay_; }
 
   std::shared_ptr<FinalizationResult> finalize_(PeriodData&& new_blk, std::vector<h256>&& finalized_dag_blk_hashes,
                                                 finalize_precommit_ext const& precommit_ext) {

--- a/libraries/core_libs/consensus/src/final_chain/replay_protection_service.cpp
+++ b/libraries/core_libs/consensus/src/final_chain/replay_protection_service.cpp
@@ -19,9 +19,9 @@ using namespace std;
 
 string senderStateKey(string const& sender_addr_hex) { return "sender_" + sender_addr_hex; }
 
-string periodDataKeysKey(uint64_t period) { return "data_keys_at_" + to_string(period); }
+string periodDataKeysKey(PbftPeriod period) { return "data_keys_at_" + to_string(period); }
 
-string maxNonceAtRoundKey(uint64_t period, string const& sender_addr_hex) {
+string maxNonceAtRoundKey(PbftPeriod period, string const& sender_addr_hex) {
   return "max_nonce_at_" + to_string(period) + "_" + sender_addr_hex;
 }
 
@@ -63,7 +63,7 @@ class ReplayProtectionServiceImpl : public virtual ReplayProtectionService {
   }
 
   // TODO use binary types instead of hex strings
-  void update(DB::Batch& batch, uint64_t period, RangeView<TransactionInfo> const& trxs) override {
+  void update(DB::Batch& batch, PbftPeriod period, RangeView<TransactionInfo> const& trxs) override {
     unique_lock l(mu_);
     unordered_map<string, shared_ptr<SenderState>> sender_states;
     sender_states.reserve(trxs.size);

--- a/libraries/core_libs/consensus/src/final_chain/state_api.cpp
+++ b/libraries/core_libs/consensus/src/final_chain/state_api.cpp
@@ -193,7 +193,7 @@ void StateAPI::transition_state_commit() {
   err_h.check();
 }
 
-void StateAPI::create_snapshot(uint64_t period) {
+void StateAPI::create_snapshot(PbftPeriod period) {
   auto path = db_path_ + std::to_string(period);
   GoString go_path;
   go_path.p = path.c_str();

--- a/libraries/core_libs/consensus/src/pbft/pbft_chain.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_chain.cpp
@@ -48,12 +48,12 @@ blk_hash_t PbftChain::getHeadHash() const {
   return head_hash_;
 }
 
-uint64_t PbftChain::getPbftChainSize() const {
+PbftPeriod PbftChain::getPbftChainSize() const {
   SharedLock lock(chain_head_access_);
   return size_;
 }
 
-uint64_t PbftChain::getPbftChainSizeExcludingEmptyPbftBlocks() const {
+PbftPeriod PbftChain::getPbftChainSizeExcludingEmptyPbftBlocks() const {
   SharedLock lock(chain_head_access_);
   return non_empty_size_;
 }

--- a/libraries/core_libs/consensus/src/pbft/proposed_blocks.cpp
+++ b/libraries/core_libs/consensus/src/pbft/proposed_blocks.cpp
@@ -12,7 +12,7 @@ bool ProposedBlocks::pushProposedPbftBlock(const std::shared_ptr<PbftBlock>& pro
   return pushProposedPbftBlock(propose_vote->getRound(), proposed_block);
 }
 
-bool ProposedBlocks::pushProposedPbftBlock(uint32_t round, const std::shared_ptr<PbftBlock>& proposed_block,
+bool ProposedBlocks::pushProposedPbftBlock(PbftRound round, const std::shared_ptr<PbftBlock>& proposed_block,
                                            bool save_to_db) {
   std::unique_lock lock(proposed_blocks_mutex_);
 
@@ -36,7 +36,7 @@ bool ProposedBlocks::pushProposedPbftBlock(uint32_t round, const std::shared_ptr
   return found_round_it->second.insert({proposed_block->getBlockHash(), {proposed_block, false}}).second;
 }
 
-void ProposedBlocks::markBlockAsValid(uint32_t round, const std::shared_ptr<PbftBlock>& proposed_block) {
+void ProposedBlocks::markBlockAsValid(PbftRound round, const std::shared_ptr<PbftBlock>& proposed_block) {
   std::unique_lock lock(proposed_blocks_mutex_);
 
   const auto found_period_it = proposed_blocks_.find(proposed_block->getPeriod());
@@ -51,7 +51,7 @@ void ProposedBlocks::markBlockAsValid(uint32_t round, const std::shared_ptr<Pbft
 }
 
 std::optional<std::pair<std::shared_ptr<PbftBlock>, bool>> ProposedBlocks::getPbftProposedBlock(
-    uint64_t period, uint32_t round, const blk_hash_t& block_hash) const {
+    PbftPeriod period, PbftRound round, const blk_hash_t& block_hash) const {
   std::shared_lock lock(proposed_blocks_mutex_);
 
   auto found_period_it = proposed_blocks_.find(period);
@@ -72,7 +72,7 @@ std::optional<std::pair<std::shared_ptr<PbftBlock>, bool>> ProposedBlocks::getPb
   return found_block_it->second;
 }
 
-bool ProposedBlocks::isInProposedBlocks(uint64_t period, uint32_t round, const blk_hash_t& block_hash) const {
+bool ProposedBlocks::isInProposedBlocks(PbftPeriod period, PbftRound round, const blk_hash_t& block_hash) const {
   std::shared_lock lock(proposed_blocks_mutex_);
 
   auto found_period_it = proposed_blocks_.find(period);
@@ -88,7 +88,7 @@ bool ProposedBlocks::isInProposedBlocks(uint64_t period, uint32_t round, const b
   return found_round_it->second.contains(block_hash);
 }
 
-void ProposedBlocks::cleanupProposedPbftBlocksByPeriod(uint64_t period) {
+void ProposedBlocks::cleanupProposedPbftBlocksByPeriod(PbftPeriod period) {
   std::unique_lock lock(proposed_blocks_mutex_);
 
   for (auto period_it = proposed_blocks_.begin(); period_it != proposed_blocks_.end() && period_it->first < period;) {
@@ -103,7 +103,7 @@ void ProposedBlocks::cleanupProposedPbftBlocksByPeriod(uint64_t period) {
   }
 }
 
-void ProposedBlocks::cleanupProposedPbftBlocksByRound(uint64_t period, uint32_t round) {
+void ProposedBlocks::cleanupProposedPbftBlocksByRound(PbftPeriod period, PbftRound round) {
   // We must keep previous round proposed blocks for voting purposes
   if (round < 3) {
     return;

--- a/libraries/core_libs/consensus/src/pbft/proposed_blocks.cpp
+++ b/libraries/core_libs/consensus/src/pbft/proposed_blocks.cpp
@@ -12,7 +12,7 @@ bool ProposedBlocks::pushProposedPbftBlock(const std::shared_ptr<PbftBlock>& pro
   return pushProposedPbftBlock(propose_vote->getRound(), proposed_block);
 }
 
-bool ProposedBlocks::pushProposedPbftBlock(uint64_t round, const std::shared_ptr<PbftBlock>& proposed_block,
+bool ProposedBlocks::pushProposedPbftBlock(uint32_t round, const std::shared_ptr<PbftBlock>& proposed_block,
                                            bool save_to_db) {
   std::unique_lock lock(proposed_blocks_mutex_);
 
@@ -36,7 +36,7 @@ bool ProposedBlocks::pushProposedPbftBlock(uint64_t round, const std::shared_ptr
   return found_round_it->second.insert({proposed_block->getBlockHash(), {proposed_block, false}}).second;
 }
 
-void ProposedBlocks::markBlockAsValid(uint64_t round, const std::shared_ptr<PbftBlock>& proposed_block) {
+void ProposedBlocks::markBlockAsValid(uint32_t round, const std::shared_ptr<PbftBlock>& proposed_block) {
   std::unique_lock lock(proposed_blocks_mutex_);
 
   const auto found_period_it = proposed_blocks_.find(proposed_block->getPeriod());
@@ -51,7 +51,7 @@ void ProposedBlocks::markBlockAsValid(uint64_t round, const std::shared_ptr<Pbft
 }
 
 std::optional<std::pair<std::shared_ptr<PbftBlock>, bool>> ProposedBlocks::getPbftProposedBlock(
-    uint64_t period, uint64_t round, const blk_hash_t& block_hash) const {
+    uint64_t period, uint32_t round, const blk_hash_t& block_hash) const {
   std::shared_lock lock(proposed_blocks_mutex_);
 
   auto found_period_it = proposed_blocks_.find(period);
@@ -72,7 +72,7 @@ std::optional<std::pair<std::shared_ptr<PbftBlock>, bool>> ProposedBlocks::getPb
   return found_block_it->second;
 }
 
-bool ProposedBlocks::isInProposedBlocks(uint64_t period, uint64_t round, const blk_hash_t& block_hash) const {
+bool ProposedBlocks::isInProposedBlocks(uint64_t period, uint32_t round, const blk_hash_t& block_hash) const {
   std::shared_lock lock(proposed_blocks_mutex_);
 
   auto found_period_it = proposed_blocks_.find(period);
@@ -103,7 +103,7 @@ void ProposedBlocks::cleanupProposedPbftBlocksByPeriod(uint64_t period) {
   }
 }
 
-void ProposedBlocks::cleanupProposedPbftBlocksByRound(uint64_t period, uint64_t round) {
+void ProposedBlocks::cleanupProposedPbftBlocksByRound(uint64_t period, uint32_t round) {
   // We must keep previous round proposed blocks for voting purposes
   if (round < 3) {
     return;

--- a/libraries/core_libs/consensus/src/pbft/soft_voted_block_data.cpp
+++ b/libraries/core_libs/consensus/src/pbft/soft_voted_block_data.cpp
@@ -19,7 +19,7 @@ TwoTPlusOneSoftVotedBlockData::TwoTPlusOneSoftVotedBlockData(dev::RLP const& rlp
   }
 
   // Parse round
-  round_ = (*it++).toInt<uint64_t>();
+  round_ = (*it++).toInt<PbftRound>();
 
   // Parse block hash
   block_hash_ = (*it++).toHash<blk_hash_t>();

--- a/libraries/core_libs/consensus/src/pbft/soft_voted_block_data.cpp
+++ b/libraries/core_libs/consensus/src/pbft/soft_voted_block_data.cpp
@@ -31,7 +31,7 @@ TwoTPlusOneSoftVotedBlockData::TwoTPlusOneSoftVotedBlockData(dev::RLP const& rlp
   soft_votes_.reserve((*it).itemCount());
   for (auto const vote_rlp : *it) {
     auto vote = std::make_shared<Vote>(vote_rlp);
-    assert(vote->getType() == PbftVoteTypes::soft_vote_type);
+    assert(vote->getType() == PbftVoteTypes::soft_vote);
     assert(vote->getRound() == round_);
     assert(vote->getBlockHash() == block_hash_);
     if (block_data_.has_value()) {
@@ -60,7 +60,7 @@ bytes TwoTPlusOneSoftVotedBlockData::rlp() const {
   s.append(block_hash_);
   s.appendList(soft_votes_.size());
   for (auto const& vote : soft_votes_) {
-    assert(vote->getType() == PbftVoteTypes::soft_vote_type);
+    assert(vote->getType() == PbftVoteTypes::soft_vote);
     assert(vote->getRound() == round_);
     assert(vote->getBlockHash() == block_hash_);
     if (block_data_.has_value()) {

--- a/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
+++ b/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
@@ -23,7 +23,7 @@ TransactionManager::TransactionManager(FullNodeConfig const &conf, std::shared_p
 }
 
 uint64_t TransactionManager::estimateTransactionGas(std::shared_ptr<Transaction> trx,
-                                                    std::optional<uint64_t> proposal_period) const {
+                                                    std::optional<PbftPeriod> proposal_period) const {
   if (trx->getGas() <= kEstimateGasLimit) {
     return trx->getGas();
   }
@@ -269,7 +269,7 @@ std::vector<trx_hash_t> TransactionManager::excludeFinalizedTransactions(const s
 /**
  * Retrieve transactions to be included in proposed block
  */
-std::pair<SharedTransactions, std::vector<uint64_t>> TransactionManager::packTrxs(uint64_t proposal_period,
+std::pair<SharedTransactions, std::vector<uint64_t>> TransactionManager::packTrxs(PbftPeriod proposal_period,
                                                                                   uint64_t weight_limit) {
   SharedTransactions trxs;
   std::vector<uint64_t> estimations;
@@ -380,7 +380,7 @@ std::optional<SharedTransactions> TransactionManager::getBlockTransactions(DagBl
   return transactions;
 }
 
-void TransactionManager::blockFinalized(uint64_t block_number) {
+void TransactionManager::blockFinalized(EthBlockNumber block_number) {
   std::unique_lock transactions_lock(transactions_mutex_);
   transactions_pool_.blockFinalized(block_number);
 }

--- a/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
+++ b/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
@@ -10,10 +10,11 @@
 #include "network/tarcap/packets_handlers/vote_packet_handler.hpp"
 #include "pbft/pbft_manager.hpp"
 
-constexpr size_t EXTENDED_PARTITION_STEPS = 1000;
-constexpr size_t FIRST_FINISH_STEP = 4;
-
 namespace taraxa {
+
+constexpr PbftStep kExtendedPartionSteps = 1000;
+constexpr PbftStep kFirstFinishStep = 4;
+
 VoteManager::VoteManager(const addr_t& node_addr, std::shared_ptr<DbStorage> db, std::shared_ptr<PbftChain> pbft_chain,
                          std::shared_ptr<FinalChain> final_chain, std::shared_ptr<NextVotesManager> next_votes_mgr)
     : db_(std::move(db)),
@@ -34,10 +35,10 @@ void VoteManager::setNetwork(std::weak_ptr<Network> network) { network_ = std::m
 void VoteManager::retreieveVotes_() {
   LOG(log_si_) << "Retrieve verified votes from DB";
   auto verified_votes = db_->getVerifiedVotes();
-  const auto pbft_step = db_->getPbftMgrField(PbftMgrRoundStep::PbftStep);
+  const auto pbft_step = db_->getPbftMgrField(PbftMgrField::Step);
   for (auto const& v : verified_votes) {
     // Rebroadcast our own next votes in case we were partitioned...
-    if (v->getStep() >= FIRST_FINISH_STEP && pbft_step > EXTENDED_PARTITION_STEPS) {
+    if (v->getStep() >= kFirstFinishStep && pbft_step > kExtendedPartionSteps) {
       if (auto net = network_.lock()) {
         net->getSpecificHandler<network::tarcap::VotePacketHandler>()->onNewPbftVote(v, nullptr);
       }
@@ -59,9 +60,9 @@ std::vector<std::shared_ptr<Vote>> VoteManager::getVerifiedVotes() const {
   votes.reserve(getVerifiedVotesSize());
 
   SharedLock lock(verified_votes_access_);
-  for (const auto& round : verified_votes_) {
-    for (const auto& period : round.second) {
-      for (const auto& step : period.second) {
+  for (const auto& period : verified_votes_) {
+    for (const auto& round : period.second) {
+      for (const auto& step : round.second) {
         for (const auto& voted_value : step.second) {
           for (const auto& v : voted_value.second.second) {
             votes.emplace_back(v.second);
@@ -78,9 +79,9 @@ uint64_t VoteManager::getVerifiedVotesSize() const {
   uint64_t size = 0;
 
   SharedLock lock(verified_votes_access_);
-  for (auto const& round : verified_votes_) {
-    for (auto const& period : round.second) {
-      for (auto const& step : period.second) {
+  for (auto const& period : verified_votes_) {
+    for (auto const& round : period.second) {
+      for (auto const& step : round.second) {
         for (auto const& voted_value : step.second) {
           size += voted_value.second.second.size();
         }
@@ -316,7 +317,7 @@ bool VoteManager::insertUniqueVote(const std::shared_ptr<Vote>& vote) {
 }
 
 // cleanup votes < pbft_round
-void VoteManager::cleanupVotesByRound(uint64_t pbft_period, uint32_t pbft_round) {
+void VoteManager::cleanupVotesByRound(PbftPeriod pbft_period, PbftRound pbft_round) {
   // Clean up cache with unique votes per period, round & step & voter
   {
     std::unique_lock unique_votes_lock(voters_unique_votes_mutex_);
@@ -364,7 +365,7 @@ void VoteManager::cleanupVotesByRound(uint64_t pbft_period, uint32_t pbft_round)
   db_->commitWriteBatch(batch);
 }
 
-void VoteManager::cleanupVotesByPeriod(uint64_t pbft_period) {
+void VoteManager::cleanupVotesByPeriod(PbftPeriod pbft_period) {
   // Clean up cache with unique votes per period, round & step & voter
   {
     std::unique_lock unique_votes_lock(voters_unique_votes_mutex_);
@@ -408,7 +409,7 @@ void VoteManager::cleanupVotesByPeriod(uint64_t pbft_period) {
   db_->commitWriteBatch(batch);
 }
 
-std::shared_ptr<Vote> VoteManager::getProposalVote(uint64_t period, uint32_t round,
+std::shared_ptr<Vote> VoteManager::getProposalVote(PbftPeriod period, PbftRound round,
                                                    const blk_hash_t& voted_block_hash) const {
   SharedLock lock(verified_votes_access_);
 
@@ -442,7 +443,7 @@ std::shared_ptr<Vote> VoteManager::getProposalVote(uint64_t period, uint32_t rou
   return found_voted_block_it->second.second.begin()->second;
 }
 
-std::vector<std::shared_ptr<Vote>> VoteManager::getProposalVotes(uint64_t period, uint32_t round) const {
+std::vector<std::shared_ptr<Vote>> VoteManager::getProposalVotes(PbftPeriod period, PbftRound round) const {
   SharedLock lock(verified_votes_access_);
 
   const auto found_period_it = verified_votes_.find(period);
@@ -471,7 +472,7 @@ std::vector<std::shared_ptr<Vote>> VoteManager::getProposalVotes(uint64_t period
   return proposal_votes;
 }
 
-std::optional<VotesBundle> VoteManager::getTwoTPlusOneVotesBundle(uint64_t period, uint32_t round, uint32_t step,
+std::optional<VotesBundle> VoteManager::getTwoTPlusOneVotesBundle(PbftPeriod period, PbftRound round, PbftStep step,
                                                                   uint64_t two_t_plus_one) const {
   SharedLock lock(verified_votes_access_);
 
@@ -532,8 +533,8 @@ std::optional<VotesBundle> VoteManager::getTwoTPlusOneVotesBundle(uint64_t perio
   return votes_bundle;
 }
 
-std::optional<std::pair<uint32_t, std::vector<std::shared_ptr<Vote>>>> VoteManager::determineRoundFromPeriodAndVotes(
-    uint64_t period, uint64_t two_t_plus_one) {
+std::optional<std::pair<PbftRound, std::vector<std::shared_ptr<Vote>>>> VoteManager::determineRoundFromPeriodAndVotes(
+    PbftPeriod period, uint64_t two_t_plus_one) {
   std::vector<std::shared_ptr<Vote>> votes;
 
   SharedLock lock(verified_votes_access_);
@@ -574,7 +575,7 @@ std::optional<std::pair<uint32_t, std::vector<std::shared_ptr<Vote>>>> VoteManag
   return {};
 }
 
-std::pair<blk_hash_t, uint64_t> VoteManager::getCurrentRewardsVotesBlock() const {
+std::pair<blk_hash_t, PbftPeriod> VoteManager::getCurrentRewardsVotesBlock() const {
   std::shared_lock lock(reward_votes_mutex_);
   return reward_votes_pbft_block_;
 }

--- a/libraries/core_libs/network/include/network/network.hpp
+++ b/libraries/core_libs/network/include/network/network.hpp
@@ -55,7 +55,7 @@ class Network {
   void restartSyncingPbft(bool force = false);
   bool pbft_syncing();
   uint64_t syncTimeSeconds() const;
-  void setSyncStatePeriod(uint64_t period);
+  void setSyncStatePeriod(PbftPeriod period);
 
   template <typename PacketHandlerType>
   std::shared_ptr<PacketHandlerType> getSpecificHandler() const;

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_syncing_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_syncing_packet_handler.hpp
@@ -51,9 +51,10 @@ class ExtSyncingPacketHandler : public PacketHandler {
    *
    * @return true if sync request was sent, otherwise false
    */
-  bool syncPeerPbft(uint64_t request_period, bool ignore_chain_size_check = false);
+  bool syncPeerPbft(PbftPeriod request_period, bool ignore_chain_size_check = false);
 
-  void requestDagBlocks(const dev::p2p::NodeID &_nodeID, const std::unordered_set<blk_hash_t> &blocks, uint64_t period);
+  void requestDagBlocks(const dev::p2p::NodeID &_nodeID, const std::unordered_set<blk_hash_t> &blocks,
+                        PbftPeriod period);
   void requestPendingDagBlocks(std::shared_ptr<TaraxaPeer> peer = nullptr);
 
   std::shared_ptr<TaraxaPeer> getMaxChainPeer();

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_votes_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_votes_packet_handler.hpp
@@ -124,9 +124,9 @@ class ExtVotesPacketHandler : public PacketHandler {
 
   // Dpos contract delay - it is used to validate pbft period in votes -> does not make sense to accept vote
   // with vote period > current pbft period + kDposDelay as the valiation will fail
-  const uint32_t kVoteAcceptingPeriods;
-  const uint16_t kVoteAcceptingRounds;
-  const uint16_t kVoteAcceptingSteps;
+  const PbftPeriod kVoteAcceptingPeriods;
+  const PbftRound kVoteAcceptingRounds;
+  const PbftStep kVoteAcceptingSteps;
   constexpr static std::chrono::seconds kSyncRequestInterval = std::chrono::seconds(10);
 
   mutable std::chrono::system_clock::time_point last_votes_sync_request_time_;

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/packet_handler.hpp
@@ -39,7 +39,7 @@ class PacketHandler {
    */
   void processPacket(const PacketData& packet_data);
 
-  void requestPbftNextVotesAtPeriodRound(const dev::p2p::NodeID& peerID, uint64_t pbft_period, uint64_t pbft_round,
+  void requestPbftNextVotesAtPeriodRound(const dev::p2p::NodeID& peerID, PbftPeriod pbft_period, PbftRound pbft_round,
                                          size_t pbft_previous_round_next_votes_size);
 
  private:

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_dag_sync_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_dag_sync_packet_handler.hpp
@@ -17,7 +17,7 @@ class GetDagSyncPacketHandler final : public PacketHandler {
                           std::shared_ptr<DbStorage> db, const addr_t& node_addr);
 
   void sendBlocks(const dev::p2p::NodeID& peer_id, std::vector<std::shared_ptr<DagBlock>>&& blocks,
-                  SharedTransactions&& transactions, uint64_t request_period, uint64_t period);
+                  SharedTransactions&& transactions, PbftPeriod request_period, PbftPeriod period);
 
   // Packet type that is processed by this handler
   static constexpr SubprotocolPacketType kPacketType_ = SubprotocolPacketType::GetDagSyncPacket;

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_pbft_sync_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_pbft_sync_packet_handler.hpp
@@ -18,7 +18,7 @@ class GetPbftSyncPacketHandler final : public PacketHandler {
                            std::shared_ptr<DbStorage> db, size_t network_sync_level_size, const addr_t& node_addr,
                            bool is_light_node = false, uint64_t light_node_history = 0);
 
-  void sendPbftBlocks(dev::p2p::NodeID const& peer_id, size_t height_to_sync, size_t blocks_to_transfer,
+  void sendPbftBlocks(dev::p2p::NodeID const& peer_id, PbftPeriod from_period, size_t blocks_to_transfer,
                       bool pbft_chain_synced);
 
   // Packet type that is processed by this handler

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/status_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/status_packet_handler.hpp
@@ -26,7 +26,7 @@ class StatusPacketHandler final : public ExtSyncingPacketHandler {
   void validatePacketRlpFormat(const PacketData& packet_data) const override;
   void process(const PacketData& packet_data, const std::shared_ptr<TaraxaPeer>& peer) override;
 
-  void syncPbftNextVotesAtPeriodRound(uint64_t pbft_period, uint64_t pbft_round,
+  void syncPbftNextVotesAtPeriodRound(PbftPeriod pbft_period, PbftRound pbft_round,
                                       size_t pbft_previous_round_next_votes_size);
 
   static constexpr uint16_t kInitialStatusPacketItemsCount = 12;

--- a/libraries/core_libs/network/include/network/tarcap/shared_states/pbft_syncing_state.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/shared_states/pbft_syncing_state.hpp
@@ -24,7 +24,7 @@ class PbftSyncingState {
    * @param current_period
    * @param peer used in case syncing flag == true to set which peer is the node syncing with
    */
-  void setPbftSyncing(bool syncing, uint64_t current_period = 0, std::shared_ptr<TaraxaPeer> peer = nullptr);
+  void setPbftSyncing(bool syncing, PbftPeriod current_period = 0, std::shared_ptr<TaraxaPeer> peer = nullptr);
 
   /**
    * @brief Set current time as last received sync packet time
@@ -34,7 +34,7 @@ class PbftSyncingState {
   /**
    * @brief Set current pbft period
    */
-  void setSyncStatePeriod(uint64_t period);
+  void setSyncStatePeriod(PbftPeriod period);
 
   /**
    * @brief Check if syncing is active

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
@@ -85,7 +85,7 @@ class TaraxaCapability : public dev::p2p::CapabilityFace {
   const std::shared_ptr<NodeStats> &getNodeStats();
 
   bool pbft_syncing() const;
-  void setSyncStatePeriod(uint64_t period);
+  void setSyncStatePeriod(PbftPeriod period);
 
   // METHODS USED IN TESTS ONLY
   size_t getReceivedBlocksCount() const;

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
@@ -85,16 +85,16 @@ class TaraxaPeer : public boost::noncopyable {
 
   std::atomic<bool> syncing_ = false;
   std::atomic<uint64_t> dag_level_ = 0;
-  std::atomic<uint64_t> pbft_chain_size_ = 0;
-  std::atomic<uint64_t> pbft_period_ = pbft_chain_size_ = 1;
-  std::atomic<uint64_t> pbft_round_ = 1;
+  std::atomic<PbftPeriod> pbft_chain_size_ = 0;
+  std::atomic<PbftPeriod> pbft_period_ = pbft_chain_size_ = 1;
+  std::atomic<PbftRound> pbft_round_ = 1;
   std::atomic<size_t> pbft_previous_round_next_votes_size_ = 0;
-  std::atomic<uint64_t> last_status_pbft_chain_size_ = 0;
+  std::atomic<PbftPeriod> last_status_pbft_chain_size_ = 0;
   std::atomic_bool peer_dag_synced_ = false;
   std::atomic_bool peer_dag_syncing_ = false;
   std::atomic_bool peer_requested_dag_syncing_ = false;
   std::atomic_bool peer_light_node = false;
-  std::atomic<uint64_t> peer_light_node_history = 0;
+  std::atomic<PbftPeriod> peer_light_node_history = 0;
 
   // Mutex used to prevent race condition between dag syncing and gossiping
   mutable boost::shared_mutex mutex_for_sending_dag_blocks_;

--- a/libraries/core_libs/network/src/network.cpp
+++ b/libraries/core_libs/network/src/network.cpp
@@ -99,7 +99,7 @@ bool Network::pbft_syncing() { return taraxa_capability_->pbft_syncing(); }
 
 uint64_t Network::syncTimeSeconds() const { return taraxa_capability_->getNodeStats()->syncTimeSeconds(); }
 
-void Network::setSyncStatePeriod(uint64_t period) { taraxa_capability_->setSyncStatePeriod(period); }
+void Network::setSyncStatePeriod(PbftPeriod period) { taraxa_capability_->setSyncStatePeriod(period); }
 
 // Only for test
 void Network::setPendingPeersToReady() {

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_syncing_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_syncing_packet_handler.cpp
@@ -68,7 +68,7 @@ void ExtSyncingPacketHandler::restartSyncingPbft(bool force) {
   }
 }
 
-bool ExtSyncingPacketHandler::syncPeerPbft(uint64_t request_period, bool ignore_chain_size_check) {
+bool ExtSyncingPacketHandler::syncPeerPbft(PbftPeriod request_period, bool ignore_chain_size_check) {
   const auto syncing_peer = pbft_syncing_state_->syncingPeer();
   if (!syncing_peer) {
     LOG(log_er_) << "Unable to send GetPbftSyncPacket. No syncing peer set.";
@@ -88,7 +88,7 @@ bool ExtSyncingPacketHandler::syncPeerPbft(uint64_t request_period, bool ignore_
 
 std::shared_ptr<TaraxaPeer> ExtSyncingPacketHandler::getMaxChainPeer() {
   std::shared_ptr<TaraxaPeer> max_pbft_chain_peer;
-  uint64_t max_pbft_chain_size = 0;
+  PbftPeriod max_pbft_chain_size = 0;
   uint64_t max_node_dag_level = 0;
 
   // Find peer with max pbft chain and dag level
@@ -151,9 +151,9 @@ void ExtSyncingPacketHandler::requestPendingDagBlocks(std::shared_ptr<TaraxaPeer
 }
 
 void ExtSyncingPacketHandler::requestDagBlocks(const dev::p2p::NodeID &_nodeID,
-                                               const std::unordered_set<blk_hash_t> &blocks, uint64_t period) {
+                                               const std::unordered_set<blk_hash_t> &blocks, PbftPeriod period) {
   dev::RLPStream s(2);  // Period + blocks list
-  s.append(static_cast<uint64_t>(period));
+  s.append(period);
   s.append(blocks);
 
   sealAndSend(_nodeID, SubprotocolPacketType::GetDagSyncPacket, std::move(s));

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/common/packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/common/packet_handler.cpp
@@ -117,8 +117,9 @@ void PacketHandler::disconnect(const dev::p2p::NodeID& node_id, dev::p2p::Discon
   }
 }
 
-void PacketHandler::requestPbftNextVotesAtPeriodRound(const dev::p2p::NodeID& peerID, uint64_t pbft_period,
-                                                      uint64_t pbft_round, size_t pbft_previous_round_next_votes_size) {
+void PacketHandler::requestPbftNextVotesAtPeriodRound(const dev::p2p::NodeID& peerID, PbftPeriod pbft_period,
+                                                      PbftRound pbft_round,
+                                                      size_t pbft_previous_round_next_votes_size) {
   LOG(log_nf_) << "Sending GetVotesSyncPacket with period:" << pbft_period << ", round:" << pbft_round
                << ", previous_round_next_votes_size:" << pbft_previous_round_next_votes_size;
   sealAndSend(peerID, GetVotesSyncPacket,

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/dag_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/dag_sync_packet_handler.cpp
@@ -29,8 +29,8 @@ void DagSyncPacketHandler::process(const PacketData& packet_data, const std::sha
   std::string received_dag_blocks_str;
 
   auto it = packet_data.rlp_.begin();
-  const auto request_period = (*it++).toInt<uint64_t>();
-  const auto response_period = (*it++).toInt<uint64_t>();
+  const auto request_period = (*it++).toInt<PbftPeriod>();
+  const auto response_period = (*it++).toInt<PbftPeriod>();
 
   // If the periods did not match restart syncing
   if (response_period > request_period) {

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/get_dag_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/get_dag_sync_packet_handler.cpp
@@ -40,7 +40,7 @@ void GetDagSyncPacketHandler::process(const PacketData &packet_data,
 
   std::unordered_set<blk_hash_t> blocks_hashes;
   auto it = packet_data.rlp_.begin();
-  const auto peer_period = (*it++).toInt<uint64_t>();
+  const auto peer_period = (*it++).toInt<PbftPeriod>();
 
   std::string blocks_hashes_to_log;
   for (const auto block_hash_rlp : *it) {
@@ -65,7 +65,8 @@ void GetDagSyncPacketHandler::process(const PacketData &packet_data,
 
 void GetDagSyncPacketHandler::sendBlocks(const dev::p2p::NodeID &peer_id,
                                          std::vector<std::shared_ptr<DagBlock>> &&blocks,
-                                         SharedTransactions &&transactions, uint64_t request_period, uint64_t period) {
+                                         SharedTransactions &&transactions, PbftPeriod request_period,
+                                         PbftPeriod period) {
   auto peer = peers_state_->getPeer(peer_id);
   if (!peer) return;
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/get_pbft_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/get_pbft_sync_packet_handler.cpp
@@ -64,13 +64,13 @@ void GetPbftSyncPacketHandler::process(const PacketData &packet_data,
 }
 
 // api for pbft syncing
-void GetPbftSyncPacketHandler::sendPbftBlocks(dev::p2p::NodeID const &peer_id, size_t height_to_sync,
+void GetPbftSyncPacketHandler::sendPbftBlocks(dev::p2p::NodeID const &peer_id, PbftPeriod from_period,
                                               size_t blocks_to_transfer, bool pbft_chain_synced) {
-  LOG(log_tr_) << "sendPbftBlocks: peer want to sync from pbft chain height " << height_to_sync
-               << ", will send at most " << blocks_to_transfer << " pbft blocks to " << peer_id;
+  LOG(log_tr_) << "sendPbftBlocks: peer want to sync from pbft chain height " << from_period << ", will send at most "
+               << blocks_to_transfer << " pbft blocks to " << peer_id;
 
-  for (auto block_period = height_to_sync; block_period < height_to_sync + blocks_to_transfer; block_period++) {
-    bool last_block = (block_period == height_to_sync + blocks_to_transfer - 1);
+  for (auto block_period = from_period; block_period < from_period + blocks_to_transfer; block_period++) {
+    bool last_block = (block_period == from_period + blocks_to_transfer - 1);
     auto data = db_->getPeriodDataRaw(block_period);
 
     if (data.size() == 0) {

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/get_votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/get_votes_sync_packet_handler.cpp
@@ -22,8 +22,8 @@ void GetVotesSyncPacketHandler::validatePacketRlpFormat(const PacketData &packet
 void GetVotesSyncPacketHandler::process(const PacketData &packet_data, const std::shared_ptr<TaraxaPeer> &peer) {
   LOG(log_dg_) << "Received GetVotesSyncPacket request";
 
-  const uint64_t peer_pbft_period = packet_data.rlp_[0].toPositiveInt64();
-  const uint64_t peer_pbft_round = packet_data.rlp_[1].toPositiveInt64();
+  const PbftPeriod peer_pbft_period = packet_data.rlp_[0].toInt<PbftPeriod>();
+  const PbftRound peer_pbft_round = packet_data.rlp_[1].toInt<PbftRound>();
   const size_t peer_pbft_previous_round_next_votes_size = packet_data.rlp_[2].toInt<unsigned>();
   const auto [pbft_round, pbft_period] = pbft_mgr_->getPbftRoundAndPeriod();
   const size_t pbft_previous_round_next_votes_size = next_votes_mgr_->getNextVotesWeight();

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/status_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/status_packet_handler.cpp
@@ -54,15 +54,15 @@ void StatusPacketHandler::process(const PacketData& packet_data, const std::shar
     auto const peer_chain_id = (*it++).toInt<uint64_t>();
     auto const peer_dag_level = (*it++).toInt<uint64_t>();
     auto const genesis_hash = (*it++).toHash<blk_hash_t>();
-    auto const peer_pbft_chain_size = (*it++).toInt<uint64_t>();
+    auto const peer_pbft_chain_size = (*it++).toInt<PbftPeriod>();
     auto const peer_syncing = (*it++).toInt();
-    auto const peer_pbft_round = (*it++).toInt<uint64_t>();
+    auto const peer_pbft_round = (*it++).toInt<PbftRound>();
     auto const peer_pbft_previous_round_next_votes_size = (*it++).toInt<unsigned>();
     auto const node_major_version = (*it++).toInt<unsigned>();
     auto const node_minor_version = (*it++).toInt<unsigned>();
     auto const node_patch_version = (*it++).toInt<unsigned>();
     auto const is_light_node = (*it++).toInt();
-    auto const node_history = (*it++).toInt<uint64_t>();
+    auto const node_history = (*it++).toInt<PbftPeriod>();
 
     if (peer_chain_id != conf_chain_id_) {
       LOG((peers_state_->getPeersCount()) ? log_nf_ : log_er_)
@@ -121,11 +121,11 @@ void StatusPacketHandler::process(const PacketData& packet_data, const std::shar
 
     auto it = packet_data.rlp_.begin();
     selected_peer->dag_level_ = (*it++).toInt<uint64_t>();
-    selected_peer->pbft_chain_size_ = (*it++).toInt<uint64_t>();
+    selected_peer->pbft_chain_size_ = (*it++).toInt<PbftPeriod>();
     selected_peer->pbft_period_ = selected_peer->pbft_chain_size_ + 1;
     selected_peer->syncing_ = (*it++).toInt();
-    selected_peer->pbft_round_ = (*it++).toInt<uint64_t>();
-    selected_peer->pbft_previous_round_next_votes_size_ = (*it++).toInt<unsigned>();
+    selected_peer->pbft_round_ = (*it++).toInt<PbftRound>();
+    selected_peer->pbft_previous_round_next_votes_size_ = (*it++).toInt<size_t>();
 
     // TODO: Address malicious status
     if (!pbft_syncing_state_->isPbftSyncing()) {
@@ -221,11 +221,11 @@ void StatusPacketHandler::sendStatusToPeers() {
   }
 }
 
-void StatusPacketHandler::syncPbftNextVotesAtPeriodRound(uint64_t pbft_period, uint64_t pbft_round,
+void StatusPacketHandler::syncPbftNextVotesAtPeriodRound(PbftPeriod pbft_period, PbftRound pbft_round,
                                                          size_t pbft_previous_round_next_votes_size) {
   dev::p2p::NodeID peer_node_ID;
-  uint64_t peer_max_pbft_period = 1;
-  uint64_t peer_max_pbft_round = 1;
+  PbftPeriod peer_max_pbft_period = 1;
+  PbftRound peer_max_pbft_round = 1;
   size_t peer_max_previous_round_next_votes_size = 0;
 
   auto peers = peers_state_->getAllPeers();

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
@@ -88,7 +88,7 @@ void VotePacketHandler::process(const PacketData &packet_data, const std::shared
     }
 
     if (vote->getPeriod() == current_pbft_period && (current_pbft_round - 1) == vote->getRound() &&
-        vote->getType() == PbftVoteTypes::next_vote_type) {
+        vote->getType() == PbftVoteTypes::next_vote) {
       // Previous round next vote
       // We could switch round before other nodes, so we need to process also previous round next votes
       if (!processNextSyncVote(vote, pbft_block)) {
@@ -104,7 +104,7 @@ void VotePacketHandler::process(const PacketData &packet_data, const std::shared
         continue;
       }
 
-    } else if (vote->getPeriod() == current_pbft_period - 1 && vote->getType() == PbftVoteTypes::cert_vote_type) {
+    } else if (vote->getPeriod() == current_pbft_period - 1 && vote->getType() == PbftVoteTypes::cert_vote) {
       // potential reward vote
       if (!processRewardVote(vote)) {
         continue;

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
@@ -71,7 +71,7 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
     }
 
     // VotesSyncPacket is only for next votes
-    if (vote->getType() != PbftVoteTypes::next_vote_type || vote->getStep() < PbftStates::finish_state) {
+    if (vote->getType() != PbftVoteTypes::next_vote) {
       LOG(log_er_) << "Received next votes bundle with non \"next_votes\" from " << packet_data.from_node_id_
                    << ". The peer may be a malicious player, will be disconnected";
       disconnect(packet_data.from_node_id_, dev::p2p::UserReason);

--- a/libraries/core_libs/network/src/tarcap/shared_states/pbft_syncing_state.cpp
+++ b/libraries/core_libs/network/src/tarcap/shared_states/pbft_syncing_state.cpp
@@ -12,7 +12,7 @@ std::shared_ptr<TaraxaPeer> PbftSyncingState::syncingPeer() const {
   return peer_;
 }
 
-void PbftSyncingState::setSyncStatePeriod(uint64_t period) {
+void PbftSyncingState::setSyncStatePeriod(PbftPeriod period) {
   if (pbft_syncing_) {
     std::shared_lock lock(peer_mutex_);
     deep_pbft_syncing_ = (peer_->pbft_chain_size_ - period >= kDeepSyncingThreshold);
@@ -21,7 +21,7 @@ void PbftSyncingState::setSyncStatePeriod(uint64_t period) {
   }
 }
 
-void PbftSyncingState::setPbftSyncing(bool syncing, uint64_t current_period,
+void PbftSyncingState::setPbftSyncing(bool syncing, PbftPeriod current_period,
                                       std::shared_ptr<TaraxaPeer> peer /*=nullptr*/) {
   assert((syncing && peer) || !syncing);
   pbft_syncing_ = syncing;

--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -337,7 +337,7 @@ const std::shared_ptr<NodeStats> &TaraxaCapability::getNodeStats() { return node
 
 bool TaraxaCapability::pbft_syncing() const { return pbft_syncing_state_->isPbftSyncing(); }
 
-void TaraxaCapability::setSyncStatePeriod(uint64_t period) { pbft_syncing_state_->setSyncStatePeriod(period); }
+void TaraxaCapability::setSyncStatePeriod(PbftPeriod period) { pbft_syncing_state_->setSyncStatePeriod(period); }
 
 // METHODS USED IN TESTS ONLY
 size_t TaraxaCapability::getReceivedBlocksCount() const { return test_state_->getBlocksSize(); }

--- a/libraries/core_libs/node/include/node/node.hpp
+++ b/libraries/core_libs/node/include/node/node.hpp
@@ -48,11 +48,6 @@ class FullNode : public std::enable_shared_from_this<FullNode> {
   using vrf_proof_t = vrf_wrapper::vrf_proof_t;
   using jsonrpc_server_t = ModularServer<net::TaraxaFace, net::NetFace, net::EthFace, net::TestFace>;
 
-  struct PostDestructionContext {
-    uint num_shared_pointers_to_check = 0;
-    bool have_leaked_shared_pointers = false;
-  };
-
   // should be destroyed after all components, since they may depend on it through unsafe pointers
   std::unique_ptr<util::ThreadPool> rpc_thread_pool_;
   std::unique_ptr<util::ThreadPool> graphql_thread_pool_;

--- a/libraries/core_libs/node/src/node.cpp
+++ b/libraries/core_libs/node/src/node.cpp
@@ -314,7 +314,7 @@ void FullNode::rebuildDb() {
   pbft_mgr_->initialState();
 
   // Read pbft blocks one by one
-  uint64_t period = 1;
+  PbftPeriod period = 1;
   std::shared_ptr<PeriodData> period_data, next_period_data;
   std::vector<std::shared_ptr<Vote>> cert_votes;
   while (true) {

--- a/libraries/types/pbft_block/include/pbft/pbft_block.hpp
+++ b/libraries/types/pbft_block/include/pbft/pbft_block.hpp
@@ -25,7 +25,7 @@ class PbftBlock {
   blk_hash_t prev_block_hash_;
   blk_hash_t dag_block_hash_as_pivot_;
   blk_hash_t order_hash_;
-  uint64_t period_;  // Block index, PBFT head block is period 0, first PBFT block is period 1
+  PbftPeriod period_;  // Block index, PBFT head block is period 0, first PBFT block is period 1
   uint64_t timestamp_;
   addr_t beneficiary_;
   sig_t signature_;
@@ -33,7 +33,7 @@ class PbftBlock {
 
  public:
   PbftBlock(const blk_hash_t& prev_blk_hash, const blk_hash_t& dag_blk_hash_as_pivot, const blk_hash_t& order_hash,
-            uint64_t period, const addr_t& beneficiary, const secret_t& sk, std::vector<vote_hash_t>&& reward_votes_);
+            PbftPeriod period, const addr_t& beneficiary, const secret_t& sk, std::vector<vote_hash_t>&& reward_votes_);
   explicit PbftBlock(dev::RLP const& rlp);
   explicit PbftBlock(bytes const& RLP);
 
@@ -106,7 +106,7 @@ class PbftBlock {
    * @brief Get period number
    * @return period number
    */
-  auto getPeriod() const { return period_; }
+  PbftPeriod getPeriod() const { return period_; }
 
   /**
    * @brief Get timestamp

--- a/libraries/types/vote/include/vote/vote.hpp
+++ b/libraries/types/vote/include/vote/vote.hpp
@@ -104,19 +104,19 @@ class Vote {
    * @brief Get vote PBFT period
    * @return vote PBFT period
    */
-  uint64_t getPeriod() const { return vrf_sortition_.pbft_msg_.period_; }
+  PbftPeriod getPeriod() const { return vrf_sortition_.pbft_msg_.period_; }
 
   /**
    * @brief Get vote PBFT round
    * @return vote PBFT round
    */
-  uint32_t getRound() const { return vrf_sortition_.pbft_msg_.round_; }
+  PbftRound getRound() const { return vrf_sortition_.pbft_msg_.round_; }
 
   /**
    * @brief Get vote PBFT step
    * @return vote PBFT step
    */
-  uint32_t getStep() const { return vrf_sortition_.pbft_msg_.step_; }
+  PbftStep getStep() const { return vrf_sortition_.pbft_msg_.step_; }
 
   /**
    * @brief Recursive Length Prefix
@@ -188,7 +188,7 @@ class Vote {
  */
 struct VotesBundle {
   blk_hash_t voted_block_hash{blk_hash_t(0)};
-  uint64_t votes_period{0};
+  PbftPeriod votes_period{0};
   std::vector<std::shared_ptr<Vote>> votes;  // Greater than 2t+1 votes
 
   VotesBundle() : voted_block_hash(blk_hash_t(0)) {}

--- a/libraries/types/vote/include/vote/vote.hpp
+++ b/libraries/types/vote/include/vote/vote.hpp
@@ -98,25 +98,25 @@ class Vote {
    * @brief Get vote type
    * @return vote type
    */
-  PbftVoteTypes getType() const { return vrf_sortition_.pbft_msg_.type; }
+  PbftVoteTypes getType() const { return vrf_sortition_.pbft_msg_.getType(); }
 
   /**
    * @brief Get vote PBFT period
    * @return vote PBFT period
    */
-  uint64_t getPeriod() const { return vrf_sortition_.pbft_msg_.period; }
+  uint64_t getPeriod() const { return vrf_sortition_.pbft_msg_.period_; }
 
   /**
    * @brief Get vote PBFT round
    * @return vote PBFT round
    */
-  uint64_t getRound() const { return vrf_sortition_.pbft_msg_.round; }
+  uint32_t getRound() const { return vrf_sortition_.pbft_msg_.round_; }
 
   /**
    * @brief Get vote PBFT step
    * @return vote PBFT step
    */
-  size_t getStep() const { return vrf_sortition_.pbft_msg_.step; }
+  uint32_t getStep() const { return vrf_sortition_.pbft_msg_.step_; }
 
   /**
    * @brief Recursive Length Prefix

--- a/libraries/types/vote/include/vote/vrf_sortition.hpp
+++ b/libraries/types/vote/include/vote/vrf_sortition.hpp
@@ -12,15 +12,27 @@ namespace taraxa {
  * @{
  */
 
-enum PbftVoteTypes : uint8_t { propose_vote_type = 0, soft_vote_type, cert_vote_type, next_vote_type };
+// PbftVoteTypes are equal to step numbers, e.g.
+// - "propose_vote" type can be created only in step 1
+// - "soft_vote" type can be created only in step 2
+// - "cert_vote" type can be created only in step 3
+// - "next_vote" type can be created only in step 4 or more
+enum class PbftVoteTypes : uint8_t { invalid_vote = 0, propose_vote, soft_vote, cert_vote, next_vote };
 
 /**
- * @brief VrfPbftMsg struct uses vote type, PBFT round, and PBFT step to generate a message for doing VRF sortition.
+ * @brief VrfPbftMsg class uses PBFT period, round and step to generate a message for doing VRF sortition.
  */
-struct VrfPbftMsg {
+class VrfPbftMsg {
  public:
   VrfPbftMsg() = default;
-  VrfPbftMsg(PbftVoteTypes type, uint64_t period, uint64_t round, size_t step);
+  VrfPbftMsg(PbftVoteTypes type, uint64_t period, uint32_t round, uint32_t step);
+
+  /**
+   * @brief Get v type based on vote step
+   *
+   * @return PbftVoteTypes based on vote step
+   */
+  PbftVoteTypes getType() const;
 
   /**
    * @brief Combine vote type, PBFT period, round and step to a string
@@ -37,17 +49,15 @@ struct VrfPbftMsg {
   bool operator==(VrfPbftMsg const& other) const;
   friend std::ostream& operator<<(std::ostream& strm, VrfPbftMsg const& pbft_msg) {
     strm << "  [Vrf Pbft Msg] " << std::endl;
-    strm << "    type: " << static_cast<uint32_t>(pbft_msg.type) << std::endl;
-    strm << "    period: " << pbft_msg.period << std::endl;
-    strm << "    round: " << pbft_msg.round << std::endl;
-    strm << "    step: " << pbft_msg.step << std::endl;
+    strm << "    period: " << pbft_msg.period_ << std::endl;
+    strm << "    round: " << pbft_msg.round_ << std::endl;
+    strm << "    step: " << pbft_msg.step_ << std::endl;
     return strm;
   }
 
-  PbftVoteTypes type;
-  uint64_t period;
-  uint64_t round;
-  size_t step;
+  uint64_t period_;
+  uint32_t round_;
+  uint32_t step_;
 };
 
 /**

--- a/libraries/types/vote/include/vote/vrf_sortition.hpp
+++ b/libraries/types/vote/include/vote/vrf_sortition.hpp
@@ -25,7 +25,7 @@ enum class PbftVoteTypes : uint8_t { invalid_vote = 0, propose_vote, soft_vote, 
 class VrfPbftMsg {
  public:
   VrfPbftMsg() = default;
-  VrfPbftMsg(PbftVoteTypes type, uint64_t period, uint32_t round, uint32_t step);
+  VrfPbftMsg(PbftVoteTypes type, PbftPeriod period, PbftRound round, PbftStep step);
 
   /**
    * @brief Get v type based on vote step
@@ -55,9 +55,9 @@ class VrfPbftMsg {
     return strm;
   }
 
-  uint64_t period_;
-  uint32_t round_;
-  uint32_t step_;
+  PbftPeriod period_;
+  PbftRound round_;
+  PbftStep step_;
 };
 
 /**
@@ -124,7 +124,7 @@ class VrfPbftSortition : public vrf_wrapper::VrfSortitionBase {
    * @param address voter public key
    * @return vote weight
    */
-  uint64_t calculateWeight(uint64_t stake, double dpos_total_votes_count, double threshold,
+  uint64_t calculateWeight(uint64_t stake, uint64_t dpos_total_votes_count, uint64_t threshold,
                            const public_t& address) const;
 
   friend std::ostream& operator<<(std::ostream& strm, const VrfPbftSortition& vrf_sortition) {

--- a/libraries/types/vote/src/vrf_sortition.cpp
+++ b/libraries/types/vote/src/vrf_sortition.cpp
@@ -7,44 +7,58 @@
 
 namespace taraxa {
 
-VrfPbftMsg::VrfPbftMsg(PbftVoteTypes type, uint64_t period, uint64_t round, size_t step)
-    : type(type), period(period), round(round), step(step) {}
+VrfPbftMsg::VrfPbftMsg(PbftVoteTypes type, uint64_t period, uint32_t round, uint32_t step)
+    : period_(period), round_(round), step_(step) {
+  // Just to make sure developers dont try to create vote type with step that does not correspond to the type
+  assert(type == getType());
+  assert(type != PbftVoteTypes::invalid_vote);
+}
+
+PbftVoteTypes VrfPbftMsg::getType() const {
+  switch (step_) {
+    case 0:
+      return PbftVoteTypes::invalid_vote;
+    case 1:
+      return PbftVoteTypes::propose_vote;
+    case 2:
+      return PbftVoteTypes::soft_vote;
+    case 3:
+      return PbftVoteTypes::cert_vote;
+    default:
+      // Vote with step >= 4 is next vote
+      return PbftVoteTypes::next_vote;
+  }
+}
 
 std::string VrfPbftMsg::toString() const {
-  return std::to_string(type) + "_" + std::to_string(period) + "_" + std::to_string(round) + "_" + std::to_string(step);
+  return std::to_string(period_) + "_" + std::to_string(round_) + "_" + std::to_string(step_);
 }
 
 bool VrfPbftMsg::operator==(VrfPbftMsg const& other) const {
-  return type == other.type && period == other.period && round == other.round && step == other.step;
+  return period_ == other.period_ && round_ == other.round_ && step_ == other.step_;
 }
 
 bytes VrfPbftMsg::getRlpBytes() const {
   dev::RLPStream s;
-  s.appendList(4);
-  s << static_cast<uint8_t>(type);
-  s << period;
-  s << round;
-  s << step;
+  s.appendList(3);
+  s << period_;
+  s << round_;
+  s << step_;
   return s.invalidate();
 }
 
 VrfPbftSortition::VrfPbftSortition(bytes const& b) {
   dev::RLP const rlp(b);
-
-  uint8_t pbft_msg_type = 0;
-  util::rlp_tuple(util::RLPDecoderRef(rlp, true), pbft_msg_type, pbft_msg_.period, pbft_msg_.round, pbft_msg_.step,
-                  proof_);
-  pbft_msg_.type = static_cast<PbftVoteTypes>(pbft_msg_type);
+  util::rlp_tuple(util::RLPDecoderRef(rlp, true), pbft_msg_.period_, pbft_msg_.round_, pbft_msg_.step_, proof_);
 }
 
 bytes VrfPbftSortition::getRlpBytes() const {
   dev::RLPStream s;
 
-  s.appendList(5);
-  s << static_cast<uint8_t>(pbft_msg_.type);
-  s << pbft_msg_.period;
-  s << pbft_msg_.round;
-  s << pbft_msg_.step;
+  s.appendList(4);
+  s << pbft_msg_.period_;
+  s << pbft_msg_.round_;
+  s << pbft_msg_.step_;
   s << proof_;
 
   return s.invalidate();

--- a/libraries/types/vote/src/vrf_sortition.cpp
+++ b/libraries/types/vote/src/vrf_sortition.cpp
@@ -7,7 +7,7 @@
 
 namespace taraxa {
 
-VrfPbftMsg::VrfPbftMsg(PbftVoteTypes type, uint64_t period, uint32_t round, uint32_t step)
+VrfPbftMsg::VrfPbftMsg(PbftVoteTypes type, PbftPeriod period, PbftRound round, PbftStep step)
     : period_(period), round_(round), step_(step) {
   // Just to make sure developers dont try to create vote type with step that does not correspond to the type
   assert(type == getType());
@@ -91,7 +91,7 @@ uint64_t VrfPbftSortition::getBinominalDistribution(uint64_t stake, double dpos_
   return stake;
 }
 
-uint64_t VrfPbftSortition::calculateWeight(uint64_t stake, double dpos_total_votes_count, double threshold,
+uint64_t VrfPbftSortition::calculateWeight(uint64_t stake, uint64_t dpos_total_votes_count, uint64_t threshold,
                                            const public_t& address) const {
   // Also hash in the address. This is necessary to decorrelate the selection of different accounts that have the same
   // VRF key.

--- a/tests/crypto_test.cpp
+++ b/tests/crypto_test.cpp
@@ -289,24 +289,24 @@ TEST_F(CryptoTest, sortition_rate) {
       "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
       "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
   int count = 0;
-  int round = 1000;
+  PbftRound round = 1000;
   int valid_sortition_players = 100;
   int sortition_threshold = 5;
   // Test for one player sign round messages to get sortition
   // Sortition rate THRESHOLD / PLAYERS = 5%
-  size_t pbft_step = 3;
-  for (int i = 0; i < round; i++) {
+  PbftStep pbft_step = 3;
+  for (uint32_t i = 0; i < round; i++) {
     VrfPbftMsg msg(PbftVoteTypes::cert_vote, i, i, pbft_step);
     VrfPbftSortition sortition(sk, msg);
     count += sortition.calculateWeight(1, valid_sortition_players, sortition_threshold, sk);
   }
-  EXPECT_EQ(count, 45);  // Test experience
+  EXPECT_EQ(count, 42);  // Test experience
 
   count = 0;
   sortition_threshold = valid_sortition_players;
   // Test for one player sign round messages to get sortition
   // Sortition rate THRESHOLD / PLAYERS = 100%
-  for (int i = 0; i < round; i++) {
+  for (uint32_t i = 0; i < round; i++) {
     VrfPbftMsg msg(PbftVoteTypes::cert_vote, i, i, pbft_step);
     VrfPbftSortition sortition(sk, msg);
     count += sortition.calculateWeight(1, valid_sortition_players, sortition_threshold, dev::FixedHash<64>::random());
@@ -321,7 +321,7 @@ TEST_F(CryptoTest, sortition_rate) {
   // Each player sign round messages, sortition rate for one player: THRESHOLD / PLAYERS = 100%
   for (int i = 0; i < valid_sortition_players; i++) {
     dev::KeyPair key_pair = dev::KeyPair::create();
-    for (int j = 0; j < round; j++) {
+    for (uint32_t j = 0; j < round; j++) {
       auto [pk, sk] = getVrfKeyPair();
       VrfPbftMsg msg(PbftVoteTypes::cert_vote, i, i, pbft_step);
       VrfPbftSortition sortition(sk, msg);

--- a/tests/crypto_test.cpp
+++ b/tests/crypto_test.cpp
@@ -95,7 +95,7 @@ TEST_F(CryptoTest, vrf_sortition) {
   vrf_sk_t sk(
       "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
       "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
-  VrfPbftMsg msg(PbftVoteTypes::cert_vote_type, 2, 2, 3);
+  VrfPbftMsg msg(PbftVoteTypes::cert_vote, 2, 2, 3);
   VrfPbftSortition sortition(sk, msg);
   VrfPbftSortition sortition2(sk, msg);
 
@@ -296,7 +296,7 @@ TEST_F(CryptoTest, sortition_rate) {
   // Sortition rate THRESHOLD / PLAYERS = 5%
   size_t pbft_step = 3;
   for (int i = 0; i < round; i++) {
-    VrfPbftMsg msg(PbftVoteTypes::cert_vote_type, i, i, pbft_step);
+    VrfPbftMsg msg(PbftVoteTypes::cert_vote, i, i, pbft_step);
     VrfPbftSortition sortition(sk, msg);
     count += sortition.calculateWeight(1, valid_sortition_players, sortition_threshold, sk);
   }
@@ -307,7 +307,7 @@ TEST_F(CryptoTest, sortition_rate) {
   // Test for one player sign round messages to get sortition
   // Sortition rate THRESHOLD / PLAYERS = 100%
   for (int i = 0; i < round; i++) {
-    VrfPbftMsg msg(PbftVoteTypes::cert_vote_type, i, i, pbft_step);
+    VrfPbftMsg msg(PbftVoteTypes::cert_vote, i, i, pbft_step);
     VrfPbftSortition sortition(sk, msg);
     count += sortition.calculateWeight(1, valid_sortition_players, sortition_threshold, dev::FixedHash<64>::random());
   }
@@ -323,7 +323,7 @@ TEST_F(CryptoTest, sortition_rate) {
     dev::KeyPair key_pair = dev::KeyPair::create();
     for (int j = 0; j < round; j++) {
       auto [pk, sk] = getVrfKeyPair();
-      VrfPbftMsg msg(PbftVoteTypes::cert_vote_type, i, i, pbft_step);
+      VrfPbftMsg msg(PbftVoteTypes::cert_vote, i, i, pbft_step);
       VrfPbftSortition sortition(sk, msg);
       count += sortition.calculateWeight(1, valid_sortition_players, sortition_threshold, dev::FixedHash<64>::random());
     }
@@ -385,7 +385,7 @@ TEST_F(CryptoTest, leader_selection) {
   };
 
   for (uint64_t i = 0; i < rounds; i++) {
-    const VrfPbftMsg msg(propose_vote_type, i, i, 1);
+    const VrfPbftMsg msg(PbftVoteTypes::propose_vote, i, i, 1);
     std::unordered_map<uint64_t, dev::h256> outputs;
 
     selector(outputs, msg, high_stake_nodes, high_stake_nodes_power);

--- a/tests/dag_test.cpp
+++ b/tests/dag_test.cpp
@@ -173,7 +173,7 @@ TEST_F(DagTest, compute_epoch) {
   taraxa::thisThreadSleepForMilliSeconds(100);
 
   vec_blk_t orders;
-  uint64_t period;
+  PbftPeriod period;
 
   // Test that with incorrect period, order is not returned
   orders = mgr->getDagBlockOrder(blkA_hash, 2);
@@ -374,7 +374,7 @@ TEST_F(DagTest, compute_epoch_2) {
   taraxa::thisThreadSleepForMilliSeconds(100);
 
   vec_blk_t orders;
-  uint64_t period = 1;
+  PbftPeriod period = 1;
   orders = mgr->getDagBlockOrder(blkA_hash, period);
   EXPECT_EQ(orders.size(), 1);
   // repeat, should not change

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -92,22 +92,22 @@ TEST_F(FullNodeTest, db_test) {
   ASSERT_EQ(*g_trx_signed_samples[3], *db.getTransaction(g_trx_signed_samples[3]->getHash()));
 
   // PBFT manager round and step
-  EXPECT_EQ(db.getPbftMgrField(PbftMgrRoundStep::PbftRound), 1);
-  EXPECT_EQ(db.getPbftMgrField(PbftMgrRoundStep::PbftStep), 1);
+  EXPECT_EQ(db.getPbftMgrField(PbftMgrField::Round), 1);
+  EXPECT_EQ(db.getPbftMgrField(PbftMgrField::Step), 1);
   uint64_t pbft_round = 30;
   size_t pbft_step = 31;
-  db.savePbftMgrField(PbftMgrRoundStep::PbftRound, pbft_round);
-  db.savePbftMgrField(PbftMgrRoundStep::PbftStep, pbft_step);
-  EXPECT_EQ(db.getPbftMgrField(PbftMgrRoundStep::PbftRound), pbft_round);
-  EXPECT_EQ(db.getPbftMgrField(PbftMgrRoundStep::PbftStep), pbft_step);
+  db.savePbftMgrField(PbftMgrField::Round, pbft_round);
+  db.savePbftMgrField(PbftMgrField::Step, pbft_step);
+  EXPECT_EQ(db.getPbftMgrField(PbftMgrField::Round), pbft_round);
+  EXPECT_EQ(db.getPbftMgrField(PbftMgrField::Step), pbft_step);
   pbft_round = 90;
   pbft_step = 91;
   batch = db.createWriteBatch();
-  db.addPbftMgrFieldToBatch(PbftMgrRoundStep::PbftRound, pbft_round, batch);
-  db.addPbftMgrFieldToBatch(PbftMgrRoundStep::PbftStep, pbft_step, batch);
+  db.addPbftMgrFieldToBatch(PbftMgrField::Round, pbft_round, batch);
+  db.addPbftMgrFieldToBatch(PbftMgrField::Step, pbft_step, batch);
   db.commitWriteBatch(batch);
-  EXPECT_EQ(db.getPbftMgrField(PbftMgrRoundStep::PbftRound), pbft_round);
-  EXPECT_EQ(db.getPbftMgrField(PbftMgrRoundStep::PbftStep), pbft_step);
+  EXPECT_EQ(db.getPbftMgrField(PbftMgrField::Round), pbft_round);
+  EXPECT_EQ(db.getPbftMgrField(PbftMgrField::Step), pbft_step);
 
   // PBFT manager status
   EXPECT_FALSE(db.getPbftMgrStatus(PbftMgrStatus::ExecutedBlock));
@@ -135,7 +135,7 @@ TEST_F(FullNodeTest, db_test) {
 
   // PBFT soft voted block data in round
   EXPECT_EQ(db.getSoftVotedBlockDataInRound(), std::nullopt);
-  uint64_t soft_voted_block_period_and_round = 123;
+  PbftRound soft_voted_block_period_and_round = 123;
   TwoTPlusOneSoftVotedBlockData soft_voted_block_data_with_block;
   soft_voted_block_data_with_block.round_ = soft_voted_block_period_and_round;
   soft_voted_block_data_with_block.block_data_ = {
@@ -282,10 +282,9 @@ TEST_F(FullNodeTest, db_test) {
   EXPECT_TRUE(verified_votes.empty());
   auto voted_pbft_block_hash = blk_hash_t(2);
   for (auto i = 0; i < 3; i++) {
-    auto period = i;
-    auto round = i;
-    auto step = i;
-    VrfPbftMsg msg(PbftVoteTypes::next_vote, period, round, step);
+    PbftPeriod period = i;
+    PbftRound round = i;
+    VrfPbftMsg msg(PbftVoteTypes::next_vote, period, round, 4);
     vrf_wrapper::vrf_sk_t vrf_sk(
         "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
         "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
@@ -308,7 +307,9 @@ TEST_F(FullNodeTest, db_test) {
   EXPECT_TRUE(db.getVerifiedVotes().empty());
 
   // Next votes
-  uint64_t period = 3, round = 3, step = 5;
+  PbftPeriod period = 3;
+  PbftRound round = 3;
+  PbftStep step = 5;
   auto next_votes = db.getPreviousRoundNextVotes();
   EXPECT_TRUE(next_votes.empty());
   for (auto i = 0; i < 3; i++) {
@@ -730,7 +731,7 @@ TEST_F(FullNodeTest, insert_anchor_and_compute_order) {
   // -------- first period ----------
 
   auto ret = node->getDagManager()->getLatestPivotAndTips();
-  uint64_t period = 1;
+  PbftPeriod period = 1;
   vec_blk_t order;
   order = node->getDagManager()->getDagBlockOrder(ret->first, period);
   EXPECT_EQ(order.size(), 6);

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -144,7 +144,8 @@ TEST_F(FullNodeTest, db_test) {
   std::vector<std::shared_ptr<Vote>> soft_votes;
   for (auto i = 0; i < 3; i++) {
     blk_hash_t voted_pbft_block_hash(i);
-    VrfPbftMsg msg(soft_vote_type, soft_voted_block_period_and_round, soft_voted_block_period_and_round, filter_state);
+    VrfPbftMsg msg(PbftVoteTypes::soft_vote, soft_voted_block_period_and_round, soft_voted_block_period_and_round,
+                   filter_state);
     vrf_wrapper::vrf_sk_t vrf_sk(
         "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
         "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
@@ -213,7 +214,7 @@ TEST_F(FullNodeTest, db_test) {
   // Certified votes
   std::vector<std::shared_ptr<Vote>> cert_votes;
   for (auto i = 0; i < 3; i++) {
-    VrfPbftMsg msg(cert_vote_type, 2, 2, 3);
+    VrfPbftMsg msg(PbftVoteTypes::cert_vote, 2, 2, 3);
     vrf_wrapper::vrf_sk_t vrf_sk(
         "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
         "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
@@ -284,7 +285,7 @@ TEST_F(FullNodeTest, db_test) {
     auto period = i;
     auto round = i;
     auto step = i;
-    VrfPbftMsg msg(next_vote_type, period, round, step);
+    VrfPbftMsg msg(PbftVoteTypes::next_vote, period, round, step);
     vrf_wrapper::vrf_sk_t vrf_sk(
         "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
         "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
@@ -312,7 +313,7 @@ TEST_F(FullNodeTest, db_test) {
   EXPECT_TRUE(next_votes.empty());
   for (auto i = 0; i < 3; i++) {
     blk_hash_t voted_pbft_block_hash(i);
-    VrfPbftMsg msg(next_vote_type, period, round, step);
+    VrfPbftMsg msg(PbftVoteTypes::next_vote, period, round, step);
     vrf_wrapper::vrf_sk_t vrf_sk(
         "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
         "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
@@ -327,7 +328,7 @@ TEST_F(FullNodeTest, db_test) {
   next_votes.clear();
   for (auto i = 3; i < 5; i++) {
     blk_hash_t voted_pbft_block_hash(i);
-    VrfPbftMsg msg(next_vote_type, period, round, step);
+    VrfPbftMsg msg(PbftVoteTypes::next_vote, period, round, step);
     vrf_wrapper::vrf_sk_t vrf_sk(
         "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
         "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -171,8 +171,9 @@ TEST_F(NetworkTest, DISABLED_update_peer_chainsize) {
   auto pbft_block =
       std::make_shared<PbftBlock>(blk_hash_t(1), blk_hash_t(0), blk_hash_t(0), node1->getPbftManager()->getPbftPeriod(),
                                   node1->getAddress(), node1->getSecretKey(), std::move(reward_votes));
-  auto vote = node1_pbft_mgr->generateVote(pbft_block->getBlockHash(), propose_vote_type, pbft_block->getPeriod(),
-                                           node1_pbft_mgr->getPbftRound() + 1, value_proposal_state);
+  auto vote =
+      node1_pbft_mgr->generateVote(pbft_block->getBlockHash(), PbftVoteTypes::propose_vote, pbft_block->getPeriod(),
+                                   node1_pbft_mgr->getPbftRound() + 1, value_proposal_state);
 
   auto node2_id = nw2->getNodeId();
   ASSERT_NE(node1->getPbftChain()->getPbftChainSize(), nw1->getPeer(node2_id)->pbft_chain_size_);
@@ -544,7 +545,7 @@ TEST_F(NetworkTest, node_pbft_sync) {
                         node1->getSecretKey(), {});
   std::vector<std::shared_ptr<Vote>> votes_for_pbft_blk1;
   votes_for_pbft_blk1.emplace_back(
-      node1->getPbftManager()->generateVote(pbft_block1.getBlockHash(), cert_vote_type, 1, 1, 3));
+      node1->getPbftManager()->generateVote(pbft_block1.getBlockHash(), PbftVoteTypes::cert_vote, 1, 1, 3));
   std::cout << "Generate 1 vote for first PBFT block" << std::endl;
   // Add cert votes in DB
   // Add PBFT block in DB
@@ -599,7 +600,7 @@ TEST_F(NetworkTest, node_pbft_sync) {
                         node1->getSecretKey(), {});
   std::vector<std::shared_ptr<Vote>> votes_for_pbft_blk2;
   votes_for_pbft_blk2.emplace_back(
-      node1->getPbftManager()->generateVote(pbft_block2.getBlockHash(), cert_vote_type, 2, 2, 3));
+      node1->getPbftManager()->generateVote(pbft_block2.getBlockHash(), PbftVoteTypes::cert_vote, 2, 2, 3));
   std::cout << "Generate 1 vote for second PBFT block" << std::endl;
   // node1 put block2 into pbft chain and store into DB
   // Add cert votes in DB
@@ -708,7 +709,7 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
                         node1->getSecretKey(), {});
   std::vector<std::shared_ptr<Vote>> votes_for_pbft_blk1;
   votes_for_pbft_blk1.emplace_back(
-      node1->getPbftManager()->generateVote(pbft_block1.getBlockHash(), cert_vote_type, 1, 1, 3));
+      node1->getPbftManager()->generateVote(pbft_block1.getBlockHash(), PbftVoteTypes::cert_vote, 1, 1, 3));
   std::cout << "Generate 1 vote for first PBFT block" << std::endl;
   // Add cert votes in DB
   // Add PBFT block in DB
@@ -798,7 +799,7 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_behind_round) {
 
   // Generate 3 next votes
   std::vector<std::shared_ptr<Vote>> next_votes;
-  PbftVoteTypes type = next_vote_type;
+  PbftVoteTypes type = PbftVoteTypes::next_vote;
   uint64_t period = 1;
   uint64_t round = 1;
   size_t step = 5;
@@ -866,7 +867,7 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_1) {
   uint64_t period = 1;
   uint64_t round = 1;
   size_t step = 5;
-  PbftVoteTypes type = next_vote_type;
+  PbftVoteTypes type = PbftVoteTypes::next_vote;
   for (uint64_t i = 0; i < 2; i++) {
     blk_hash_t voted_pbft_block_hash1(i);  // Next votes could vote on 2 values
     auto vote = pbft_mgr1->generateVote(voted_pbft_block_hash1, type, period, round, step);
@@ -928,7 +929,7 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_2) {
 
   // Node1 generate 1 next vote voted at NULL_BLOCK_HASH
   blk_hash_t voted_pbft_block_hash1(blk_hash_t(0));
-  PbftVoteTypes type = next_vote_type;
+  PbftVoteTypes type = PbftVoteTypes::next_vote;
   uint64_t period = 1;
   uint64_t round = 1;
   size_t step = 5;

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -522,7 +522,7 @@ TEST_F(NetworkTest, node_pbft_sync) {
 
   // generate first PBFT block sample
   blk_hash_t prev_block_hash(0);
-  uint64_t period = 1;
+  PbftPeriod period = 1;
   addr_t beneficiary(987);
 
   level_t level = 1;
@@ -687,7 +687,7 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
 
   // generate first PBFT block sample
   blk_hash_t prev_block_hash(0);
-  uint64_t period = 1;
+  PbftPeriod period = 1;
   addr_t beneficiary(876);
   level_t level = 1;
   vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk, getRlpBytes(level));
@@ -800,9 +800,9 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_behind_round) {
   // Generate 3 next votes
   std::vector<std::shared_ptr<Vote>> next_votes;
   PbftVoteTypes type = PbftVoteTypes::next_vote;
-  uint64_t period = 1;
-  uint64_t round = 1;
-  size_t step = 5;
+  PbftPeriod period = 1;
+  PbftRound round = 1;
+  PbftStep step = 5;
   for (auto i = 0; i < 3; i++) {
     blk_hash_t voted_pbft_block_hash(i % 2);  // Next votes could vote on 2 values
     std::cout << voted_pbft_block_hash << std::endl;
@@ -864,9 +864,9 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_1) {
 
   // Generate 2 next votes for node1
   std::vector<std::shared_ptr<Vote>> next_votes1;
-  uint64_t period = 1;
-  uint64_t round = 1;
-  size_t step = 5;
+  PbftPeriod period = 1;
+  PbftRound round = 1;
+  PbftStep step = 5;
   PbftVoteTypes type = PbftVoteTypes::next_vote;
   for (uint64_t i = 0; i < 2; i++) {
     blk_hash_t voted_pbft_block_hash1(i);  // Next votes could vote on 2 values
@@ -930,9 +930,9 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_2) {
   // Node1 generate 1 next vote voted at NULL_BLOCK_HASH
   blk_hash_t voted_pbft_block_hash1(blk_hash_t(0));
   PbftVoteTypes type = PbftVoteTypes::next_vote;
-  uint64_t period = 1;
-  uint64_t round = 1;
-  size_t step = 5;
+  PbftPeriod period = 1;
+  PbftRound round = 1;
+  PbftStep step = 5;
   auto vote1 = pbft_mgr1->generateVote(voted_pbft_block_hash1, type, period, round, step);
   vote1->calculateWeight(1, 1, 1);
   std::vector<std::shared_ptr<Vote>> next_votes1{vote1};

--- a/tests/pbft_chain_test.cpp
+++ b/tests/pbft_chain_test.cpp
@@ -23,7 +23,7 @@ TEST_F(PbftChainTest, serialize_desiriablize_pbft_block) {
   // Generate PBFT block sample
   blk_hash_t prev_block_hash(12345);
   blk_hash_t dag_block_hash_as_pivot(45678);
-  uint64_t period = 1;
+  PbftPeriod period = 1;
   addr_t beneficiary(98765);
   PbftBlock pbft_block1(prev_block_hash, dag_block_hash_as_pivot, blk_hash_t(), period, beneficiary, sk, {});
 
@@ -54,7 +54,7 @@ TEST_F(PbftChainTest, pbft_db_test) {
   vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
   DagBlock blk1(dag_genesis, 1, {}, {}, {}, vdf1, sk);
 
-  uint64_t period = 1;
+  PbftPeriod period = 1;
   addr_t beneficiary(987);
   PbftBlock pbft_block(prev_block_hash, blk1.getHash(), blk_hash_t(), period, beneficiary, node->getSecretKey(), {});
 

--- a/tests/pbft_manager_test.cpp
+++ b/tests/pbft_manager_test.cpp
@@ -205,7 +205,7 @@ TEST_F(PbftManagerTest, terminate_soft_voting_pbft_block) {
 
   // Generate bogus votes
   auto stale_block_hash = blk_hash_t("0000000100000000000000000000000000000000000000000000000000000000");
-  auto propose_vote = pbft_mgr->generateVote(stale_block_hash, propose_vote_type, 2, 2, 1);
+  auto propose_vote = pbft_mgr->generateVote(stale_block_hash, PbftVoteTypes::propose_vote, 2, 2, 1);
   propose_vote->calculateWeight(1, 1, 1);
   vote_mgr->addVerifiedVote(propose_vote);
 
@@ -232,7 +232,7 @@ TEST_F(PbftManagerTest, terminate_soft_voting_pbft_block) {
   bool skipped_soft_voting = true;
   auto votes = vote_mgr->getVerifiedVotes();
   for (const auto &v : votes) {
-    if (soft_vote_type == v->getType()) {
+    if (PbftVoteTypes::soft_vote == v->getType()) {
       if (v->getBlockHash() == stale_block_hash) {
         skipped_soft_voting = false;
       }
@@ -285,7 +285,7 @@ TEST_F(PbftManagerTest, terminate_bogus_dag_anchor) {
   auto period = 1;
   auto round = 1;
   auto step = 4;
-  auto propose_vote = pbft_mgr->generateVote(pbft_block_hash, next_vote_type, period, round, step);
+  auto propose_vote = pbft_mgr->generateVote(pbft_block_hash, PbftVoteTypes::next_vote, period, round, step);
   propose_vote->calculateWeight(1, 1, 1);
   vote_mgr->addVerifiedVote(propose_vote);
 
@@ -299,7 +299,7 @@ TEST_F(PbftManagerTest, terminate_bogus_dag_anchor) {
     blk_hash_t soft_vote_value;
     auto votes = vote_mgr->getVerifiedVotes();
     for (const auto &v : votes) {
-      if (soft_vote_type == v->getType() && v->getBlockHash() == pbft_block_hash) {
+      if (PbftVoteTypes::soft_vote == v->getType() && v->getBlockHash() == pbft_block_hash) {
         soft_vote_value = v->getBlockHash();
         break;
       }
@@ -313,7 +313,7 @@ TEST_F(PbftManagerTest, terminate_bogus_dag_anchor) {
     auto proposal_value = pbft_block_hash;
     auto votes = vote_mgr->getVerifiedVotes();
     for (const auto &v : votes) {
-      if (propose_vote_type == v->getType() && v->getBlockHash() != pbft_block_hash) {
+      if (PbftVoteTypes::propose_vote == v->getType() && v->getBlockHash() != pbft_block_hash) {
         proposal_value = v->getBlockHash();
         break;
       }
@@ -345,7 +345,7 @@ TEST_F(PbftManagerTest, terminate_missing_proposed_pbft_block) {
   auto round = 1;
   auto step = 4;
   auto pbft_block_hash = blk_hash_t("0000000100000000000000000000000000000000000000000000000000000000");
-  auto next_vote = pbft_mgr->generateVote(pbft_block_hash, next_vote_type, period, round, step);
+  auto next_vote = pbft_mgr->generateVote(pbft_block_hash, PbftVoteTypes::next_vote, period, round, step);
   next_vote->calculateWeight(1, 1, 1);
   vote_mgr->addVerifiedVote(next_vote);
 
@@ -359,7 +359,7 @@ TEST_F(PbftManagerTest, terminate_missing_proposed_pbft_block) {
     blk_hash_t soft_vote_value;
     auto votes = vote_mgr->getVerifiedVotes();
     for (auto const &v : votes) {
-      if (soft_vote_type == v->getType() && v->getBlockHash() == pbft_block_hash) {
+      if (PbftVoteTypes::soft_vote == v->getType() && v->getBlockHash() == pbft_block_hash) {
         soft_vote_value = v->getBlockHash();
         break;
       }
@@ -375,7 +375,7 @@ TEST_F(PbftManagerTest, terminate_missing_proposed_pbft_block) {
     auto votes = vote_mgr->getVerifiedVotes();
 
     for (auto const &v : votes) {
-      if (propose_vote_type == v->getType() && v->getBlockHash() != pbft_block_hash) {
+      if (PbftVoteTypes::propose_vote == v->getType() && v->getBlockHash() != pbft_block_hash) {
         // PBFT has terminated on the missing PBFT block value and proposed a new block value
         proposal_value = v->getBlockHash();
         break;
@@ -646,9 +646,9 @@ TEST_F(PbftManagerTest, propose_block_and_vote_broadcast) {
   auto proposed_pbft_block = std::make_shared<PbftBlock>(prev_block_hash, blk_hash_t(0), blk_hash_t(0),
                                                          node1->getPbftManager()->getPbftPeriod(), node1->getAddress(),
                                                          node1->getSecretKey(), std::move(reward_votes_hashes));
-  auto propose_vote =
-      pbft_mgr1->generateVote(proposed_pbft_block->getBlockHash(), propose_vote_type, proposed_pbft_block->getPeriod(),
-                              node1->getPbftManager()->getPbftRound() + 1, value_proposal_state);
+  auto propose_vote = pbft_mgr1->generateVote(proposed_pbft_block->getBlockHash(), PbftVoteTypes::propose_vote,
+                                              proposed_pbft_block->getPeriod(),
+                                              node1->getPbftManager()->getPbftRound() + 1, value_proposal_state);
   pbft_mgr1->processProposedBlock(proposed_pbft_block, propose_vote);
 
   auto block1_from_node1 = pbft_mgr1->getProposedBlocksSt().getPbftProposedBlock(

--- a/tests/sortition_test.cpp
+++ b/tests/sortition_test.cpp
@@ -18,7 +18,7 @@ vec_trx_t generateTrxHashes(size_t count) {
   return res;
 }
 
-PeriodData createBlock(uint64_t period, uint16_t efficiency, size_t dag_blocks_count = 5,
+PeriodData createBlock(PbftPeriod period, uint16_t efficiency, size_t dag_blocks_count = 5,
                        blk_hash_t anchor_hash = blk_hash_t(1)) {
   // produced transactions count should be equal to or multiple of this value to produce block with accurate enough
   // efficiency

--- a/tests/util_test/util.hpp
+++ b/tests/util_test/util.hpp
@@ -367,7 +367,7 @@ inline auto make_simple_pbft_block(h256 const& hash, uint64_t period, h256 const
 }
 
 inline std::vector<blk_hash_t> getOrderedDagBlocks(std::shared_ptr<DbStorage> const& db) {
-  uint64_t period = 1;
+  PbftPeriod period = 1;
   std::vector<blk_hash_t> res;
   while (true) {
     auto pbft_block = db->getPbftBlock(period);

--- a/tests/vote_test.cpp
+++ b/tests/vote_test.cpp
@@ -23,10 +23,10 @@ auto g_sk = Lazy([] {
 });
 struct VoteTest : BaseTest {};
 
-std::pair<uint64_t, uint64_t> clearAllVotes(const std::vector<std::shared_ptr<FullNode>> &nodes) {
+std::pair<PbftPeriod, PbftRound> clearAllVotes(const std::vector<std::shared_ptr<FullNode>> &nodes) {
   // Get highest round from all nodes
-  uint64_t max_period = 0;
-  uint64_t max_round = 1;
+  PbftPeriod max_period = 0;
+  PbftRound max_round = 1;
   for (const auto &node : nodes) {
     auto [node_round, node_period] = node->getPbftManager()->getPbftRoundAndPeriod();
     if (node_period > max_period) {
@@ -73,7 +73,7 @@ TEST_F(VoteTest, verified_votes) {
   // Generate a vote
   blk_hash_t blockhash(1);
   PbftVoteTypes type = PbftVoteTypes::soft_vote;
-  auto step = 2;
+  PbftStep step = 2;
   auto vote = pbft_mgr->generateVote(blockhash, type, period, round, step);
   vote->calculateWeight(1, 1, 1);
 
@@ -112,9 +112,9 @@ TEST_F(VoteTest, DISABLED_add_cleanup_get_votes) {
   PbftVoteTypes type = PbftVoteTypes::next_vote;
   for (int i = 1; i <= 3; i++) {
     for (int j = 1; j <= 2; j++) {
-      uint64_t period = i;
-      uint64_t round = 1;
-      size_t step = 3 + j;
+      PbftPeriod period = i;
+      PbftRound round = 1;
+      PbftStep step = 3 + j;
       auto vote = pbft_mgr->generateVote(voted_block_hash, type, period, round, step);
       vote->calculateWeight(1, 1, 1);
       vote_mgr->addVerifiedVote(vote);
@@ -159,9 +159,9 @@ TEST_F(VoteTest, round_determine_from_next_votes) {
   PbftVoteTypes type = PbftVoteTypes::next_vote;
   for (int i = 10; i <= 12; i++) {
     for (int j = 4; j <= 5; j++) {
-      uint64_t period = i;
-      uint64_t round = i;
-      size_t step = j;
+      PbftPeriod period = i;
+      PbftRound round = i;
+      PbftStep step = j;
       auto vote = pbft_mgr->generateVote(voted_block_hash, type, period, round, step);
       vote->calculateWeight(3, 3, 3);
       vote_mgr->addVerifiedVote(vote);
@@ -178,9 +178,9 @@ TEST_F(VoteTest, reconstruct_votes) {
   sig_t vote_sig(9878766);
   blk_hash_t propose_blk_hash(111111);
   PbftVoteTypes type(PbftVoteTypes::propose_vote);
-  uint64_t period(999);
-  uint64_t round(999);
-  size_t step(2);
+  PbftPeriod period(999);
+  PbftRound round(999);
+  PbftStep step(1);
   VrfPbftMsg msg(type, period, round, step);
   VrfPbftSortition vrf_sortition(g_vrf_sk, msg);
   Vote vote1(g_sk, vrf_sortition, propose_blk_hash);
@@ -209,10 +209,10 @@ TEST_F(VoteTest, transfer_vote) {
 
   // generate a vote far ahead (never exist in PBFT manager)
   blk_hash_t propose_block_hash(11);
-  PbftVoteTypes type = PbftVoteTypes::next_vote;
-  uint64_t period = 1;
-  uint64_t round = 1;
-  size_t step = 1;
+  PbftVoteTypes type = PbftVoteTypes::propose_vote;
+  PbftPeriod period = 1;
+  PbftRound round = 1;
+  PbftStep step = 1;
   auto vote = pbft_mgr1->generateVote(propose_block_hash, type, period, round, step);
 
   nw1->getSpecificHandler<network::tarcap::VotePacketHandler>()->sendPbftVote(nw1->getPeer(nw2->getNodeId()), vote,
@@ -243,8 +243,8 @@ TEST_F(VoteTest, vote_broadcast) {
 
   // generate a vote far ahead (never exist in PBFT manager)
   blk_hash_t propose_block_hash(111);
-  PbftVoteTypes type = PbftVoteTypes::next_vote;
-  size_t step = 1;
+  PbftVoteTypes type = PbftVoteTypes::propose_vote;
+  PbftStep step = 1;
   auto vote = pbft_mgr1->generateVote(propose_block_hash, type, period, round, step);
 
   node1->getNetwork()->getSpecificHandler<network::tarcap::VotePacketHandler>()->onNewPbftVote(vote, nullptr);
@@ -281,9 +281,9 @@ TEST_F(VoteTest, previous_round_next_votes) {
 
   // Generate a vote voted at NULL_BLOCK_HASH
   PbftVoteTypes type = PbftVoteTypes::next_vote;
-  auto period = 1;
-  auto round = 1;
-  auto step = 4;
+  PbftPeriod period = 1;
+  PbftRound round = 1;
+  PbftStep step = 4;
   blk_hash_t voted_pbft_block_hash(0);
   auto vote1 = pbft_mgr->generateVote(voted_pbft_block_hash, type, period, round, step);
   vote1->calculateWeight(1, 1, 1);

--- a/tests/vote_test.cpp
+++ b/tests/vote_test.cpp
@@ -72,7 +72,7 @@ TEST_F(VoteTest, verified_votes) {
 
   // Generate a vote
   blk_hash_t blockhash(1);
-  PbftVoteTypes type = soft_vote_type;
+  PbftVoteTypes type = PbftVoteTypes::soft_vote;
   auto step = 2;
   auto vote = pbft_mgr->generateVote(blockhash, type, period, round, step);
   vote->calculateWeight(1, 1, 1);
@@ -109,7 +109,7 @@ TEST_F(VoteTest, DISABLED_add_cleanup_get_votes) {
   // generate 6 votes, 3 periods, 2 votes in round 1 each
   auto vote_mgr = node->getVoteManager();
   blk_hash_t voted_block_hash(1);
-  PbftVoteTypes type = next_vote_type;
+  PbftVoteTypes type = PbftVoteTypes::next_vote;
   for (int i = 1; i <= 3; i++) {
     for (int j = 1; j <= 2; j++) {
       uint64_t period = i;
@@ -156,7 +156,7 @@ TEST_F(VoteTest, round_determine_from_next_votes) {
 
   // Generate votes in 3 rounds, 2 steps, each step have 3 votes
   blk_hash_t voted_block_hash(1);
-  PbftVoteTypes type = next_vote_type;
+  PbftVoteTypes type = PbftVoteTypes::next_vote;
   for (int i = 10; i <= 12; i++) {
     for (int j = 4; j <= 5; j++) {
       uint64_t period = i;
@@ -177,7 +177,7 @@ TEST_F(VoteTest, reconstruct_votes) {
   sig_t sortition_sig(1234567);
   sig_t vote_sig(9878766);
   blk_hash_t propose_blk_hash(111111);
-  PbftVoteTypes type(propose_vote_type);
+  PbftVoteTypes type(PbftVoteTypes::propose_vote);
   uint64_t period(999);
   uint64_t round(999);
   size_t step(2);
@@ -209,7 +209,7 @@ TEST_F(VoteTest, transfer_vote) {
 
   // generate a vote far ahead (never exist in PBFT manager)
   blk_hash_t propose_block_hash(11);
-  PbftVoteTypes type = next_vote_type;
+  PbftVoteTypes type = PbftVoteTypes::next_vote;
   uint64_t period = 1;
   uint64_t round = 1;
   size_t step = 1;
@@ -243,7 +243,7 @@ TEST_F(VoteTest, vote_broadcast) {
 
   // generate a vote far ahead (never exist in PBFT manager)
   blk_hash_t propose_block_hash(111);
-  PbftVoteTypes type = next_vote_type;
+  PbftVoteTypes type = PbftVoteTypes::next_vote;
   size_t step = 1;
   auto vote = pbft_mgr1->generateVote(propose_block_hash, type, period, round, step);
 
@@ -280,7 +280,7 @@ TEST_F(VoteTest, previous_round_next_votes) {
   EXPECT_EQ(pbft_2t_plus_1, 1);
 
   // Generate a vote voted at NULL_BLOCK_HASH
-  PbftVoteTypes type = next_vote_type;
+  PbftVoteTypes type = PbftVoteTypes::next_vote;
   auto period = 1;
   auto round = 1;
   auto step = 4;


### PR DESCRIPTION
## Purpose
<!-- Provide any information reviewers might need to have context on your changes. -->

Optimize vote structure by:
- removing vote type as it can be deducted from step
- making round uint32_t instead of uint64_t

The actual optimization is in these files:
- libraries/types/vote/include/vrf_sortition.hpp
- libraries/types/vote/src/vrf_sortition.cpp

The rest of the changes is just refactor for using the custom types for period round and step instead of uintXY_t

```
using PbftPeriodType = uint64_t;
using PbftRoundType = uint32_t;
using PbftStepType = uint32_t;
```

## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
