### PR TITLE
fix: replace gmp and mpfr libs from conan with libs from system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,10 @@ add_custom_target(check-static DEPENDS cpp-check clang-format clang-format-check
 # execute command to get git info
 include(CMakeModules/git_info.cmake)
 
+# find and include system libraries used in submodues and libraries
+find_package(GMP)
+find_package(MPFR)
+
 # Add sub-directories cmakes
 add_subdirectory(submodules)
 add_subdirectory(libraries)

--- a/CMakeModules/FindGMP.cmake
+++ b/CMakeModules/FindGMP.cmake
@@ -1,0 +1,21 @@
+# Try to find the GNU Multiple Precision Arithmetic Library (GMP)
+# See http://gmplib.org/
+
+if (GMP_INCLUDES AND GMP_LIBRARIES)
+  set(GMP_FIND_QUIETLY TRUE)
+endif (GMP_INCLUDES AND GMP_LIBRARIES)
+
+find_path(GMP_INCLUDES
+  NAMES
+  gmp.h
+  PATHS
+  $ENV{GMPDIR}
+  ${INCLUDE_INSTALL_DIR}
+)
+
+find_library(GMP_LIBRARIES gmp PATHS $ENV{GMPDIR} ${LIB_INSTALL_DIR})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GMP DEFAULT_MSG
+                                  GMP_INCLUDES GMP_LIBRARIES)
+mark_as_advanced(GMP_INCLUDES GMP_LIBRARIES)

--- a/CMakeModules/FindMPFR.cmake
+++ b/CMakeModules/FindMPFR.cmake
@@ -1,0 +1,21 @@
+# Try to find the GNU MPFR lib
+# See https://www.mpfr.org/
+
+if (MPFR_INCLUDES AND MPFR_LIBRARIES)
+  set(MPFR_FIND_QUIETLY TRUE)
+endif (MPFR_INCLUDES AND MPFR_LIBRARIES)
+
+find_path(MPFR_INCLUDES
+  NAMES
+  mpfr.h
+  PATHS
+  $ENV{MPFRDIR}
+  ${INCLUDE_INSTALL_DIR}
+)
+
+find_library(MPFR_LIBRARIES mpfr PATHS $ENV{MPFRDIR} ${LIB_INSTALL_DIR})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(MPFR DEFAULT_MSG
+                                  MPFR_INCLUDES MPFR_LIBRARIES)
+mark_as_advanced(MPFR_INCLUDES MPFR_LIBRARIES)

--- a/CMakeModules/ProjectLibFF.cmake
+++ b/CMakeModules/ProjectLibFF.cmake
@@ -5,7 +5,7 @@ set(prefix "${CMAKE_BINARY_DIR}/deps")
 set(libff_library "${prefix}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}ff${CMAKE_STATIC_LIBRARY_SUFFIX}")
 set(libff_inlcude_dir "${prefix}/include/libff")
 
