### PR TITLE
fix: peer chain size

### DIFF
--- a/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/vote_packet_handler.cpp
@@ -70,7 +70,7 @@ void VotePacketHandler::process(const PacketData &packet_data, const std::shared
   onNewPbftVote(vote, pbft_block);
 
   // Update peer's max chain size
-  if (peer_chain_size.has_value() && *peer_chain_size > peer->pbft_chain_size_) {
+  if (peer_chain_size.has_value() && vote->getVoter() == peer->getId() && *peer_chain_size > peer->pbft_chain_size_) {
     peer->pbft_chain_size_ = *peer_chain_size;
   }
 }


### PR DESCRIPTION
Vote with the proposed pbft block might be gossiped over nodes that might not be fully synced. We can not assume the chain size from the proposed block to be the same as the peer that sent it. Only exception is if the peer that is sending it is the actual voter.

This might have caused pbft syncing issues related to the issue this PR is linked to