### PR TITLE
chore: change logs verbosity

### DIFF
--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -289,7 +289,7 @@ std::optional<uint64_t> PbftManager::getCurrentDposTotalVotesCount() const {
   try {
     return final_chain_->dpos_eligible_total_vote_count(pbft_chain_->getPbftChainSize());
   } catch (state_api::ErrFutureBlock &e) {
-    LOG(log_er_) << "Unable to get CurrentDposTotalVotesCount for period: " << pbft_chain_->getPbftChainSize()
+    LOG(log_wr_) << "Unable to get CurrentDposTotalVotesCount for period: " << pbft_chain_->getPbftChainSize()
                  << ". Period is too far ahead of actual finalized pbft chain size ("
                  << final_chain_->last_block_number() << "). Err msg: " << e.what();
   }
@@ -301,7 +301,7 @@ std::optional<uint64_t> PbftManager::getCurrentNodeVotesCount() const {
   try {
     return final_chain_->dpos_eligible_vote_count(pbft_chain_->getPbftChainSize(), node_addr_);
   } catch (state_api::ErrFutureBlock &e) {
-    LOG(log_er_) << "Unable to get CurrentNodeVotesCount for period: " << pbft_chain_->getPbftChainSize()
+    LOG(log_wr_) << "Unable to get CurrentNodeVotesCount for period: " << pbft_chain_->getPbftChainSize()
                  << ". Period is too far ahead of actual finalized pbft chain size ("
                  << final_chain_->last_block_number() << "). Err msg: " << e.what();
   }
@@ -1975,7 +1975,7 @@ bool PbftManager::validatePbftBlockCertVotes(const std::shared_ptr<PbftBlock> pb
   }
 
   if (votes_weight < *two_t_plus_one) {
-    LOG(log_er_) << "Invalid votes weight " << votes_weight << " < two_t_plus_one " << *two_t_plus_one
+    LOG(log_wr_) << "Invalid votes weight " << votes_weight << " < two_t_plus_one " << *two_t_plus_one
                  << ", pbft block " << pbft_block->getBlockHash();
     return false;
   }


### PR DESCRIPTION
## Purpose
<!-- Provide any information reviewers might need to have context on your changes. -->

I had multiple errors during syncing:
```
0x00007f6698ff9640 942767c9… PBFT_MGR [2022-11-08 10:04:37.115966] ERROR: Unable to get CurrentDposTotalVotesCount for period: 42746. Period is too far ahead of actual finalized pbft chain size (42740). Err msg: Requested blk num:42741, last committed:42740
0x00007f6698ff9640 942767c9… PBFT_MGR [2022-11-08 10:04:37.116219] ERROR: Unable to get CurrentNodeVotesCount for period: 42746. Period is too far ahead of actual finalized pbft chain size (42740). Err msg: Requested blk num:42741, last committed:42740
0x00007f6698ff9640 942767c9… PBFT_MGR [2022-11-08 10:04:37.116346] ERROR: Unable to calculate 2t + 1 for period: 42746. Period is too far ahead of actual finalized pbft chain size (42740). Err msg: Requested blk num:42741, last committed:42740
```

These errors were printed when logging node stats - these are rather warnings as it can happen during syncing due to excessive processing of synced blocks when we increased pbft chain size but block was nto finalized yet

## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
