### PR TITLE
chore: add use_packet_ip option for an option to force use of packet …

### DIFF
--- a/libraries/aleth/libp2p/Host.cpp
+++ b/libraries/aleth/libp2p/Host.cpp
@@ -83,7 +83,7 @@ Host::Host(std::string _clientVersion, KeyPair const& kp, NetworkConfig _n, Tara
   m_nodeTable = make_unique<NodeTable>(
       ioc_, m_alias, NodeIPEndpoint(bi::make_address(listenAddress()), listenPort(), listenPort()),
       updateENR(enr, m_tcpPublic, listenPort()), m_netConfig.discovery, m_netConfig.allowLocalDiscovery,
-      taraxa_conf_.is_boot_node, taraxa_conf_.chain_id);
+      taraxa_conf_.is_boot_node, taraxa_conf_.chain_id, m_netConfig.usePacketIp);
   m_nodeTable->setEventHandler(new NodeTableEventHandler([this](auto const&... args) { onNodeTableEvent(args...); }));
   if (restored_state) {
     for (auto const& node : restored_state->known_nodes) {

--- a/libraries/aleth/libp2p/Network.h
+++ b/libraries/aleth/libp2p/Network.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "Common.h"
+#include "NodeTable.h"
 namespace ba = boost::asio;
 namespace bi = ba::ip;
 
@@ -58,6 +59,8 @@ struct NetworkConfig {
   bool discovery = true;             // Discovery is activated with network.
   bool allowLocalDiscovery = false;  // Include nodes with local IP addresses in the discovery process.
   bool pin = false;                  // Only accept or connect to trusted peers.
+
+  NodeTable::UsePacketIpMode usePacketIp = NodeTable::UsePacketIpMode::UseDefault;
 };
 
 /**

--- a/libraries/aleth/libp2p/NodeTable.h
+++ b/libraries/aleth/libp2p/NodeTable.h
@@ -106,10 +106,13 @@ class NodeTable : UDPSocketEvents {
   // sending new PONG
   static constexpr uint32_t c_bondingTimeSeconds{12 * 60 * 60};
 
+  enum class UsePacketIpMode { UseDefault = 0, UsePacketIpIfNotPrivateAddress, UsePacketIp };
+
   /// Constructor requiring host for I/O, credentials, and IP Address, port to
   /// listen on and host ENR.
   NodeTable(ba::io_context& _io, KeyPair const& _alias, NodeIPEndpoint const& _endpoint, ENR const& _enr,
-            bool _enabled = true, bool _allowLocalDiscovery = false, bool is_boot_node = false, unsigned chain_id = 0);
+            bool _enabled = true, bool _allowLocalDiscovery = false, bool is_boot_node = false, unsigned chain_id = 0,
+            UsePacketIpMode use_packet_ip = UsePacketIpMode::UseDefault);
 
   ~NodeTable() {
     if (m_socket->isOpen()) {
@@ -386,6 +389,8 @@ class NodeTable : UDPSocketEvents {
 
   const bool is_boot_node_ = false;
   const uint32_t chain_id_ = 0;
+
+  UsePacketIpMode use_packet_ip_;
 };
 
 /**


### PR DESCRIPTION
Packet IP address which is sent in a ping discovery is only used if from address is private address. This causes problems in our networks setup. This new param enables having an option to force use of packet IP and not from IP