### PR TITLE
chore: dag production dependent on stake

### DIFF
--- a/doc/RPC.md
+++ b/doc/RPC.md
@@ -470,7 +470,8 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"taraxa_getConfig","params":[],"i
         "difficulty_max": "0x12",
         "difficulty_min": "0x10",
         "difficulty_stale": "0x14",
-        "lambda_bound": "0x64"
+        "lambda_bound": "0x64",
+        "stake_threshold": "0x4e20"
       },
       "vrf": {
         "threshold_upper": "0x1770"

--- a/libraries/cli/include/cli/config_jsons/default/default_genesis.json
+++ b/libraries/cli/include/cli/config_jsons/default/default_genesis.json
@@ -91,7 +91,8 @@
       "difficulty_max": 21,
       "difficulty_min": 16,
       "difficulty_stale": 23,
-      "lambda_bound": "0x64"
+      "lambda_bound": "0x64",
+      "stake_threshold": 20000
     }
   }
 }

--- a/libraries/cli/include/cli/config_jsons/devnet/devnet_genesis.json
+++ b/libraries/cli/include/cli/config_jsons/devnet/devnet_genesis.json
@@ -260,7 +260,8 @@
       "difficulty_max": 21,
       "difficulty_min": 16,
       "difficulty_stale": 23,
-      "lambda_bound": "0x64"
+      "lambda_bound": "0x64",
+      "stake_threshold": 20000
     }
   }
 }

--- a/libraries/cli/include/cli/config_jsons/mainnet/mainnet_genesis.json
+++ b/libraries/cli/include/cli/config_jsons/mainnet/mainnet_genesis.json
@@ -283,7 +283,8 @@
       "difficulty_max": 21,
       "difficulty_min": 16,
       "difficulty_stale": 23,
-      "lambda_bound": "0x64"
+      "lambda_bound": "0x64",
+      "stake_threshold": 20000
     }
   }
 }

--- a/libraries/cli/include/cli/config_jsons/testnet/testnet_genesis.json
+++ b/libraries/cli/include/cli/config_jsons/testnet/testnet_genesis.json
@@ -1709,7 +1709,8 @@
       "difficulty_max": 21,
       "difficulty_min": 16,
       "difficulty_stale": 23,
-      "lambda_bound": "0x64"
+      "lambda_bound": "0x64",
+      "stake_threshold": 20000
     }
   }
 }

--- a/libraries/core_libs/consensus/src/dag/dag_block_proposer.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_block_proposer.cpp
@@ -67,11 +67,15 @@ bool DagBlockProposer::proposeDagBlock() {
     return false;
   }
 
