### PR TITLE
chore: cleanup pbft params

### DIFF
--- a/libraries/cli/include/cli/config_jsons/default.json
+++ b/libraries/cli/include/cli/config_jsons/default.json
@@ -234,8 +234,6 @@
     "pbft": {
       "committee_size": "0x3e8",
       "number_of_proposers": "0x14",
-      "dag_blocks_size": "0x32",
-      "ghost_path_move_back": "0x0",
       "lambda_ms_min": "0x29a",
       "gas_limit": "0x3938700"
     },

--- a/libraries/cli/include/cli/config_jsons/devnet.json
+++ b/libraries/cli/include/cli/config_jsons/devnet.json
@@ -418,8 +418,6 @@
     "pbft": {
       "committee_size": "0x3e8",
       "number_of_proposers": "0x14",
-      "dag_blocks_size": "0x32",
-      "ghost_path_move_back": "0x0",
       "lambda_ms_min": "0x29a",
       "gas_limit": "0x7d2b7500"
     },

--- a/libraries/cli/include/cli/config_jsons/mainnet.json
+++ b/libraries/cli/include/cli/config_jsons/mainnet.json
@@ -339,8 +339,6 @@
     "pbft": {
       "committee_size": "0x3e8",
       "number_of_proposers": "0x14",
-      "dag_blocks_size": "0xa",
-      "ghost_path_move_back": "0x0",
       "lambda_ms_min": "0x5dc",
       "gas_limit": "0x3938700"
     },

--- a/libraries/cli/include/cli/config_jsons/testnet.json
+++ b/libraries/cli/include/cli/config_jsons/testnet.json
@@ -301,8 +301,6 @@
     "pbft": {
       "committee_size": "0x3e8",
       "number_of_proposers": "0x14",
-      "dag_blocks_size": "0x32",
-      "ghost_path_move_back": "0x0",
       "lambda_ms_min": "0x5dc",
       "gas_limit": "0x7d2b7500"
     },

