### PR TITLE
chore: remove todo for already implemented feature

### DIFF
--- a/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
+++ b/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
@@ -542,7 +542,6 @@ bool VoteManager::isValidRewardVote(const std::shared_ptr<Vote>& vote) const {
 
   // !!! Important: Different nodes might finalize/push the same block in different rounds and therefore they can
   // include different reward votes when creating new block - accept all cert votes with matching period & block_hash
-  // TODO[1938]: implement ddos protection so user cannot sent indefinite number of valid reward votes with different
   // round Dummy round protection - if we pushed the block in round reward_votes_round_, the rest of the network should
   // push it shortly after - 100 rounds buffer
   if (vote->getRound() > reward_votes_round_ + 100) {


### PR DESCRIPTION
## Purpose
<!-- Provide any information reviewers might need to have context on your changes. -->

There was a TODO for implementing protection against ddos attack through generating reward votes with potentially unlimited rounds... 

There is a dummy protection, wich I think is sufficient enough - if we pushed the block lets say at period 10 & round 1, we expect all other nodes to push the same block max at period 10 & round 101 - there is a 100 rounds buffer 

## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
