### PR TITLE
fix: do not saved proposed blocks based on rounds, use just periods

### DIFF
--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -541,12 +541,10 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
    *        already validated
    *
    * @param period
-   * @param round
    * @param block_hash
    * @return valid proposed pbft block or nullptr
    */
-  std::shared_ptr<PbftBlock> getValidPbftProposedBlock(PbftPeriod period, PbftRound round,
-                                                       const blk_hash_t &block_hash);
+  std::shared_ptr<PbftBlock> getValidPbftProposedBlock(PbftPeriod period, const blk_hash_t &block_hash);
 
   /**
    * @brief Process synced PBFT blocks if PBFT syncing queue is not empty

--- a/libraries/core_libs/consensus/include/pbft/proposed_blocks.hpp
+++ b/libraries/core_libs/consensus/include/pbft/proposed_blocks.hpp
@@ -30,39 +30,35 @@ class ProposedBlocks {
 
   /**
    * @brief Push proposed PBFT block into the proposed blocks
-   * @param round
    * @param proposed_block
    * @param save_to_db if true save to db
    * @return true if block was successfully pushed, otherwise false
    */
-  bool pushProposedPbftBlock(PbftRound round, const std::shared_ptr<PbftBlock>& proposed_block, bool save_to_db = true);
+  bool pushProposedPbftBlock(const std::shared_ptr<PbftBlock>& proposed_block, bool save_to_db = true);
 
   /**
    * @brief Mark block as valid - no need to validate it again
    *
-   * @param round
    * @param proposed_block
    */
-  void markBlockAsValid(PbftRound round, const std::shared_ptr<PbftBlock>& proposed_block);
+  void markBlockAsValid(const std::shared_ptr<PbftBlock>& proposed_block);
 
   /**
    * @brief Get a proposed PBFT block based on specified period, round and block hash
    * @param period
-   * @param round
    * @param block_hash
    * @return optional<pair<block, is_valid flag>>
    */
