### PR TITLE
chore: dag tips verification

### DIFF
--- a/libraries/common/include/common/constants.hpp
+++ b/libraries/common/include/common/constants.hpp
@@ -18,6 +18,7 @@ static const blk_hash_t kNullBlockHash;
 constexpr uint16_t kOnePercent = 100;
 constexpr uint16_t kMaxLevelsPerPeriod = 100;
 constexpr uint32_t kDagExpiryLevelLimit = 1000;
+constexpr uint32_t kDagBlockMaxTips = 16;
 
 const uint32_t kMaxTransactionsInPacket{500};
 

--- a/libraries/core_libs/consensus/include/dag/dag_block_proposer.hpp
+++ b/libraries/core_libs/consensus/include/dag/dag_block_proposer.hpp
@@ -74,6 +74,15 @@ class DagBlockProposer {
    */
   uint64_t getProposedBlocksCount() const { return proposed_blocks_count_; }
 
+  /**
+   * @brief Select tips for DagBlock proposal up to max allowed
+   *
+   * @param frontier_tips
+   *
+   * @return tips
+   */
+  vec_blk_t selectDagBlockTips(const vec_blk_t& frontier_tips) const;
+
  private:
   /**
    * @brief Creates a new block with provided data

--- a/libraries/core_libs/consensus/include/dag/dag_manager.hpp
+++ b/libraries/core_libs/consensus/include/dag/dag_manager.hpp
@@ -39,7 +39,8 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
     NotEligible,
     ExpiredBlock,
     IncorrectTransactionsEstimation,
-    BlockTooBig
+    BlockTooBig,
+    FailedTipsVerification
   };
 
   using ULock = std::unique_lock<std::shared_mutex>;

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/dag_block_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/dag_block_packet_handler.cpp
@@ -102,7 +102,8 @@ void DagBlockPacketHandler::onNewBlockReceived(DagBlock &&block, const std::shar
       case DagManager::VerifyBlockReturnType::IncorrectTransactionsEstimation:
       case DagManager::VerifyBlockReturnType::BlockTooBig:
       case DagManager::VerifyBlockReturnType::FailedVdfVerification:
-      case DagManager::VerifyBlockReturnType::NotEligible: {
+      case DagManager::VerifyBlockReturnType::NotEligible:
+      case DagManager::VerifyBlockReturnType::FailedTipsVerification: {
         std::ostringstream err_msg;
         err_msg << "DagBlock" << block_hash << " failed verification with error code "
                 << static_cast<uint32_t>(verified);


### PR DESCRIPTION
Added limit of max 16 tips in a DAG block to block malicious producers creating dag blocks with unlimited number of tips.

If there is more then max possible tips to be included in a block, prioritizing tips with higher level and unique producer. This serves as protection from malicious producers producing too many blocks at the same level. This is in combination with the CPU cost of such an attack should probably be enough to discourage it but slashing could be later introduced as well.

Added check that the same tip/pivot is not included more than once within the same dag block.

Main idea in limiting the number of tips is to prevent someone maliciously pointing to large number of old blocks or someone producing too many blocks on the same level. This change in combination with the VDF computation I believe should be enough to prevent these attacks.