--- a/libraries/config/include/config/pbft_config.hpp
+++ b/libraries/config/include/config/pbft_config.hpp
@@ -10,8 +10,6 @@ struct PbftConfig {
   uint32_t lambda_ms_min = 0;
   uint32_t committee_size = 0;
   uint32_t number_of_proposers = 20;
-  uint32_t dag_blocks_size = 0;
-  uint32_t ghost_path_move_back = 0;
   uint64_t gas_limit = 0;
 
   bytes rlp() const;

--- a/libraries/config/src/chain_config.cpp
+++ b/libraries/config/src/chain_config.cpp
@@ -98,8 +98,6 @@ decltype(ChainConfig::predefined_) const ChainConfig::predefined_([] {
     // PBFT config
     cfg.pbft.lambda_ms_min = 2000;
     cfg.pbft.committee_size = 5;
-    cfg.pbft.dag_blocks_size = 100;
-    cfg.pbft.ghost_path_move_back = 1;
     cfg.pbft.gas_limit = 60000000;
 
     // DAG config

--- a/libraries/config/src/pbft_config.cpp
+++ b/libraries/config/src/pbft_config.cpp
@@ -10,8 +10,6 @@ Json::Value enc_json(PbftConfig const& obj) {
   ret["lambda_ms_min"] = dev::toJS(obj.lambda_ms_min);
   ret["committee_size"] = dev::toJS(obj.committee_size);
   ret["number_of_proposers"] = dev::toJS(obj.number_of_proposers);
-  ret["dag_blocks_size"] = dev::toJS(obj.dag_blocks_size);
-  ret["ghost_path_move_back"] = dev::toJS(obj.ghost_path_move_back);
   ret["gas_limit"] = dev::toJS(obj.gas_limit);
   return ret;
 }
@@ -20,20 +18,16 @@ void dec_json(Json::Value const& json, PbftConfig& obj) {
   obj.lambda_ms_min = dev::jsToInt(json["lambda_ms_min"].asString());
   obj.committee_size = dev::jsToInt(json["committee_size"].asString());
   obj.number_of_proposers = dev::jsToInt(json["number_of_proposers"].asString());
-  obj.dag_blocks_size = dev::jsToInt(json["dag_blocks_size"].asString());
-  obj.ghost_path_move_back = dev::jsToInt(json["ghost_path_move_back"].asString());
   obj.gas_limit = dev::getUInt(json["gas_limit"]);
 }
 
 bytes PbftConfig::rlp() const {
   dev::RLPStream s;
-  s.appendList(6);
+  s.appendList(4);
 
   s << lambda_ms_min;
   s << committee_size;
   s << number_of_proposers;
-  s << dag_blocks_size;
-  s << ghost_path_move_back;
   s << gas_limit;
 
   return s.out();

--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -623,8 +623,6 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
 
   const size_t COMMITTEE_SIZE;
   const size_t NUMBER_OF_PROPOSERS;
-  const size_t DAG_BLOCKS_SIZE;
-  const size_t GHOST_PATH_MOVE_BACK;
 
   PbftStates state_ = value_proposal_state;
 

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -49,8 +49,6 @@ PbftManager::PbftManager(const PbftConfig &conf, const blk_hash_t &dag_genesis_b
       LAMBDA_ms_MIN(conf.lambda_ms_min),
       COMMITTEE_SIZE(conf.committee_size),
       NUMBER_OF_PROPOSERS(conf.number_of_proposers),
-      DAG_BLOCKS_SIZE(conf.dag_blocks_size),
-      GHOST_PATH_MOVE_BACK(conf.ghost_path_move_back),
       dag_genesis_block_hash_(dag_genesis_block_hash),
       config_(conf),
       proposed_blocks_(db_),
@@ -1373,20 +1371,7 @@ std::shared_ptr<PbftBlock> PbftManager::proposePbftBlock_() {
     return generatePbftBlock(current_pbft_period, last_pbft_block_hash, NULL_BLOCK_HASH, NULL_BLOCK_HASH);
   }
 
-  blk_hash_t dag_block_hash;
-  if (ghost.size() <= DAG_BLOCKS_SIZE) {
-    // Move back GHOST_PATH_MOVE_BACK DAG blocks for DAG sycning
-    auto ghost_index = (ghost.size() < GHOST_PATH_MOVE_BACK + 1) ? 0 : (ghost.size() - 1 - GHOST_PATH_MOVE_BACK);
-    while (ghost_index < ghost.size() - 1) {
-      if (ghost[ghost_index] != last_period_dag_anchor_block_hash) {
-        break;
-      }
-      ghost_index += 1;
-    }
-    dag_block_hash = ghost[ghost_index];
-  } else {
-    dag_block_hash = ghost[DAG_BLOCKS_SIZE - 1];
-  }
+  blk_hash_t dag_block_hash = ghost[ghost.size() - 1];
 
   if (dag_block_hash == dag_genesis_block_hash_) {
     LOG(log_dg_) << "No new DAG blocks generated. DAG only has genesis " << dag_block_hash

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -1459,8 +1459,6 @@ TEST_F(FullNodeTest, chain_config_json) {
   },
   "pbft": {
     "committee_size": "0x5",
-    "dag_blocks_size": "0x64",
-    "ghost_path_move_back": "0x1",
     "lambda_ms_min": "0x7d0",
     "number_of_proposers" : "0x14",
     "gas_limit": "0x3938700"

--- a/tests/util_test/node_dag_creation_fixture.hpp
+++ b/tests/util_test/node_dag_creation_fixture.hpp
@@ -24,7 +24,6 @@ struct NodeDagCreationFixture : BaseTest {
     vdf_config.difficulty_min = 1;
     vdf_config.difficulty_max = 3;
     vdf_config.difficulty_stale = 4;
-    cfg.chain.pbft.ghost_path_move_back = 0;
   }
   void makeNode(bool start = true) {
     auto cfgs = make_node_cfgs<5, true>(1);


### PR DESCRIPTION
Default params values of DAG_BLOCKS_SIZE=100 and GHOST_PATH_MOVE_BACK=0 were not really doing anything so this is removed and the part of code using them. 