### PR TITLE
chore: prune light node

### DIFF
--- a/libraries/core_libs/consensus/include/final_chain/final_chain.hpp
+++ b/libraries/core_libs/consensus/include/final_chain/final_chain.hpp
@@ -220,6 +220,12 @@ class FinalChain {
    */
   virtual vrf_wrapper::vrf_pk_t dpos_get_vrf_key(EthBlockNumber blk_n, const addr_t& addr) const = 0;
 
+  /**
+   * @brief Prune state db for all blocks older than blk_n
+   * @param blk_n number of block we are getting state from
+   */
+  virtual void prune(EthBlockNumber blk_n) = 0;
+
   // TODO move out of here:
 
   std::pair<val_t, bool> getBalance(addr_t const& addr) const {

--- a/libraries/core_libs/consensus/include/final_chain/state_api.hpp
+++ b/libraries/core_libs/consensus/include/final_chain/state_api.hpp
@@ -48,6 +48,8 @@ class StateAPI {
                                                 const RewardsStats& rewards_stats = {});
   void transition_state_commit();
   void create_snapshot(PbftPeriod period);
+  void prune(const dev::h256& state_root_to_keep, const std::vector<dev::h256>& state_root_to_prune,
+             EthBlockNumber blk_num);
 
   // DPOS
   uint64_t dpos_eligible_total_vote_count(EthBlockNumber blk_num) const;

--- a/libraries/core_libs/consensus/src/final_chain/state_api.cpp
+++ b/libraries/core_libs/consensus/src/final_chain/state_api.cpp
@@ -99,7 +99,7 @@ Result c_method_args_rlp(taraxa_evm_state_API_ptr this_c, const Params&... args)
 template <void (*fn)(taraxa_evm_state_API_ptr, taraxa_evm_Bytes, taraxa_evm_BytesCallback), typename... Params>
 void c_method_args_rlp(taraxa_evm_state_API_ptr this_c, const Params&... args) {
   dev::RLPStream encoding;
-  rlp_tuple(encoding, args...);
+  util::rlp_tuple(encoding, args...);
   ErrorHandler err_h;
   fn(this_c, map_bytes(encoding.out()), err_h.cgo_part_);
   err_h.check();
@@ -201,6 +201,11 @@ void StateAPI::create_snapshot(PbftPeriod period) {
   ErrorHandler err_h;
   taraxa_evm_state_api_db_snapshot(this_c_, go_path, 0, err_h.cgo_part_);
   err_h.check();
+}
+
+void StateAPI::prune(const dev::h256& state_root_to_keep, const std::vector<dev::h256>& state_root_to_prune,
+                     EthBlockNumber blk_num) {
+  return c_method_args_rlp<taraxa_evm_state_api_prune>(this_c_, state_root_to_keep, state_root_to_prune, blk_num);
 }
 
 uint64_t StateAPI::dpos_eligible_total_vote_count(EthBlockNumber blk_num) const {

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -315,6 +315,8 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
 
   bool hasMinorVersionChanged() { return minor_version_changed_; }
 
+  void compactColumn(Column const& column) { db_->CompactRange({}, handle(column), nullptr, nullptr); }
+
   inline static bytes asBytes(string const& b) {
     return bytes((byte const*)b.data(), (byte const*)(b.data() + b.size()));
   }


### PR DESCRIPTION
Review this PR as well:
https://github.com/Taraxa-project/taraxa-evm/pull/136

For a light node deleting the data from the state_db. This is done with method prune which instructs to delete all the data which is  below light_node_history number of blocks