-  std::optional<std::pair<std::shared_ptr<PbftBlock>, bool>> getPbftProposedBlock(PbftPeriod period, PbftRound round,
+  std::optional<std::pair<std::shared_ptr<PbftBlock>, bool>> getPbftProposedBlock(PbftPeriod period,
                                                                                   const blk_hash_t& block_hash) const;
 
   /**
    * @brief Check if specified block is already in proposed blocks
    * @param period
-   * @param round
    * @param block_hash
    * @return true if block is present, otherwise false
    */
-  bool isInProposedBlocks(PbftPeriod period, PbftRound round, const blk_hash_t& block_hash) const;
+  bool isInProposedBlocks(PbftPeriod period, const blk_hash_t& block_hash) const;
 
   /**
    * @brief Cleanup all proposed PBFT blocks for the finalized period
@@ -70,18 +66,9 @@ class ProposedBlocks {
    */
   void cleanupProposedPbftBlocksByPeriod(PbftPeriod period);
 
-  /**
-   * @brief Cleanup all proposed PBFT blocks for the finalized round - 1. We must keep previous round proposed blocks
-   *        for voting purposes
-   * @param period
-   * @param round
-   */
-  void cleanupProposedPbftBlocksByRound(PbftPeriod period, PbftRound round);
-
  private:
-  // <PBFT period, <PBFT round, <block hash, [block, is_valid_flag]>>>
-  std::map<PbftPeriod, std::map<PbftRound, std::unordered_map<blk_hash_t, std::pair<std::shared_ptr<PbftBlock>, bool>>>>
-      proposed_blocks_;
+  // <PBFT period, <block hash, [block, is_valid_flag]>>
+  std::map<PbftPeriod, std::unordered_map<blk_hash_t, std::pair<std::shared_ptr<PbftBlock>, bool>>> proposed_blocks_;
   mutable std::shared_mutex proposed_blocks_mutex_;
   std::shared_ptr<DbStorage> db_;
 };

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -358,8 +358,7 @@ bool PbftManager::tryPushCertVotesBlock() {
   LOG(log_nf_) << "Found enough cert votes for PBFT block " << certified_block->voted_block_hash << ", period "
                << current_pbft_period << ", round " << current_pbft_round;
 
-  auto pbft_block =
-      getValidPbftProposedBlock(current_pbft_period, current_pbft_round, certified_block->voted_block_hash);
+  auto pbft_block = getValidPbftProposedBlock(current_pbft_period, certified_block->voted_block_hash);
   if (!pbft_block) {
     LOG(log_er_) << "Invalid cert voted block " << certified_block->voted_block_hash;
     return false;
@@ -413,11 +412,6 @@ bool PbftManager::advanceRound() {
 
   // Move to a new round, cleanup previous round votes in vote manager
   vote_mgr_->cleanupVotesByRound(current_pbft_period, determined_round_with_votes->first);
-
-  // Cleanup proposed blocks for deremined round - 1. We must keep previous round proposed blocks for voting purposes
-  if (determined_round_with_votes->first >= 3) {
-    proposed_blocks_.cleanupProposedPbftBlocksByRound(current_pbft_period, determined_round_with_votes->first);
-  }
 
   // Cleanup previous round next votes & set new previous round 2t+1 next votes in next vote manager
   next_votes_manager_->updateNextVotes(determined_round_with_votes->second, *two_t_plus_one);
@@ -536,7 +530,7 @@ void PbftManager::initialState() {
   }
 
   for (const auto &block : db_->getProposedPbftBlocks()) {
-    proposed_blocks_.pushProposedPbftBlock(block.first, block.second, false);
+    proposed_blocks_.pushProposedPbftBlock(block, false);
   }
 
   // This is used to offset endtime for second finishing step...
@@ -553,7 +547,7 @@ void PbftManager::initialState() {
     // If there is also actual block, push it into the proposed blocks
     if (soft_voted_block_data->block_data_) {
       const auto soft_voted_block = soft_voted_block_data->block_data_->first;
-      if (proposed_blocks_.pushProposedPbftBlock(soft_voted_block_data->round_, soft_voted_block)) {
+      if (proposed_blocks_.pushProposedPbftBlock(soft_voted_block)) {
         LOG(log_nf_) << "Last soft voted block " << soft_voted_block->getBlockHash() << " with period "
                      << soft_voted_block->getPeriod() << ", round " << soft_voted_block_data->round_
                      << " pushed into proposed blocks";
@@ -574,8 +568,8 @@ void PbftManager::initialState() {
 
   // Process saved cert voted block from db
   if (auto cert_voted_block_data = db_->getCertVotedBlockInRound(); cert_voted_block_data.has_value()) {
-    const auto &[cert_voted_block_round, cert_voted_block] = *cert_voted_block_data;
-    if (proposed_blocks_.pushProposedPbftBlock(cert_voted_block_round, cert_voted_block)) {
+    const auto [cert_voted_block_round, cert_voted_block] = *cert_voted_block_data;
+    if (proposed_blocks_.pushProposedPbftBlock(cert_voted_block)) {
       LOG(log_nf_) << "Last cert voted block " << cert_voted_block->getBlockHash() << " with period "
                    << cert_voted_block->getPeriod() << ", round " << cert_voted_block_round
                    << " pushed into proposed blocks";
@@ -796,7 +790,7 @@ const std::optional<TwoTPlusOneSoftVotedBlockData> &PbftManager::getTwoTPlusOneS
 
     // In case we dont have full block object yet, try to get it and save into db
     if (!soft_voted_block_for_round_->block_data_.has_value()) {
-      auto block_data = proposed_blocks_.getPbftProposedBlock(period, round, soft_voted_block_for_round_->block_hash_);
+      auto block_data = proposed_blocks_.getPbftProposedBlock(period, soft_voted_block_for_round_->block_hash_);
       if (block_data.has_value()) {
         soft_voted_block_for_round_->block_data_ = std::move(block_data);
         db_->saveSoftVotedBlockDataInRound(*soft_voted_block_for_round_);
@@ -811,7 +805,7 @@ const std::optional<TwoTPlusOneSoftVotedBlockData> &PbftManager::getTwoTPlusOneS
       soft_voted_block_data.block_hash_ = soft_votes_bundle->voted_block_hash;
       soft_voted_block_data.soft_votes_ = std::move(soft_votes_bundle->votes);
       soft_voted_block_data.block_data_ =
-          proposed_blocks_.getPbftProposedBlock(period, round, soft_votes_bundle->voted_block_hash);
+          proposed_blocks_.getPbftProposedBlock(period, soft_votes_bundle->voted_block_hash);
 
       db_->saveSoftVotedBlockDataInRound(soft_voted_block_data);
       soft_voted_block_for_round_ = std::move(soft_voted_block_data);
@@ -823,18 +817,17 @@ const std::optional<TwoTPlusOneSoftVotedBlockData> &PbftManager::getTwoTPlusOneS
       !soft_voted_block_for_round_->block_data_->second) {
     if (validatePbftBlock(soft_voted_block_for_round_->block_data_->first)) {
       soft_voted_block_for_round_->block_data_->second = true;
-      proposed_blocks_.markBlockAsValid(round, soft_voted_block_for_round_->block_data_->first);
+      proposed_blocks_.markBlockAsValid(soft_voted_block_for_round_->block_data_->first);
     }
   }
 
   return soft_voted_block_for_round_;
 }
 
-std::shared_ptr<PbftBlock> PbftManager::getValidPbftProposedBlock(PbftPeriod period, PbftRound round,
-                                                                  const blk_hash_t &block_hash) {
-  const auto block_data = proposed_blocks_.getPbftProposedBlock(period, round, block_hash);
+std::shared_ptr<PbftBlock> PbftManager::getValidPbftProposedBlock(PbftPeriod period, const blk_hash_t &block_hash) {
+  const auto block_data = proposed_blocks_.getPbftProposedBlock(period, block_hash);
   if (!block_data.has_value()) {
-    LOG(log_er_) << "Unable to find proposed block " << block_hash << ", period " << period << ", round " << round;
+    LOG(log_er_) << "Unable to find proposed block " << block_hash << ", period " << period;
     return nullptr;
   }
 
@@ -844,11 +837,11 @@ std::shared_ptr<PbftBlock> PbftManager::getValidPbftProposedBlock(PbftPeriod per
   // Block is not validated yet
   if (!block_data->second) {
     if (!validatePbftBlock(block)) {
-      LOG(log_er_) << "Proposed block " << block_hash << " failed validation, period " << period << ", round " << round;
+      LOG(log_er_) << "Proposed block " << block_hash << " failed validation, period " << period;
       return nullptr;
     }
 
-    proposed_blocks_.markBlockAsValid(round, block);
+    proposed_blocks_.markBlockAsValid(block);
   }
 
   return block;
@@ -947,7 +940,7 @@ void PbftManager::proposeBlock_() {
     // Round greater than 1 and next voted some value that is not null block hash
     const auto &next_voted_block_hash = *previous_round_next_voted_value_;
 
-    const auto next_voted_block = getValidPbftProposedBlock(period, round - 1, next_voted_block_hash);
+    const auto next_voted_block = getValidPbftProposedBlock(period, next_voted_block_hash);
     if (!next_voted_block) {
       // This should never happen - if so, we probably have a bug in storing the blocks in proposed_blocks_
       LOG(log_er_) << "Unable to re-propose previous round next voted block " << next_voted_block_hash << ", period "
@@ -987,7 +980,7 @@ void PbftManager::identifyBlock_() {
     }
   } else if (previous_round_next_voted_value_.has_value()) {
     const auto &next_voted_block_hash = *previous_round_next_voted_value_;
-    const auto next_voted_block = getValidPbftProposedBlock(period, round - 1, next_voted_block_hash);
+    const auto next_voted_block = getValidPbftProposedBlock(period, next_voted_block_hash);
     if (!next_voted_block) {
       // This should never happen - if so, we probably have a bug in storing the blocks in proposed_blocks_
       LOG(log_er_) << "Unable to soft-vote previous round next voted block " << next_voted_block_hash << ", period "
@@ -1092,7 +1085,7 @@ void PbftManager::firstFinish_() {
     // we dont know for which value we saw 2t+1 next votes as first so we prefer specific block if possible
     std::pair<blk_hash_t, std::shared_ptr<PbftBlock>> starting_value;
     if (previous_round_next_voted_value_.has_value()) {
-      auto block = getValidPbftProposedBlock(period, round - 1, *previous_round_next_voted_value_);
+      auto block = getValidPbftProposedBlock(period, *previous_round_next_voted_value_);
       if (!block) {
         // This should never happen - if so, we probably have a bug in storing the blocks in proposed_blocks_
         LOG(log_er_) << "Unable to first finish next-vote starting value " << *previous_round_next_voted_value_
@@ -1223,8 +1216,7 @@ std::pair<bool, std::string> PbftManager::validateVote(const std::shared_ptr<Vot
 
 void PbftManager::processProposedBlock(const std::shared_ptr<PbftBlock> &proposed_block,
                                        const std::shared_ptr<Vote> &propose_vote) {
-  if (proposed_blocks_.isInProposedBlocks(propose_vote->getPeriod(), propose_vote->getRound(),
-                                          propose_vote->getBlockHash())) {
+  if (proposed_blocks_.isInProposedBlocks(propose_vote->getPeriod(), propose_vote->getBlockHash())) {
     return;
   }
 
@@ -1529,8 +1521,7 @@ std::shared_ptr<PbftBlock> PbftManager::identifyLeaderBlock_(PbftRound round, Pb
       continue;
     }
 
-    auto leader_block =
-        getValidPbftProposedBlock(leader_vote.second->getPeriod(), leader_vote.second->getRound(), proposed_block_hash);
+    auto leader_block = getValidPbftProposedBlock(leader_vote.second->getPeriod(), proposed_block_hash);
     if (!leader_block) {
       LOG(log_er_) << "Unable to get valid proposed block " << proposed_block_hash;
       continue;

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -253,9 +253,9 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   bool pbftBlockInDb(blk_hash_t const& hash);
 
   // Proposed pbft blocks
-  void saveProposedPbftBlock(const std::shared_ptr<PbftBlock>& block, PbftRound round);
+  void saveProposedPbftBlock(const std::shared_ptr<PbftBlock>& block);
   void removeProposedPbftBlock(const blk_hash_t& block_hash, Batch& write_batch);
-  std::vector<std::pair<uint64_t, std::shared_ptr<PbftBlock>>> getProposedPbftBlocks();
+  std::vector<std::shared_ptr<PbftBlock>> getProposedPbftBlocks();
 
   // pbft_blocks (head)
   string getPbftHead(blk_hash_t const& hash);

--- a/libraries/core_libs/storage/src/storage.cpp
+++ b/libraries/core_libs/storage/src/storage.cpp
@@ -519,25 +519,25 @@ std::unordered_map<trx_hash_t, PbftPeriod> DbStorage::getAllTransactionPeriod() 
 }
 
 // Proposed pbft blocks
-void DbStorage::saveProposedPbftBlock(const std::shared_ptr<PbftBlock>& block, PbftRound round) {
+void DbStorage::saveProposedPbftBlock(const std::shared_ptr<PbftBlock>& block) {
   dev::RLPStream s;
   s.appendList(2);
   s.appendRaw(block->rlp(true));
-  s << round;
-  insert(Columns::proposed_pbft_blocks, toSlice(block->getBlockHash().asBytes()), toSlice(s.out()));
+  s << 0;
+  insert(Columns::proposed_pbft_blocks, block->getBlockHash().asBytes(), s.out());
 }
 
 void DbStorage::removeProposedPbftBlock(const blk_hash_t& block_hash, Batch& write_batch) {
   remove(write_batch, Columns::proposed_pbft_blocks, toSlice(block_hash.asBytes()));
 }
 
-std::vector<std::pair<uint64_t, std::shared_ptr<PbftBlock>>> DbStorage::getProposedPbftBlocks() {
-  std::vector<std::pair<uint64_t, std::shared_ptr<PbftBlock>>> res;
+std::vector<std::shared_ptr<PbftBlock>> DbStorage::getProposedPbftBlocks() {
+  std::vector<std::shared_ptr<PbftBlock>> res;
   auto i = std::unique_ptr<rocksdb::Iterator>(db_->NewIterator(read_options_, handle(Columns::proposed_pbft_blocks)));
   for (i->SeekToFirst(); i->Valid(); i->Next()) {
     auto data = asBytes(i->value().ToString());
-    dev::RLP const rlp(data);
-    res.push_back({rlp[1].toInt<PbftRound>(), std::make_shared<PbftBlock>(rlp[0])});
+    const dev::RLP rlp(data);
+    res.push_back(std::make_shared<PbftBlock>(rlp[0]));
   }
   return res;
 }

--- a/tests/pbft_manager_test.cpp
+++ b/tests/pbft_manager_test.cpp
@@ -651,8 +651,8 @@ TEST_F(PbftManagerTest, propose_block_and_vote_broadcast) {
                                               node1->getPbftManager()->getPbftRound() + 1, value_proposal_state);
   pbft_mgr1->processProposedBlock(proposed_pbft_block, propose_vote);
 
-  auto block1_from_node1 = pbft_mgr1->getProposedBlocksSt().getPbftProposedBlock(
-      propose_vote->getPeriod(), propose_vote->getRound(), propose_vote->getBlockHash());
+  auto block1_from_node1 =
+      pbft_mgr1->getProposedBlocksSt().getPbftProposedBlock(propose_vote->getPeriod(), propose_vote->getBlockHash());
   ASSERT_TRUE(block1_from_node1);
   EXPECT_EQ(block1_from_node1->first->getJsonStr(), proposed_pbft_block->getJsonStr());
 
@@ -663,10 +663,10 @@ TEST_F(PbftManagerTest, propose_block_and_vote_broadcast) {
   std::optional<std::pair<std::shared_ptr<PbftBlock>, bool>> node3_synced_proposed_block_and_vote = std::nullopt;
 
   EXPECT_HAPPENS({20s, 200ms}, [&](auto &ctx) {
-    node2_synced_proposed_block_and_vote = pbft_mgr2->getProposedBlocksSt().getPbftProposedBlock(
-        propose_vote->getPeriod(), propose_vote->getRound(), propose_vote->getBlockHash());
-    node3_synced_proposed_block_and_vote = pbft_mgr3->getProposedBlocksSt().getPbftProposedBlock(
-        propose_vote->getPeriod(), propose_vote->getRound(), propose_vote->getBlockHash());
+    node2_synced_proposed_block_and_vote =
+        pbft_mgr2->getProposedBlocksSt().getPbftProposedBlock(propose_vote->getPeriod(), propose_vote->getBlockHash());
+    node3_synced_proposed_block_and_vote =
+        pbft_mgr3->getProposedBlocksSt().getPbftProposedBlock(propose_vote->getPeriod(), propose_vote->getBlockHash());
 
     WAIT_EXPECT_TRUE(ctx, node2_synced_proposed_block_and_vote)
     WAIT_EXPECT_TRUE(ctx, node3_synced_proposed_block_and_vote)
@@ -940,7 +940,7 @@ TEST_F(PbftManagerWithDagCreation, proposed_blocks) {
   }
   auto now = std::chrono::steady_clock::now();
   for (auto b : blocks) {
-    proposed_blocks.pushProposedPbftBlock(1, b.second);
+    proposed_blocks.pushProposedPbftBlock(b.second);
   }
   std::cout << "Time to push " << block_count
             << " blocks: " << duration_cast<microseconds>(std::chrono::steady_clock::now() - now).count()
@@ -948,7 +948,7 @@ TEST_F(PbftManagerWithDagCreation, proposed_blocks) {
   auto blocks_from_db = db->getProposedPbftBlocks();
   EXPECT_EQ(blocks_from_db.size(), blocks.size());
   for (auto b : blocks_from_db) {
-    EXPECT_TRUE(blocks.find(b.second->getBlockHash()) != blocks.end());
+    EXPECT_TRUE(blocks.find(b->getBlockHash()) != blocks.end());
   }
   now = std::chrono::steady_clock::now();
   proposed_blocks.cleanupProposedPbftBlocksByPeriod(3);


### PR DESCRIPTION
## Purpose
<!-- Provide any information reviewers might need to have context on your changes. -->

Do not use rounds for saving proposed blocks. Rason:

This line probably contains logic bug:
`auto block = getValidPbftProposedBlock(period, round - 1, *previous_round_next_voted_value_);`

Theoretical scenario when this would not work:
1. lets say in round 1 we found 2t+1 soft votes for block A, so nodes next voted it
2. we found 2t+1 next votes for block A in round 1, so we moved for round 2
3. In round 2, nobody propose/soft/cert vote(for whatever reason) but everyone next votes block A in first finish step because it is 2t+1 next voted value from previous round(1) - here getValidPbftProposedBlock(period, round - 1, *previous_round_next_voted_value_)should still work as it was saved in round 1 in proposed blocks
4. In round 3 the scenarionas in round 2 is repeated. Nobody propose/soft/cert vote(for whatever reason) but everyone next votes block A in first finish step because it is 2t+1 next voted value from previous round(2) - here getValidPbftProposedBlock(period, round - 1, *previous_round_next_voted_value_) would not work as it was saved in round 1 in proposed blocks but we are trying to get it for round 2

## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
