### PR TITLE
chore: reduce omit vdf range

### DIFF
--- a/libraries/cli/include/cli/config_jsons/default.json
+++ b/libraries/cli/include/cli/config_jsons/default.json
@@ -255,7 +255,7 @@
       "computation_interval": 50,
       "vrf": {
         "threshold_upper": "0xafff",
-        "threshold_range": 80
+        "threshold_range": 95
       },
       "vdf": {
         "difficulty_max": 21,

--- a/libraries/cli/include/cli/config_jsons/devnet.json
+++ b/libraries/cli/include/cli/config_jsons/devnet.json
@@ -442,7 +442,7 @@
       "computation_interval": 50,
       "vrf": {
         "threshold_upper": "0xafff",
-        "threshold_range": 80
+        "threshold_range": 95
       },
       "vdf": {
         "difficulty_max": 21,

--- a/libraries/cli/include/cli/config_jsons/mainnet.json
+++ b/libraries/cli/include/cli/config_jsons/mainnet.json
@@ -360,7 +360,7 @@
       "computation_interval": 50,
       "vrf": {
         "threshold_upper": "0xafff",
-        "threshold_range": 80
+        "threshold_range": 95
       },
       "vdf": {
         "difficulty_max": 21,

--- a/libraries/cli/include/cli/config_jsons/testnet.json
+++ b/libraries/cli/include/cli/config_jsons/testnet.json
@@ -325,7 +325,7 @@
       "computation_interval": 50,
       "vrf": {
         "threshold_upper": "0xafff",
-        "threshold_range": 80
+        "threshold_range": 95
       },
       "vdf": {
         "difficulty_max": 21,

--- a/libraries/config/src/chain_config.cpp
+++ b/libraries/config/src/chain_config.cpp
@@ -89,7 +89,7 @@ decltype(ChainConfig::predefined_) const ChainConfig::predefined_([] {
 
     // VDF config
     cfg.sortition.vrf.threshold_upper = 0xafff;
-    cfg.sortition.vrf.threshold_range = 80;
+    cfg.sortition.vrf.threshold_range = 95;
     cfg.sortition.vdf.difficulty_min = 16;
     cfg.sortition.vdf.difficulty_max = 21;
     cfg.sortition.vdf.difficulty_stale = 23;


### PR DESCRIPTION
Increasing threshold_range to 95 will reduce the omit vdf range which will make block production more evenly distributed among different difficulties. Currently about 90% of all produced dag blocks are omit vdf blocks.

This should as effect have a consequence that the difficulty will adjust in a way that it will make occurrence of stale blocks very rare.