### PR TITLE
refactor: use the same function for getting the peer based on node id…

### DIFF
--- a/libraries/core_libs/network/include/network/tarcap/shared_states/peers_state.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/shared_states/peers_state.hpp
@@ -22,10 +22,17 @@ class PeersState {
 
   std::shared_ptr<TaraxaPeer> getPeer(const dev::p2p::NodeID& node_id) const;
   std::shared_ptr<TaraxaPeer> getPendingPeer(const dev::p2p::NodeID& node_id) const;
+
   /**
-   * @brief Returns TaraxaPeer object for specified node_id and bool value that indicates if peer was still pending
+   * @brief Get known peer based on packet sender and packet type. For StatusPacket peer can be obtained from
+   *        pending_peers, for all other packet types peer can be obtained only from peers map, in which are only
+   *        peers that already sent initial StatusPacket
+   *
+   * @return <std::shared_ptr<TaraxaPeer>, ""> if packet sender is known peer, otherwise <nullptr, "err message">
    */
-  std::pair<std::shared_ptr<TaraxaPeer>, bool> getAnyPeer(const dev::p2p::NodeID& node_id) const;
+  std::pair<std::shared_ptr<TaraxaPeer>, std::string> getPacketSenderPeer(const dev::p2p::NodeID& node_id,
+                                                                          SubprotocolPacketType packet_type) const;
+
   std::unordered_map<dev::p2p::NodeID, std::shared_ptr<TaraxaPeer>> getAllPeers() const;
   std::vector<dev::p2p::NodeID> getAllPendingPeersIDs() const;
   size_t getPeersCount() const;

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
@@ -76,9 +76,6 @@ class TaraxaCapability : public dev::p2p::CapabilityFace {
    */
   void stop();
 
-  // TODO: tarcap threadpool might be responsible for verifying, putting objects into internal structures, etc... and in
-  //       such case we would not need to broadcast packets from outside of packet handlers (except very few cases)
-  //       and most of these methods could be deleted
   // Interface required in network class to access packets handlers functionality
   // METHODS USED IN REAL CODE
   const std::shared_ptr<PeersState> &getPeersState();

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/common/packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/common/packet_handler.cpp
@@ -18,14 +18,13 @@ void PacketHandler::checkPacketRlpIsList(const PacketData& packet_data) const {
 
 void PacketHandler::processPacket(const PacketData& packet_data) {
   try {
-    SinglePacketStats packet_stats{packet_data.from_node_id_, packet_data.rlp_.data().size(),
-                                   std::chrono::microseconds(0), std::chrono::microseconds(0)};
     const auto begin = std::chrono::steady_clock::now();
 
-    auto tmp_peer = peers_state_->getPeer(packet_data.from_node_id_);
-    if (!tmp_peer && packet_data.type_ != SubprotocolPacketType::StatusPacket) {
-      LOG(log_er_) << "Peer " << packet_data.from_node_id_.abridged()
-                   << " not in peers map. He probably did not send initial status message - will be disconnected.";
+    // It can rarely happen that packet was received and pushed into the queue when peer was still in peers map,
+    // in the meantime the connection was lost and we started to process packet from such peer
+    const auto peer = peers_state_->getPacketSenderPeer(packet_data.from_node_id_, packet_data.type_);
+    if (!peer.first) [[unlikely]] {
+      LOG(log_er_) << "Unable to process packet. Reason: " << peer.second;
       disconnect(packet_data.from_node_id_, dev::p2p::UserReason);
       return;
     }
@@ -37,15 +36,15 @@ void PacketHandler::processPacket(const PacketData& packet_data) {
     validatePacketRlpFormat(packet_data);
 
     // Main processing function
-    process(packet_data, tmp_peer);
+    process(packet_data, peer.first);
 
     auto processing_duration =
         std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - begin);
     auto tp_wait_duration = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() -
                                                                                   packet_data.receive_time_);
-    packet_stats.processing_duration_ = processing_duration;
-    packet_stats.tp_wait_duration_ = tp_wait_duration;
 
+    SinglePacketStats packet_stats{packet_data.from_node_id_, packet_data.rlp_.data().size(), processing_duration,
+                                   tp_wait_duration};
     packets_stats_->addReceivedPacket(packet_data.type_str_, packet_stats);
 
   } catch (const PacketProcessingException& e) {
@@ -82,14 +81,8 @@ bool PacketHandler::sealAndSend(const dev::p2p::NodeID& node_id, SubprotocolPack
     return false;
   }
 
-  const auto [peer, is_pending] = peers_state_->getAnyPeer(node_id);
-  if (!peer) [[unlikely]] {
-    LOG(log_wr_) << "sealAndSend failed to find peer";
-    return false;
-  }
-
-  if (is_pending && packet_type != SubprotocolPacketType::StatusPacket) [[unlikely]] {
-    LOG(log_wr_) << "sealAndSend failed initial status check, peer " << node_id.abridged() << " will be disconnected";
+  if (const auto peer = peers_state_->getPacketSenderPeer(node_id, packet_type); !peer.first) [[unlikely]] {
+    LOG(log_er_) << "Unable to send packet. Reason: " << peer.second;
     host->disconnect(node_id, dev::p2p::UserReason);
     return false;
   }
@@ -111,6 +104,7 @@ bool PacketHandler::sealAndSend(const dev::p2p::NodeID& node_id, SubprotocolPack
 
 void PacketHandler::disconnect(const dev::p2p::NodeID& node_id, dev::p2p::DisconnectReason reason) {
   if (auto host = peers_state_->host_.lock(); host) {
+    LOG(log_nf_) << "Disconnect node " << node_id.abridged();
     host->disconnect(node_id, reason);
   } else {
     LOG(log_er_) << "Unable to disconnect node " << node_id.abridged() << " due to invalid host.";


### PR DESCRIPTION
This PR is not fixing any issue. It is just refactoring the way we are obtaining/checking peer from peers map based on node_id and packet type. We were using the same code snippet on 3 different places before. Now we use function for it. 

## Purpose
<!-- Provide any information reviewers might need to have context on your changes. -->


## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
