### PR TITLE
fix: incorrect binary for rpc_test in ctest

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -87,7 +87,7 @@ add_test(gas_pricer_test ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/gas_pricer_test)
 
 add_executable(rpc_test rpc_test.cpp)
 target_link_libraries(rpc_test test_util)
-add_test(rpc_test ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/gas_pricer_test)
+add_test(rpc_test ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/rpc_test)
 
 add_custom_target(py_test)
 

--- a/tests/rpc_test.cpp
+++ b/tests/rpc_test.cpp
@@ -24,9 +24,9 @@ TEST_F(RPCTest, eth_estimateGas) {
   {
     Json::Value trx(Json::objectValue);
     trx["data"] = samples::greeter_contract_code;
-    EXPECT_EQ(eth_json_rpc->eth_estimateGas(trx), "0x5ca85");
+    EXPECT_EQ(eth_json_rpc->eth_estimateGas(trx), "0x5ccc5");
     trx["from"] = from;
-    EXPECT_EQ(eth_json_rpc->eth_estimateGas(trx), "0x5ca85");
+    EXPECT_EQ(eth_json_rpc->eth_estimateGas(trx), "0x5ccc5");
   }
 
   // Contract creation with value
@@ -34,7 +34,7 @@ TEST_F(RPCTest, eth_estimateGas) {
     Json::Value trx(Json::objectValue);
     trx["value"] = 1;
     trx["data"] = samples::greeter_contract_code;
-    EXPECT_EQ(eth_json_rpc->eth_estimateGas(trx), "0x5ca85");
+    EXPECT_EQ(eth_json_rpc->eth_estimateGas(trx), "0x5ccc5");
   }
 
   // Simple transfer estimations with author + without author


### PR DESCRIPTION
Fix incorrect binary in ctest for `rpc_test`. So we didn't executed this at all during ctest runs 