### PR TITLE
chore: log additional info when disconnecting light node

### DIFF
--- a/libraries/config/include/config/config.hpp
+++ b/libraries/config/include/config/config.hpp
@@ -64,7 +64,7 @@ struct DBConfig {
 };
 
 struct FullNodeConfig {
-  static const uint32_t kDefaultLightNodeHistoryDays = 7;
+  static constexpr uint64_t kDefaultLightNodeHistoryDays = 7;
 
   FullNodeConfig() = default;
   // The reason of using Json::Value as a union is that in the tests

--- a/libraries/config/src/config.cpp
+++ b/libraries/config/src/config.cpp
@@ -265,11 +265,12 @@ FullNodeConfig::FullNodeConfig(Json::Value const &string_or_object, Json::Value 
 
   is_light_node = getConfigDataAsBoolean(root, {"is_light_node"}, true, false);
   if (is_light_node) {
-    uint64_t min_light_node_history =
-        (uint64_t)kDefaultLightNodeHistoryDays * 24 * 60 * 60000 / (chain.pbft.lambda_ms_min * 6);
+    const auto min_light_node_history =
+        (chain.final_chain.state.dpos.blocks_per_year * kDefaultLightNodeHistoryDays) / 365;
     light_node_history = getConfigDataAsUInt(root, {"light_node_history"}, true, min_light_node_history);
     if (light_node_history < min_light_node_history) {
-      light_node_history = min_light_node_history;
+      throw ConfigException("Min. required light node history is " + std::to_string(min_light_node_history) +
+                            " blocks (" + std::to_string(kDefaultLightNodeHistoryDays) + " days)");
     }
   }
 
@@ -359,15 +360,17 @@ void FullNodeConfig::validate() const {
   if (rpc) {
     rpc->validate();
   }
+
   if (network.vote_accepting_periods > chain.final_chain.state.dpos.delegation_delay) {
-    throw ConfigException(std::string(
-        "network.vote_accepting_periods(" + std::to_string(network.vote_accepting_periods) +
-        ") must be <= DPOS.delegation_delay(" + std::to_string(chain.final_chain.state.dpos.delegation_delay) + ")"));
+    throw ConfigException("network.vote_accepting_periods(" + std::to_string(network.vote_accepting_periods) +
+                          ") must be <= DPOS.delegation_delay(" +
+                          std::to_string(chain.final_chain.state.dpos.delegation_delay) + ")");
   }
   if (transactions_pool_size < kMinTransactionPoolSize) {
-    throw ConfigException(std::string("transactions_pool_size cannot be smaller than ") +
-                          std::to_string(kMinTransactionPoolSize) + ".");
+    throw ConfigException("transactions_pool_size cannot be smaller than " + std::to_string(kMinTransactionPoolSize) +
+                          ".");
   }
+
   // TODO: add validation of other config values
 }
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/status_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/status_packet_handler.cpp
@@ -86,8 +86,10 @@ void StatusPacketHandler::process(const PacketData& packet_data, const std::shar
       selected_peer->peer_light_node_history = node_history;
       if (pbft_synced_period + node_history < peer_pbft_chain_size) {
         LOG((peers_state_->getPeersCount()) ? log_nf_ : log_er_)
-            << "Light node is not able to serve our syncing request. " << packet_data.from_node_id_.abridged()
-            << " peer will be disconnected";
+            << "Light node " << packet_data.from_node_id_.abridged()
+            << " would not be able to serve our syncing request. "
+            << "Current synced period " << pbft_synced_period << ", peer synced period " << pbft_synced_period
+            << ", peer light node history " << node_history << ". Peer will be disconnected";
         disconnect(packet_data.from_node_id_, dev::p2p::UserReason);
         return;
       }


### PR DESCRIPTION
## Purpose
<!-- Provide any information reviewers might need to have context on your changes. -->

During monitoring I saw multiple times this error message:
`Light node is not able to serve our syncing request.` 

It also happened on brand new testnet, which was few hours old so this message should never be logged because minimu light node history is 7 days.

I added:

- additional info in log message to see some data
- changed the way we calculate min blocks count for min light node history 

## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
