### PR TITLE
chore: vdf changes

### DIFF
--- a/doc/RPC.md
+++ b/doc/RPC.md
@@ -465,7 +465,6 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"taraxa_getConfig","params":[],"i
         "lambda_bound": "0x64"
       },
       "vrf": {
-        "threshold_range": "0xbb8",
         "threshold_upper": "0x1770"
       }
     }
@@ -489,8 +488,7 @@ Get sortition params changes for closest smaller period to specified
 `OBJECT` - sortition parameters
 * `interval_efficiency`: `QUANTITY` - efficiency of interval
 * `period`: `QUANTITY` - number of period when closest smaller change happened
-* `threshold_range`: `QUANTITY` - range of normal selection
-* `threshold_upper`: `QUANTITY` - upper bound of normal selection
+* `threshold_upper`: `QUANTITY` - upper bound of selection
 * `kThresholdUpperMinValue`: `QUANTITY` - const that represents minimum value of `threshold_upper`
 
 #### Example
@@ -507,7 +505,6 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"get_sortition_change","params":[
     "interval_efficiency": 1327,
     "kThresholdUpperMinValue": 80,
     "period": 2820,
-    "threshold_range": 80,
     "threshold_upper": 31953
   }
 }

--- a/libraries/cli/include/cli/config_jsons/default.json
+++ b/libraries/cli/include/cli/config_jsons/default.json
@@ -259,8 +259,7 @@
       "changing_interval": 200,
       "computation_interval": 50,
       "vrf": {
-        "threshold_upper": "0xafff",
-        "threshold_range": 80
+        "threshold_upper": "0xafff"
       },
       "vdf": {
         "difficulty_max": 21,

--- a/libraries/cli/include/cli/config_jsons/devnet.json
+++ b/libraries/cli/include/cli/config_jsons/devnet.json
@@ -446,8 +446,7 @@
       "changing_interval": 200,
       "computation_interval": 50,
       "vrf": {
-        "threshold_upper": "0xafff",
-        "threshold_range": 80
+        "threshold_upper": "0xafff"
       },
       "vdf": {
         "difficulty_max": 21,

--- a/libraries/cli/include/cli/config_jsons/mainnet.json
+++ b/libraries/cli/include/cli/config_jsons/mainnet.json
@@ -496,8 +496,7 @@
       "changing_interval": 200,
       "computation_interval": 50,
       "vrf": {
-        "threshold_upper": "0xafff",
-        "threshold_range": 80
+        "threshold_upper": "0xafff"
       },
       "vdf": {
         "difficulty_max": 21,

--- a/libraries/cli/include/cli/config_jsons/testnet.json
+++ b/libraries/cli/include/cli/config_jsons/testnet.json
@@ -329,8 +329,7 @@
       "changing_interval": 200,
       "computation_interval": 50,
       "vrf": {
-        "threshold_upper": "0xafff",
-        "threshold_range": 80
+        "threshold_upper": "0xafff"
       },
       "vdf": {
         "difficulty_max": 21,

--- a/libraries/config/src/chain_config.cpp
+++ b/libraries/config/src/chain_config.cpp
@@ -89,7 +89,6 @@ decltype(ChainConfig::predefined_) const ChainConfig::predefined_([] {
 
     // VDF config
     cfg.sortition.vrf.threshold_upper = 0xafff;
-    cfg.sortition.vrf.threshold_range = 80;
     cfg.sortition.vdf.difficulty_min = 16;
     cfg.sortition.vdf.difficulty_max = 21;
     cfg.sortition.vdf.difficulty_stale = 23;

--- a/libraries/core_libs/consensus/include/dag/dag_manager.hpp
+++ b/libraries/core_libs/consensus/include/dag/dag_manager.hpp
@@ -219,6 +219,20 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
    */
   uint64_t getDagExpiryLevel() { return dag_expiry_level_; }
 
+  /**
+   * @brief Retrieves VDF message from block hash and transactions
+   *
+   * @return message
+   */
+  static dev::bytes getVdfMessage(blk_hash_t const &hash, SharedTransactions const &trxs);
+
+  /**
+   * @brief Retrieves VDF message from block hash and transactions
+   *
+   * @return message
+   */
+  static dev::bytes getVdfMessage(blk_hash_t const &hash, std::vector<trx_hash_t> const &trx_hashes);
+
  private:
   void recoverDag();
   void addToDag(blk_hash_t const &hash, blk_hash_t const &pivot, std::vector<blk_hash_t> const &tips, uint64_t level,

--- a/libraries/core_libs/consensus/src/dag/dag_manager.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_manager.cpp
@@ -672,4 +672,22 @@ std::shared_ptr<DagBlock> DagManager::getDagBlock(const blk_hash_t &hash) const 
   return db_->getDagBlock(hash);
 }
 
+dev::bytes DagManager::getVdfMessage(blk_hash_t const &hash, SharedTransactions const &trxs) {
+  dev::RLPStream s;
+  s << hash;
+  for (const auto &t : trxs) {
+    s << t->getHash();
+  }
+  return s.invalidate();
+}
+
+dev::bytes DagManager::getVdfMessage(blk_hash_t const &hash, std::vector<trx_hash_t> const &trx_hashes) {
+  dev::RLPStream s;
+  s << hash;
+  for (const auto &h : trx_hashes) {
+    s << h;
+  }
+  return s.invalidate();
+}
+
 }  // namespace taraxa

--- a/libraries/core_libs/consensus/src/dag/sortition_params_manager.cpp
+++ b/libraries/core_libs/consensus/src/dag/sortition_params_manager.cpp
@@ -9,8 +9,7 @@ SortitionParamsChange::SortitionParamsChange(PbftPeriod period, uint16_t efficie
 
 bytes SortitionParamsChange::rlp() const {
   dev::RLPStream s;
-  s.appendList(4);
-  s << vrf_params.threshold_range;
+  s.appendList(3);
   s << vrf_params.threshold_upper;
   s << period;
   s << interval_efficiency;
@@ -21,10 +20,9 @@ bytes SortitionParamsChange::rlp() const {
 SortitionParamsChange SortitionParamsChange::from_rlp(const dev::RLP& rlp) {
   SortitionParamsChange p;
 
-  p.vrf_params.threshold_range = rlp[0].toInt<uint16_t>();
-  p.vrf_params.threshold_upper = rlp[1].toInt<uint16_t>();
-  p.period = rlp[2].toInt<PbftPeriod>();
-  p.interval_efficiency = rlp[3].toInt<uint16_t>();
+  p.vrf_params.threshold_upper = rlp[0].toInt<uint16_t>();
+  p.period = rlp[1].toInt<PbftPeriod>();
+  p.interval_efficiency = rlp[2].toInt<uint16_t>();
 
   return p;
 }

--- a/libraries/core_libs/consensus/src/final_chain/final_chain.cpp
+++ b/libraries/core_libs/consensus/src/final_chain/final_chain.cpp
@@ -143,6 +143,23 @@ class FinalChainImpl final : public FinalChain {
 
     block_applying_emitter_.emit(block_header()->number + 1);
 
+    /*
+    // Any dag block producer producing duplicate dag blocks on same level should be slashed
+
+
+    std::map<std::pair<addr_t, uint64_t>, uint32_t> dag_blocks_per_addr_and_level;
+    std::unordered_map<addr_t, uint32_t> duplicate_dag_blocks_count;
+
+    for (const auto& block : new_blk.dag_blocks) {
+      dag_blocks_per_addr_and_level[{block.getSender(), block.getLevel()}]++;
+    }
+
+    for (const auto& it : dag_blocks_per_addr_and_level) {
+      if (it.second > 1) {
+        duplicate_dag_blocks_count[it.first.first] += it.second - 1;
+      }
+    } */
+
     auto const& [exec_results, state_root] =
         state_api_.transition_state({new_blk.pbft_blk->getBeneficiary(), kBlockGasLimit,
                                      new_blk.pbft_blk->getTimestamp(), BlockHeader::difficulty()},

--- a/libraries/core_libs/network/rpc/Test.cpp
+++ b/libraries/core_libs/network/rpc/Test.cpp
@@ -27,7 +27,6 @@ Json::Value Test::get_sortition_change(const Json::Value &param1) {
       auto params_change = node->getDB()->getParamsChangeForPeriod(period);
       res["interval_efficiency"] = params_change->interval_efficiency;
       res["period"] = params_change->period;
-      res["threshold_range"] = params_change->vrf_params.threshold_range;
       res["threshold_upper"] = params_change->vrf_params.threshold_upper;
       res["kThresholdUpperMinValue"] = params_change->vrf_params.kThresholdUpperMinValue;
     }

--- a/libraries/types/dag_block/src/dag_block.cpp
+++ b/libraries/types/dag_block/src/dag_block.cpp
@@ -118,8 +118,14 @@ bool DagBlock::verifySig() const {
 
 void DagBlock::verifyVdf(const SortitionParams &vdf_config, const h256 &proposal_period_hash,
                          const vrf_wrapper::vrf_pk_t &pk) const {
-  vdf_.verifyVdf(vdf_config, VrfSortitionBase::makeVrfInput(getLevel(), proposal_period_hash), pk,
-                 getPivot().asBytes());
+  dev::RLPStream s;
+  s << getPivot();
+  for (const auto &trx : getTrxs()) {
+    s << trx;
+  }
+  dev::bytes vdf_msg = s.invalidate();
+
+  vdf_.verifyVdf(vdf_config, VrfSortitionBase::makeVrfInput(getLevel(), proposal_period_hash), pk, vdf_msg);
 }
 
 blk_hash_t const &DagBlock::getHash() const {

--- a/libraries/vdf/include/vdf/config.hpp
+++ b/libraries/vdf/include/vdf/config.hpp
@@ -8,8 +8,7 @@
 namespace taraxa {
 
 struct VrfParams {
-  uint16_t threshold_upper = 0;  // upper bound of normal selection
-  uint16_t threshold_range = 0;  // range of normal selection
+  uint16_t threshold_upper = 0;  // upper bound of selection
   VrfParams& operator+=(int32_t change);
 
   static constexpr uint16_t kThresholdUpperMinValue = 0x50;
@@ -24,15 +23,13 @@ struct VdfParams {
 
 struct SortitionParams {
   SortitionParams() = default;
-  SortitionParams(uint16_t threshold_upper, uint16_t threshold_range, uint16_t min, uint16_t max, uint16_t stale,
-                  uint16_t lambda_max_bound)
-      : vrf{threshold_upper, threshold_range}, vdf{min, max, stale, lambda_max_bound} {}
+  SortitionParams(uint16_t threshold_upper, uint16_t min, uint16_t max, uint16_t stale, uint16_t lambda_max_bound)
+      : vrf{threshold_upper}, vdf{min, max, stale, lambda_max_bound} {}
   SortitionParams(const VrfParams& vrf, const VdfParams& vdf) : vrf{vrf}, vdf{vdf} {}
 
   friend std::ostream& operator<<(std::ostream& strm, const SortitionParams& config) {
     strm << " [VDF config] " << std::endl;
     strm << "    vrf upper threshold: " << config.vrf.threshold_upper << std::endl;
-    strm << "    vrf threshold range: " << config.vrf.threshold_range << std::endl;
     strm << "    difficulty minimum: " << config.vdf.difficulty_min << std::endl;
     strm << "    difficulty maximum: " << config.vdf.difficulty_max << std::endl;
     strm << "    difficulty stale: " << config.vdf.difficulty_stale << std::endl;

--- a/libraries/vdf/include/vdf/sortition.hpp
+++ b/libraries/vdf/include/vdf/sortition.hpp
@@ -52,7 +52,6 @@ class VdfSortition : public vrf_wrapper::VrfSortitionBase {
   auto getComputationTime() const { return vdf_computation_time_; }
   uint16_t getDifficulty() const;
   uint16_t calculateDifficulty(SortitionParams const& config) const;
-  bool isOmitVdf(SortitionParams const& config) const;
   bool isStale(SortitionParams const& config) const;
   Json::Value getJson() const;
 

--- a/libraries/vdf/src/config.cpp
+++ b/libraries/vdf/src/config.cpp
@@ -26,12 +26,10 @@ VrfParams& VrfParams::operator+=(int32_t change) {
 Json::Value enc_json(VrfParams const& obj) {
   Json::Value ret(Json::objectValue);
   ret["threshold_upper"] = dev::toJS(obj.threshold_upper);
-  ret["threshold_range"] = obj.threshold_range;
   return ret;
 }
 void dec_json(Json::Value const& json, VrfParams& obj) {
   obj.threshold_upper = dev::jsToInt(json["threshold_upper"].asString());
-  obj.threshold_range = json["threshold_range"].asInt();
 }
 
 Json::Value enc_json(VdfParams const& obj) {

--- a/tests/crypto_test.cpp
+++ b/tests/crypto_test.cpp
@@ -109,7 +109,7 @@ TEST_F(CryptoTest, vrf_sortition) {
 }
 
 TEST_F(CryptoTest, vdf_sortition) {
-  SortitionParams sortition_params(0xffff, 0xffff - 0xe665, 5, 10, 10, 1500);
+  SortitionParams sortition_params(0xffff, 5, 10, 10, 1500);
   vrf_sk_t sk(
       "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
       "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
@@ -125,20 +125,18 @@ TEST_F(CryptoTest, vdf_sortition) {
   EXPECT_EQ(vdf, vdf2);
   EXPECT_EQ(vdf, vdf3);
 
-  SortitionParams sortition_params_no_omit_no_stale(0xffff, 100, 5, 10, 10, 1500);
+  SortitionParams sortition_params_no_omit_no_stale(0xffff, 5, 10, 10, 1500);
   EXPECT_FALSE(vdf.isStale(sortition_params_no_omit_no_stale));
-  EXPECT_FALSE(vdf.isOmitVdf(sortition_params_no_omit_no_stale));
 
-  SortitionParams sortition_params_omit_no_stale(0xffff, 50, 5, 10, 10, 1500);
+  SortitionParams sortition_params_omit_no_stale(0xffff, 5, 10, 10, 1500);
   EXPECT_FALSE(vdf.isStale(sortition_params_omit_no_stale));
-  EXPECT_TRUE(vdf.isOmitVdf(sortition_params_omit_no_stale));
 
-  SortitionParams sortition_params_stale(0xfff, 0xfff, 5, 10, 10, 1500);
+  SortitionParams sortition_params_stale(0xfff, 5, 10, 10, 1500);
   EXPECT_TRUE(vdf.isStale(sortition_params_stale));
 }
 
 TEST_F(CryptoTest, vdf_solution) {
-  SortitionParams sortition_params(0xffff, 0xffff - 0xe665, 5, 10, 10, 1500);
+  SortitionParams sortition_params(0xffff, 5, 10, 10, 1500);
   vrf_sk_t sk(
       "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
       "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
@@ -163,7 +161,7 @@ TEST_F(CryptoTest, vdf_solution) {
 }
 
 TEST_F(CryptoTest, vdf_proof_verify) {
-  SortitionParams sortition_params(255, 0, 5, 10, 10, 1500);
+  SortitionParams sortition_params(255, 5, 10, 10, 1500);
   vrf_sk_t sk(
       "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
       "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
@@ -184,7 +182,6 @@ TEST_F(CryptoTest, DISABLED_compute_vdf_solution_cost_time) {
       "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
   level_t level = 1;
   uint16_t threshold_upper = 0;  // diffculty == diffuclty_stale
-  uint16_t threshold_range = 0;  // Force no omit VDF
   uint16_t difficulty_min = 0;
   uint16_t difficulty_max = 0;
   uint16_t lambda_bound = 100;
@@ -197,8 +194,7 @@ TEST_F(CryptoTest, DISABLED_compute_vdf_solution_cost_time) {
   // Fix lambda, vary difficulty
   for (uint16_t difficulty_stale = 0; difficulty_stale <= 20; difficulty_stale++) {
     std::cout << "Start at difficulty " << difficulty_stale << " :" << std::endl;
-    SortitionParams sortition_params(threshold_upper, threshold_range, difficulty_min, difficulty_max, difficulty_stale,
-                                     lambda_bound);
+    SortitionParams sortition_params(threshold_upper, difficulty_min, difficulty_max, difficulty_stale, lambda_bound);
     VdfSortition vdf(sortition_params, sk, getRlpBytes(level));
     vdf.computeVdfSolution(sortition_params, proposal_dag_block_pivot_hash1.asBytes(), false);
     vdf_computation_time = vdf.getComputationTime();
@@ -217,8 +213,7 @@ TEST_F(CryptoTest, DISABLED_compute_vdf_solution_cost_time) {
   uint16_t difficulty_stale = 15;
   for (uint16_t lambda = 100; lambda <= 5000; lambda += 200) {
     std::cout << "Start at lambda " << lambda << " :" << std::endl;
-    SortitionParams sortition_params(threshold_upper, threshold_range, difficulty_min, difficulty_max, difficulty_stale,
-                                     lambda);
+    SortitionParams sortition_params(threshold_upper, difficulty_min, difficulty_max, difficulty_stale, lambda);
     VdfSortition vdf(sortition_params, sk, getRlpBytes(level));
     vdf.computeVdfSolution(sortition_params, proposal_dag_block_pivot_hash1.asBytes(), false);
     vdf_computation_time = vdf.getComputationTime();
@@ -234,7 +229,7 @@ TEST_F(CryptoTest, DISABLED_compute_vdf_solution_cost_time) {
               << vdf.getDifficulty() << ", computation cost time " << vdf_computation_time << "(ms)" << std::endl;
   }
 
-  SortitionParams sortition_params(32768, 29184, 16, 21, 22, 100);
+  SortitionParams sortition_params(32768, 16, 21, 22, 100);
   VdfSortition vdf(sortition_params, sk, getRlpBytes(level));
   std::cout << "output " << vdf.output_ << std::endl;
   int i = 0;

--- a/tests/dag_block_test.cpp
+++ b/tests/dag_block_test.cpp
@@ -41,7 +41,7 @@ TEST_F(DagBlockTest, clear) {
 }
 
 TEST_F(DagBlockTest, serialize_deserialize) {
-  SortitionParams sortition_params(0xFFFF, 0xe665, 0, 5, 5, 1500);
+  SortitionParams sortition_params(0xFFFF, 0, 5, 5, 1500);
   vrf_sk_t sk(
       "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
       "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
@@ -222,7 +222,9 @@ TEST_F(DagBlockMgrTest, incorrect_tx_estimation) {
   const auto period_block_hash = node->getDB()->getPeriodBlockHash(propose_level);
   vdf_sortition::VdfSortition vdf1(vdf_config, node->getVrfSecretKey(),
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
+
+  dev::bytes vdf_msg = DagManager::getVdfMessage(dag_genesis, {trx});
+  vdf1.computeVdfSolution(vdf_config, vdf_msg, false);
 
   // transactions.size and estimations size is not equal
   {
@@ -267,7 +269,8 @@ TEST_F(DagBlockMgrTest, too_big_dag_block) {
   const auto period_block_hash = node->getDB()->getPeriodBlockHash(propose_level);
   vdf_sortition::VdfSortition vdf1(vdf_config, node->getVrfSecretKey(),
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
+  dev::bytes vdf_msg = DagManager::getVdfMessage(dag_genesis, hashes);
+  vdf1.computeVdfSolution(vdf_config, vdf_msg, false);
 
   {
     DagBlock blk(dag_genesis, propose_level, {}, hashes, estimations, vdf1, node->getSecretKey());

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -1477,8 +1477,7 @@ TEST_F(FullNodeTest, chain_config_json) {
       "changing_interval": 200,
       "computation_interval": 50,
       "vrf": {
-        "threshold_upper": "0xafff",
-        "threshold_range": 80
+        "threshold_upper": "0xafff"
       },
       "vdf": {
         "difficulty_max": 21,
@@ -1687,7 +1686,9 @@ TEST_F(FullNodeTest, transaction_pool_overflow) {
                                   VrfSortitionBase::makeVrfInput(proposal_level, period_block_hash));
   const auto dag_genesis = node0->getConfig().chain.dag_genesis_block.getHash();
   const auto estimation = node0->getTransactionManager()->estimateTransactionGas(trx, proposal_period);
-  vdf.computeVdfSolution(sortition_params, dag_genesis.asBytes(), false);
+  dev::bytes vdf_msg = DagManager::getVdfMessage(dag_genesis, {trx});
+
+  vdf.computeVdfSolution(sortition_params, vdf_msg, false);
 
   DagBlock blk(dag_genesis, proposal_level, {}, {trx->getHash()}, estimation, vdf, node0->getSecretKey());
   const auto blk_hash = blk.getHash();

--- a/tests/hardfork_test.cpp
+++ b/tests/hardfork_test.cpp
@@ -45,7 +45,6 @@ struct HardforkTest : WithDataDir {
     // speed up block production
     {
       node_cfg.chain.sortition.vrf.threshold_upper = 0xffff;
-      node_cfg.chain.sortition.vrf.threshold_range = 0xa;
       node_cfg.chain.sortition.vdf.difficulty_min = 0;
       node_cfg.chain.sortition.vdf.difficulty_max = 3;
       node_cfg.chain.sortition.vdf.difficulty_stale = 3;

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -107,7 +107,8 @@ TEST_F(NetworkTest, transfer_lot_of_blocks) {
   vdf_sortition::VdfSortition vdf(sortition_params, node1->getVrfSecretKey(),
                                   VrfSortitionBase::makeVrfInput(proposal_level, period_block_hash));
   const auto dag_genesis = node1->getConfig().chain.dag_genesis_block.getHash();
-  vdf.computeVdfSolution(sortition_params, dag_genesis.asBytes(), false);
+  dev::bytes vdf_msg = DagManager::getVdfMessage(dag_genesis, {trxs[0]});
+  vdf.computeVdfSolution(sortition_params, vdf_msg, false);
   DagBlock blk(dag_genesis, proposal_level, {}, {trxs[0]->getHash()}, estimation, vdf, node1->getSecretKey());
   auto block_hash = blk.getHash();
   std::vector<std::shared_ptr<DagBlock>> dag_blocks;
@@ -440,37 +441,44 @@ TEST_F(NetworkTest, node_sync) {
   const auto period_block_hash = node1->getDB()->getPeriodBlockHash(propose_level);
   vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
+
+  dev::bytes vdf_msg1 = DagManager::getVdfMessage(dag_genesis, {g_signed_trx_samples[1]});
+  vdf1.computeVdfSolution(vdf_config, vdf_msg1, false);
   DagBlock blk1(dag_genesis, propose_level, {}, {g_signed_trx_samples[1]->getHash()}, estimation, vdf1, sk);
 
   propose_level = 2;
   vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf2.computeVdfSolution(vdf_config, blk1.getHash().asBytes(), false);
+  dev::bytes vdf_msg2 = DagManager::getVdfMessage(blk1.getHash(), {g_signed_trx_samples[2]});
+  vdf2.computeVdfSolution(vdf_config, vdf_msg2, false);
   DagBlock blk2(blk1.getHash(), propose_level, {}, {g_signed_trx_samples[2]->getHash()}, estimation, vdf2, sk);
 
   propose_level = 3;
   vdf_sortition::VdfSortition vdf3(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf3.computeVdfSolution(vdf_config, blk2.getHash().asBytes(), false);
+  dev::bytes vdf_msg3 = DagManager::getVdfMessage(blk2.getHash(), {g_signed_trx_samples[3]});
+  vdf3.computeVdfSolution(vdf_config, vdf_msg3, false);
   DagBlock blk3(blk2.getHash(), propose_level, {}, {g_signed_trx_samples[3]->getHash()}, estimation, vdf3, sk);
 
   propose_level = 4;
   vdf_sortition::VdfSortition vdf4(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf4.computeVdfSolution(vdf_config, blk3.getHash().asBytes(), false);
+  dev::bytes vdf_msg4 = DagManager::getVdfMessage(blk3.getHash(), {g_signed_trx_samples[4]});
+  vdf4.computeVdfSolution(vdf_config, vdf_msg4, false);
   DagBlock blk4(blk3.getHash(), propose_level, {}, {g_signed_trx_samples[4]->getHash()}, estimation, vdf4, sk);
 
   propose_level = 5;
   vdf_sortition::VdfSortition vdf5(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf5.computeVdfSolution(vdf_config, blk4.getHash().asBytes(), false);
+  dev::bytes vdf_msg5 = DagManager::getVdfMessage(blk4.getHash(), {g_signed_trx_samples[5]});
+  vdf5.computeVdfSolution(vdf_config, vdf_msg5, false);
   DagBlock blk5(blk4.getHash(), propose_level, {}, {g_signed_trx_samples[5]->getHash()}, estimation, vdf5, sk);
 
   propose_level = 6;
   vdf_sortition::VdfSortition vdf6(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf6.computeVdfSolution(vdf_config, blk5.getHash().asBytes(), false);
+  dev::bytes vdf_msg6 = DagManager::getVdfMessage(blk5.getHash(), {g_signed_trx_samples[6]});
+  vdf6.computeVdfSolution(vdf_config, vdf_msg6, false);
   DagBlock blk6(blk5.getHash(), propose_level, {blk4.getHash(), blk3.getHash()}, {g_signed_trx_samples[6]->getHash()},
                 estimation, vdf6, sk);
 
@@ -527,7 +535,8 @@ TEST_F(NetworkTest, node_pbft_sync) {
 
   level_t level = 1;
   vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk, getRlpBytes(level));
-  vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
+  dev::bytes vdf_msg1 = DagManager::getVdfMessage(dag_genesis, {g_signed_trx_samples[0], g_signed_trx_samples[1]});
+  vdf1.computeVdfSolution(vdf_config, vdf_msg1, false);
   DagBlock blk1(dag_genesis, 1, {}, {g_signed_trx_samples[0]->getHash(), g_signed_trx_samples[1]->getHash()}, 0, vdf1,
                 sk);
   node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr<Transaction>(g_signed_trx_samples[0]),
@@ -580,7 +589,8 @@ TEST_F(NetworkTest, node_pbft_sync) {
 
   level = 2;
   vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk, getRlpBytes(level));
-  vdf2.computeVdfSolution(vdf_config, blk1.getHash().asBytes(), false);
+  dev::bytes vdf_msg2 = DagManager::getVdfMessage(blk1.getHash(), {g_signed_trx_samples[2], g_signed_trx_samples[3]});
+  vdf2.computeVdfSolution(vdf_config, vdf_msg2, false);
   DagBlock blk2(blk1.getHash(), 2, {}, {g_signed_trx_samples[2]->getHash(), g_signed_trx_samples[3]->getHash()}, 0,
                 vdf2, sk);
   node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[2]),
@@ -691,7 +701,8 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   addr_t beneficiary(876);
   level_t level = 1;
   vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk, getRlpBytes(level));
-  vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
+  dev::bytes vdf_msg1 = DagManager::getVdfMessage(dag_genesis, {g_signed_trx_samples[0], g_signed_trx_samples[1]});
+  vdf1.computeVdfSolution(vdf_config, vdf_msg1, false);
   DagBlock blk1(dag_genesis, 1, {}, {g_signed_trx_samples[0]->getHash(), g_signed_trx_samples[1]->getHash()}, 0, vdf1,
                 sk);
   node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[0]),
@@ -734,7 +745,8 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   prev_block_hash = pbft_block1.getBlockHash();
   level = 2;
   vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk, getRlpBytes(level));
-  vdf2.computeVdfSolution(vdf_config, blk1.getHash().asBytes(), false);
+  dev::bytes vdf_msg2 = DagManager::getVdfMessage(blk1.getHash(), {g_signed_trx_samples[2], g_signed_trx_samples[3]});
+  vdf2.computeVdfSolution(vdf_config, vdf_msg2, false);
   DagBlock blk2(blk1.getHash(), 2, {}, {g_signed_trx_samples[2]->getHash(), g_signed_trx_samples[3]->getHash()}, 0,
                 vdf2, sk);
   node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[2]),
@@ -997,7 +1009,9 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
   const auto period_block_hash = node1->getDB()->getPeriodBlockHash(propose_level);
   vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
+  dev::RLPStream s;
+  dev::bytes vdf_msg1 = DagManager::getVdfMessage(dag_genesis, {g_signed_trx_samples[0], g_signed_trx_samples[1]});
+  vdf1.computeVdfSolution(vdf_config, vdf_msg1, false);
   DagBlock blk1(dag_genesis, propose_level, {},
                 {g_signed_trx_samples[0]->getHash(), g_signed_trx_samples[1]->getHash()}, 2 * estimation, vdf1, sk);
   std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> tr1{
@@ -1006,7 +1020,8 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
   propose_level = 2;
   vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf2.computeVdfSolution(vdf_config, blk1.getHash().asBytes(), false);
+  dev::bytes vdf_msg2 = DagManager::getVdfMessage(blk1.getHash(), {g_signed_trx_samples[2]});
+  vdf2.computeVdfSolution(vdf_config, vdf_msg2, false);
   DagBlock blk2(blk1.getHash(), propose_level, {}, {g_signed_trx_samples[2]->getHash()}, estimation, vdf2, sk);
   std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> tr2{
       {g_signed_trx_samples[2], TransactionStatus::Verified}};
@@ -1014,7 +1029,8 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
   propose_level = 3;
   vdf_sortition::VdfSortition vdf3(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf3.computeVdfSolution(vdf_config, blk2.getHash().asBytes(), false);
+  dev::bytes vdf_msg3 = DagManager::getVdfMessage(blk2.getHash(), {g_signed_trx_samples[3]});
+  vdf3.computeVdfSolution(vdf_config, vdf_msg3, false);
   DagBlock blk3(blk2.getHash(), propose_level, {}, {g_signed_trx_samples[3]->getHash()}, estimation, vdf3, sk);
   std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> tr3{
       {g_signed_trx_samples[3], TransactionStatus::Verified}};
@@ -1022,7 +1038,8 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
   propose_level = 4;
   vdf_sortition::VdfSortition vdf4(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf4.computeVdfSolution(vdf_config, blk3.getHash().asBytes(), false);
+  dev::bytes vdf_msg4 = DagManager::getVdfMessage(blk3.getHash(), {g_signed_trx_samples[4]});
+  vdf4.computeVdfSolution(vdf_config, vdf_msg4, false);
   DagBlock blk4(blk3.getHash(), propose_level, {}, {g_signed_trx_samples[4]->getHash()}, estimation, vdf4, sk);
   std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> tr4{
       {g_signed_trx_samples[4], TransactionStatus::Verified}};
@@ -1030,7 +1047,9 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
   propose_level = 5;
   vdf_sortition::VdfSortition vdf5(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf5.computeVdfSolution(vdf_config, blk4.getHash().asBytes(), false);
+  dev::bytes vdf_msg5 = DagManager::getVdfMessage(blk4.getHash(), {g_signed_trx_samples[5], g_signed_trx_samples[6],
+                                                                   g_signed_trx_samples[7], g_signed_trx_samples[8]});
+  vdf5.computeVdfSolution(vdf_config, vdf_msg5, false);
   DagBlock blk5(blk4.getHash(), propose_level, {},
                 {g_signed_trx_samples[5]->getHash(), g_signed_trx_samples[6]->getHash(),
                  g_signed_trx_samples[7]->getHash(), g_signed_trx_samples[8]->getHash()},
@@ -1044,7 +1063,8 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
   propose_level = 6;
   vdf_sortition::VdfSortition vdf6(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf6.computeVdfSolution(vdf_config, blk5.getHash().asBytes(), false);
+  dev::bytes vdf_msg6 = DagManager::getVdfMessage(blk5.getHash(), {g_signed_trx_samples[9]});
+  vdf6.computeVdfSolution(vdf_config, vdf_msg6, false);
   DagBlock blk6(blk5.getHash(), propose_level, {blk4.getHash(), blk3.getHash()}, {g_signed_trx_samples[9]->getHash()},
                 estimation, vdf6, sk);
   std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> tr6{
@@ -1118,7 +1138,8 @@ TEST_F(NetworkTest, node_sync2) {
   const auto period_block_hash = node1->getDB()->getPeriodBlockHash(propose_level);
   vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
+  dev::bytes vdf_msg = DagManager::getVdfMessage(dag_genesis, {transactions[0], transactions[1]});
+  vdf1.computeVdfSolution(vdf_config, vdf_msg, false);
   DagBlock blk1(dag_genesis, propose_level, {}, {transactions[0]->getHash(), transactions[1]->getHash()},
                 2 * estimation, vdf1, sk);
   SharedTransactions tr1({transactions[0], transactions[1]});
@@ -1126,7 +1147,8 @@ TEST_F(NetworkTest, node_sync2) {
   propose_level = 1;
   vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf2.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
+  vdf_msg = DagManager::getVdfMessage(dag_genesis, {transactions[2], transactions[3]});
+  vdf2.computeVdfSolution(vdf_config, vdf_msg, false);
   DagBlock blk2(dag_genesis, propose_level, {}, {transactions[2]->getHash(), transactions[3]->getHash()},
                 2 * estimation, vdf2, sk);
   SharedTransactions tr2({transactions[2], transactions[3]});
@@ -1134,7 +1156,8 @@ TEST_F(NetworkTest, node_sync2) {
   propose_level = 2;
   vdf_sortition::VdfSortition vdf3(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf3.computeVdfSolution(vdf_config, blk1.getHash().asBytes(), false);
+  vdf_msg = DagManager::getVdfMessage(blk1.getHash(), {transactions[4], transactions[5]});
+  vdf3.computeVdfSolution(vdf_config, vdf_msg, false);
   DagBlock blk3(blk1.getHash(), propose_level, {}, {transactions[4]->getHash(), transactions[5]->getHash()},
                 2 * estimation, vdf3, sk);
   SharedTransactions tr3({transactions[4], transactions[5]});
@@ -1142,7 +1165,8 @@ TEST_F(NetworkTest, node_sync2) {
   propose_level = 3;
   vdf_sortition::VdfSortition vdf4(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf4.computeVdfSolution(vdf_config, blk3.getHash().asBytes(), false);
+  vdf_msg = DagManager::getVdfMessage(blk3.getHash(), {transactions[6], transactions[7]});
+  vdf4.computeVdfSolution(vdf_config, vdf_msg, false);
   DagBlock blk4(blk3.getHash(), propose_level, {}, {transactions[6]->getHash(), transactions[7]->getHash()},
                 2 * estimation, vdf4, sk);
   SharedTransactions tr4({transactions[6], transactions[7]});
@@ -1150,7 +1174,8 @@ TEST_F(NetworkTest, node_sync2) {
   propose_level = 2;
   vdf_sortition::VdfSortition vdf5(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf5.computeVdfSolution(vdf_config, blk2.getHash().asBytes(), false);
+  vdf_msg = DagManager::getVdfMessage(blk2.getHash(), {transactions[8], transactions[9]});
+  vdf5.computeVdfSolution(vdf_config, vdf_msg, false);
   DagBlock blk5(blk2.getHash(), propose_level, {}, {transactions[8]->getHash(), transactions[9]->getHash()},
                 2 * estimation, vdf5, sk);
   SharedTransactions tr5({transactions[8], transactions[9]});
@@ -1158,7 +1183,8 @@ TEST_F(NetworkTest, node_sync2) {
   propose_level = 2;
   vdf_sortition::VdfSortition vdf6(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf6.computeVdfSolution(vdf_config, blk1.getHash().asBytes(), false);
+  vdf_msg = DagManager::getVdfMessage(blk1.getHash(), {transactions[10], transactions[11]});
+  vdf6.computeVdfSolution(vdf_config, vdf_msg, false);
   DagBlock blk6(blk1.getHash(), propose_level, {}, {transactions[10]->getHash(), transactions[11]->getHash()},
                 2 * estimation, vdf6, sk);
   SharedTransactions tr6({transactions[10], transactions[11]});
@@ -1166,7 +1192,8 @@ TEST_F(NetworkTest, node_sync2) {
   propose_level = 3;
   vdf_sortition::VdfSortition vdf7(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf7.computeVdfSolution(vdf_config, blk6.getHash().asBytes(), false);
+  vdf_msg = DagManager::getVdfMessage(blk6.getHash(), {transactions[12], transactions[13]});
+  vdf7.computeVdfSolution(vdf_config, vdf_msg, false);
   DagBlock blk7(blk6.getHash(), propose_level, {}, {transactions[12]->getHash(), transactions[13]->getHash()},
                 2 * estimation, vdf7, sk);
   SharedTransactions tr7({transactions[12], transactions[13]});
@@ -1174,7 +1201,8 @@ TEST_F(NetworkTest, node_sync2) {
   propose_level = 4;
   vdf_sortition::VdfSortition vdf8(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf8.computeVdfSolution(vdf_config, blk1.getHash().asBytes(), false);
+  vdf_msg = DagManager::getVdfMessage(blk1.getHash(), {transactions[14], transactions[15]});
+  vdf8.computeVdfSolution(vdf_config, vdf_msg, false);
   DagBlock blk8(blk1.getHash(), propose_level, {blk7.getHash()},
                 {transactions[14]->getHash(), transactions[15]->getHash()}, 2 * estimation, vdf8, sk);
   SharedTransactions tr8({transactions[14], transactions[15]});
@@ -1182,7 +1210,8 @@ TEST_F(NetworkTest, node_sync2) {
   propose_level = 2;
   vdf_sortition::VdfSortition vdf9(vdf_config, vrf_sk,
                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf9.computeVdfSolution(vdf_config, blk1.getHash().asBytes(), false);
+  vdf_msg = DagManager::getVdfMessage(blk1.getHash(), {transactions[16], transactions[17]});
+  vdf9.computeVdfSolution(vdf_config, vdf_msg, false);
   DagBlock blk9(blk1.getHash(), propose_level, {}, {transactions[16]->getHash(), transactions[17]->getHash()},
                 2 * estimation, vdf9, sk);
   SharedTransactions tr9({transactions[16], transactions[17]});
@@ -1190,7 +1219,8 @@ TEST_F(NetworkTest, node_sync2) {
   propose_level = 5;
   vdf_sortition::VdfSortition vdf10(vdf_config, vrf_sk,
                                     VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf10.computeVdfSolution(vdf_config, blk8.getHash().asBytes(), false);
+  vdf_msg = DagManager::getVdfMessage(blk8.getHash(), {transactions[18], transactions[19]});
+  vdf10.computeVdfSolution(vdf_config, vdf_msg, false);
   DagBlock blk10(blk8.getHash(), propose_level, {}, {transactions[18]->getHash(), transactions[19]->getHash()},
                  2 * estimation, vdf10, sk);
   SharedTransactions tr10({transactions[18], transactions[19]});
@@ -1198,7 +1228,8 @@ TEST_F(NetworkTest, node_sync2) {
   propose_level = 3;
   vdf_sortition::VdfSortition vdf11(vdf_config, vrf_sk,
                                     VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf11.computeVdfSolution(vdf_config, blk3.getHash().asBytes(), false);
+  vdf_msg = DagManager::getVdfMessage(blk3.getHash(), {transactions[20], transactions[21]});
+  vdf11.computeVdfSolution(vdf_config, vdf_msg, false);
   DagBlock blk11(blk3.getHash(), propose_level, {}, {transactions[20]->getHash(), transactions[21]->getHash()},
                  2 * estimation, vdf11, sk);
   SharedTransactions tr11({transactions[20], transactions[21]});
@@ -1206,7 +1237,8 @@ TEST_F(NetworkTest, node_sync2) {
   propose_level = 3;
   vdf_sortition::VdfSortition vdf12(vdf_config, vrf_sk,
                                     VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
-  vdf12.computeVdfSolution(vdf_config, blk5.getHash().asBytes(), false);
+  vdf_msg = DagManager::getVdfMessage(blk5.getHash(), {transactions[22], transactions[23]});
+  vdf12.computeVdfSolution(vdf_config, vdf_msg, false);
   DagBlock blk12(blk5.getHash(), propose_level, {}, {transactions[22]->getHash(), transactions[23]->getHash()},
                  2 * estimation, vdf12, sk);
   SharedTransactions tr12({transactions[22], transactions[23]});

--- a/tests/sortition_test.cpp
+++ b/tests/sortition_test.cpp
@@ -53,22 +53,18 @@ PeriodData createBlock(PbftPeriod period, uint16_t efficiency, size_t dag_blocks
 TEST_F(SortitionTest, vrf_lower_overflow) {
   VrfParams vrf;
 
-  vrf.threshold_range = 200;
   vrf.threshold_upper = 300;
 
   vrf += -200;
 
-  EXPECT_EQ(vrf.threshold_range, 200);
   EXPECT_EQ(vrf.threshold_upper, 100);
 
   vrf += -200;
 
-  EXPECT_EQ(vrf.threshold_range, 200);
   EXPECT_EQ(vrf.threshold_upper, VrfParams::kThresholdUpperMinValue);
 
   vrf += 50;
 
-  EXPECT_EQ(vrf.threshold_range, 200);
   EXPECT_EQ(vrf.threshold_upper, VrfParams::kThresholdUpperMinValue + 50);
 }
 
@@ -76,17 +72,14 @@ TEST_F(SortitionTest, vrf_upper_overflow) {
   VrfParams vrf;
 
   vrf.threshold_upper = std::numeric_limits<uint16_t>::max() - 100;
-  vrf.threshold_range = 200;
 
   vrf += 200;
 
   EXPECT_EQ(vrf.threshold_upper, std::numeric_limits<uint16_t>::max());
-  EXPECT_EQ(vrf.threshold_range, 200);
 
   vrf += 200;
 
   EXPECT_EQ(vrf.threshold_upper, std::numeric_limits<uint16_t>::max());
-  EXPECT_EQ(vrf.threshold_range, 200);
 }
 
 TEST_F(SortitionTest, sortition_config_serialization) {
@@ -101,7 +94,6 @@ TEST_F(SortitionTest, sortition_config_serialization) {
   config.vdf.difficulty_stale = std::rand();
   config.vdf.lambda_bound = std::rand();
 
-  config.vrf.threshold_range = std::rand();
   config.vrf.threshold_upper = std::rand();
 
   auto config_json = enc_json(config);
@@ -117,19 +109,17 @@ TEST_F(SortitionTest, sortition_config_serialization) {
   EXPECT_EQ(config.vdf.difficulty_stale, restored_config.vdf.difficulty_stale);
   EXPECT_EQ(config.vdf.lambda_bound, restored_config.vdf.lambda_bound);
 
-  EXPECT_EQ(config.vrf.threshold_range, restored_config.vrf.threshold_range);
   EXPECT_EQ(config.vrf.threshold_upper, restored_config.vrf.threshold_upper);
 }
 
 TEST_F(SortitionTest, params_change_serialization) {
-  SortitionParamsChange start(1, 25 * kOnePercent, {1100, 1500});
+  SortitionParamsChange start(1, 25 * kOnePercent, {1100});
   // 1700 - 1500 / 2 = 100 (change per percent)
-  SortitionParamsChange params(2, 27 * kOnePercent, {1300, 1700});
+  SortitionParamsChange params(2, 27 * kOnePercent, {1300});
 
   const auto params_rlp = params.rlp();
   const auto deserialized_params = SortitionParamsChange::from_rlp(dev::RLP(params_rlp));
 
-  EXPECT_EQ(params.vrf_params.threshold_range, deserialized_params.vrf_params.threshold_range);
   EXPECT_EQ(params.vrf_params.threshold_upper, deserialized_params.vrf_params.threshold_upper);
   EXPECT_EQ(params.interval_efficiency, deserialized_params.interval_efficiency);
 }
@@ -168,7 +158,7 @@ TEST_F(SortitionTest, params_changes_from_db) {
 
   auto batch = db->createWriteBatch();
   for (uint16_t i = 0; i < 10; ++i) {
-    SortitionParamsChange p{i, i, {i, i}};
+    SortitionParamsChange p{i, i, {i}};
     db->saveSortitionParamsChange(i, p, batch);
   }
   db->commitWriteBatch(batch);
@@ -178,7 +168,6 @@ TEST_F(SortitionTest, params_changes_from_db) {
   for (uint16_t i = 0; i < 5; ++i) {
     // +5 is offset to the middle of data
     EXPECT_EQ(res[i].interval_efficiency, i + 5);
-    EXPECT_EQ(res[i].vrf_params.threshold_range, i + 5);
     EXPECT_EQ(res[i].vrf_params.threshold_upper, i + 5);
   }
 }
@@ -188,7 +177,7 @@ TEST_F(SortitionTest, params_changes_from_db2) {
 
   auto batch = db->createWriteBatch();
   for (uint16_t i = 0; i < 2; ++i) {
-    SortitionParamsChange p{i, i, {i, i}};
+    SortitionParamsChange p{i, i, {i}};
     db->saveSortitionParamsChange(i, p, batch);
   }
   db->commitWriteBatch(batch);
@@ -197,7 +186,6 @@ TEST_F(SortitionTest, params_changes_from_db2) {
   EXPECT_EQ(res.size(), 2);
   for (uint16_t i = 0; i < 2; ++i) {
     EXPECT_EQ(res[i].interval_efficiency, i);
-    EXPECT_EQ(res[i].vrf_params.threshold_range, i);
     EXPECT_EQ(res[i].vrf_params.threshold_upper, i);
   }
 }
@@ -507,7 +495,6 @@ TEST_F(SortitionTest, params_restart) {
     EXPECT_EQ(params_changes.size(), 1);
     EXPECT_EQ(params_changes[0].period, 0);
     EXPECT_EQ(params_changes[0].vrf_params.threshold_upper, cfg.vrf.threshold_upper);
-    EXPECT_EQ(params_changes[0].vrf_params.threshold_range, cfg.vrf.threshold_range);
     auto batch = db->createWriteBatch();
     auto b = createBlock(1, 75 * kOnePercent);
     sp.pbftBlockPushed(b, batch, 1);

--- a/tests/util_test/util.hpp
+++ b/tests/util_test/util.hpp
@@ -188,7 +188,6 @@ inline auto make_node_cfgs(size_t total_count, size_t validators_count = 1) {
     if constexpr (tests_speed != 1) {
       // VDF config
       cfg.chain.sortition.vrf.threshold_upper = 0xffff;
-      cfg.chain.sortition.vrf.threshold_range = 0x199a;
       cfg.chain.sortition.vdf.difficulty_min = 0;
       cfg.chain.sortition.vdf.difficulty_max = 5;
       cfg.chain.sortition.vdf.difficulty_stale = 5;


### PR DESCRIPTION
- Omit VDF removed
- Base for calculating VDF now includes the hashes of transactions in the dag block so it is only possible to use VDF in an unique block