### PR TITLE
chore: handle transactions queue overflow

### DIFF
--- a/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
+++ b/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
@@ -186,6 +186,13 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
   std::pair<std::vector<std::shared_ptr<Transaction>>, std::vector<trx_hash_t>> getPoolTransactions(
       const std::vector<trx_hash_t> &trx_to_query) const;
 
+  /**
+   * @brief Have transactions been recently dropped due to queue reaching max size
+   * This call is thread-safe
+   * @return Returns true if txs were dropped
+   */
+  bool transactionsDropped() const;
+
   std::shared_ptr<Transaction> getTransaction(const trx_hash_t &hash) const;
   std::shared_ptr<Transaction> getNonFinalizedTransaction(const trx_hash_t &hash) const;
   unsigned long getTransactionCount() const;

--- a/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
+++ b/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
@@ -385,4 +385,9 @@ void TransactionManager::blockFinalized(EthBlockNumber block_number) {
   transactions_pool_.blockFinalized(block_number);
 }
 
+bool TransactionManager::transactionsDropped() const {
+  std::shared_lock transactions_lock(transactions_mutex_);
+  return transactions_pool_.transactionsDropped();
+}
+
 }  // namespace taraxa

--- a/libraries/core_libs/consensus/src/transaction/transaction_queue.cpp
+++ b/libraries/core_libs/consensus/src/transaction/transaction_queue.cpp
@@ -134,6 +134,7 @@ bool TransactionQueue::insert(std::shared_ptr<Transaction> &&transaction, const 
         auto ordered_transactions = getOrderedTransactions(queue_size);
         uint32_t counter = 0;
         for (auto it = ordered_transactions.rbegin(); it != ordered_transactions.rend(); it++) {
+          transaction_overflow_time_ = std::chrono::system_clock::now();
           erase((*it)->getHash());
           known_txs_.erase((*it)->getHash());
           counter++;

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -1661,6 +1661,8 @@ TEST_F(FullNodeTest, transaction_pool_overflow) {
     EXPECT_TRUE(node0->getTransactionManager()->insertTransaction(trx).first);
   } while (!node0->getTransactionManager()->isTransactionPoolFull());
 
+  EXPECT_FALSE(node0->getTransactionManager()->transactionsDropped());
+
   // Crate transaction with lower gasprice
   auto trx = std::make_shared<Transaction>(nonce++, 0, gasprice - 1, gas, dev::fromHex("00FEDCBA9876543210000000"),
                                            node0->getSecretKey(), addr_t::random());
@@ -1673,6 +1675,8 @@ TEST_F(FullNodeTest, transaction_pool_overflow) {
 
   // Should fail as trx pool should be full
   EXPECT_FALSE(node0->getTransactionManager()->insertTransaction(trx).first);
+
+  EXPECT_TRUE(node0->getTransactionManager()->transactionsDropped());
 
   // Add one valid block
   const auto proposal_level = 1;

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -1470,6 +1470,43 @@ TEST_F(NetworkTest, suspicious_packets) {
   EXPECT_TRUE(peer.reportSuspiciousPacket());*/
 }
 
+TEST_F(NetworkTest, dag_syncing_limit) {
+  network::tarcap::TaraxaPeer peer1, peer2;
+  const uint64_t dag_sync_limit = 300;
+
+  EXPECT_TRUE(peer1.dagSyncingAllowed());
+  peer1.peer_dag_synced_ = true;
+  peer1.peer_dag_synced_time_ =
+      std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+  EXPECT_FALSE(peer1.dagSyncingAllowed());
+  peer1.peer_dag_synced_time_ =
+      std::chrono::duration_cast<std::chrono::seconds>(
+          (std::chrono::system_clock::now() - std::chrono::seconds(dag_sync_limit - 1)).time_since_epoch())
+          .count();
+  EXPECT_FALSE(peer1.dagSyncingAllowed());
+  peer1.peer_dag_synced_time_ =
+      std::chrono::duration_cast<std::chrono::seconds>(
+          (std::chrono::system_clock::now() - std::chrono::seconds(dag_sync_limit + 1)).time_since_epoch())
+          .count();
+  EXPECT_TRUE(peer1.dagSyncingAllowed());
+
+  EXPECT_TRUE(peer2.requestDagSyncingAllowed());
+  peer2.peer_requested_dag_syncing_ = true;
+  peer2.peer_requested_dag_syncing_time_ =
+      std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+  EXPECT_FALSE(peer2.requestDagSyncingAllowed());
+  peer2.peer_requested_dag_syncing_time_ =
+      std::chrono::duration_cast<std::chrono::seconds>(
+          (std::chrono::system_clock::now() - std::chrono::seconds(dag_sync_limit - 1)).time_since_epoch())
+          .count();
+  EXPECT_FALSE(peer2.requestDagSyncingAllowed());
+  peer2.peer_requested_dag_syncing_time_ =
+      std::chrono::duration_cast<std::chrono::seconds>(
+          (std::chrono::system_clock::now() - std::chrono::seconds(dag_sync_limit + 1)).time_since_epoch())
+          .count();
+  EXPECT_TRUE(peer2.requestDagSyncingAllowed());
+}
+
 }  // namespace taraxa::core_tests
 
 using namespace taraxa;


### PR DESCRIPTION
Once a peer has been dag synced, it should always send transactions and dag blocks in order so that dag block will never miss a transaction and dag block should never have a missing tip or pivot.

One exception to this rule is when transaction pool is full and node is forced to drop transactions. If transactions are dropped a DAG block might arrive with transactions missing. In this case there is a need to sync DAG again. At the same time allowing nodes to dag sync multiple times which is an expensive operations leaves us vulnerable to attacks. A limit is introduced that a peer can only ask for dag syncing once every kDagSyncingLimit(300) seconds.

Once transactions are dropped when transactions queue is full this is marked with transaction_overflow_time_ where node saves last time transactions were dropped. If in the next kTransactionOverflowTimeLimit (300 seconds) node receives a dag block with a missing transaction it is safe to assume that dag syncing needs to be done to receive this transaction.

This change aims to allow dag resyncing when transaction queue is full while at the same time limiting how often dag sync can be requested.