### PR TITLE
chore: gas limit on dag block tips

### DIFF
--- a/libraries/core_libs/consensus/include/dag/dag_block_proposer.hpp
+++ b/libraries/core_libs/consensus/include/dag/dag_block_proposer.hpp
@@ -38,7 +38,7 @@ class DagBlockProposer {
   DagBlockProposer(const DagBlockProposerConfig& bp_config, std::shared_ptr<DagManager> dag_mgr,
                    std::shared_ptr<TransactionManager> trx_mgr, std::shared_ptr<final_chain::FinalChain> final_chain,
                    std::shared_ptr<DbStorage> db, std::shared_ptr<KeyManager> key_manager, addr_t node_addr,
-                   secret_t node_sk, vrf_wrapper::vrf_sk_t vrf_sk);
+                   secret_t node_sk, vrf_wrapper::vrf_sk_t vrf_sk, uint64_t pbft_gas_limit, uint64_t dag_gas_limit);
   ~DagBlockProposer() { stop(); }
   DagBlockProposer(const DagBlockProposer&) = delete;
   DagBlockProposer(DagBlockProposer&&) = delete;
@@ -78,10 +78,11 @@ class DagBlockProposer {
    * @brief Select tips for DagBlock proposal up to max allowed
    *
    * @param frontier_tips
+   * @param gas_limit gas limit for the tips
    *
    * @return tips
    */
-  vec_blk_t selectDagBlockTips(const vec_blk_t& frontier_tips) const;
+  vec_blk_t selectDagBlockTips(const vec_blk_t& frontier_tips, uint64_t gas_limit) const;
 
  private:
   /**
@@ -144,6 +145,9 @@ class DagBlockProposer {
   const secret_t node_sk_;
   const vrf_wrapper::vrf_sk_t vrf_sk_;
   const vrf_wrapper::vrf_pk_t vrf_pk_;
+
+  const uint64_t kPbftGasLimit;
+  const uint64_t kDagGasLimit;
 
   LOG_OBJECTS_DEFINE
 };

--- a/libraries/core_libs/consensus/include/dag/dag_manager.hpp
+++ b/libraries/core_libs/consensus/include/dag/dag_manager.hpp
@@ -46,7 +46,7 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
   explicit DagManager(const DagBlock &dag_genesis_block, addr_t node_addr, const SortitionConfig &sortition_config,
                       const DagConfig &dag_config, std::shared_ptr<TransactionManager> trx_mgr,
                       std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<FinalChain> final_chain,
-                      std::shared_ptr<DbStorage> db, std::shared_ptr<KeyManager> key_manager,
+                      std::shared_ptr<DbStorage> db, std::shared_ptr<KeyManager> key_manager, uint64_t pbft_gas_limit,
                       bool is_light_node = false, uint64_t light_node_history = 0,
                       uint32_t max_levels_per_period = kMaxLevelsPerPeriod,
                       uint32_t dag_expiry_limit = kDagExpiryLevelLimit);
@@ -275,6 +275,7 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
   const uint32_t cache_delete_step_ = 100;
   ExpirationCacheMap<blk_hash_t, DagBlock> seen_blocks_;
   std::shared_ptr<FinalChain> final_chain_;
+  const uint64_t kPbftGasLimit;
 
   LOG_OBJECTS_DEFINE
 };

--- a/libraries/core_libs/node/src/node.cpp
+++ b/libraries/core_libs/node/src/node.cpp
@@ -114,16 +114,16 @@ void FullNode::init() {
   pbft_chain_ = std::make_shared<PbftChain>(node_addr, db_);
   dag_mgr_ = std::make_shared<DagManager>(conf_.genesis.dag_genesis_block, node_addr, conf_.genesis.sortition,
                                           conf_.genesis.dag, trx_mgr_, pbft_chain_, final_chain_, db_, key_manager_,
-                                          conf_.is_light_node, conf_.light_node_history, conf_.max_levels_per_period,
-                                          conf_.dag_expiry_limit);
+                                          conf_.genesis.pbft.gas_limit, conf_.is_light_node, conf_.light_node_history,
+                                          conf_.max_levels_per_period, conf_.dag_expiry_limit);
   vote_mgr_ = std::make_shared<VoteManager>(node_addr, conf_.genesis.pbft, kp_.secret(), conf_.vrf_secret, db_,
                                             pbft_chain_, final_chain_, key_manager_);
   pbft_mgr_ = std::make_shared<PbftManager>(conf_.genesis.pbft, conf_.genesis.dag_genesis_block.getHash(), node_addr,
                                             db_, pbft_chain_, vote_mgr_, dag_mgr_, trx_mgr_, final_chain_, kp_.secret(),
                                             conf_.max_levels_per_period);
-  dag_block_proposer_ =
-      std::make_shared<DagBlockProposer>(conf_.genesis.dag.block_proposer, dag_mgr_, trx_mgr_, final_chain_, db_,
-                                         key_manager_, node_addr, getSecretKey(), getVrfSecretKey());
+  dag_block_proposer_ = std::make_shared<DagBlockProposer>(
+      conf_.genesis.dag.block_proposer, dag_mgr_, trx_mgr_, final_chain_, db_, key_manager_, node_addr, getSecretKey(),
+      getVrfSecretKey(), conf_.genesis.pbft.gas_limit, conf_.genesis.dag.gas_limit);
   network_ = std::make_shared<Network>(conf_, genesis_hash, dev::p2p::Host::CapabilitiesFactory(),
                                        conf_.net_file_path().string(), kp_, db_, pbft_mgr_, pbft_chain_, vote_mgr_,
                                        dag_mgr_, trx_mgr_);

--- a/tests/dag_test.cpp
+++ b/tests/dag_test.cpp
@@ -137,7 +137,7 @@ TEST_F(DagTest, compute_epoch) {
   const blk_hash_t GENESIS = node_cfgs[0].genesis.dag_genesis_block.getHash();
   auto mgr =
       std::make_shared<DagManager>(node_cfgs[0].genesis.dag_genesis_block, addr_t(), node_cfgs[0].genesis.sortition,
-                                   node_cfgs[0].genesis.dag, trx_mgr, pbft_chain, nullptr, db_ptr, nullptr);
+                                   node_cfgs[0].genesis.dag, trx_mgr, pbft_chain, nullptr, db_ptr, nullptr, 100000);
 
   DagBlock blkA(GENESIS, 1, {}, {trx_hash_t(2)}, sig_t(1), blk_hash_t(2), addr_t(1));
   DagBlock blkB(GENESIS, 1, {}, {trx_hash_t(3), trx_hash_t(4)}, sig_t(1), blk_hash_t(3), addr_t(1));
@@ -230,7 +230,7 @@ TEST_F(DagTest, dag_expiry) {
   const blk_hash_t GENESIS = node_cfgs[0].genesis.dag_genesis_block.getHash();
   auto mgr = std::make_shared<DagManager>(node_cfgs[0].genesis.dag_genesis_block, addr_t(),
                                           node_cfgs[0].genesis.sortition, node_cfgs[0].genesis.dag, trx_mgr, pbft_chain,
-                                          nullptr, db_ptr, nullptr, false, 0, 3, EXPIRY_LIMIT);
+                                          nullptr, db_ptr, nullptr, 100000, false, 0, 3, EXPIRY_LIMIT);
 
   DagBlock blkA(GENESIS, 1, {}, {trx_hash_t(2)}, sig_t(1), blk_hash_t(2), addr_t(1));
   DagBlock blkB(GENESIS, 1, {}, {trx_hash_t(3), trx_hash_t(4)}, sig_t(1), blk_hash_t(3), addr_t(1));
@@ -306,7 +306,7 @@ TEST_F(DagTest, receive_block_in_order) {
   const blk_hash_t GENESIS = node_cfgs[0].genesis.dag_genesis_block.getHash();
   auto mgr =
       std::make_shared<DagManager>(node_cfgs[0].genesis.dag_genesis_block, addr_t(), node_cfgs[0].genesis.sortition,
-                                   node_cfgs[0].genesis.dag, trx_mgr, pbft_chain, nullptr, db_ptr, nullptr);
+                                   node_cfgs[0].genesis.dag, trx_mgr, pbft_chain, nullptr, db_ptr, nullptr, 100000);
 
   DagBlock blk1(GENESIS, 1, {}, {}, sig_t(777), blk_hash_t(1), addr_t(15));
   DagBlock blk2(blk_hash_t(1), 2, {}, {}, sig_t(777), blk_hash_t(2), addr_t(15));
@@ -338,7 +338,7 @@ TEST_F(DagTest, compute_epoch_2) {
   const blk_hash_t GENESIS = node_cfgs[0].genesis.dag_genesis_block.getHash();
   auto mgr =
       std::make_shared<DagManager>(node_cfgs[0].genesis.dag_genesis_block, addr_t(), node_cfgs[0].genesis.sortition,
-                                   node_cfgs[0].genesis.dag, trx_mgr, pbft_chain, nullptr, db_ptr, nullptr);
+                                   node_cfgs[0].genesis.dag, trx_mgr, pbft_chain, nullptr, db_ptr, nullptr, 100000);
 
   DagBlock blkA(GENESIS, 1, {}, {trx_hash_t(2)}, sig_t(1), blk_hash_t(2), addr_t(1));
   DagBlock blkB(GENESIS, 1, {}, {trx_hash_t(3), trx_hash_t(4)}, sig_t(1), blk_hash_t(3), addr_t(1));
@@ -421,7 +421,7 @@ TEST_F(DagTest, get_latest_pivot_tips) {
   const blk_hash_t GENESIS = node_cfgs[0].genesis.dag_genesis_block.getHash();
   auto mgr =
       std::make_shared<DagManager>(node_cfgs[0].genesis.dag_genesis_block, addr_t(), node_cfgs[0].genesis.sortition,
-                                   node_cfgs[0].genesis.dag, trx_mgr, pbft_chain, nullptr, db_ptr, nullptr);
+                                   node_cfgs[0].genesis.dag, trx_mgr, pbft_chain, nullptr, db_ptr, nullptr, 100000);
 
   DagBlock blk2(GENESIS, 1, {}, {}, sig_t(1), blk_hash_t(2), addr_t(15));
   DagBlock blk3(blk_hash_t(2), 2, {}, {}, sig_t(1), blk_hash_t(3), addr_t(15));
@@ -448,7 +448,7 @@ TEST_F(DagTest, initial_pivot) {
   auto pbft_chain = std::make_shared<PbftChain>(addr_t(), db_ptr);
   auto mgr =
       std::make_shared<DagManager>(node_cfgs[0].genesis.dag_genesis_block, addr_t(), node_cfgs[0].genesis.sortition,
-                                   node_cfgs[0].genesis.dag, trx_mgr, pbft_chain, nullptr, db_ptr, nullptr);
+                                   node_cfgs[0].genesis.dag, trx_mgr, pbft_chain, nullptr, db_ptr, nullptr, 100000);
 
   auto pt = mgr->getLatestPivotAndTips();
 


### PR DESCRIPTION
A limitation is added that a DAG block together with its tips is not allowed to have a gas limit over the pbft gas limit. This will make overweight pbft blocks very unlikely to happen. There are some edge cases when block could have pivot of one level and multiple levels of tips which could make overweight pbft blocks but this should be extremely rare.