+  const auto total_vote_count = final_chain_->dpos_eligible_total_vote_count(*proposal_period);
+  const auto vote_count = final_chain_->dpos_eligible_vote_count(*proposal_period, node_addr_);
+
   const auto period_block_hash = db_->getPeriodBlockHash(*proposal_period);
   // get sortition
   const auto sortition_params = dag_mgr_->sortitionParamsManager().getSortitionParams(*proposal_period);
   vdf_sortition::VdfSortition vdf(sortition_params, vrf_sk_,
-                                  VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+                                  VrfSortitionBase::makeVrfInput(propose_level, period_block_hash), vote_count,
+                                  total_vote_count);
   if (vdf.isStale(sortition_params)) {
     if (last_propose_level_ == propose_level) {
       if (num_tries_ < max_num_tries_) {

--- a/libraries/core_libs/consensus/src/dag/dag_manager.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_manager.cpp
@@ -496,8 +496,10 @@ void DagManager::recoverDag() {
         }
         // Verify VDF solution
         try {
+          const auto total_vote_count = final_chain_->dpos_eligible_total_vote_count(*propose_period);
+          const auto vote_count = final_chain_->dpos_eligible_vote_count(*propose_period, blk.getSender());
           blk.verifyVdf(sortition_params_manager_.getSortitionParams(*propose_period),
-                        db_->getPeriodBlockHash(*propose_period), *pk);
+                        db_->getPeriodBlockHash(*propose_period), *pk, vote_count, total_vote_count);
         } catch (vdf_sortition::VdfSortition::InvalidVdfSortition const &e) {
           LOG(log_er_) << "DAG block " << blk.getHash() << " with " << blk.getLevel()
                        << " level failed on VDF verification with pivot hash " << blk.getPivot() << " reason "
@@ -622,7 +624,10 @@ DagManager::VerifyBlockReturnType DagManager::verifyBlock(const DagBlock &blk) {
 
   try {
     const auto proposal_period_hash = db_->getPeriodBlockHash(*propose_period);
-    blk.verifyVdf(sortition_params_manager_.getSortitionParams(*propose_period), proposal_period_hash, *pk);
+    const auto total_vote_count = final_chain_->dpos_eligible_total_vote_count(*propose_period);
+    const auto vote_count = final_chain_->dpos_eligible_vote_count(*propose_period, blk.getSender());
+    blk.verifyVdf(sortition_params_manager_.getSortitionParams(*propose_period), proposal_period_hash, *pk, vote_count,
+                  total_vote_count);
   } catch (vdf_sortition::VdfSortition::InvalidVdfSortition const &e) {
     LOG(log_er_) << "DAG block " << block_hash << " with " << blk.getLevel()
                  << " level failed on VDF verification with pivot hash " << blk.getPivot() << " reason " << e.what();

--- a/libraries/types/dag_block/include/dag/dag_block.hpp
+++ b/libraries/types/dag_block/include/dag/dag_block.hpp
@@ -100,8 +100,8 @@ class DagBlock {
   std::string getJsonStr() const;
 
   bool verifySig() const;
-  void verifyVdf(const SortitionParams &vdf_config, const h256 &proposal_period_hash,
-                 const vrf_wrapper::vrf_pk_t &pk) const;
+  void verifyVdf(const SortitionParams &vdf_config, const h256 &proposal_period_hash, const vrf_wrapper::vrf_pk_t &pk,
+                 uint64_t vote_count, uint64_t total_vote_count) const;
   bytes rlp(bool include_sig) const;
 
   /**

--- a/libraries/types/dag_block/src/dag_block.cpp
+++ b/libraries/types/dag_block/src/dag_block.cpp
@@ -117,7 +117,7 @@ bool DagBlock::verifySig() const {
 }
 
 void DagBlock::verifyVdf(const SortitionParams &vdf_config, const h256 &proposal_period_hash,
-                         const vrf_wrapper::vrf_pk_t &pk) const {
+                         const vrf_wrapper::vrf_pk_t &pk, uint64_t vote_count, uint64_t total_vote_count) const {
   dev::RLPStream s;
   s << getPivot();
   for (const auto &trx : getTrxs()) {
@@ -125,7 +125,8 @@ void DagBlock::verifyVdf(const SortitionParams &vdf_config, const h256 &proposal
   }
   dev::bytes vdf_msg = s.invalidate();
 
-  vdf_.verifyVdf(vdf_config, VrfSortitionBase::makeVrfInput(getLevel(), proposal_period_hash), pk, vdf_msg);
+  vdf_.verifyVdf(vdf_config, VrfSortitionBase::makeVrfInput(getLevel(), proposal_period_hash), pk, vdf_msg, vote_count,
+                 total_vote_count);
 }
 
 blk_hash_t const &DagBlock::getHash() const {

--- a/libraries/vdf/include/vdf/config.hpp
+++ b/libraries/vdf/include/vdf/config.hpp
@@ -19,6 +19,8 @@ struct VdfParams {
   uint16_t difficulty_max = 1;
   uint16_t difficulty_stale = 0;
   uint16_t lambda_bound = 1500;  // lambda upper bound, should be constant
+  uint16_t stake_threshold =
+      20000;  // Range 0 - UINT16_MAX. Decreasing this value, increases dag block production for higher stake nodes
 };
 
 struct SortitionParams {
@@ -34,6 +36,7 @@ struct SortitionParams {
     strm << "    difficulty maximum: " << config.vdf.difficulty_max << std::endl;
     strm << "    difficulty stale: " << config.vdf.difficulty_stale << std::endl;
     strm << "    lambda bound: " << config.vdf.lambda_bound << std::endl;
+    strm << "    stake threshold: " << config.vdf.stake_threshold << std::endl;
     return strm;
   }
   VrfParams vrf;

--- a/libraries/vdf/include/vdf/sortition.hpp
+++ b/libraries/vdf/include/vdf/sortition.hpp
@@ -23,14 +23,15 @@ class VdfSortition : public vrf_wrapper::VrfSortitionBase {
   };
 
   VdfSortition() = default;
-  explicit VdfSortition(SortitionParams const& config, vrf_sk_t const& sk, bytes const& vrf_input);
+  explicit VdfSortition(SortitionParams const& config, vrf_sk_t const& sk, bytes const& vrf_input, uint64_t vote_count,
+                        uint64_t total_vote_count);
   explicit VdfSortition(bytes const& b);
   explicit VdfSortition(Json::Value const& json);
 
   void computeVdfSolution(const SortitionParams& config, const bytes& msg, const std::atomic_bool& cancelled);
 
-  void verifyVdf(SortitionParams const& config, bytes const& vrf_input, const vrf_pk_t& pk,
-                 bytes const& vdf_input) const;
+  void verifyVdf(SortitionParams const& config, bytes const& vrf_input, const vrf_pk_t& pk, bytes const& vdf_input,
+                 uint64_t vote_count, uint64_t total_vote_count) const;
 
   bytes rlp() const;
   bool operator==(VdfSortition const& other) const {
@@ -51,7 +52,7 @@ class VdfSortition : public vrf_wrapper::VrfSortitionBase {
 
   auto getComputationTime() const { return vdf_computation_time_; }
   uint16_t getDifficulty() const;
-  uint16_t calculateDifficulty(SortitionParams const& config) const;
+  uint16_t calculateDifficulty(SortitionParams const& config, uint64_t vote_count, uint64_t total_vote_count) const;
   bool isStale(SortitionParams const& config) const;
   Json::Value getJson() const;
 

--- a/libraries/vdf/src/config.cpp
+++ b/libraries/vdf/src/config.cpp
@@ -38,6 +38,7 @@ Json::Value enc_json(VdfParams const& obj) {
   ret["difficulty_max"] = obj.difficulty_max;
   ret["difficulty_stale"] = obj.difficulty_stale;
   ret["lambda_bound"] = dev::toJS(obj.lambda_bound);
+  ret["stake_threshold"] = obj.stake_threshold;
   return ret;
 }
 
@@ -46,6 +47,7 @@ void dec_json(Json::Value const& json, VdfParams& obj) {
   obj.difficulty_max = json["difficulty_max"].asInt();
   obj.difficulty_stale = json["difficulty_stale"].asInt();
   obj.lambda_bound = dev::jsToInt(json["lambda_bound"].asString());
+  obj.stake_threshold = json["stake_threshold"].asInt();
 }
 
 Json::Value enc_json(SortitionParams const& obj) {

--- a/tests/dag_block_test.cpp
+++ b/tests/dag_block_test.cpp
@@ -47,7 +47,7 @@ TEST_F(DagBlockTest, serialize_deserialize) {
       "0b6627a6680e01cea3d9f36fa797f7f34e8869c3a526d9ed63ed8170e35542aad05dc12c"
       "1df1edc9f3367fba550b7971fc2de6c5998d8784051c5be69abc9644");
   level_t level = 3;
-  VdfSortition vdf(sortition_params, sk, getRlpBytes(level));
+  VdfSortition vdf(sortition_params, sk, getRlpBytes(level), 1, 100);
   blk_hash_t vdf_input(200);
   vdf.computeVdfSolution(sortition_params, vdf_input.asBytes(), false);
   DagBlock blk1(blk_hash_t(1), 2, {}, {}, {}, vdf, secret_t::random());
@@ -223,7 +223,7 @@ TEST_F(DagBlockMgrTest, incorrect_tx_estimation) {
   auto propose_level = 1;
   const auto period_block_hash = node->getDB()->getPeriodBlockHash(propose_level);
   vdf_sortition::VdfSortition vdf1(vdf_config, node->getVrfSecretKey(),
-                                   VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+                                   VrfSortitionBase::makeVrfInput(propose_level, period_block_hash), 1, 1);
 
   dev::bytes vdf_msg = DagManager::getVdfMessage(dag_genesis, {trx});
   vdf1.computeVdfSolution(vdf_config, vdf_msg, false);
@@ -258,7 +258,7 @@ TEST_F(DagBlockMgrTest, dag_block_tips_verification) {
   auto propose_level = 1;
   const auto period_block_hash = node->getDB()->getPeriodBlockHash(propose_level);
   vdf_sortition::VdfSortition vdf(vdf_config, node->getVrfSecretKey(),
-                                  VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+                                  VrfSortitionBase::makeVrfInput(propose_level, period_block_hash), 1, 1);
 
   std::vector<blk_hash_t> dag_blocks_hashes;
   for (auto trx : trxs) {
@@ -326,7 +326,7 @@ TEST_F(DagBlockMgrTest, dag_block_tips_proposal) {
   auto propose_level = 1;
   auto period_block_hash = node->getDB()->getPeriodBlockHash(propose_level);
   vdf_sortition::VdfSortition vdf(vdf_config, node->getVrfSecretKey(),
-                                  VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+                                  VrfSortitionBase::makeVrfInput(propose_level, period_block_hash), 1, 1);
 
   std::vector<blk_hash_t> dag_blocks_hashes;
   for (auto trx : trxs) {
@@ -348,7 +348,7 @@ TEST_F(DagBlockMgrTest, dag_block_tips_proposal) {
   propose_level = 2;
   period_block_hash = node->getDB()->getPeriodBlockHash(propose_level);
   vdf = vdf_sortition::VdfSortition(vdf_config, node->getVrfSecretKey(),
-                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash), 1, 1);
   for (auto trx : trxs) {
     dev::bytes vdf_msg = DagManager::getVdfMessage(dag_blocks_hashes[0], {trx});
     vdf.computeVdfSolution(vdf_config, vdf_msg, false);
@@ -369,7 +369,7 @@ TEST_F(DagBlockMgrTest, dag_block_tips_proposal) {
   propose_level = 1;
   period_block_hash = node->getDB()->getPeriodBlockHash(propose_level);
   vdf = vdf_sortition::VdfSortition(vdf_config, node_cfgs[1].vrf_secret,
-                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash), 1, 1);
 
   dev::bytes vdf_msg = DagManager::getVdfMessage(dag_genesis, {trxs[0]});
   vdf.computeVdfSolution(vdf_config, vdf_msg, false);
@@ -416,7 +416,7 @@ TEST_F(DagBlockMgrTest, too_big_dag_block) {
   auto propose_level = 1;
   const auto period_block_hash = node->getDB()->getPeriodBlockHash(propose_level);
   vdf_sortition::VdfSortition vdf1(vdf_config, node->getVrfSecretKey(),
-                                   VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+                                   VrfSortitionBase::makeVrfInput(propose_level, period_block_hash), 1, 1);
   dev::bytes vdf_msg = DagManager::getVdfMessage(dag_genesis, hashes);
   vdf1.computeVdfSolution(vdf_config, vdf_msg, false);
 

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -1568,7 +1568,7 @@ TEST_F(FullNodeTest, transaction_pool_overflow) {
   const auto sortition_params =
       nodes.front()->getDagManager()->sortitionParamsManager().getSortitionParams(proposal_period);
   vdf_sortition::VdfSortition vdf(sortition_params, node0->getVrfSecretKey(),
-                                  VrfSortitionBase::makeVrfInput(proposal_level, period_block_hash));
+                                  VrfSortitionBase::makeVrfInput(proposal_level, period_block_hash), 1, 2);
   const auto dag_genesis = node0->getConfig().genesis.dag_genesis_block.getHash();
   const auto estimation = node0->getTransactionManager()->estimateTransactionGas(trx, proposal_period);
   dev::bytes vdf_msg = DagManager::getVdfMessage(dag_genesis, {trx});

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -101,7 +101,7 @@ TEST_F(NetworkTest, transfer_lot_of_blocks) {
   const auto period_block_hash = db1->getPeriodBlockHash(proposal_period);
   const auto sortition_params = dag_mgr1->sortitionParamsManager().getSortitionParams(proposal_period);
   vdf_sortition::VdfSortition vdf(sortition_params, node1->getVrfSecretKey(),
-                                  VrfSortitionBase::makeVrfInput(proposal_level, period_block_hash));
+                                  VrfSortitionBase::makeVrfInput(proposal_level, period_block_hash), 1, 1);
   const auto dag_genesis = node1->getConfig().genesis.dag_genesis_block.getHash();
   dev::bytes vdf_msg = DagManager::getVdfMessage(dag_genesis, {trxs[0]});
   vdf.computeVdfSolution(sortition_params, vdf_msg, false);
@@ -126,7 +126,7 @@ TEST_F(NetworkTest, transfer_lot_of_blocks) {
     const auto period_block_hash = db1->getPeriodBlockHash(proposal_period);
     const auto sortition_params = dag_mgr1->sortitionParamsManager().getSortitionParams(proposal_period);
     vdf_sortition::VdfSortition vdf(sortition_params, node1->getVrfSecretKey(),
-                                    VrfSortitionBase::makeVrfInput(proposal_level + 1, period_block_hash));
+                                    VrfSortitionBase::makeVrfInput(proposal_level + 1, period_block_hash), 1, 1);
     DagBlock blk(block_hash, proposal_level + 1, {}, {trxs[i + 1]->getHash()}, {}, vdf, node1->getSecretKey());
     dag_blocks.emplace_back(std::make_shared<DagBlock>(blk));
   }
@@ -441,44 +441,44 @@ TEST_F(NetworkTest, node_sync) {
 
   auto propose_level = 1;
   const auto period_block_hash = node1->getDB()->getPeriodBlockHash(propose_level);
-  vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk,
-                                   VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+  vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk, VrfSortitionBase::makeVrfInput(propose_level, period_block_hash),
+                                   1, 1);
 
   dev::bytes vdf_msg1 = DagManager::getVdfMessage(dag_genesis, {g_signed_trx_samples[1]});
   vdf1.computeVdfSolution(vdf_config, vdf_msg1, false);
   DagBlock blk1(dag_genesis, propose_level, {}, {g_signed_trx_samples[1]->getHash()}, estimation, vdf1, sk);
 
   propose_level = 2;
-  vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk,
-                                   VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+  vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk, VrfSortitionBase::makeVrfInput(propose_level, period_block_hash),
+                                   1, 1);
   dev::bytes vdf_msg2 = DagManager::getVdfMessage(blk1.getHash(), {g_signed_trx_samples[2]});
   vdf2.computeVdfSolution(vdf_config, vdf_msg2, false);
   DagBlock blk2(blk1.getHash(), propose_level, {}, {g_signed_trx_samples[2]->getHash()}, estimation, vdf2, sk);
 
   propose_level = 3;
-  vdf_sortition::VdfSortition vdf3(vdf_config, vrf_sk,
-                                   VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+  vdf_sortition::VdfSortition vdf3(vdf_config, vrf_sk, VrfSortitionBase::makeVrfInput(propose_level, period_block_hash),
+                                   1, 1);
   dev::bytes vdf_msg3 = DagManager::getVdfMessage(blk2.getHash(), {g_signed_trx_samples[3]});
   vdf3.computeVdfSolution(vdf_config, vdf_msg3, false);
   DagBlock blk3(blk2.getHash(), propose_level, {}, {g_signed_trx_samples[3]->getHash()}, estimation, vdf3, sk);
 
   propose_level = 4;
-  vdf_sortition::VdfSortition vdf4(vdf_config, vrf_sk,
-                                   VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+  vdf_sortition::VdfSortition vdf4(vdf_config, vrf_sk, VrfSortitionBase::makeVrfInput(propose_level, period_block_hash),
+                                   1, 1);
   dev::bytes vdf_msg4 = DagManager::getVdfMessage(blk3.getHash(), {g_signed_trx_samples[4]});
   vdf4.computeVdfSolution(vdf_config, vdf_msg4, false);
   DagBlock blk4(blk3.getHash(), propose_level, {}, {g_signed_trx_samples[4]->getHash()}, estimation, vdf4, sk);
 
   propose_level = 5;
-  vdf_sortition::VdfSortition vdf5(vdf_config, vrf_sk,
-                                   VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+  vdf_sortition::VdfSortition vdf5(vdf_config, vrf_sk, VrfSortitionBase::makeVrfInput(propose_level, period_block_hash),
+                                   1, 1);
   dev::bytes vdf_msg5 = DagManager::getVdfMessage(blk4.getHash(), {g_signed_trx_samples[5]});
   vdf5.computeVdfSolution(vdf_config, vdf_msg5, false);
   DagBlock blk5(blk4.getHash(), propose_level, {}, {g_signed_trx_samples[5]->getHash()}, estimation, vdf5, sk);
 
   propose_level = 6;
-  vdf_sortition::VdfSortition vdf6(vdf_config, vrf_sk,
-                                   VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+  vdf_sortition::VdfSortition vdf6(vdf_config, vrf_sk, VrfSortitionBase::makeVrfInput(propose_level, period_block_hash),
+                                   1, 1);
   dev::bytes vdf_msg6 = DagManager::getVdfMessage(blk5.getHash(), {g_signed_trx_samples[6]});
   vdf6.computeVdfSolution(vdf_config, vdf_msg6, false);
   DagBlock blk6(blk5.getHash(), propose_level, {blk4.getHash(), blk3.getHash()}, {g_signed_trx_samples[6]->getHash()},
@@ -536,7 +536,7 @@ TEST_F(NetworkTest, node_pbft_sync) {
   addr_t beneficiary(987);
 
   level_t level = 1;
-  vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk, getRlpBytes(level));
+  vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk, getRlpBytes(level), 1, 1);
   dev::bytes vdf_msg1 = DagManager::getVdfMessage(dag_genesis, {g_signed_trx_samples[0], g_signed_trx_samples[1]});
   vdf1.computeVdfSolution(vdf_config, vdf_msg1, false);
   DagBlock blk1(dag_genesis, 1, {}, {g_signed_trx_samples[0]->getHash(), g_signed_trx_samples[1]->getHash()}, 0, vdf1,
@@ -590,7 +590,7 @@ TEST_F(NetworkTest, node_pbft_sync) {
   prev_block_hash = pbft_block1.getBlockHash();
 
   level = 2;
-  vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk, getRlpBytes(level));
+  vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk, getRlpBytes(level), 1, 1);
   dev::bytes vdf_msg2 = DagManager::getVdfMessage(blk1.getHash(), {g_signed_trx_samples[2], g_signed_trx_samples[3]});
   vdf2.computeVdfSolution(vdf_config, vdf_msg2, false);
   DagBlock blk2(blk1.getHash(), 2, {}, {g_signed_trx_samples[2]->getHash(), g_signed_trx_samples[3]->getHash()}, 0,
@@ -685,7 +685,7 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   PbftPeriod period = 1;
   addr_t beneficiary(876);
   level_t level = 1;
-  vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk, getRlpBytes(level));
+  vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk, getRlpBytes(level), 1, 1);
   dev::bytes vdf_msg1 = DagManager::getVdfMessage(dag_genesis, {g_signed_trx_samples[0], g_signed_trx_samples[1]});
   vdf1.computeVdfSolution(vdf_config, vdf_msg1, false);
   DagBlock blk1(dag_genesis, 1, {}, {g_signed_trx_samples[0]->getHash(), g_signed_trx_samples[1]->getHash()}, 0, vdf1,
@@ -729,7 +729,7 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   // generate second PBFT block sample
   prev_block_hash = pbft_block1.getBlockHash();
   level = 2;
-  vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk, getRlpBytes(level));
+  vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk, getRlpBytes(level), 1, 1);
   dev::bytes vdf_msg2 = DagManager::getVdfMessage(blk1.getHash(), {g_signed_trx_samples[2], g_signed_trx_samples[3]});
   vdf2.computeVdfSolution(vdf_config, vdf_msg2, false);
   DagBlock blk2(blk1.getHash(), 2, {}, {g_signed_trx_samples[2]->getHash(), g_signed_trx_samples[3]->getHash()}, 0,
@@ -903,8 +903,8 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
   SortitionConfig vdf_config(node_cfgs[0].genesis.sortition);
   auto propose_level = 1;
   const auto period_block_hash = node1->getDB()->getPeriodBlockHash(propose_level);
-  vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk,
-                                   VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+  vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk, VrfSortitionBase::makeVrfInput(propose_level, period_block_hash),
+                                   1, 1);
   dev::RLPStream s;
   dev::bytes vdf_msg1 = DagManager::getVdfMessage(dag_genesis, {g_signed_trx_samples[0], g_signed_trx_samples[1]});
   vdf1.computeVdfSolution(vdf_config, vdf_msg1, false);
@@ -914,8 +914,8 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
       {g_signed_trx_samples[0], TransactionStatus::Verified}, {g_signed_trx_samples[1], TransactionStatus::Verified}};
 
   propose_level = 2;
-  vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk,
-                                   VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+  vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk, VrfSortitionBase::makeVrfInput(propose_level, period_block_hash),
+                                   1, 1);
   dev::bytes vdf_msg2 = DagManager::getVdfMessage(blk1.getHash(), {g_signed_trx_samples[2]});
   vdf2.computeVdfSolution(vdf_config, vdf_msg2, false);
   DagBlock blk2(blk1.getHash(), propose_level, {}, {g_signed_trx_samples[2]->getHash()}, estimation, vdf2, sk);
@@ -923,8 +923,8 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
       {g_signed_trx_samples[2], TransactionStatus::Verified}};
 
   propose_level = 3;
-  vdf_sortition::VdfSortition vdf3(vdf_config, vrf_sk,
-                                   VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+  vdf_sortition::VdfSortition vdf3(vdf_config, vrf_sk, VrfSortitionBase::makeVrfInput(propose_level, period_block_hash),
+                                   1, 1);
   dev::bytes vdf_msg3 = DagManager::getVdfMessage(blk2.getHash(), {g_signed_trx_samples[3]});
   vdf3.computeVdfSolution(vdf_config, vdf_msg3, false);
   DagBlock blk3(blk2.getHash(), propose_level, {}, {g_signed_trx_samples[3]->getHash()}, estimation, vdf3, sk);
@@ -932,8 +932,8 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
       {g_signed_trx_samples[3], TransactionStatus::Verified}};
 
   propose_level = 4;
-  vdf_sortition::VdfSortition vdf4(vdf_config, vrf_sk,
-                                   VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+  vdf_sortition::VdfSortition vdf4(vdf_config, vrf_sk, VrfSortitionBase::makeVrfInput(propose_level, period_block_hash),
+                                   1, 1);
   dev::bytes vdf_msg4 = DagManager::getVdfMessage(blk3.getHash(), {g_signed_trx_samples[4]});
   vdf4.computeVdfSolution(vdf_config, vdf_msg4, false);
   DagBlock blk4(blk3.getHash(), propose_level, {}, {g_signed_trx_samples[4]->getHash()}, estimation, vdf4, sk);
@@ -941,8 +941,8 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
       {g_signed_trx_samples[4], TransactionStatus::Verified}};
 
   propose_level = 5;
-  vdf_sortition::VdfSortition vdf5(vdf_config, vrf_sk,
-                                   VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+  vdf_sortition::VdfSortition vdf5(vdf_config, vrf_sk, VrfSortitionBase::makeVrfInput(propose_level, period_block_hash),
+                                   1, 1);
   dev::bytes vdf_msg5 = DagManager::getVdfMessage(blk4.getHash(), {g_signed_trx_samples[5], g_signed_trx_samples[6],
                                                                    g_signed_trx_samples[7], g_signed_trx_samples[8]});
   vdf5.computeVdfSolution(vdf_config, vdf_msg5, false);
@@ -957,8 +957,8 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
       {g_signed_trx_samples[8], TransactionStatus::Verified}};
 
   propose_level = 6;
-  vdf_sortition::VdfSortition vdf6(vdf_config, vrf_sk,
-                                   VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+  vdf_sortition::VdfSortition vdf6(vdf_config, vrf_sk, VrfSortitionBase::makeVrfInput(propose_level, period_block_hash),
+                                   1, 1);
   dev::bytes vdf_msg6 = DagManager::getVdfMessage(blk5.getHash(), {g_signed_trx_samples[9]});
   vdf6.computeVdfSolution(vdf_config, vdf_msg6, false);
   DagBlock blk6(blk5.getHash(), propose_level, {blk4.getHash(), blk3.getHash()}, {g_signed_trx_samples[9]->getHash()},
@@ -1032,8 +1032,8 @@ TEST_F(NetworkTest, node_sync2) {
   // DAG block1
   auto propose_level = 1;
   const auto period_block_hash = node1->getDB()->getPeriodBlockHash(propose_level);
-  vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk,
-                                   VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+  vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk, VrfSortitionBase::makeVrfInput(propose_level, period_block_hash),
+                                   1, 1);
   dev::bytes vdf_msg = DagManager::getVdfMessage(dag_genesis, {transactions[0], transactions[1]});
   vdf1.computeVdfSolution(vdf_config, vdf_msg, false);
   DagBlock blk1(dag_genesis, propose_level, {}, {transactions[0]->getHash(), transactions[1]->getHash()},
@@ -1041,8 +1041,8 @@ TEST_F(NetworkTest, node_sync2) {
   SharedTransactions tr1({transactions[0], transactions[1]});
   // DAG block2
   propose_level = 1;
-  vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk,
-                                   VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+  vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk, VrfSortitionBase::makeVrfInput(propose_level, period_block_hash),
+                                   1, 1);
   vdf_msg = DagManager::getVdfMessage(dag_genesis, {transactions[2], transactions[3]});
   vdf2.computeVdfSolution(vdf_config, vdf_msg, false);
   DagBlock blk2(dag_genesis, propose_level, {}, {transactions[2]->getHash(), transactions[3]->getHash()},
@@ -1050,8 +1050,8 @@ TEST_F(NetworkTest, node_sync2) {
   SharedTransactions tr2({transactions[2], transactions[3]});
   // DAG block3
   propose_level = 2;
-  vdf_sortition::VdfSortition vdf3(vdf_config, vrf_sk,
-                                   VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+  vdf_sortition::VdfSortition vdf3(vdf_config, vrf_sk, VrfSortitionBase::makeVrfInput(propose_level, period_block_hash),
+                                   1, 1);
   vdf_msg = DagManager::getVdfMessage(blk1.getHash(), {transactions[4], transactions[5]});
   vdf3.computeVdfSolution(vdf_config, vdf_msg, false);
   DagBlock blk3(blk1.getHash(), propose_level, {}, {transactions[4]->getHash(), transactions[5]->getHash()},
@@ -1059,8 +1059,8 @@ TEST_F(NetworkTest, node_sync2) {
   SharedTransactions tr3({transactions[4], transactions[5]});
   // DAG block4
   propose_level = 3;
-  vdf_sortition::VdfSortition vdf4(vdf_config, vrf_sk,
-                                   VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+  vdf_sortition::VdfSortition vdf4(vdf_config, vrf_sk, VrfSortitionBase::makeVrfInput(propose_level, period_block_hash),
+                                   1, 1);
   vdf_msg = DagManager::getVdfMessage(blk3.getHash(), {transactions[6], transactions[7]});
   vdf4.computeVdfSolution(vdf_config, vdf_msg, false);
   DagBlock blk4(blk3.getHash(), propose_level, {}, {transactions[6]->getHash(), transactions[7]->getHash()},
@@ -1068,8 +1068,8 @@ TEST_F(NetworkTest, node_sync2) {
   SharedTransactions tr4({transactions[6], transactions[7]});
   // DAG block5
   propose_level = 2;
-  vdf_sortition::VdfSortition vdf5(vdf_config, vrf_sk,
-                                   VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+  vdf_sortition::VdfSortition vdf5(vdf_config, vrf_sk, VrfSortitionBase::makeVrfInput(propose_level, period_block_hash),
+                                   1, 1);
   vdf_msg = DagManager::getVdfMessage(blk2.getHash(), {transactions[8], transactions[9]});
   vdf5.computeVdfSolution(vdf_config, vdf_msg, false);
   DagBlock blk5(blk2.getHash(), propose_level, {}, {transactions[8]->getHash(), transactions[9]->getHash()},
@@ -1077,8 +1077,8 @@ TEST_F(NetworkTest, node_sync2) {
   SharedTransactions tr5({transactions[8], transactions[9]});
   // DAG block6
   propose_level = 2;
-  vdf_sortition::VdfSortition vdf6(vdf_config, vrf_sk,
-                                   VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+  vdf_sortition::VdfSortition vdf6(vdf_config, vrf_sk, VrfSortitionBase::makeVrfInput(propose_level, period_block_hash),
+                                   1, 1);
   vdf_msg = DagManager::getVdfMessage(blk1.getHash(), {transactions[10], transactions[11]});
   vdf6.computeVdfSolution(vdf_config, vdf_msg, false);
   DagBlock blk6(blk1.getHash(), propose_level, {}, {transactions[10]->getHash(), transactions[11]->getHash()},
@@ -1086,8 +1086,8 @@ TEST_F(NetworkTest, node_sync2) {
   SharedTransactions tr6({transactions[10], transactions[11]});
   // DAG block7
   propose_level = 3;
-  vdf_sortition::VdfSortition vdf7(vdf_config, vrf_sk,
-                                   VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+  vdf_sortition::VdfSortition vdf7(vdf_config, vrf_sk, VrfSortitionBase::makeVrfInput(propose_level, period_block_hash),
+                                   1, 1);
   vdf_msg = DagManager::getVdfMessage(blk6.getHash(), {transactions[12], transactions[13]});
   vdf7.computeVdfSolution(vdf_config, vdf_msg, false);
   DagBlock blk7(blk6.getHash(), propose_level, {}, {transactions[12]->getHash(), transactions[13]->getHash()},
@@ -1095,8 +1095,8 @@ TEST_F(NetworkTest, node_sync2) {
   SharedTransactions tr7({transactions[12], transactions[13]});
   // DAG block8
   propose_level = 4;
-  vdf_sortition::VdfSortition vdf8(vdf_config, vrf_sk,
-                                   VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+  vdf_sortition::VdfSortition vdf8(vdf_config, vrf_sk, VrfSortitionBase::makeVrfInput(propose_level, period_block_hash),
+                                   1, 1);
   vdf_msg = DagManager::getVdfMessage(blk1.getHash(), {transactions[14], transactions[15]});
   vdf8.computeVdfSolution(vdf_config, vdf_msg, false);
   DagBlock blk8(blk1.getHash(), propose_level, {blk7.getHash()},
@@ -1104,8 +1104,8 @@ TEST_F(NetworkTest, node_sync2) {
   SharedTransactions tr8({transactions[14], transactions[15]});
   // DAG block9
   propose_level = 2;
-  vdf_sortition::VdfSortition vdf9(vdf_config, vrf_sk,
-                                   VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+  vdf_sortition::VdfSortition vdf9(vdf_config, vrf_sk, VrfSortitionBase::makeVrfInput(propose_level, period_block_hash),
+                                   1, 1);
   vdf_msg = DagManager::getVdfMessage(blk1.getHash(), {transactions[16], transactions[17]});
   vdf9.computeVdfSolution(vdf_config, vdf_msg, false);
   DagBlock blk9(blk1.getHash(), propose_level, {}, {transactions[16]->getHash(), transactions[17]->getHash()},
@@ -1114,7 +1114,7 @@ TEST_F(NetworkTest, node_sync2) {
   // DAG block10
   propose_level = 5;
   vdf_sortition::VdfSortition vdf10(vdf_config, vrf_sk,
-                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash), 1, 1);
   vdf_msg = DagManager::getVdfMessage(blk8.getHash(), {transactions[18], transactions[19]});
   vdf10.computeVdfSolution(vdf_config, vdf_msg, false);
   DagBlock blk10(blk8.getHash(), propose_level, {}, {transactions[18]->getHash(), transactions[19]->getHash()},
@@ -1123,7 +1123,7 @@ TEST_F(NetworkTest, node_sync2) {
   // DAG block11
   propose_level = 3;
   vdf_sortition::VdfSortition vdf11(vdf_config, vrf_sk,
-                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash), 1, 1);
   vdf_msg = DagManager::getVdfMessage(blk3.getHash(), {transactions[20], transactions[21]});
   vdf11.computeVdfSolution(vdf_config, vdf_msg, false);
   DagBlock blk11(blk3.getHash(), propose_level, {}, {transactions[20]->getHash(), transactions[21]->getHash()},
@@ -1132,7 +1132,7 @@ TEST_F(NetworkTest, node_sync2) {
   // DAG block12
   propose_level = 3;
   vdf_sortition::VdfSortition vdf12(vdf_config, vrf_sk,
-                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash));
+                                    VrfSortitionBase::makeVrfInput(propose_level, period_block_hash), 1, 1);
   vdf_msg = DagManager::getVdfMessage(blk5.getHash(), {transactions[22], transactions[23]});
   vdf12.computeVdfSolution(vdf_config, vdf_msg, false);
   DagBlock blk12(blk5.getHash(), propose_level, {}, {transactions[22]->getHash(), transactions[23]->getHash()},

--- a/tests/pbft_chain_test.cpp
+++ b/tests/pbft_chain_test.cpp
@@ -51,7 +51,7 @@ TEST_F(PbftChainTest, pbft_db_test) {
   // generate PBFT block sample
   blk_hash_t prev_block_hash(0);
   level_t level = 1;
-  vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk, getRlpBytes(level));
+  vdf_sortition::VdfSortition vdf1(vdf_config, vrf_sk, getRlpBytes(level), 1, 100);
   vdf1.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
   DagBlock blk1(dag_genesis, 1, {}, {}, {}, vdf1, sk);
 

--- a/tests/test_util/src/node_dag_creation_fixture.cpp
+++ b/tests/test_util/src/node_dag_creation_fixture.cpp
@@ -134,7 +134,7 @@ std::vector<NodeDagCreationFixture::DagBlockWithTxs> NodeDagCreationFixture::gen
       const auto proposal_period = db->getProposalPeriodForDagLevel(level);
       const auto period_block_hash = db->getPeriodBlockHash(*proposal_period);
       vdf_sortition::VdfSortition vdf(vdf_config, node->getVrfSecretKey(),
-                                      vrf_wrapper::VrfSortitionBase::makeVrfInput(level, period_block_hash));
+                                      vrf_wrapper::VrfSortitionBase::makeVrfInput(level, period_block_hash), 1, 1);
       vdf.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
       std::vector<trx_hash_t> trx_hashes;
       std::transform(trx_itr, trx_itr_next, std::back_inserter(trx_hashes),
@@ -153,7 +153,7 @@ std::vector<NodeDagCreationFixture::DagBlockWithTxs> NodeDagCreationFixture::gen
   const auto period_block_hash = db->getPeriodBlockHash(*proposal_period);
   auto level = start_level + levels;
   vdf_sortition::VdfSortition vdf(vdf_config, node->getVrfSecretKey(),
-                                  vrf_wrapper::VrfSortitionBase::makeVrfInput(level, period_block_hash));
+                                  vrf_wrapper::VrfSortitionBase::makeVrfInput(level, period_block_hash), 1, 1);
   vdf.computeVdfSolution(vdf_config, dag_genesis.asBytes(), false);
   DagBlock blk(pivot, level, tips, {transactions.rbegin()->get()->getHash()}, trx_per_block * trx_estimation, vdf,
                node->getSecretKey());


### PR DESCRIPTION
This PR changes the DAG proposal to be dependent on the stake that a node has. This is accomplished by occasional decreasing difficulty for nodes with higher stake. All nodes will still have a probability of producing DAG blocks but nodes with higher stake will produce more blocks relative to its stake. 