### PR TITLE
refactor: use VotePacket for single vote and VotesSyncPacket for vote…

### DIFF
--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -290,7 +290,7 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
    * @brief Get PBFT committee size
    * @return PBFT committee size
    */
-  size_t getPbftCommitteeSize() const { return COMMITTEE_SIZE; }
+  size_t getPbftCommitteeSize() const { return config_.committee_size; }
 
   /**
    * @brief Get 2t+1. 2t+1 is 2/3 of PBFT sortition threshold and plus 1 for a specific period
@@ -624,13 +624,7 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
 
   std::default_random_engine random_engine_{std::random_device{}()};
 
-  const size_t COMMITTEE_SIZE;
-  const size_t NUMBER_OF_PROPOSERS;
-  const size_t DAG_BLOCKS_SIZE;
-  const size_t GHOST_PATH_MOVE_BACK;
-
   PbftStates state_ = value_proposal_state;
-
   std::atomic<PbftRound> round_ = 1;
   PbftStep step_ = 1;
   PbftStep startingStepInRound_ = 1;

--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -382,11 +382,11 @@ class VoteManager {
   uint64_t getPbftSortitionThreshold(uint64_t total_dpos_votes_count, PbftVoteTypes vote_type) const;
 
  private:
-  const addr_t node_addr_;
-  const PbftConfig& pbft_config_;
-  const vrf_wrapper::vrf_sk_t vrf_sk_;
-  const secret_t node_sk_;
-  const dev::Public node_pub_;
+  const addr_t kNodeAddr;
+  const PbftConfig& kPbftConfig;
+  const vrf_wrapper::vrf_sk_t kVrfSk;
+  const secret_t kNodeSk;
+  const dev::Public kNodePub;
 
   std::shared_ptr<DbStorage> db_;
   std::shared_ptr<PbftChain> pbft_chain_;

--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -351,6 +351,16 @@ class VoteManager {
    */
   std::optional<uint64_t> getPbftTwoTPlusOne(PbftPeriod pbft_period) const;
 
+  /**
+   * @param vote_hash
+   * @return true if vote_hash was already validated, otherwise false
+   */
+  bool voteAlreadyValidated(const vote_hash_t& vote_hash) const;
+
+  /**
+   * @brief Generates vrf sorition and calculates its weight
+   * @return true if sortition weight > 0, otherwise false
+   */
   bool genAndValidateVrfSortition(PbftPeriod pbft_period, PbftRound pbft_round) const;
 
  private:
