### PR TITLE
chore: optimize block proposal and pbft leader selection

### DIFF
--- a/libraries/core_libs/consensus/include/dag/block_proposer.hpp
+++ b/libraries/core_libs/consensus/include/dag/block_proposer.hpp
@@ -72,7 +72,7 @@ class SortitionPropose : public ProposeModelFace {
  private:
   int num_tries_ = 0;
   int max_num_tries_ = 20;  // Wait 2000(ms)
-  DagFrontier last_frontier_;
+  uint64_t last_propose_level_ = 0;
   util::ThreadPool executor_{1};
   std::shared_ptr<DbStorage> db_;
   std::shared_ptr<DagManager> dag_mgr_;

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1500,6 +1500,7 @@ std::shared_ptr<PbftBlock> PbftManager::identifyLeaderBlock_(PbftRound round, Pb
     leader_candidates[getProposal(v)] = v;
   }
 
+  std::shared_ptr<PbftBlock> empty_leader_block;
   for (auto const &leader_vote : leader_candidates) {
     const auto proposed_block_hash = leader_vote.second->getBlockHash();
 
@@ -1514,11 +1515,15 @@ std::shared_ptr<PbftBlock> PbftManager::identifyLeaderBlock_(PbftRound round, Pb
       continue;
     }
 
+    if (leader_block->getPivotDagBlockHash() == NULL_BLOCK_HASH && empty_leader_block == nullptr) {
+      empty_leader_block = leader_block;
+      continue;
+    }
     return leader_block;
   }
 
   // no eligible leader
-  return nullptr;
+  return empty_leader_block;
 }
 
 bool PbftManager::validatePbftBlock(const std::shared_ptr<PbftBlock> &pbft_block) const {

--- a/libraries/core_libs/consensus/src/transaction/transaction_queue.cpp
+++ b/libraries/core_libs/consensus/src/transaction/transaction_queue.cpp
@@ -165,6 +165,7 @@ bool TransactionQueue::insert(std::shared_ptr<Transaction> &&transaction, const 
 void TransactionQueue::blockFinalized(uint64_t block_number) {
   for (auto it = non_proposable_transactions_.begin(); it != non_proposable_transactions_.end();) {
     if (it->second.first + kNonProposableTransactionsPeriodExpiryLimit < block_number) {
+      known_txs_.erase(it->first);
       it = non_proposable_transactions_.erase(it);
     } else {
       ++it;


### PR DESCRIPTION
On block proposal only give up proposal if new dag block of same level was added to the DAG. Previous implementation would give up if an old DAG block was added to the DAG as well. This would unnecessary delay block proposal for both stale and non-stale blocks.

Pbft block leader selection now favors non-empty pbft blocks over empty ones. 