### PR TITLE
chore: fix possible reason of crash on testnet

### DIFF
--- a/libraries/core_libs/network/graphql/src/query.cpp
+++ b/libraries/core_libs/network/graphql/src/query.cpp
@@ -167,9 +167,9 @@ std::vector<std::shared_ptr<object::DagBlock>> Query::getDagBlocks(std::optional
     }
   }
 
-  auto addDagBlocks = [&final_chain = final_chain_, &pbft_manager = pbft_manager_,
-                       &transaction_manager = transaction_manager_](auto taraxa_dag_blocks,
-                                                                    auto& result_dag_blocks) -> size_t {
+  auto addDagBlocks = [final_chain = final_chain_, pbft_manager = pbft_manager_,
+                       transaction_manager = transaction_manager_](auto taraxa_dag_blocks,
+                                                                   auto& result_dag_blocks) -> size_t {
     for (auto& dag_block : taraxa_dag_blocks) {
       result_dag_blocks.emplace_back(std::make_shared<object::DagBlock>(
           std::make_shared<DagBlock>(std::move(dag_block), final_chain, pbft_manager, transaction_manager)));


### PR DESCRIPTION
## Purpose
```#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=140189577983552) at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=6, threadid=140189577983552) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=140189577983552, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
#3  0x00007f80cf5e4476 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#4  0x00007f80cf5ca7f3 in __GI_abort () at ./stdlib/abort.c:79
#5  0x00007f80cf88ebbe in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f80cf89a24c in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#7  0x00007f80cf89a2b7 in std::terminate() () from /lib/x86_64-linux-gnu/libstdc++.so.6
#8  0x00007f80d173939b in __clang_call_terminate () from /usr/local/lib/libcore_libs.so
#9  0x00007f80d17dd1d6 in graphql::taraxa::Account::Account (this=<optimized out>, final_chain=..., address=...) at /opt/taraxa/libraries/core_libs/network/graphql/src/account.cpp:18
#10 0x00007f80d17e15e6 in std::construct_at<graphql::taraxa::Account, std::shared_ptr<taraxa::final_chain::FinalChain> const&, dev::FixedHash<20u> const&> (__location=__location@entry=0x7f80396572e0, __args=..., __args=...)
    at /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:97
#11 0x00007f80d17f2409 in std::allocator_traits<std::allocator<graphql::taraxa::Account> >::construct<graphql::taraxa::Account, std::shared_ptr<taraxa::final_chain::FinalChain> const&, dev::FixedHash<20u> const&> (
    __p=0x7f80396572e0, __args=..., __a=..., __args=...) at /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:518
#12 std::_Sp_counted_ptr_inplace<graphql::taraxa::Account, std::allocator<graphql::taraxa::Account>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<std::shared_ptr<taraxa::final_chain::FinalChain> const&, dev::FixedHash<20u> const&> (this=0x7f80396572d0, __args=..., __a=..., __args=...) at /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:519
#13 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<graphql::taraxa::Account, std::allocator<graphql::taraxa::Account>, std::shared_ptr<taraxa::final_chain::FinalChain> const&, dev::FixedHash<20u> const&> (
    this=0x7f806dfef4e8, __p=@0x7f806dfef4e0: 0x0, __args=..., __args=..., __a=...) at /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:651
#14 std::__shared_ptr<graphql::taraxa::Account, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<graphql::taraxa::Account>, std::shared_ptr<taraxa::final_chain::FinalChain> const&, dev::FixedHash<20u> const&> (
    this=0x7f806dfef4e0, __args=..., __args=..., __tag=...) at /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1342
#15 std::shared_ptr<graphql::taraxa::Account>::shared_ptr<std::allocator<graphql::taraxa::Account>, std::shared_ptr<taraxa::final_chain::FinalChain> const&, dev::FixedHash<20u> const&> (this=0x7f806dfef4e0, __args=..., 
    __args=..., __tag=...) at /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr.h:409
#16 std::allocate_shared<graphql::taraxa::Account, std::allocator<graphql::taraxa::Account>, std::shared_ptr<taraxa::final_chain::FinalChain> const&, dev::FixedHash<20u> const&> (__args=..., __args=..., __a=...)
    at /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr.h:862
#17 std::make_shared<graphql::taraxa::Account, std::shared_ptr<taraxa::final_chain::FinalChain> const&, dev::FixedHash<20u> const&> (__args=..., __args=...)
    at /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr.h:878
#18 graphql::taraxa::DagBlock::getAuthor (this=<optimized out>) at /opt/taraxa/libraries/core_libs/network/graphql/src/types/dag_block.cpp:56
#19 0x00007f80d17ee714 in graphql::taraxa::object::DagBlock::Model<graphql::taraxa::DagBlock>::getAuthor (this=<optimized out>, params=...) at /opt/taraxa/libraries/core_libs/network/graphql/gen/DagBlockObject.h:283
#20 0x00007f80d196354a in graphql::taraxa::object::DagBlock::resolveAuthor (this=0x7f803ae62a00, params=...) at /opt/taraxa/libraries/core_libs/network/graphql/gen/DagBlockObject.cpp:120
#21 0x00007f80d196902c in graphql::taraxa::object::DagBlock::getResolvers() const::$_5::operator()(graphql::service::ResolverParams&&) const (params=..., this=<optimized out>)
    at /opt/taraxa/libraries/core_libs/network/graphql/gen/DagBlockObject.cpp:46
#22 std::__invoke_impl<graphql::internal::Awaitable<graphql::service::ResolverResult>, graphql::taraxa::object::DagBlock::getResolvers() const::$_5&, graphql::service::ResolverParams>(std::__invoke_other, graphql::taraxa::object::DagBlock::getResolvers() const::$_5&, graphql::service::ResolverParams&&) (__args=..., __f=...) at /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
#23 std::__invoke_r<graphql::internal::Awaitable<graphql::service::ResolverResult>, graphql::taraxa::object::DagBlock::getResolvers() const::$_5&, graphql::service::ResolverParams>(graphql::taraxa::object::DagBlock::getResolvers() const::$_5&, graphql::service::ResolverParams&&) (__args=..., __fn=...) at /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:114
#24 std::_Function_handler<graphql::internal::Awaitable<graphql::service::ResolverResult> (graphql::service::ResolverParams&&), graphql::taraxa::object::DagBlock::getResolvers() const::$_5>::_M_invoke(std::_Any_data const&, graphql::service::ResolverParams&&) (__functor=..., __args=...) at /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:290
#25 0x00007f80cfdce5bc in std::function<graphql::internal::Awaitable<graphql::service::ResolverResult> (graphql::service::ResolverParams&&)>::operator()(graphql::service::ResolverParams&&) const (__args=..., this=<optimized out>)
    at /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:590
#26 graphql::service::SelectionVisitor::visitField (this=this@entry=0x7f803a873dc8, field=...) at /opt/taraxa/cmake-docker-build-debug/_deps/cppgraphqlgen-src/src/GraphQLService.cpp:1039
#27 0x00007f80cfdcc55b in graphql::service::SelectionVisitor::visit (this=0x7f803a873dc8, selection=...) at /opt/taraxa/cmake-docker-build-debug/_deps/cppgraphqlgen-src/src/GraphQLService.cpp:938
#28 graphql::service::Object::resolve (this=0x7f803ae62a00, selectionSetParams=..., selection=..., fragments=..., variables=...) at /opt/taraxa/cmake-docker-build-debug/_deps/cppgraphqlgen-src/src/GraphQLService.cpp:1212
#29 0x00007f80cfdcc04b in graphql::service::Result<graphql::service::Object>::convert (result=..., params=...) at /opt/taraxa/cmake-docker-build-debug/_deps/cppgraphqlgen-src/src/GraphQLService.cpp:802
#30 0x00007f80d1994124 in graphql::service::(anonymous namespace)::ModifiedResult<graphql::taraxa::object::DagBlock>::convert<(graphql::service::TypeModifier)0> (result=..., params=...)
    at /opt/taraxa/cmake-docker-build-debug/_deps/cppgraphqlgen-src/src/../include/graphqlservice/GraphQLService.h:1015
#31 0x00007f80d19883f0 in graphql::service::(anonymous namespace)::ModifiedResult<graphql::taraxa::object::DagBlock>::convert<(graphql::service::TypeModifier)1> (result=..., params=...)
    at /opt/taraxa/cmake-docker-build-debug/_deps/cppgraphqlgen-src/src/../include/graphqlservice/GraphQLService.h:1049
#32 0x00007f80d198ab37 in graphql::service::(anonymous namespace)::ModifiedResult<graphql::taraxa::object::DagBlock>::convert<(graphql::service::TypeModifier)2, (graphql::service::TypeModifier)1> (result=..., params=...)
    at /opt/taraxa/cmake-docker-build-debug/_deps/cppgraphqlgen-src/src/../include/graphqlservice/GraphQLService.h:1141
#33 0x00007f80d198a63b in graphql::taraxa::object::Query::resolvePeriodDagBlocks (this=<optimized out>, params=...) at /opt/taraxa/libraries/core_libs/network/graphql/gen/QueryObject.cpp:183
#34 0x00007f80d199255c in graphql::taraxa::object::Query::getResolvers() const::$_13::operator()(graphql::service::ResolverParams&&) const (params=..., this=<optimized out>)
    at /opt/taraxa/libraries/core_libs/network/graphql/gen/QueryObject.cpp:60
#35 std::__invoke_impl<graphql::internal::Awaitable<graphql::service::ResolverResult>, graphql::taraxa::object::Query::getResolvers() const::$_13&, graphql::service::ResolverParams>(std::__invoke_other, graphql::taraxa::object::Query::getResolvers() const::$_13&, graphql::service::ResolverParams&&) (__args=..., __f=...) at /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
#36 std::__invoke_r<graphql::internal::Awaitable<graphql::service::ResolverResult>, graphql::taraxa::object::Query::getResolvers() const::$_13&, graphql::service::ResolverParams>(graphql::taraxa::object::Query::getResolvers() const::$_13&, graphql::service::ResolverParams&&) (__args=..., __fn=...) at /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:114
--Type <RET> for more, q to quit, c to continue without paging--
#37 std::_Function_handler<graphql::internal::Awaitable<graphql::service::ResolverResult> (graphql::service::ResolverParams&&), graphql::taraxa::object::Query::getResolvers() const::$_13>::_M_invoke(std::_Any_data const&, graphql::service::ResolverParams&&) (__functor=..., __args=...) at /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:290
#38 0x00007f80cfdce5bc in std::function<graphql::internal::Awaitable<graphql::service::ResolverResult> (graphql::service::ResolverParams&&)>::operator()(graphql::service::ResolverParams&&) const (__args=..., this=<optimized out>)
    at /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:590
#39 graphql::service::SelectionVisitor::visitField (this=this@entry=0x7f803ad9f0f8, field=...) at /opt/taraxa/cmake-docker-build-debug/_deps/cppgraphqlgen-src/src/GraphQLService.cpp:1039
#40 0x00007f80cfdcc55b in graphql::service::SelectionVisitor::visit (this=0x7f803ad9f0f8, selection=...) at /opt/taraxa/cmake-docker-build-debug/_deps/cppgraphqlgen-src/src/GraphQLService.cpp:938
#41 graphql::service::Object::resolve (this=0x55d1f6e66200, selectionSetParams=..., selection=..., fragments=..., variables=...) at /opt/taraxa/cmake-docker-build-debug/_deps/cppgraphqlgen-src/src/GraphQLService.cpp:1212
#42 0x00007f80cfdd03fd in graphql::service::OperationDefinitionVisitor::visit (this=this@entry=0x7f803a506ab8, operationType=..., operationDefinition=...)
    at /opt/taraxa/cmake-docker-build-debug/_deps/cppgraphqlgen-src/src/GraphQLService.cpp:1437
#43 0x00007f80cfdd2438 in graphql::service::Request::resolve (this=<optimized out>, params=...) at /opt/taraxa/cmake-docker-build-debug/_deps/cppgraphqlgen-src/src/GraphQLService.cpp:1803
#44 0x00007f80d17e3176 in taraxa::net::GraphQlHttpProcessor::process (this=0x0, request=...) at /opt/taraxa/libraries/core_libs/network/graphql/src/http_processor.cpp:68
#45 0x00007f80d181a2be in taraxa::net::HttpConnection::read()::$_1::operator()(boost::system::error_code const&, unsigned long) const (this=<optimized out>, ec=...)
    at /opt/taraxa/libraries/core_libs/network/src/http_server.cpp:89
#46 boost::beast::async_base<taraxa::net::HttpConnection::read()::$_1, boost::asio::any_io_executor, std::allocator<void> >::complete_now<boost::system::error_code&, unsigned long&>(boost::system::error_code&, unsigned long&) (
    this=<optimized out>, args=<optimized out>, args=<optimized out>) at /root/.conan/data/boost/1.80.0/_/_/package/a0571de9d55eb3f36817851d86e396a221942df9/include/boost/beast/core/async_base.hpp:392
#47 boost::beast::http::detail::read_msg_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::beast::basic_flat_buffer<std::allocator<char> >, true, boost::beast::http::basic_string_body<char, std::char_traits<char>, std::allocator<char> >, std::allocator<char>, taraxa::net::HttpConnection::read()::$_1>::operator()(boost::system::error_code, unsigned long) (this=<optimized out>, ec=..., 
    bytes_transferred=<optimized out>) at /root/.conan/data/boost/1.80.0/_/_/package/a0571de9d55eb3f36817851d86e396a221942df9/include/boost/beast/http/impl/read.hpp:114
#48 boost::asio::detail::composed_op<boost::beast::http::detail::read_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::beast::basic_flat_buffer<std::allocator<char> >, true, boost::beast::http::detail::parser_is_done>, boost::asio::detail::composed_work<void (boost::asio::any_io_executor)>, boost::beast::http::detail::read_msg_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::beast::basic_flat_buffer<std::allocator<char> >, true, boost::beast::http::basic_string_body<char, std::char_traits<char>, std::allocator<char> >, std::allocator<char>, taraxa::net::HttpConnection::read()::$_1>, void (boost::system::error_code, unsigned long)>::complete(boost::system::error_code, unsigned long) (this=0x7f806dff1db8, args=<optimized out>, args=<optimized out>)
    at /root/.conan/data/boost/1.80.0/_/_/package/a0571de9d55eb3f36817851d86e396a221942df9/include/boost/asio/compose.hpp:380
#49 boost::beast::http::detail::read_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::beast::basic_flat_buffer<std::allocator<char> >, true, boost::beast::http::detail::parser_is_done>::operator()<boost::asio::detail::composed_op<boost::beast::http::detail::read_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::beast::basic_flat_buffer<std::allocator<char> >, true, boost::beast::http::detail::parser_is_done>, boost::asio::detail::composed_work<void (boost::asio::any_io_executor)>, boost::beast::http::detail::read_msg_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::beast::basic_flat_buffer<std::allocator<char> >, true, boost::beast::http::basic_string_body<char, std::char_traits<char>, std::allocator<char> >, std::allocator<char>, taraxa::net::HttpConnection::read()::$_1>, void (boost::system::error_code, unsigned long)> >(boost::asio::detail::composed_op<boost::beast::http::detail::read_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::beast::basic_flat_buffer<std::allocator<char> >, true, boost::beast::http::detail::parser_is_done>, boost::asio::detail::composed_work<void (boost::asio::any_io_executor)>, boost::beast::http::detail::read_msg_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::beast::basic_flat_buffer<std::allocator<char> >, true, boost::beast::http::basic_string_body<char, std::char_traits<char>, std::allocator<char> >, std::allocator<char>, taraxa::net::HttpConnection::read()::$_1>, void (boost::system::error_code, unsigned long)>&, boost::system::error_code, unsigned long) (this=0x7f806dff1db8, self=..., ec=..., bytes_transferred=<optimized out>)
    at /root/.conan/data/boost/1.80.0/_/_/package/a0571de9d55eb3f36817851d86e396a221942df9/include/boost/beast/http/impl/read.hpp:307
#50 0x00007f80d181ba9d in boost::asio::detail::composed_op<boost::beast::http::detail::read_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::beast::basic_flat_buffer<std::allocator<char> >, true, boost::beast::http::detail::parser_is_done>, boost::asio::detail::composed_work<void (boost::asio::any_io_executor)>, boost::beast::http::detail::read_msg_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::beast::basic_flat_buffer<std::allocator<char> >, true, boost::beast::http::basic_string_body<char, std::char_traits<char>, std::allocator<char> >, std::allocator<char>, taraxa::net::HttpConnection::read()::$_1>, void (boost::system::error_code, unsigned long)>::operator()<boost::system::error_code, unsigned long>(boost::system::error_code&&, unsigned long&&) (this=0x7, this@entry=0x7f806dff17a0, t=<optimized out>, 
    t=<optimized out>) at /root/.conan/data/boost/1.80.0/_/_/package/a0571de9d55eb3f36817851d86e396a221942df9/include/boost/asio/compose.hpp:374
#51 boost::asio::detail::composed_op<boost::beast::http::detail::read_some_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::beast::basic_flat_buffer<std::allocator<char> >, true>, boost::asio::detail::composed_work<void (boost::asio::any_io_executor)>, boost::asio::detail::composed_op<boost::beast::http::detail::read_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::beast::basic_flat_buffer<std::allocator<char> >, true, boost::beast::http::detail::parser_is_done>, boost::asio::detail::composed_work<void (boost::asio::any_io_executor)>, boost::beast::http::detail::read_msg_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::beast::basic_flat_buffer<std::allocator<char> >, true, boost::beast::http::basic_string_body<char, std::char_traits<char>, std::allocator<char> >, std::allocator<char>, taraxa::net::HttpConnection::read()::$_1>, void (boost::system::error_code, unsigned long)>, void (boost::system::error_code, unsigned long)>::complete(boost::system::error_code, unsigned long) (
    this=0x7f806dff1d50, args=..., args=...) at /root/.conan/data/boost/1.80.0/_/_/package/a0571de9d55eb3f36817851d86e396a221942df9/include/boost/asio/compose.hpp:380

```


## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