@@ -420,6 +430,10 @@ class VoteManager {
   // always call getPbftTwoTPlusOne instead !!!
   mutable std::pair<PbftPeriod, uint64_t /* two_t_plus_one for period */> current_two_t_plus_one_;
   mutable std::shared_mutex current_two_t_plus_one_mutex_;
+
+  // Votes that have been already validated in terms of signature, stake, etc...
+  // It is used as protection against ddos attack so we do no validate/process vote more than once
+  mutable ExpirationCache<vote_hash_t> already_validated_votes_;
 
   LOG_OBJECTS_DEFINE
 };

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -711,7 +711,7 @@ void PbftManager::broadcastVotes(bool rebroadcast) {
   }
 
   if (auto soft_voted_block_data = getTwoTPlusOneSoftVotedBlockData(period, round); soft_voted_block_data.has_value()) {
-    net->getSpecificHandler<network::tarcap::VotePacketHandler>()->onNewPbftVotes(
+    net->getSpecificHandler<network::tarcap::VotesSyncPacketHandler>()->onNewPbftVotesBundle(
         std::move(soft_voted_block_data->soft_votes_), rebroadcast);
     vote_mgr_->sendRewardVotes(getLastPbftBlockHash(), rebroadcast);
   }

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1077,7 +1077,8 @@ void PbftManager::firstFinish_() {
   } else if (round >= 2 && previous_round_next_voted_null_block_hash_) {
     // Starting value in round 1 is always null block hash... So combined with other condition for next
     // voting null block hash...
-    if (auto vote = vote_mgr_->generateVoteWithWeight(kNullBlockHash, PbftVoteTypes::next_vote, period, round, step_); vote) {
+    if (auto vote = vote_mgr_->generateVoteWithWeight(kNullBlockHash, PbftVoteTypes::next_vote, period, round, step_);
+        vote) {
       placeVote(vote, "first finish next vote", nullptr);
     }
   } else {

--- a/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
+++ b/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
@@ -8,6 +8,7 @@
 
 #include "network/network.hpp"
 #include "network/tarcap/packets_handlers/vote_packet_handler.hpp"
+#include "network/tarcap/packets_handlers/votes_sync_packet_handler.hpp"
 #include "pbft/pbft_manager.hpp"
 
 namespace taraxa {
@@ -729,7 +730,8 @@ void VoteManager::sendRewardVotes(const blk_hash_t& pbft_block_hash, bool rebroa
   if (reward_votes.empty()) return;
 
   if (auto net = network_.lock()) {
-    net->getSpecificHandler<network::tarcap::VotePacketHandler>()->onNewPbftVotes(std::move(reward_votes), rebroadcast);
+    net->getSpecificHandler<network::tarcap::VotesSyncPacketHandler>()->onNewPbftVotesBundle(std::move(reward_votes),
+                                                                                             rebroadcast);
   }
 }
 

--- a/libraries/core_libs/network/include/network/tarcap/packet_types.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packet_types.hpp
@@ -13,7 +13,7 @@ enum SubprotocolPacketType : uint32_t {
   // Consensus packets with high processing priority
   HighPriorityPackets = 0,
   VotePacket,  // Vote packer can contain (optional) also pbft block
-  GetVotesSyncPacket,
+  GetNextVotesSyncPacket,
   VotesSyncPacket,
 
   // Standard packets with mid processing priority
@@ -51,8 +51,8 @@ inline std::string convertPacketTypeToString(SubprotocolPacketType packet_type) 
       return "TransactionPacket";
     case VotePacket:
       return "VotePacket";
-    case GetVotesSyncPacket:
-      return "GetVotesSyncPacket";
+    case GetNextVotesSyncPacket:
+      return "GetNextVotesSyncPacket";
     case VotesSyncPacket:
       return "VotesSyncPacket";
     case GetPbftSyncPacket:

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_votes_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/ext_votes_packet_handler.hpp
@@ -58,20 +58,6 @@ class ExtVotesPacketHandler : public PacketHandler {
    */
   bool processNextSyncVote(const std::shared_ptr<Vote>& vote, const std::shared_ptr<PbftBlock>& pbft_block) const;
 
-  /**
-   * @brief Sends pbft votes to connected peers
-   *
-   * @param votes Votes to send
-   * @param rebroadcast if rebroadcast is true, all votes are resent to all peers
-   */
-  void onNewPbftVotes(std::vector<std::shared_ptr<Vote>>&& votes, bool rebroadcast = false);
-  void sendPbftVotes(const std::shared_ptr<TaraxaPeer>& peer, std::vector<std::shared_ptr<Vote>>&& votes,
-                     bool is_next_votes = false);
-
-  void onNewPbftVote(const std::shared_ptr<Vote>& vote, const std::shared_ptr<PbftBlock>& block);
-  void sendPbftVote(const std::shared_ptr<TaraxaPeer>& peer, const std::shared_ptr<Vote>& vote,
-                    const std::shared_ptr<PbftBlock>& block);
-
  protected:
   /**
    * @brief Validates standard vote
@@ -118,9 +104,10 @@ class ExtVotesPacketHandler : public PacketHandler {
    */
   bool validateVoteAndBlock(const std::shared_ptr<Vote>& vote, const std::shared_ptr<PbftBlock>& pbft_block) const;
 
+  void sendPbftVotesBundle(const std::shared_ptr<TaraxaPeer>& peer, std::vector<std::shared_ptr<Vote>>&& votes);
+
  protected:
   constexpr static size_t kMaxVotesInPacket{1000};
-  constexpr static size_t kVotePacketWithBlockSize{3};
   constexpr static std::chrono::seconds kSyncRequestInterval = std::chrono::seconds(10);
 
   mutable std::chrono::system_clock::time_point last_votes_sync_request_time_;

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/common/packet_handler.hpp
@@ -40,8 +40,7 @@ class PacketHandler {
    */
   void processPacket(const PacketData& packet_data);
 
-  void requestPbftNextVotesAtPeriodRound(const dev::p2p::NodeID& peerID, PbftPeriod pbft_period, PbftRound pbft_round,
-                                         size_t pbft_previous_round_next_votes_size);
+  void requestPbftNextVotesAtPeriodRound(const dev::p2p::NodeID& peerID, PbftPeriod pbft_period, PbftRound pbft_round);
 
  private:
   void handle_caught_exception(std::string_view exception_msg, const PacketData& packet_data,

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_next_votes_sync_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_next_votes_sync_packet_handler.hpp
@@ -13,10 +13,10 @@ namespace taraxa::network::tarcap {
 class GetNextVotesSyncPacketHandler final : public ExtVotesPacketHandler {
  public:
   GetNextVotesSyncPacketHandler(const FullNodeConfig& conf, std::shared_ptr<PeersState> peers_state,
-                            std::shared_ptr<TimePeriodPacketsStats> packets_stats,
-                            std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<PbftChain> pbft_chain,
-                            std::shared_ptr<VoteManager> vote_mgr, std::shared_ptr<NextVotesManager> next_votes_mgr,
-                            const addr_t& node_addr);
+                                std::shared_ptr<TimePeriodPacketsStats> packets_stats,
+                                std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<PbftChain> pbft_chain,
+                                std::shared_ptr<VoteManager> vote_mgr, std::shared_ptr<NextVotesManager> next_votes_mgr,
+                                const addr_t& node_addr);
 
   // Packet type that is processed by this handler
   static constexpr SubprotocolPacketType kPacketType_ = SubprotocolPacketType::GetNextVotesSyncPacket;

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_votes_sync_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_votes_sync_packet_handler.hpp
@@ -10,16 +10,16 @@ class NextVotesManager;
 
 namespace taraxa::network::tarcap {
 
-class GetVotesSyncPacketHandler final : public ExtVotesPacketHandler {
+class GetNextVotesSyncPacketHandler final : public ExtVotesPacketHandler {
  public:
-  GetVotesSyncPacketHandler(const FullNodeConfig& conf, std::shared_ptr<PeersState> peers_state,
+  GetNextVotesSyncPacketHandler(const FullNodeConfig& conf, std::shared_ptr<PeersState> peers_state,
                             std::shared_ptr<TimePeriodPacketsStats> packets_stats,
                             std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<PbftChain> pbft_chain,
                             std::shared_ptr<VoteManager> vote_mgr, std::shared_ptr<NextVotesManager> next_votes_mgr,
                             const addr_t& node_addr);
 
   // Packet type that is processed by this handler
-  static constexpr SubprotocolPacketType kPacketType_ = SubprotocolPacketType::GetVotesSyncPacket;
+  static constexpr SubprotocolPacketType kPacketType_ = SubprotocolPacketType::GetNextVotesSyncPacket;
 
  private:
   void validatePacketRlpFormat(const PacketData& packet_data) const override;

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/status_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/status_packet_handler.hpp
@@ -27,9 +27,6 @@ class StatusPacketHandler final : public ExtSyncingPacketHandler {
   void validatePacketRlpFormat(const PacketData& packet_data) const override;
   void process(const PacketData& packet_data, const std::shared_ptr<TaraxaPeer>& peer) override;
 
-  void syncPbftNextVotesAtPeriodRound(PbftPeriod pbft_period, PbftRound pbft_round,
-                                      size_t pbft_previous_round_next_votes_size);
-
   static constexpr uint16_t kInitialStatusPacketItemsCount = 12;
   static constexpr uint16_t kStandardStatusPacketItemsCount = 5;
 

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/vote_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/vote_packet_handler.hpp
@@ -2,12 +2,6 @@
 
 #include "network/tarcap/packets_handlers/common/ext_votes_packet_handler.hpp"
 
-namespace taraxa {
-class PbftManager;
-class VoteManager;
-class NextVotesManager;
-}  // namespace taraxa
-
 namespace taraxa::network::tarcap {
 
 class VotePacketHandler final : public ExtVotesPacketHandler {
@@ -15,7 +9,7 @@ class VotePacketHandler final : public ExtVotesPacketHandler {
   VotePacketHandler(const FullNodeConfig& conf, std::shared_ptr<PeersState> peers_state,
                     std::shared_ptr<TimePeriodPacketsStats> packets_stats, std::shared_ptr<PbftManager> pbft_mgr,
                     std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<VoteManager> vote_mgr,
-                    std::shared_ptr<NextVotesManager> next_votes_mgr, const addr_t& node_addr);
+                    const addr_t& node_addr);
 
   /**
    * @brief Sends pbft vote to connected peers
@@ -31,15 +25,12 @@ class VotePacketHandler final : public ExtVotesPacketHandler {
   static constexpr SubprotocolPacketType kPacketType_ = SubprotocolPacketType::VotePacket;
 
  private:
-  const size_t kVotePacketSize{1};
-  const size_t kExtendedVotePacketSize{3};
-
- private:
   void validatePacketRlpFormat(const PacketData& packet_data) const override;
   void process(const PacketData& packet_data, const std::shared_ptr<TaraxaPeer>& peer) override;
 
-  ExpirationCache<vote_hash_t> seen_votes_;
-  std::shared_ptr<NextVotesManager> next_votes_mgr_;
+ private:
+  const size_t kVotePacketSize{1};
+  const size_t kExtendedVotePacketSize{3};
 };
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/vote_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/vote_packet_handler.hpp
@@ -17,8 +17,22 @@ class VotePacketHandler final : public ExtVotesPacketHandler {
                     std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<VoteManager> vote_mgr,
                     std::shared_ptr<NextVotesManager> next_votes_mgr, const addr_t& node_addr);
 
+  /**
+   * @brief Sends pbft vote to connected peers
+   *
+   * @param vote Votes to send
+   * @param block block to send - nullptr means no block
+   */
+  void onNewPbftVote(const std::shared_ptr<Vote>& vote, const std::shared_ptr<PbftBlock>& block);
+  void sendPbftVote(const std::shared_ptr<TaraxaPeer>& peer, const std::shared_ptr<Vote>& vote,
+                    const std::shared_ptr<PbftBlock>& block);
+
   // Packet type that is processed by this handler
   static constexpr SubprotocolPacketType kPacketType_ = SubprotocolPacketType::VotePacket;
+
+ private:
+  const size_t kVotePacketSize{1};
+  const size_t kExtendedVotePacketSize{3};
 
  private:
   void validatePacketRlpFormat(const PacketData& packet_data) const override;

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/votes_sync_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/votes_sync_packet_handler.hpp
@@ -26,6 +26,16 @@ class VotesSyncPacketHandler final : public ExtVotesPacketHandler {
    */
   void broadcastPreviousRoundNextVotesBundle(bool rebroadcast = false);
 
+  /**
+   * @brief Sends pbft votes bundle to connected peers
+   *
+   * @param votes Votes to send
+   * @param rebroadcast if rebroadcast is true, all votes are resent to all peers
+   * @param exclude_node do not send votes to excluded node
+   */
+  void onNewPbftVotesBundle(std::vector<std::shared_ptr<Vote>>&& votes, bool rebroadcast = false,
+                            const std::optional<dev::p2p::NodeID>& exclude_node = {});
+
   // Packet type that is processed by this handler
   static constexpr SubprotocolPacketType kPacketType_ = SubprotocolPacketType::VotesSyncPacket;
 

--- a/libraries/core_libs/network/rpc/Test.cpp
+++ b/libraries/core_libs/network/rpc/Test.cpp
@@ -133,7 +133,7 @@ Json::Value Test::get_node_status() {
       const auto chain_size = node->getPbftChain()->getPbftChainSize();
       const auto dpos_total_votes_opt = node->getPbftManager()->getCurrentDposTotalVotesCount();
       const auto dpos_node_votes_opt = node->getPbftManager()->getCurrentNodeVotesCount();
-      const auto two_t_plus_one_opt = node->getPbftManager()->getPbftTwoTPlusOne(chain_size);
+      const auto two_t_plus_one_opt = node->getVoteManager()->getPbftTwoTPlusOne(chain_size);
 
       res["synced"] = !node->getNetwork()->pbft_syncing();
       res["syncing_seconds"] = Json::UInt64(node->getNetwork()->syncTimeSeconds());

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_votes_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/common/ext_votes_packet_handler.cpp
@@ -253,7 +253,7 @@ std::pair<bool, std::string> ExtVotesPacketHandler::validateVote(const std::shar
     return unique_vote_validation;
   }
 
-  const auto vote_valid = pbft_mgr_->validateVote(vote);
+  const auto vote_valid = vote_mgr_->validateVote(vote);
   if (!vote_valid.first) {
     LOG(log_er_) << "Vote \"dpos\" validation failed: " << vote_valid.second;
   }

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/common/packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/common/packet_handler.cpp
@@ -122,8 +122,8 @@ void PacketHandler::disconnect(const dev::p2p::NodeID& node_id, dev::p2p::Discon
 
 void PacketHandler::requestPbftNextVotesAtPeriodRound(const dev::p2p::NodeID& peerID, PbftPeriod pbft_period,
                                                       PbftRound pbft_round) {
-  LOG(log_dg_) << "Sending GetVotesSyncPacket with period:" << pbft_period << ", round:" << pbft_round;
-  sealAndSend(peerID, GetVotesSyncPacket, std::move(dev::RLPStream(2) << pbft_period << pbft_round));
+  LOG(log_dg_) << "Sending GetNextVotesSyncPacket with period:" << pbft_period << ", round:" << pbft_round;
+  sealAndSend(peerID, GetNextVotesSyncPacket, std::move(dev::RLPStream(2) << pbft_period << pbft_round));
 }
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/common/packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/common/packet_handler.cpp
@@ -121,12 +121,9 @@ void PacketHandler::disconnect(const dev::p2p::NodeID& node_id, dev::p2p::Discon
 }
 
 void PacketHandler::requestPbftNextVotesAtPeriodRound(const dev::p2p::NodeID& peerID, PbftPeriod pbft_period,
-                                                      PbftRound pbft_round,
-                                                      size_t pbft_previous_round_next_votes_size) {
-  LOG(log_nf_) << "Sending GetVotesSyncPacket with period:" << pbft_period << ", round:" << pbft_round
-               << ", previous_round_next_votes_size:" << pbft_previous_round_next_votes_size;
-  sealAndSend(peerID, GetVotesSyncPacket,
-              std::move(dev::RLPStream(3) << pbft_period << pbft_round << pbft_previous_round_next_votes_size));
+                                                      PbftRound pbft_round) {
+  LOG(log_dg_) << "Sending GetVotesSyncPacket with period:" << pbft_period << ", round:" << pbft_round;
+  sealAndSend(peerID, GetVotesSyncPacket, std::move(dev::RLPStream(2) << pbft_period << pbft_round));
 }
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/get_next_votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/get_next_votes_sync_packet_handler.cpp
@@ -1,4 +1,4 @@
-#include "network/tarcap/packets_handlers/get_votes_sync_packet_handler.hpp"
+#include "network/tarcap/packets_handlers/get_next_votes_sync_packet_handler.hpp"
 
 #include "pbft/pbft_manager.hpp"
 #include "vote_manager/vote_manager.hpp"

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/get_votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/get_votes_sync_packet_handler.cpp
@@ -5,24 +5,23 @@
 
 namespace taraxa::network::tarcap {
 
-GetVotesSyncPacketHandler::GetVotesSyncPacketHandler(
+GetNextVotesSyncPacketHandler::GetNextVotesSyncPacketHandler(
     const FullNodeConfig &conf, std::shared_ptr<PeersState> peers_state,
     std::shared_ptr<TimePeriodPacketsStats> packets_stats, std::shared_ptr<PbftManager> pbft_mgr,
     std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<VoteManager> vote_mgr,
     std::shared_ptr<NextVotesManager> next_votes_mgr, const addr_t &node_addr)
     : ExtVotesPacketHandler(conf, std::move(peers_state), std::move(packets_stats), std::move(pbft_mgr),
-                            std::move(pbft_chain), std::move(vote_mgr), node_addr, "GET_VOTES_SYNC_PH"),
+                            std::move(pbft_chain), std::move(vote_mgr), node_addr, "GET_NEXT_VOTES_SYNC_PH"),
       next_votes_mgr_(std::move(next_votes_mgr)) {}
 
-void GetVotesSyncPacketHandler::validatePacketRlpFormat(const PacketData &packet_data) const {
+void GetNextVotesSyncPacketHandler::validatePacketRlpFormat(const PacketData &packet_data) const {
   if (constexpr size_t required_size = 2; packet_data.rlp_.itemCount() != required_size) {
     throw InvalidRlpItemsCountException(packet_data.type_str_, packet_data.rlp_.itemCount(), required_size);
   }
 }
 
-// TODO: rename to GetNextVotesSyncPacket
-void GetVotesSyncPacketHandler::process(const PacketData &packet_data, const std::shared_ptr<TaraxaPeer> &peer) {
-  LOG(log_dg_) << "Received GetVotesSyncPacket request";
+void GetNextVotesSyncPacketHandler::process(const PacketData &packet_data, const std::shared_ptr<TaraxaPeer> &peer) {
+  LOG(log_dg_) << "Received GetNextVotesSyncPacket request";
 
   const PbftPeriod peer_pbft_period = packet_data.rlp_[0].toInt<PbftPeriod>();
   const PbftRound peer_pbft_round = packet_data.rlp_[1].toInt<PbftRound>();

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
@@ -159,7 +159,7 @@ void PbftSyncPacketHandler::process(const PacketData &packet_data, const std::sh
         if (auto vote_is_valid = vote_mgr_->validateVote(v); vote_is_valid.first == false) {
           LOG(log_er_) << "Invalid reward votes in block " << period_data.pbft_blk->getBlockHash() << " from peer "
                        << packet_data.from_node_id_.abridged()
-                       << " received, stop syncing.   Validation failed. Err: " << vote_is_valid.second;
+                       << " received, stop syncing. Validation failed. Err: " << vote_is_valid.second;
           handleMaliciousSyncPeer(packet_data.from_node_id_);
           return;
         }

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/pbft_sync_packet_handler.cpp
@@ -156,7 +156,7 @@ void PbftSyncPacketHandler::process(const PacketData &packet_data, const std::sh
     // have been verified before
     if (pbft_mgr_->periodDataQueueEmpty()) {
       for (const auto &v : period_data.previous_block_cert_votes) {
-        if (auto vote_is_valid = pbft_mgr_->validateVote(v); vote_is_valid.first == false) {
+        if (auto vote_is_valid = vote_mgr_->validateVote(v); vote_is_valid.first == false) {
           LOG(log_er_) << "Invalid reward votes in block " << period_data.pbft_blk->getBlockHash() << " from peer "
                        << packet_data.from_node_id_.abridged()
                        << " received, stop syncing.   Validation failed. Err: " << vote_is_valid.second;

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
@@ -17,126 +17,134 @@ VotePacketHandler::VotePacketHandler(const FullNodeConfig &conf, std::shared_ptr
 
 void VotePacketHandler::validatePacketRlpFormat([[maybe_unused]] const PacketData &packet_data) const {
   auto items = packet_data.rlp_.itemCount();
-  if (items == 0 || items > kMaxVotesInPacket) {
-    throw InvalidRlpItemsCountException(packet_data.type_str_, items, kMaxVotesInPacket);
+  // Vote packet can contain either just a vote or vote + block + peer_chain_size
+  if (items != kVotePacketSize && items != kExtendedVotePacketSize) {
+    throw InvalidRlpItemsCountException(packet_data.type_str_, items, kExtendedVotePacketSize);
   }
 }
 
 void VotePacketHandler::process(const PacketData &packet_data, const std::shared_ptr<TaraxaPeer> &peer) {
   const auto [current_pbft_round, current_pbft_period] = pbft_mgr_->getPbftRoundAndPeriod();
 
-  std::shared_ptr<Vote> vote = nullptr;
+  // Optional packet items
+  std::shared_ptr<PbftBlock> pbft_block{nullptr};
+  std::optional<uint64_t> peer_chain_size{};
 
-  std::shared_ptr<Vote> single_vote_with_block = nullptr;
-  std::shared_ptr<PbftBlock> pbft_block = nullptr;
-  uint64_t peer_chain_size = 0;
+  std::shared_ptr<Vote> vote = std::make_shared<Vote>(packet_data.rlp_[0]);
+  if (const size_t item_count = packet_data.rlp_.itemCount(); item_count == kExtendedVotePacketSize) {
+    pbft_block = std::make_shared<PbftBlock>(packet_data.rlp_[1]);
+    peer_chain_size = packet_data.rlp_[2].toInt();
+    LOG(log_dg_) << "Received PBFT vote " << vote->getHash() << " with PBFT block " << pbft_block->getBlockHash();
+  } else {
+    LOG(log_dg_) << "Received PBFT vote " << vote->getHash();
+  }
 
-  std::vector<std::shared_ptr<Vote>> votes;
-  std::vector<std::shared_ptr<Vote>> previous_next_votes;
-  vote_hash_t vote_hash;
-  for (size_t i = 0; i < packet_data.rlp_.itemCount(); i++) {
-    // TODO[2031]: the way we differentiate now between receiving single vote with some optional data vs
-    //             batch of simple votes is ugly now. We could change the way we use VotePacket vs VotesSyncPacket to
-    //             make it more clear
-    // There is included also PBFT block as optional value in Vote packet
-    if (packet_data.rlp_.itemCount() == 1 && packet_data.rlp_[0].itemCount() == kVotePacketWithBlockSize &&
-        packet_data.rlp_[0][0].isList()) {
-      // We allow only single votes to be sent together with block in a bundle(1 item)
-      const auto &vote_with_block_rlp = packet_data.rlp_[0];
-      if (vote_with_block_rlp.itemCount() != kVotePacketWithBlockSize) {
-        LOG(log_er_) << "Vote packet with included PBFT block invalid items count: " << vote_with_block_rlp.itemCount();
-        throw InvalidRlpItemsCountException(packet_data.type_str_, vote_with_block_rlp.itemCount(),
-                                            kVotePacketWithBlockSize);
-      }
+  const auto vote_hash = vote->getHash();
+  // Synchronization point in case multiple threads are processing the same vote at the same time
+  if (!seen_votes_.insert(vote_hash)) {
+    LOG(log_tr_) << "Received vote " << vote_hash << " (from " << packet_data.from_node_id_.abridged()
+                 << ") already seen.";
+    return;
+  }
 
-      vote = std::make_shared<Vote>(vote_with_block_rlp[0]);
-      vote_hash = vote->getHash();
-
-      // Synchronization point in case multiple threads are processing the same vote at the same time
-      if (!seen_votes_.insert(vote_hash)) {
-        LOG(log_tr_) << "Received vote " << vote_hash << " (from " << packet_data.from_node_id_.abridged()
-                     << ") already seen.";
-        continue;
-      }
-
-      pbft_block = std::make_shared<PbftBlock>(vote_with_block_rlp[1]);
-      peer_chain_size = vote_with_block_rlp[2].toInt();
-      single_vote_with_block = vote;
-
-      if (pbft_block->getBlockHash() != vote->getBlockHash()) {
-        std::ostringstream err_msg;
-        err_msg << "Vote " << vote->getHash().abridged() << " voted block " << vote->getBlockHash().abridged()
-                << " != actual block " << pbft_block->getBlockHash().abridged();
-        throw MaliciousPeerException(err_msg.str());
-      }
-
-      peer->markPbftBlockAsKnown(pbft_block->getBlockHash());
-      LOG(log_dg_) << "Received PBFT vote " << vote->getHash() << " with PBFT block " << pbft_block->getBlockHash();
-    } else {
-      vote = std::make_shared<Vote>(packet_data.rlp_[i]);
-      vote_hash = vote->getHash();
-
-      // Synchronization point in case multiple threads are processing the same vote at the same time
-      if (!seen_votes_.insert(vote_hash)) {
-        LOG(log_tr_) << "Received vote " << vote_hash << " (from " << packet_data.from_node_id_.abridged()
-                     << ") already seen.";
-        continue;
-      }
-      pbft_block = nullptr;
-      peer_chain_size = 0;
-      LOG(log_dg_) << "Received PBFT vote " << vote->getHash();
+  if (pbft_block) {
+    if (pbft_block->getBlockHash() != vote->getBlockHash()) {
+      std::ostringstream err_msg;
+      err_msg << "Vote " << vote->getHash().abridged() << " voted block " << vote->getBlockHash().abridged()
+              << " != actual block " << pbft_block->getBlockHash().abridged();
+      throw MaliciousPeerException(err_msg.str());
     }
 
-    if (vote->getPeriod() == current_pbft_period && (current_pbft_round - 1) == vote->getRound() &&
-        vote->getType() == PbftVoteTypes::next_vote) {
-      // Previous round next vote
-      // We could switch round before other nodes, so we need to process also previous round next votes
-      if (!processNextSyncVote(vote, pbft_block)) {
-        continue;
-      }
+    peer->markPbftBlockAsKnown(pbft_block->getBlockHash());
+  }
 
-      // Not perfect way to to do this, but this whole process could be possibly refactored
-      previous_next_votes.push_back(vote);
+  if (vote->getPeriod() == current_pbft_period && (current_pbft_round - 1) == vote->getRound() &&
+      vote->getType() == PbftVoteTypes::next_vote) {
+    // Previous round next vote
+    // We could switch round before other nodes, so we need to process also previous round next votes
+    if (!processNextSyncVote(vote, pbft_block)) {
+      return;
+    }
+  } else if (vote->getPeriod() >= current_pbft_period) {
+    // Standard vote
+    if (!processStandardVote(vote, pbft_block, peer, true)) {
+      return;
+    }
 
-    } else if (vote->getPeriod() >= current_pbft_period) {
-      // Standard vote
-      if (!processStandardVote(vote, pbft_block, peer, true)) {
-        continue;
-      }
+  } else if (vote->getPeriod() == current_pbft_period - 1 && vote->getType() == PbftVoteTypes::cert_vote) {
+    // potential reward vote
+    if (!processRewardVote(vote)) {
+      return;
+    }
 
-    } else if (vote->getPeriod() == current_pbft_period - 1 && vote->getType() == PbftVoteTypes::cert_vote) {
-      // potential reward vote
-      if (!processRewardVote(vote)) {
-        continue;
-      }
+  } else {
+    // Too old vote
+    LOG(log_dg_) << "Drop vote " << vote_hash << ". Vote period " << vote->getPeriod()
+                 << " too old. current_pbft_period " << current_pbft_period;
+    return;
+  }
 
-    } else {
-      // Too old vote
-      LOG(log_dg_) << "Drop vote " << vote_hash.abridged() << ". Vote period " << vote->getPeriod()
-                   << " too old. current_pbft_period " << current_pbft_period;
+  // Do not mark it before, as peers have small caches of known votes. Only mark gossiping votes
+  peer->markVoteAsKnown(vote_hash);
+
+  onNewPbftVote(vote, pbft_block);
+
+  // Update peer's max chain size
+  if (peer_chain_size.has_value() && *peer_chain_size > peer->pbft_chain_size_) {
+    peer->pbft_chain_size_ = *peer_chain_size;
+  }
+}
+
+void VotePacketHandler::onNewPbftVote(const std::shared_ptr<Vote> &vote, const std::shared_ptr<PbftBlock> &block) {
+  for (const auto &peer : peers_state_->getAllPeers()) {
+    if (peer.second->syncing_) {
+      LOG(log_dg_) << " PBFT vote " << vote->getHash() << " not sent to " << peer.first << " peer syncing";
       continue;
     }
 
-    // Do not mark it before, as peers have small caches of known votes. Only mark gossiping votes
-    peer->markVoteAsKnown(vote_hash);
-    votes.push_back(std::move(vote));
-  }
+    if (peer.second->isVoteKnown(vote->getHash())) {
+      continue;
+    }
 
-  if (!previous_next_votes.empty()) {
-    if (const auto two_t_plus_one = pbft_mgr_->getPbftTwoTPlusOne(current_pbft_period - 1);
-        two_t_plus_one.has_value()) {
-      next_votes_mgr_->updateWithSyncedVotes(previous_next_votes, *two_t_plus_one);
+    // Peer already has pbft block, do not send it (do not check it for propose votes as it could happen that nodes
+    // re-propose the same block for new round, in which case we need to send the block again
+    if (vote->getType() != PbftVoteTypes::propose_vote && peer.second->isPbftBlockKnown(vote->getBlockHash())) {
+      sendPbftVote(peer.second, vote, nullptr);
+    } else {
+      sendPbftVote(peer.second, vote, block);
     }
   }
+}
 
-  if (single_vote_with_block && !votes.empty()) {
-    onNewPbftVote(single_vote_with_block, pbft_block);
-    // Update peer's max chain size
-    if (peer_chain_size > peer->pbft_chain_size_) {
-      peer->pbft_chain_size_ = peer_chain_size;
-    }
+void VotePacketHandler::sendPbftVote(const std::shared_ptr<TaraxaPeer> &peer, const std::shared_ptr<Vote> &vote,
+                                     const std::shared_ptr<PbftBlock> &block) {
+  if (block && block->getBlockHash() != vote->getBlockHash()) {
+    LOG(log_er_) << "Vote " << vote->getHash().abridged() << " voted block " << vote->getBlockHash().abridged()
+                 << " != actual block " << block->getBlockHash().abridged();
+    return;
+  }
+
+  dev::RLPStream s;
+
+  if (block) {
+    s = dev::RLPStream(kExtendedVotePacketSize);
+    s.appendRaw(vote->rlp(true, false));
+    s.appendRaw(block->rlp(true));
+    s.append(pbft_chain_->getPbftChainSize());
   } else {
-    onNewPbftVotes(std::move(votes));
+    s = dev::RLPStream(kVotePacketSize);
+    s.appendRaw(vote->rlp(true, false));
+  }
+
+  if (sealAndSend(peer->getId(), SubprotocolPacketType::VotePacket, std::move(s))) {
+    peer->markVoteAsKnown(vote->getHash());
+    if (block) {
+      peer->markPbftBlockAsKnown(block->getBlockHash());
+      LOG(log_dg_) << " PBFT vote " << vote->getHash() << " together with block " << block->getBlockHash()
+                   << " sent to " << peer->getId();
+    } else {
+      LOG(log_dg_) << " PBFT vote " << vote->getHash() << " sent to " << peer->getId();
+    }
   }
 }
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
@@ -10,8 +10,7 @@ VotePacketHandler::VotePacketHandler(const FullNodeConfig &conf, std::shared_ptr
                                      std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<PbftChain> pbft_chain,
                                      std::shared_ptr<VoteManager> vote_mgr, const addr_t &node_addr)
     : ExtVotesPacketHandler(conf, std::move(peers_state), std::move(packets_stats), std::move(pbft_mgr),
-                            std::move(pbft_chain), std::move(vote_mgr), node_addr, "PBFT_VOTE_PH"),
-{}
+                            std::move(pbft_chain), std::move(vote_mgr), node_addr, "PBFT_VOTE_PH") {}
 
 void VotePacketHandler::validatePacketRlpFormat([[maybe_unused]] const PacketData &packet_data) const {
   auto items = packet_data.rlp_.itemCount();

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
@@ -86,7 +86,6 @@ void VotePacketHandler::process(const PacketData &packet_data, const std::shared
 
   // Do not mark it before, as peers have small caches of known votes. Only mark gossiping votes
   peer->markVoteAsKnown(vote_hash);
-
   onNewPbftVote(vote, pbft_block);
 
   // Update peer's max chain size

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
@@ -25,70 +25,100 @@ void VotesSyncPacketHandler::validatePacketRlpFormat([[maybe_unused]] const Pack
 }
 
 void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::shared_ptr<TaraxaPeer> &peer) {
-  // We already have 2t+1 votes for both kNullBlockHash as well as some specific block hash
-  if (next_votes_mgr_->enoughNextVotes()) {
-    LOG(log_nf_) << "Already have enought next votes for perevious round.";
+  const auto reference_vote = std::make_shared<Vote>(packet_data.rlp_[0]);
+
+  const auto [current_pbft_round, current_pbft_period] = pbft_mgr_->getPbftRoundAndPeriod();
+  const auto votes_bundle_pbft_period = reference_vote->getPeriod();
+  const auto votes_bundle_pbft_round = reference_vote->getRound();
+  const auto votes_bundle_votes_type = reference_vote->getType();
+  const auto votes_bundle_voted_block = reference_vote->getBlockHash();
+
+  // Accept only votes, which period is >= current pbft period - 1 (reward votes period)
+  if (votes_bundle_pbft_period < current_pbft_period - 1) {
+    LOG(log_wr_) << "Dropping votes sync packet due to period. Votes period: " << votes_bundle_pbft_period
+                 << ", current pbft period: " << current_pbft_period;
+    return;
+  } else if (votes_bundle_pbft_period == current_pbft_period) {
+    if (votes_bundle_pbft_round < current_pbft_round - 1) {
+      // Accept only votes, which round is >= previous round(current pbft round - 1) in case their period == current
+      // pbft period
+      LOG(log_wr_) << "Dropping votes sync packet due to round. Votes round: " << votes_bundle_pbft_round
+                   << ", current pbft round: " << current_pbft_round;
+      return;
+    } else if (votes_bundle_pbft_round == current_pbft_round - 1 &&
+               votes_bundle_votes_type == PbftVoteTypes::next_vote) {
+      // Already have 2t+1 previous round next votes for both NULL_BLOCK_HASH as well as some specific block hash
+      if (next_votes_mgr_->enoughNextVotes()) {
+        LOG(log_nf_) << "Dropping next votes sync packet - already have enough next votes for previous round";
+        return;
+      }
+    }
+  }
+
+  // VotesSyncPacket does not support propose votes
+  if (votes_bundle_votes_type == PbftVoteTypes::propose_vote) {
+    LOG(log_er_) << "Dropping votes sync packet due to received \"propose_votes\" votes from "
+                 << packet_data.from_node_id_ << ". The peer may be a malicious player, will be disconnected";
+    disconnect(packet_data.from_node_id_, dev::p2p::UserReason);
     return;
   }
 
-  auto reference_vote = std::make_shared<Vote>(packet_data.rlp_[0].data().toBytes());
-
-  const auto [pbft_current_round, pbft_current_period] = pbft_mgr_->getPbftRoundAndPeriod();
-  const auto peer_pbft_period = reference_vote->getPeriod();
-  const auto peer_pbft_round = reference_vote->getRound();
-
-  // Accept only votes, which period is >= current pbft period
-  if (peer_pbft_period < pbft_current_period) {
-    LOG(log_er_) << "Dropping votes sync packet due to period. Votes period: " << peer_pbft_period
-                 << ", current pbft period: " << peer_pbft_period;
-    return;
-  }
-
-  // Accept only votes, which round is >= previous round(current pbft round - 1) in case their period == current pbft
-  // period
-  if (peer_pbft_period == pbft_current_period && peer_pbft_round < pbft_current_round - 1) {
-    LOG(log_er_) << "Dropping votes sync packet due to round. Votes round: " << peer_pbft_round
-                 << ", current pbft round: " << pbft_current_round;
-    return;
-  }
-
-  std::vector<std::shared_ptr<Vote>> next_votes;
-  blk_hash_t voted_value = kNullBlockHash;
+  std::vector<std::shared_ptr<Vote>> votes;
+  blk_hash_t next_votes_bundle_voted_block = NULL_BLOCK_HASH;
 
   const auto next_votes_count = packet_data.rlp_.itemCount();
   //  It is done in separate cycle because we don't need to process this next_votes if some of checks will fail
   for (size_t i = 0; i < next_votes_count; i++) {
-    auto vote = std::make_shared<Vote>(packet_data.rlp_[i].data().toBytes());
-    if (voted_value == kNullBlockHash && vote->getBlockHash() != kNullBlockHash) {
-      // initialize voted value with first block hash that not equal to kNullBlockHash
-      voted_value = vote->getBlockHash();
-    } else if (vote->getBlockHash() != kNullBlockHash && voted_value != kNullBlockHash &&
-               vote->getBlockHash() != voted_value) {
-      // we see different voted value, so bundle is invalid
-      LOG(log_er_) << "Received next votes bundle with unmatched voted values(" << voted_value << ", "
-                   << vote->getBlockHash() << ") from " << packet_data.from_node_id_
+    auto vote = std::make_shared<Vote>(packet_data.rlp_[i]);
+    peer->markVoteAsKnown(vote->getHash());
+
+    // TODO: use seen_votes ???
+
+    // Next votes bundle can contain votes for NULL_BLOCK_HASH as well as some specific block hash
+    // TODO[2047]: when implementing issue 2047, check if this is correct -> we are sending all next votes so
+    //             there could be potentially multiple voted blocks ???
+    if (vote->getType() == PbftVoteTypes::next_vote) {
+      if (next_votes_bundle_voted_block == NULL_BLOCK_HASH && vote->getBlockHash() != NULL_BLOCK_HASH) {
+        // initialize voted value with first block hash not equal to NULL_BLOCK_HASH
+        next_votes_bundle_voted_block = vote->getBlockHash();
+      }
+
+      if (vote->getBlockHash() != NULL_BLOCK_HASH && vote->getBlockHash() != next_votes_bundle_voted_block) {
+        // we see different voted value, so bundle is invalid
+        LOG(log_er_) << "Received next votes bundle with unmatched voted values(" << next_votes_bundle_voted_block
+                     << ", " << vote->getBlockHash() << ") from " << packet_data.from_node_id_
+                     << ". The peer may be a malicious player, will be disconnected";
+        disconnect(packet_data.from_node_id_, dev::p2p::UserReason);
+        return;
+      }
+    } else {
+      // Other votes bundles can contain votes only for 1 specific block hash
+      if (vote->getBlockHash() != votes_bundle_voted_block) {
+        // we see different voted value, so bundle is invalid
+        LOG(log_er_) << "Received votes bundle with unmatched voted values(" << votes_bundle_voted_block << ", "
+                     << vote->getBlockHash() << ") from " << packet_data.from_node_id_
+                     << ". The peer may be a malicious player, will be disconnected";
+        disconnect(packet_data.from_node_id_, dev::p2p::UserReason);
+        return;
+      }
+    }
+
+    if (vote->getType() != votes_bundle_votes_type) {
+      LOG(log_er_) << "Received votes bundle with unmatched types from " << packet_data.from_node_id_
                    << ". The peer may be a malicious player, will be disconnected";
       disconnect(packet_data.from_node_id_, dev::p2p::UserReason);
       return;
     }
 
-    // VotesSyncPacket is only for next votes
-    if (vote->getType() != PbftVoteTypes::next_vote) {
-      LOG(log_er_) << "Received next votes bundle with non \"next_votes\" from " << packet_data.from_node_id_
+    if (vote->getPeriod() != votes_bundle_pbft_period) {
+      LOG(log_er_) << "Received votes bundle with unmatched periods from " << packet_data.from_node_id_
                    << ". The peer may be a malicious player, will be disconnected";
       disconnect(packet_data.from_node_id_, dev::p2p::UserReason);
       return;
     }
 
-    if (vote->getRound() != peer_pbft_round) {
-      LOG(log_er_) << "Received next votes bundle with unmatched rounds from " << packet_data.from_node_id_
-                   << ". The peer may be a malicious player, will be disconnected";
-      disconnect(packet_data.from_node_id_, dev::p2p::UserReason);
-      return;
-    }
-
-    if (vote->getPeriod() != peer_pbft_period) {
-      LOG(log_er_) << "Received next votes bundle with unmatched periods from " << packet_data.from_node_id_
+    if (vote->getRound() != votes_bundle_pbft_round) {
+      LOG(log_er_) << "Received votes bundle with unmatched rounds from " << packet_data.from_node_id_
                    << ". The peer may be a malicious player, will be disconnected";
       disconnect(packet_data.from_node_id_, dev::p2p::UserReason);
       return;
@@ -96,67 +126,54 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
 
     LOG(log_dg_) << "Received sync vote " << vote->getHash().abridged();
 
-    // Previous round vote
-    if (peer_pbft_period == pbft_current_period && (pbft_current_round - 1) == peer_pbft_round) {
+    // Previous round next vote
+    if (votes_bundle_votes_type == PbftVoteTypes::next_vote && votes_bundle_pbft_period == current_pbft_period &&
+        votes_bundle_pbft_round == (current_pbft_round - 1)) {
       if (!processNextSyncVote(vote, nullptr)) {
         continue;
       }
+    } else if (votes_bundle_pbft_period >= current_pbft_period) {
+      // Standard vote
+
+      // Process processStandardVote is called with false in case of next votes bundle -> does not check max boundaries
+      // for round and step to actually being able to sync the current round in case network is stalled
+      bool check_max_round_step = votes_bundle_votes_type == PbftVoteTypes::next_vote ? false : true;
+      if (!processStandardVote(vote, nullptr, peer, check_max_round_step)) {
+        continue;
+      }
+    } else if (votes_bundle_votes_type == PbftVoteTypes::cert_vote &&
+               votes_bundle_pbft_period == current_pbft_period - 1) {
+      // Potential reward vote
+      if (!processRewardVote(vote)) {
+        continue;
+      }
     } else {
-      // Standard vote -> peer_pbft_period > pbft_current_period || pbft_current_round >= peer_pbft_round
-      // Process processStandardVote is called with false -> does not check max boundaries for round and step to
-      // actually being able to sync the current round in case network is stalled
-      if (!processStandardVote(vote, nullptr, peer, false)) {
-        continue;
-      }
+      // Too old vote
+      LOG(log_dg_) << "Drop vote " << vote->getHash() << ". Vote period " << vote->getPeriod()
+                   << " too old. current_pbft_period " << current_pbft_period;
+      continue;
     }
 
-    peer->markVoteAsKnown(vote->getHash());
-    next_votes.push_back(std::move(vote));
+    votes.push_back(std::move(vote));
   }
 
-  LOG(log_nf_) << "Received " << next_votes_count << " (processed " << next_votes.size() << " ) sync votes from peer "
-               << packet_data.from_node_id_ << " node current round " << pbft_current_round << ", peer pbft round "
-               << peer_pbft_round;
+  LOG(log_nf_) << "Received " << next_votes_count << " (processed " << votes.size() << " ) sync votes from peer "
+               << packet_data.from_node_id_ << " node current round " << current_pbft_round << ", peer pbft round "
+               << votes_bundle_pbft_round;
 
-  // Previous round votes
-  if (peer_pbft_period == pbft_current_period && (pbft_current_round - 1) == peer_pbft_round) {
-    const auto two_t_plus_one = pbft_mgr_->getPbftTwoTPlusOne(pbft_current_period - 1);
-    if (two_t_plus_one.has_value()) {
+  // Previous round next votes
+  if (votes_bundle_votes_type == PbftVoteTypes::next_vote) {
+    const auto [pbft_round, pbft_period] = pbft_mgr_->getPbftRoundAndPeriod();
+    const auto two_t_plus_one = pbft_mgr_->getPbftTwoTPlusOne(pbft_period - 1);
+    // Check if we did not move to the next period/round in the meantime
+    if (votes_bundle_pbft_period == pbft_period && votes_bundle_pbft_round == (pbft_round - 1) &&
+        two_t_plus_one.has_value()) {
       // Update our previous round next vote bundles...
-      next_votes_mgr_->updateWithSyncedVotes(next_votes, *two_t_plus_one);
+      next_votes_mgr_->updateWithSyncedVotes(votes, *two_t_plus_one);
     }
-
-    // Pass them on to our peers...
-    const auto updated_next_votes_size = next_votes_mgr_->getNextVotesWeight();
-    for (auto const &peer_to_share_to : peers_state_->getAllPeers()) {
-      // Do not send votes right back to same peer...
-      if (peer_to_share_to.first == packet_data.from_node_id_) {
-        continue;
-      }
-
-      // Do not send votes to nodes that already have as many bundles as we do...
-      if (peer_to_share_to.second->pbft_previous_round_next_votes_size_ >= updated_next_votes_size) {
-        continue;
-      }
-
-      // Nodes may vote at different values at previous round, so need less or equal
-      if (!peer_to_share_to.second->syncing_ && peer_to_share_to.second->pbft_round_ > pbft_current_round) {
-        continue;
-      }
-
-      std::vector<std::shared_ptr<Vote>> send_next_votes_bundle;
-      for (const auto &v : next_votes) {
-        if (!peer_to_share_to.second->isVoteKnown(v->getHash())) {
-          send_next_votes_bundle.push_back(v);
-        }
-      }
-      sendPbftVotes(peer_to_share_to.second, std::move(send_next_votes_bundle), true);
-    }
-  } else {
-    // Standard votes -> peer_pbft_period > pbft_current_period || (peer_pbft_period == pbft_current_period &&
-    // peer_pbft_round > pbft_current_round - 1)
-    onNewPbftVotes(std::move(next_votes));
   }
+
+  onNewPbftVotesBundle(std::move(votes), false, packet_data.from_node_id_);
 }
 
 void VotesSyncPacketHandler::broadcastPreviousRoundNextVotesBundle(bool rebroadcast) {
@@ -177,8 +194,32 @@ void VotesSyncPacketHandler::broadcastPreviousRoundNextVotesBundle(bool rebroadc
           send_next_votes_bundle.push_back(v);
         }
       }
-      sendPbftVotes(peer.second, std::move(send_next_votes_bundle), true);
+      sendPbftVotesBundle(peer.second, std::move(send_next_votes_bundle));
     }
+  }
+}
+
+void VotesSyncPacketHandler::onNewPbftVotesBundle(std::vector<std::shared_ptr<Vote>> &&votes, bool rebroadcast,
+                                                  const std::optional<dev::p2p::NodeID> &exclude_node) {
+  for (const auto &peer : peers_state_->getAllPeers()) {
+    if (peer.second->syncing_) {
+      continue;
+    }
+
+    if (exclude_node.has_value() && *exclude_node == peer.first) {
+      continue;
+    }
+
+    std::vector<std::shared_ptr<Vote>> peer_votes;
+    for (const auto &vote : votes) {
+      if (!rebroadcast && peer.second->isVoteKnown(vote->getHash())) {
+        continue;
+      }
+
+      peer_votes.push_back(vote);
+    }
+
+    sendPbftVotesBundle(peer.second, std::move(peer_votes));
   }
 }
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
@@ -164,7 +164,7 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
   // Previous round next votes
   if (votes_bundle_votes_type == PbftVoteTypes::next_vote) {
     const auto [pbft_round, pbft_period] = pbft_mgr_->getPbftRoundAndPeriod();
-    const auto two_t_plus_one = pbft_mgr_->getPbftTwoTPlusOne(pbft_period - 1);
+    const auto two_t_plus_one = vote_mgr_->getPbftTwoTPlusOne(pbft_period - 1);
     // Check if we did not move to the next period/round in the meantime
     if (votes_bundle_pbft_period == pbft_period && votes_bundle_pbft_round == (pbft_round - 1) &&
         two_t_plus_one.has_value()) {

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
@@ -72,7 +72,11 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
     auto vote = std::make_shared<Vote>(packet_data.rlp_[i]);
     peer->markVoteAsKnown(vote->getHash());
 
-    // TODO: use seen_votes ???
+    // Do not process vote that has already been validated
+    if (vote_mgr_->voteAlreadyValidated(vote->getHash())) {
+      LOG(log_dg_) << "Received vote " << vote->getHash() << " has already been validated";
+      return;
+    }
 
     // Next votes bundle can contain votes for NULL_BLOCK_HASH as well as some specific block hash
     // TODO[2047]: when implementing issue 2047, check if this is correct -> we are sending all next votes so

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
@@ -47,7 +47,7 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
       return;
     } else if (votes_bundle_pbft_round == current_pbft_round - 1 &&
                votes_bundle_votes_type == PbftVoteTypes::next_vote) {
-      // Already have 2t+1 previous round next votes for both NULL_BLOCK_HASH as well as some specific block hash
+      // Already have 2t+1 previous round next votes for both kNullBlockHash as well as some specific block hash
       if (next_votes_mgr_->enoughNextVotes()) {
         LOG(log_nf_) << "Dropping next votes sync packet - already have enough next votes for previous round";
         return;
@@ -64,7 +64,7 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
   }
 
   std::vector<std::shared_ptr<Vote>> votes;
-  blk_hash_t next_votes_bundle_voted_block = NULL_BLOCK_HASH;
+  blk_hash_t next_votes_bundle_voted_block = kNullBlockHash;
 
   const auto next_votes_count = packet_data.rlp_.itemCount();
   //  It is done in separate cycle because we don't need to process this next_votes if some of checks will fail
@@ -78,16 +78,16 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
       return;
     }
 
-    // Next votes bundle can contain votes for NULL_BLOCK_HASH as well as some specific block hash
+    // Next votes bundle can contain votes for kNullBlockHash as well as some specific block hash
     // TODO[2047]: when implementing issue 2047, check if this is correct -> we are sending all next votes so
     //             there could be potentially multiple voted blocks ???
     if (vote->getType() == PbftVoteTypes::next_vote) {
-      if (next_votes_bundle_voted_block == NULL_BLOCK_HASH && vote->getBlockHash() != NULL_BLOCK_HASH) {
-        // initialize voted value with first block hash not equal to NULL_BLOCK_HASH
+      if (next_votes_bundle_voted_block == kNullBlockHash && vote->getBlockHash() != kNullBlockHash) {
+        // initialize voted value with first block hash not equal to kNullBlockHash
         next_votes_bundle_voted_block = vote->getBlockHash();
       }
 
-      if (vote->getBlockHash() != NULL_BLOCK_HASH && vote->getBlockHash() != next_votes_bundle_voted_block) {
+      if (vote->getBlockHash() != kNullBlockHash && vote->getBlockHash() != next_votes_bundle_voted_block) {
         // we see different voted value, so bundle is invalid
         LOG(log_er_) << "Received next votes bundle with unmatched voted values(" << next_votes_bundle_voted_block
                      << ", " << vote->getBlockHash() << ") from " << packet_data.from_node_id_

--- a/libraries/core_libs/network/src/tarcap/stats/node_stats.cpp
+++ b/libraries/core_libs/network/src/tarcap/stats/node_stats.cpp
@@ -82,7 +82,7 @@ void NodeStats::logNodeStats() {
 
   const auto local_dpos_total_votes_count = pbft_mgr_->getCurrentDposTotalVotesCount();
   const auto local_dpos_node_votes_count = pbft_mgr_->getCurrentNodeVotesCount();
-  const auto local_twotplusone = pbft_mgr_->getPbftTwoTPlusOne(local_pbft_period - 1);
+  const auto local_twotplusone = vote_mgr_->getPbftTwoTPlusOne(local_pbft_period - 1);
 
   // Syncing period...
   const auto local_pbft_sync_period = pbft_mgr_->pbftSyncingPeriod();

--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -190,7 +190,7 @@ void TaraxaCapability::registerPacketHandlers(
   // Consensus packets with high processing priority
   packets_handlers_->registerHandler<VotePacketHandler>(kConf, peers_state_, packets_stats, pbft_mgr, pbft_chain,
                                                         vote_mgr, node_addr);
-  packets_handlers_->registerHandler<GetVotesSyncPacketHandler>(kConf, peers_state_, packets_stats, pbft_mgr,
+  packets_handlers_->registerHandler<GetNextVotesSyncPacketHandler>(kConf, peers_state_, packets_stats, pbft_mgr,
                                                                 pbft_chain, vote_mgr, next_votes_mgr, node_addr);
   packets_handlers_->registerHandler<VotesSyncPacketHandler>(kConf, peers_state_, packets_stats, pbft_mgr, pbft_chain,
                                                              vote_mgr, next_votes_mgr, db, node_addr);

--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -7,8 +7,8 @@
 #include "network/tarcap/packets_handlers/dag_block_packet_handler.hpp"
 #include "network/tarcap/packets_handlers/dag_sync_packet_handler.hpp"
 #include "network/tarcap/packets_handlers/get_dag_sync_packet_handler.hpp"
+#include "network/tarcap/packets_handlers/get_next_votes_sync_packet_handler.hpp"
 #include "network/tarcap/packets_handlers/get_pbft_sync_packet_handler.hpp"
-#include "network/tarcap/packets_handlers/get_votes_sync_packet_handler.hpp"
 #include "network/tarcap/packets_handlers/pbft_sync_packet_handler.hpp"
 #include "network/tarcap/packets_handlers/status_packet_handler.hpp"
 #include "network/tarcap/packets_handlers/transaction_packet_handler.hpp"
@@ -191,7 +191,7 @@ void TaraxaCapability::registerPacketHandlers(
   packets_handlers_->registerHandler<VotePacketHandler>(kConf, peers_state_, packets_stats, pbft_mgr, pbft_chain,
                                                         vote_mgr, node_addr);
   packets_handlers_->registerHandler<GetNextVotesSyncPacketHandler>(kConf, peers_state_, packets_stats, pbft_mgr,
-                                                                pbft_chain, vote_mgr, next_votes_mgr, node_addr);
+                                                                    pbft_chain, vote_mgr, next_votes_mgr, node_addr);
   packets_handlers_->registerHandler<VotesSyncPacketHandler>(kConf, peers_state_, packets_stats, pbft_mgr, pbft_chain,
                                                              vote_mgr, next_votes_mgr, db, node_addr);
 

--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -189,7 +189,7 @@ void TaraxaCapability::registerPacketHandlers(
 
   // Consensus packets with high processing priority
   packets_handlers_->registerHandler<VotePacketHandler>(kConf, peers_state_, packets_stats, pbft_mgr, pbft_chain,
-                                                        vote_mgr, next_votes_mgr, node_addr);
+                                                        vote_mgr, node_addr);
   packets_handlers_->registerHandler<GetVotesSyncPacketHandler>(kConf, peers_state_, packets_stats, pbft_mgr,
                                                                 pbft_chain, vote_mgr, next_votes_mgr, node_addr);
   packets_handlers_->registerHandler<VotesSyncPacketHandler>(kConf, peers_state_, packets_stats, pbft_mgr, pbft_chain,

--- a/libraries/core_libs/node/src/node.cpp
+++ b/libraries/core_libs/node/src/node.cpp
@@ -105,10 +105,11 @@ void FullNode::init() {
       std::make_shared<DagManager>(dag_genesis_block_hash, node_addr, conf_.genesis.sortition, conf_.genesis.dag,
                                    trx_mgr_, pbft_chain_, final_chain_, db_, key_manager_, conf_.is_light_node,
                                    conf_.light_node_history, conf_.max_levels_per_period, conf_.dag_expiry_limit);
-  vote_mgr_ = std::make_shared<VoteManager>(node_addr, db_, pbft_chain_, final_chain_, next_votes_mgr_);
+  vote_mgr_ = std::make_shared<VoteManager>(node_addr, conf_.genesis.pbft, kp_.secret(), conf_.vrf_secret, db_,
+                                            pbft_chain_, final_chain_, key_manager_);
   pbft_mgr_ = std::make_shared<PbftManager>(conf_.genesis.pbft, dag_genesis_block_hash, node_addr, db_, pbft_chain_,
-                                            vote_mgr_, next_votes_mgr_, dag_mgr_, trx_mgr_, final_chain_, key_manager_,
-                                            kp_.secret(), conf_.vrf_secret, conf_.max_levels_per_period);
+                                            vote_mgr_, next_votes_mgr_, dag_mgr_, trx_mgr_, final_chain_, kp_.secret(),
+                                            conf_.max_levels_per_period);
   dag_block_proposer_ =
       std::make_shared<DagBlockProposer>(conf_.genesis.dag.block_proposer, dag_mgr_, trx_mgr_, final_chain_, db_,
                                          key_manager_, node_addr, getSecretKey(), getVrfSecretKey());

--- a/libraries/types/vote/include/vote/vote.hpp
+++ b/libraries/types/vote/include/vote/vote.hpp
@@ -25,16 +25,6 @@ class Vote {
   bool operator==(Vote const& other) const { return rlp() == other.rlp(); }
 
   /**
-   * @brief vote validation
-   * @param stake voter DPOS eligible votes count
-   * @param dpos_total_votes_count total DPOS votes count
-   * @param sortition_threshold PBFT sortition threshold that is minimum of between PBFT committee size and total DPOS
-   * votes count
-   */
-  void validate(uint64_t stake, double dpos_total_votes_count, double sortition_threshold,
-                const vrf_wrapper::vrf_pk_t& pk) const;
-
-  /**
    * @brief Get vote hash
    * @return vote hash
    */

--- a/libraries/types/vote/src/vote.cpp
+++ b/libraries/types/vote/src/vote.cpp
@@ -25,36 +25,6 @@ Vote::Vote(secret_t const& node_sk, VrfPbftSortition vrf_sortition, blk_hash_t c
   cached_voter_ = dev::toPublic(node_sk);
 }
 
-void Vote::validate(uint64_t stake, double dpos_total_votes_count, double sortition_threshold,
-                    const vrf_wrapper::vrf_pk_t& pk) const {
-  if (!stake) {
-    // After deep syncing, node could receive votes but still behind, may don't have vote sender state in table
-    // If in PBFT blocks syncing for cert votes, that's malicious blocks
-    std::stringstream err;
-    err << "Invalid stake " << *this;
-    throw std::logic_error(err.str());
-  }
-
-  if (!verifyVote()) {
-    std::stringstream err;
-    err << "Invalid vote signature. " << dev::toHex(rlp(false)) << "  " << *this;
-    throw std::logic_error(err.str());
-  }
-
-  if (!verifyVrfSortition(pk)) {
-    std::stringstream err;
-    err << "Invalid vrf proof. " << *this;
-    throw std::logic_error(err.str());
-  }
-
-  if (!calculateWeight(stake, dpos_total_votes_count, sortition_threshold)) {
-    std::stringstream err;
-    err << "Vote sortition failed. Sortition threshold " << sortition_threshold << ", DPOS total votes count "
-        << dpos_total_votes_count << " " << *this;
-    throw std::logic_error(err.str());
-  }
-}
-
 bytes Vote::rlp(bool inc_sig, bool inc_weight) const {
   dev::RLPStream s;
   uint32_t number_of_items = 2;

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -156,7 +156,6 @@ TEST_F(NetworkTest, DISABLED_update_peer_chainsize) {
   auto nodes = launch_nodes(node_cfgs);
 
   const auto& node1 = nodes[0];
-  const auto node1_pbft_mgr = node1->getPbftManager();
 
   nodes[0]->getPbftManager()->stop();
   nodes[1]->getPbftManager()->stop();
@@ -169,8 +168,8 @@ TEST_F(NetworkTest, DISABLED_update_peer_chainsize) {
                                                 node1->getPbftManager()->getPbftPeriod(), node1->getAddress(),
                                                 node1->getSecretKey(), std::move(reward_votes));
   auto vote =
-      node1_pbft_mgr->generateVote(pbft_block->getBlockHash(), PbftVoteTypes::propose_vote, pbft_block->getPeriod(),
-                                   node1_pbft_mgr->getPbftRound() + 1, value_proposal_state);
+      node1->getVoteManager()->generateVote(pbft_block->getBlockHash(), PbftVoteTypes::propose_vote, pbft_block->getPeriod(),
+                                   node1->getPbftManager()->getPbftRound() + 1, value_proposal_state);
 
   auto node2_id = nw2->getNodeId();
   ASSERT_NE(node1->getPbftChain()->getPbftChainSize(), nw1->getPeer(node2_id)->pbft_chain_size_);
@@ -549,7 +548,7 @@ TEST_F(NetworkTest, node_pbft_sync) {
                         beneficiary, node1->getSecretKey(), {});
   std::vector<std::shared_ptr<Vote>> votes_for_pbft_blk1;
   votes_for_pbft_blk1.emplace_back(
-      node1->getPbftManager()->generateVote(pbft_block1.getBlockHash(), PbftVoteTypes::cert_vote, 1, 1, 3));
+      node1->getVoteManager()->generateVote(pbft_block1.getBlockHash(), PbftVoteTypes::cert_vote, 1, 1, 3));
   std::cout << "Generate 1 vote for first PBFT block" << std::endl;
   // Add cert votes in DB
   // Add PBFT block in DB
@@ -605,7 +604,7 @@ TEST_F(NetworkTest, node_pbft_sync) {
                         beneficiary, node1->getSecretKey(), {});
   std::vector<std::shared_ptr<Vote>> votes_for_pbft_blk2;
   votes_for_pbft_blk2.emplace_back(
-      node1->getPbftManager()->generateVote(pbft_block2.getBlockHash(), PbftVoteTypes::cert_vote, 2, 2, 3));
+      node1->getVoteManager()->generateVote(pbft_block2.getBlockHash(), PbftVoteTypes::cert_vote, 2, 2, 3));
   std::cout << "Generate 1 vote for second PBFT block" << std::endl;
   // node1 put block2 into pbft chain and store into DB
   // Add cert votes in DB
@@ -715,7 +714,7 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
                         beneficiary, node1->getSecretKey(), {});
   std::vector<std::shared_ptr<Vote>> votes_for_pbft_blk1;
   votes_for_pbft_blk1.emplace_back(
-      node1->getPbftManager()->generateVote(pbft_block1.getBlockHash(), PbftVoteTypes::cert_vote, 1, 1, 3));
+      node1->getVoteManager()->generateVote(pbft_block1.getBlockHash(), PbftVoteTypes::cert_vote, 1, 1, 3));
   std::cout << "Generate 1 vote for first PBFT block" << std::endl;
   // Add cert votes in DB
   // Add PBFT block in DB
@@ -801,8 +800,10 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_behind_round) {
   auto node1 = create_nodes({node_cfgs[0]}, true /*start*/).front();
 
   // Stop PBFT manager, that will place vote
-  std::shared_ptr<PbftManager> pbft_mgr1 = node1->getPbftManager();
+  auto pbft_mgr1 = node1->getPbftManager();
   pbft_mgr1->stop();
+
+  auto vote_mgr1 = node1->getVoteManager();
 
   // Generate 3 next votes
   std::vector<std::shared_ptr<Vote>> next_votes;
@@ -813,7 +814,7 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_behind_round) {
   for (auto i = 0; i < 3; i++) {
     blk_hash_t voted_pbft_block_hash(i % 2);  // Next votes could vote on 2 values
     std::cout << voted_pbft_block_hash << std::endl;
-    auto vote = pbft_mgr1->generateVote(voted_pbft_block_hash, type, period, round, step + i);
+    auto vote = vote_mgr1->generateVote(voted_pbft_block_hash, type, period, round, step + i);
     vote->calculateWeight(1, 1, 1);
     next_votes.push_back(std::move(vote));
   }
@@ -862,11 +863,11 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_1) {
   node1_next_votes_mgr->clearVotes();
   node2_next_votes_mgr->clearVotes();
 
-  auto pbft_mgr1 = node1->getPbftManager();
-  auto pbft_mgr2 = node2->getPbftManager();
-  auto node1_pbft_2t_plus_1 = pbft_mgr1->getPbftTwoTPlusOne(node1->getPbftChain()->getPbftChainSize()).value();
+  auto vote_mgr1 = node1->getVoteManager();
+  auto vote_mgr2 = node2->getVoteManager();
+  auto node1_pbft_2t_plus_1 = vote_mgr1->getPbftTwoTPlusOne(node1->getPbftChain()->getPbftChainSize()).value();
   EXPECT_EQ(node1_pbft_2t_plus_1, 1);
-  auto node2_pbft_2t_plus_1 = pbft_mgr2->getPbftTwoTPlusOne(node2->getPbftChain()->getPbftChainSize()).value();
+  auto node2_pbft_2t_plus_1 = vote_mgr2->getPbftTwoTPlusOne(node2->getPbftChain()->getPbftChainSize()).value();
   EXPECT_EQ(node2_pbft_2t_plus_1, 1);
 
   // Generate 2 next votes for node1
@@ -877,7 +878,7 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_1) {
   PbftVoteTypes type = PbftVoteTypes::next_vote;
   for (uint64_t i = 0; i < 2; i++) {
     blk_hash_t voted_pbft_block_hash1(i);  // Next votes could vote on 2 values
-    auto vote = pbft_mgr1->generateVote(voted_pbft_block_hash1, type, period, round, step);
+    auto vote = vote_mgr1->generateVote(voted_pbft_block_hash1, type, period, round, step);
     vote->calculateWeight(1, 1, 1);
     next_votes1.push_back(std::move(vote));
   }
@@ -888,7 +889,7 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_1) {
 
   // Generate 1 same next votes with node1, voted same value on kNullBlockHash
   blk_hash_t voted_pbft_block_hash2(0);
-  auto vote1 = pbft_mgr1->generateVote(voted_pbft_block_hash2, type, period, round, step);
+  auto vote1 = vote_mgr1->generateVote(voted_pbft_block_hash2, type, period, round, step);
   vote1->calculateWeight(1, 1, 1);
   std::vector<std::shared_ptr<Vote>> next_votes2{vote1};
 
@@ -897,8 +898,8 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_1) {
   EXPECT_EQ(node2_next_votes_mgr->getNextVotesWeight(), next_votes2.size());
 
   // Set both node1 and node2 pbft manager round to 2
-  pbft_mgr1->setPbftRound(2);
-  pbft_mgr2->setPbftRound(2);
+  node1->getPbftManager()->setPbftRound(2);
+  node2->getPbftManager()->setPbftRound(2);
 
   auto expect_size = next_votes1.size();
   EXPECT_HAPPENS({30s, 500ms},
@@ -927,11 +928,11 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_2) {
   node1_next_votes_mgr->clearVotes();
   node2_next_votes_mgr->clearVotes();
 
-  auto pbft_mgr1 = node1->getPbftManager();
-  auto pbft_mgr2 = node2->getPbftManager();
-  auto node1_pbft_2t_plus_1 = pbft_mgr1->getPbftTwoTPlusOne(node1->getPbftChain()->getPbftChainSize()).value();
+  auto vote_mgr1 = node1->getVoteManager();
+  auto vote_mgr2 = node2->getVoteManager();
+  auto node1_pbft_2t_plus_1 = vote_mgr1->getPbftTwoTPlusOne(node1->getPbftChain()->getPbftChainSize()).value();
   EXPECT_EQ(node1_pbft_2t_plus_1, 1);
-  auto node2_pbft_2t_plus_1 = pbft_mgr2->getPbftTwoTPlusOne(node2->getPbftChain()->getPbftChainSize()).value();
+  auto node2_pbft_2t_plus_1 = vote_mgr2->getPbftTwoTPlusOne(node2->getPbftChain()->getPbftChainSize()).value();
   EXPECT_EQ(node2_pbft_2t_plus_1, 1);
 
   // Node1 generate 1 next vote voted at kNullBlockHash
@@ -939,7 +940,7 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_2) {
   PbftPeriod period = 1;
   PbftRound round = 1;
   PbftStep step = 5;
-  auto vote1 = pbft_mgr1->generateVote(kNullBlockHash, type, period, round, step);
+  auto vote1 = vote_mgr1->generateVote(kNullBlockHash, type, period, round, step);
   vote1->calculateWeight(1, 1, 1);
   std::vector<std::shared_ptr<Vote>> next_votes1{vote1};
 
@@ -949,7 +950,7 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_2) {
 
   // Node1 generate 1 different next vote for node2, because node2 is not delegated
   blk_hash_t voted_pbft_block_hash2("1234567890000000000000000000000000000000000000000000000000000000");
-  auto vote2 = pbft_mgr1->generateVote(voted_pbft_block_hash2, type, period, round, step);
+  auto vote2 = vote_mgr1->generateVote(voted_pbft_block_hash2, type, period, round, step);
   vote2->calculateWeight(1, 1, 1);
   std::vector<std::shared_ptr<Vote>> next_votes2{vote2};
 
@@ -958,8 +959,8 @@ TEST_F(NetworkTest, pbft_next_votes_sync_in_same_round_2) {
   EXPECT_EQ(node2_next_votes_mgr->getNextVotesWeight(), next_votes2.size());
 
   // Set both node1 and node2 pbft manager round to 2
-  pbft_mgr1->setPbftRound(2);
-  pbft_mgr2->setPbftRound(2);
+  node1->getPbftManager()->setPbftRound(2);
+  node2->getPbftManager()->setPbftRound(2);
 
   std::shared_ptr<Network> nw1 = node1->getNetwork();
   std::shared_ptr<Network> nw2 = node2->getNetwork();

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -14,7 +14,7 @@
 #include "logger/logger.hpp"
 #include "network/tarcap/packets_handlers/dag_block_packet_handler.hpp"
 #include "network/tarcap/packets_handlers/get_dag_sync_packet_handler.hpp"
-#include "network/tarcap/packets_handlers/get_votes_sync_packet_handler.hpp"
+#include "network/tarcap/packets_handlers/get_next_votes_sync_packet_handler.hpp"
 #include "network/tarcap/packets_handlers/status_packet_handler.hpp"
 #include "network/tarcap/packets_handlers/transaction_packet_handler.hpp"
 #include "network/tarcap/packets_handlers/vote_packet_handler.hpp"
@@ -167,9 +167,9 @@ TEST_F(NetworkTest, DISABLED_update_peer_chainsize) {
   auto pbft_block = std::make_shared<PbftBlock>(blk_hash_t(1), kNullBlockHash, kNullBlockHash, kNullBlockHash,
                                                 node1->getPbftManager()->getPbftPeriod(), node1->getAddress(),
                                                 node1->getSecretKey(), std::move(reward_votes));
-  auto vote =
-      node1->getVoteManager()->generateVote(pbft_block->getBlockHash(), PbftVoteTypes::propose_vote, pbft_block->getPeriod(),
-                                   node1->getPbftManager()->getPbftRound() + 1, value_proposal_state);
+  auto vote = node1->getVoteManager()->generateVote(pbft_block->getBlockHash(), PbftVoteTypes::propose_vote,
+                                                    pbft_block->getPeriod(),
+                                                    node1->getPbftManager()->getPbftRound() + 1, value_proposal_state);
 
   auto node2_id = nw2->getNodeId();
   ASSERT_NE(node1->getPbftChain()->getPbftChainSize(), nw1->getPeer(node2_id)->pbft_chain_size_);

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -17,6 +17,7 @@
 #include "network/tarcap/packets_handlers/get_votes_sync_packet_handler.hpp"
 #include "network/tarcap/packets_handlers/status_packet_handler.hpp"
 #include "network/tarcap/packets_handlers/transaction_packet_handler.hpp"
+#include "network/tarcap/packets_handlers/vote_packet_handler.hpp"
 #include "network/tarcap/packets_handlers/votes_sync_packet_handler.hpp"
 #include "pbft/pbft_manager.hpp"
 #include "test_util/samples.hpp"
@@ -174,8 +175,7 @@ TEST_F(NetworkTest, DISABLED_update_peer_chainsize) {
   auto node2_id = nw2->getNodeId();
   ASSERT_NE(node1->getPbftChain()->getPbftChainSize(), nw1->getPeer(node2_id)->pbft_chain_size_);
 
-  nw2->getSpecificHandler<network::tarcap::VotesSyncPacketHandler>()->sendPbftVote(nw1->getPeer(node2_id), vote,
-                                                                                   pbft_block);
+  nw2->getSpecificHandler<network::tarcap::VotePacketHandler>()->sendPbftVote(nw1->getPeer(node2_id), vote, pbft_block);
 
   EXPECT_HAPPENS({10s, 200ms}, [&](auto& ctx) {
     WAIT_EXPECT_EQ(ctx, nw1->getPeer(node2_id)->pbft_chain_size_, node1->getPbftChain()->getPbftChainSize())

--- a/tests/pbft_manager_test.cpp
+++ b/tests/pbft_manager_test.cpp
@@ -643,9 +643,9 @@ TEST_F(PbftManagerTest, propose_block_and_vote_broadcast) {
   auto proposed_pbft_block = std::make_shared<PbftBlock>(
       prev_block_hash, kNullBlockHash, kNullBlockHash, kNullBlockHash, node1->getPbftManager()->getPbftPeriod(),
       node1->getAddress(), node1->getSecretKey(), std::move(reward_votes_hashes));
-  auto propose_vote = node1->getVoteManager()->generateVote(proposed_pbft_block->getBlockHash(), PbftVoteTypes::propose_vote,
-                                              proposed_pbft_block->getPeriod(),
-                                              node1->getPbftManager()->getPbftRound() + 1, value_proposal_state);
+  auto propose_vote = node1->getVoteManager()->generateVote(
+      proposed_pbft_block->getBlockHash(), PbftVoteTypes::propose_vote, proposed_pbft_block->getPeriod(),
+      node1->getPbftManager()->getPbftRound() + 1, value_proposal_state);
   pbft_mgr1->processProposedBlock(proposed_pbft_block, propose_vote);
 
   auto block1_from_node1 = pbft_mgr1->getProposedBlocksSt().getPbftProposedBlock(

--- a/tests/pbft_manager_test.cpp
+++ b/tests/pbft_manager_test.cpp
@@ -127,7 +127,7 @@ struct PbftManagerTest : NodesTest {
     for (size_t i(0); i < nodes.size(); ++i) {
       auto pbft_mgr = nodes[i]->getPbftManager();
       const auto chain_size = nodes[i]->getPbftChain()->getPbftChainSize();
-      two_t_plus_one = pbft_mgr->getPbftTwoTPlusOne(chain_size).value();
+      two_t_plus_one = nodes[i]->getVoteManager()->getPbftTwoTPlusOne(chain_size).value();
 
       committee = pbft_mgr->getPbftCommitteeSize();
       valid_voting_players = pbft_mgr->getCurrentDposTotalVotesCount().value();
@@ -180,7 +180,7 @@ struct PbftManagerTest : NodesTest {
     for (size_t i(0); i < nodes.size(); ++i) {
       auto pbft_mgr = nodes[i]->getPbftManager();
       const auto chain_size = nodes[i]->getPbftChain()->getPbftChainSize();
-      two_t_plus_one = pbft_mgr->getPbftTwoTPlusOne(chain_size).value();
+      two_t_plus_one = nodes[i]->getVoteManager()->getPbftTwoTPlusOne(chain_size).value();
       committee = pbft_mgr->getPbftCommitteeSize();
       valid_voting_players = pbft_mgr->getCurrentDposTotalVotesCount().value();
       std::cout << "Node" << i << " committee " << committee << ", valid voting players " << valid_voting_players
@@ -198,14 +198,13 @@ TEST_F(PbftManagerTest, terminate_soft_voting_pbft_block) {
   makeNodesWithNonces(node_cfgs);
 
   auto pbft_mgr = nodes[0]->getPbftManager();
+  auto vote_mgr = nodes[0]->getVoteManager();
   pbft_mgr->stop();
   std::cout << "PBFT manager stopped" << std::endl;
 
-  auto vote_mgr = nodes[0]->getVoteManager();
-
   // Generate bogus votes
   auto stale_block_hash = blk_hash_t("0000000100000000000000000000000000000000000000000000000000000000");
-  auto propose_vote = pbft_mgr->generateVote(stale_block_hash, PbftVoteTypes::propose_vote, 2, 2, 1);
+  auto propose_vote = vote_mgr->generateVote(stale_block_hash, PbftVoteTypes::propose_vote, 2, 2, 1);
   propose_vote->calculateWeight(1, 1, 1);
   vote_mgr->addVerifiedVote(propose_vote);
 
@@ -516,7 +515,7 @@ TEST_F(PbftManagerTest, check_get_eligible_vote_count) {
   for (size_t i(0); i < nodes.size(); ++i) {
     auto pbft_mgr = nodes[i]->getPbftManager();
     const auto chain_size = nodes[i]->getPbftChain()->getPbftChainSize();
-    two_t_plus_one = pbft_mgr->getPbftTwoTPlusOne(chain_size).value();
+    two_t_plus_one = nodes[i]->getVoteManager()->getPbftTwoTPlusOne(chain_size).value();
     committee = pbft_mgr->getPbftCommitteeSize();
     eligible_total_vote_count = pbft_mgr->getCurrentDposTotalVotesCount().value();
     std::cout << "Node" << i << " committee " << committee << ", eligible total vote count "
@@ -644,7 +643,7 @@ TEST_F(PbftManagerTest, propose_block_and_vote_broadcast) {
   auto proposed_pbft_block = std::make_shared<PbftBlock>(
       prev_block_hash, kNullBlockHash, kNullBlockHash, kNullBlockHash, node1->getPbftManager()->getPbftPeriod(),
       node1->getAddress(), node1->getSecretKey(), std::move(reward_votes_hashes));
-  auto propose_vote = pbft_mgr1->generateVote(proposed_pbft_block->getBlockHash(), PbftVoteTypes::propose_vote,
+  auto propose_vote = node1->getVoteManager()->generateVote(proposed_pbft_block->getBlockHash(), PbftVoteTypes::propose_vote,
                                               proposed_pbft_block->getPeriod(),
                                               node1->getPbftManager()->getPbftRound() + 1, value_proposal_state);
   pbft_mgr1->processProposedBlock(proposed_pbft_block, propose_vote);

--- a/tests/tarcap_threadpool_test.cpp
+++ b/tests/tarcap_threadpool_test.cpp
@@ -152,14 +152,14 @@ class DummyVotePacketHandler : public DummyPacketHandler {
   static constexpr tarcap::SubprotocolPacketType kPacketType_ = tarcap::SubprotocolPacketType::VotePacket;
 };
 
-class DummyGetVotesSyncPacketHandler : public DummyPacketHandler {
+class DummyGetNextVotesSyncPacketHandler : public DummyPacketHandler {
  public:
-  DummyGetVotesSyncPacketHandler(const HandlersInitData& init_data, const std::string& log_channel_name,
-                                 uint32_t processing_delay_ms)
+  DummyGetNextVotesSyncPacketHandler(const HandlersInitData& init_data, const std::string& log_channel_name,
+                                     uint32_t processing_delay_ms)
       : DummyPacketHandler(init_data, log_channel_name, processing_delay_ms) {}
 
   // Packet type that is processed by this handler
-  static constexpr tarcap::SubprotocolPacketType kPacketType_ = tarcap::SubprotocolPacketType::GetVotesSyncPacket;
+  static constexpr tarcap::SubprotocolPacketType kPacketType_ = tarcap::SubprotocolPacketType::GetNextVotesSyncPacket;
 };
 
 class DummyVotesSyncPacketHandler : public DummyPacketHandler {
@@ -314,7 +314,7 @@ TEST_F(TarcapTpTest, block_free_packets) {
   packets_handler->registerHandler<DummyDagBlockPacketHandler>(init_data, "DAG_BLOCK_PH", 20);
   packets_handler->registerHandler<DummyStatusPacketHandler>(init_data, "STATUS_PH", 20);
   packets_handler->registerHandler<DummyVotePacketHandler>(init_data, "VOTE_PH", 20);
-  packets_handler->registerHandler<DummyGetVotesSyncPacketHandler>(init_data, "GET_VOTES_SYNC_PH", 20);
+  packets_handler->registerHandler<DummyGetNextVotesSyncPacketHandler>(init_data, "GET_NEXT_VOTES_SYNC_PH", 20);
   packets_handler->registerHandler<DummyVotesSyncPacketHandler>(init_data, "VOTES_SYNC_PH", 20);
 
   // Creates threadpool
@@ -353,9 +353,9 @@ TEST_F(TarcapTpTest, block_free_packets) {
       tp.push(createPacket(init_data.copySender(), tarcap::SubprotocolPacketType::VotePacket, {})).value();
 
   const auto packet14_get_pbft_next_votes_id =
-      tp.push(createPacket(init_data.copySender(), tarcap::SubprotocolPacketType::GetVotesSyncPacket, {})).value();
+      tp.push(createPacket(init_data.copySender(), tarcap::SubprotocolPacketType::GetNextVotesSyncPacket, {})).value();
   const auto packet15_get_pbft_next_votes_id =
-      tp.push(createPacket(init_data.copySender(), tarcap::SubprotocolPacketType::GetVotesSyncPacket, {})).value();
+      tp.push(createPacket(init_data.copySender(), tarcap::SubprotocolPacketType::GetNextVotesSyncPacket, {})).value();
 
   const auto packet16_pbft_next_votes_id =
       tp.push(createPacket(init_data.copySender(), tarcap::SubprotocolPacketType::VotesSyncPacket, {})).value();


### PR DESCRIPTION
Votes processing refactor:

- VotePacket handler process only single votes generated during standard voting
- VotesSyncPacket handler process only votes bundles (any type)
- vote validating & generating functions moved from pbft manager into the vote manager
- when processing votes, use "already validated votes" filter instead of "seen votes" filter. Before it could happen that we would mark vote as seen, it was dropped because asynchronous pbft processing was behind and we would not process this vote even if it was later received again due to seen votes filter. Now we drop only votes that have already been validated
- multiple small improvements that were related to the code I touched

## Purpose
<!-- Provide any information reviewers might need to have context on your changes. -->


## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
