### PR TITLE
fix: dag insertion

### DIFF
--- a/libraries/core_libs/consensus/src/dag/dag_manager.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_manager.cpp
@@ -370,6 +370,7 @@ uint DagManager::setDagBlockOrder(blk_hash_t const &new_anchor, uint64_t period,
         addToDag(blk_hash, pivot_hash, dag_block->getTips(), dag_block->getLevel(), false);
       } else {
         db_->removeDagBlock(blk_hash);
+        seen_blocks_.erase(blk_hash);
         for (const auto &trx : dag_block->getTrxs()) expired_dag_blocks_transactions.emplace_back(trx);
       }
     }
@@ -507,8 +508,15 @@ void DagManager::recoverDag() {
       }
 
       // In case an invalid block somehow ended in DAG db, remove it
-      if (!addDagBlock(std::move(blk), {}, false, false).first) {
-        LOG(log_er_) << "DAG block " << blk.getHash() << " could not be added to DAG on startup, removing from db";
+      auto res = pivotAndTipsAvailable(blk);
+      if (res.first) {
+        if (!addDagBlock(std::move(blk), {}, false, false).first) {
+          LOG(log_er_) << "DAG block " << blk.getHash() << " could not be added to DAG on startup, removing from db";
+          db_->removeDagBlock(blk.getHash());
+        }
+      } else {
+        LOG(log_er_) << "DAG block " << blk.getHash()
+                     << " could not be added to DAG on startup since it has missing tip/pivot";
         db_->removeDagBlock(blk.getHash());
       }
     }

--- a/libraries/core_libs/consensus/src/transaction/transaction_queue.cpp
+++ b/libraries/core_libs/consensus/src/transaction/transaction_queue.cpp
@@ -164,6 +164,7 @@ bool TransactionQueue::insert(std::shared_ptr<Transaction> &&transaction, const 
 void TransactionQueue::blockFinalized(uint64_t block_number) {
   for (auto it = non_proposable_transactions_.begin(); it != non_proposable_transactions_.end();) {
     if (it->second.first + kNonProposableTransactionsPeriodExpiryLimit < block_number) {
+      known_txs_.erase(it->first);
       it = non_proposable_transactions_.erase(it);
     } else {
       ++it;


### PR DESCRIPTION
When dag blocks expires it was deleted from the db and the dag but it was not removed from seen_blocks_ cache.

DagManager::pivotAndTipsAvailable used seen_blocks_ cache to check for tips/pivot meaning it was possible to insert a dag block with expired pivot and tip and corrupt the DAG.
The fix contains a check in DagManager::recoverDag which should clean all invalid blocks from db on startup.

This fix also contains a minor fix where transaction was not removed from transaction cache in certain use case.