-file(GLOB gmp_libs "${CONAN_LIB_DIRS_GMP}/*gmp.*")
+# file(GLOB gmp_libs "${CONAN_LIB_DIRS_GMP}/*gmp.*")
 
 ExternalProject_Add(libff
     PREFIX "${prefix}"
@@ -17,8 +17,8 @@ ExternalProject_Add(libff
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_POSITION_INDEPENDENT_CODE=${CMAKE_POSITION_INDEPENDENT_CODE}
         -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-        -DGMP_INCLUDE_DIR=${CONAN_INCLUDE_DIRS_GMP}
-        -DGMP_LIBRARY=${gmp_libs}
+        -DGMP_INCLUDE_DIR=${GMP_INCLUDES}
+        -DGMP_LIBRARY=${GMP_LIBRARIES}
         -DOPENSSL_INCLUDE_DIR=${CONAN_INCLUDE_DIRS_OPENSSL}
         -DOPENSSL_ROOT_DIR=${CONAN_OPENSSL_ROOT}
         -DCURVE=ALT_BN128 -DPERFORMANCE=Off -DWITH_PROCPS=Off
@@ -30,6 +30,7 @@ ExternalProject_Add(libff
     LOG_BUILD 1
     INSTALL_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config Release --target install
     BUILD_BYPRODUCTS "${libff_library}"
+    DOWNLOAD_EXTRACT_TIMESTAMP NEW
 )
 
 # Create snark imported library

--- a/CMakeModules/ProjectSecp256k1.cmake
+++ b/CMakeModules/ProjectSecp256k1.cmake
@@ -28,6 +28,7 @@ ExternalProject_Add(
     ${_overwrite_install_command}
     LOG_INSTALL 1
     BUILD_BYPRODUCTS "${SECP256K1_LIBRARY}"
+    DOWNLOAD_EXTRACT_TIMESTAMP NEW
 )
 
 # Create imported library

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,9 @@ FROM ubuntu:22.04 as builder
 ARG LLVM_VERSION=14
 
 # Install standard packages
-RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y --no-install-recommends \
+    tzdata \
     && apt-get install -y \
     tar \
     git \
@@ -20,6 +21,8 @@ RUN apt-get update \
     wget \
     python3-pip \
     lsb-release \
+    libgmp-dev \
+    libmpfr-dev \
     software-properties-common \
     && rm -rf /var/lib/apt/lists/*
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -13,7 +13,6 @@ class TaraxaConan(ConanFile):
     generators = "cmake"
 
     def requirements(self):
-        self.requires("mpfr/4.1.0")
         self.requires("boost/1.80.0")
         self.requires("cppcheck/2.7.5")
         self.requires("openssl/1.1.1s")
@@ -21,7 +20,6 @@ class TaraxaConan(ConanFile):
         self.requires("gtest/1.12.1")
         self.requires("lz4/1.9.4")
         self.requires("rocksdb/6.29.5")
-        self.requires("gmp/6.2.1")
         self.requires("prometheus-cpp/1.1.0")
         self.requires("libjson-rpc-cpp/1.3.0@bincrafters/stable")
 

--- a/doc/building.md
+++ b/doc/building.md
@@ -27,7 +27,9 @@ will build out of the box without further effort:
         # this libs are required for arm build by go part. you can skip it for amd64 build
         libzstd-dev \
         libsnappy-dev \
-        rapidjson-dev
+        rapidjson-dev \
+        libgmp-dev \
+        libmpfr-dev
 
     # Optional. Needed to run py_test. This won't install on arm64 OS because package is missing in apt
     sudo add-apt-repository ppa:ethereum/ethereum
@@ -86,7 +88,9 @@ will build out of the box without further effort:
         libjsoncpp-dev \
         libjsonrpccpp-dev \
         python3-pip \
-        rapidjson-dev
+        rapidjson-dev \
+        libgmp-dev \
+        libmpfr-dev
 
 
     # Install conan package manager
@@ -168,7 +172,7 @@ And optional:
 First you need to get (Brew)[https://brew.sh/] package manager. After that you need tot install dependencies with it. Currently there is no llvm-14 in brew, but it works well with llvm-13
 
     brew update
-    brew install coreutils go autoconf automake gflags git libtool llvm@13 make pkg-config cmake conan snappy zstd rapidjson
+    brew install coreutils go autoconf automake gflags git libtool llvm@13 make pkg-config cmake conan snappy zstd rapidjson gmp mpfr
 
 ### Clone the Repository
 
@@ -260,7 +264,7 @@ You should be able to build project following default MacOS building process. Bu
 
 ### Install dependencies 
 
-    /usr/local/bin/brew install coreutils go autoconf automake gflags git libtool llvm@13 make pkg-config cmake conan snappy zstd rapidjson
+    /usr/local/bin/brew install coreutils go autoconf automake gflags git libtool llvm@13 make pkg-config cmake conan snappy zstd rapidjson gmp mpfr
 
 ### Clone the Repository
 

--- a/libraries/aleth/libdevcrypto/CMakeLists.txt
+++ b/libraries/aleth/libdevcrypto/CMakeLists.txt
@@ -2,6 +2,6 @@ file(GLOB SOURCES "*.cpp")
 file(GLOB HEADERS "*.h")
 
 add_library(devcrypto ${SOURCES} ${HEADERS})
-target_include_directories(devcrypto PUBLIC ${UTILS_INCLUDE_DIR})
+target_include_directories(devcrypto PUBLIC ${UTILS_INCLUDE_DIR} ${GMP_INCLUDES})
 
-target_link_libraries(devcrypto PUBLIC devcore Secp256k1 libff::ff CONAN_PKG::cryptopp CONAN_PKG::gmp)
+target_link_libraries(devcrypto PUBLIC devcore Secp256k1 libff::ff CONAN_PKG::cryptopp ${GMP_LIBRARIES})

--- a/libraries/types/vote/CMakeLists.txt
+++ b/libraries/types/vote/CMakeLists.txt
@@ -3,5 +3,5 @@ set(SOURCES src/vote.cpp src/vrf_sortition.cpp)
 
 add_library(vote ${SOURCES} ${HEADERS})
 target_include_directories(vote PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_link_libraries(vote PUBLIC common devcrypto CONAN_PKG::boost CONAN_PKG::mpfr)
+target_link_libraries(vote PUBLIC common devcrypto CONAN_PKG::boost)
 

--- a/libraries/vdf/CMakeLists.txt
+++ b/libraries/vdf/CMakeLists.txt
@@ -9,11 +9,11 @@ set(SOURCES
 )
 
 add_library(vdf ${SOURCES} ${HEADERS})
-target_include_directories(vdf PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_include_directories(vdf PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include ${MPFR_INCLUDES})
 target_link_libraries(vdf PUBLIC
     logger
     taraxa-vdf
-    CONAN_PKG::mpfr
+    ${MPFR_LIBRARIES}
 )
 
 install(TARGETS vdf

--- a/submodules/CMakeLists.txt
+++ b/submodules/CMakeLists.txt
@@ -71,7 +71,7 @@ endfunction()
 # Add taraxa-vdf
 set(VDF_LIBRARY_COMMAND "\
  ${CMAKE_MAKE_PROGRAM}\
- CPPFLAGS=\"-I./include -I${CONAN_INCLUDE_DIRS_OPENSSL} -I${CONAN_INCLUDE_DIRS_GMP} -I${CONAN_INCLUDE_DIRS_MPFR} -fPIC -std=c++20 -O3\"\
+ CPPFLAGS=\"-I./include -I${CONAN_INCLUDE_DIRS_OPENSSL} -I${GMP_INCLUDES} -I${MPFR_INCLUDES} -fPIC -std=c++20 -O3\"\
  lib/libvdf.a")
 add_make_target(vdf libvdf.a "${VDF_LIBRARY_COMMAND}")
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(crypto_test crypto_test.cpp)
 target_link_libraries(crypto_test
     config
     vote
+    ${MPFR_LIBRARIES}
     CONAN_PKG::gtest
 )
 add_test(crypto_test ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/crypto_test)


### PR DESCRIPTION
Replace conan built GMP and MPFR libs with system ones. GMP is not really well maintained, so there could be difficulties to download sources to build it(conan is doing this). And MPFR is depends on GMP, so we need to replace it also 