### PR TITLE
chore: vote sync error log remove

### DIFF
--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -197,23 +197,19 @@ class VoteManager {
    * @param period
    * @param round
    * @param type
-   * @param peer_filter if specified, get only votes that are unknown for peer
    * @return vector of votes if 2t+1 voted block votes found, otherwise empty vector
    */
-  std::vector<std::shared_ptr<Vote>> getTwoTPlusOneVotedBlockVotes(
-      PbftPeriod period, PbftRound round, TwoTPlusOneVotedBlockType type,
-      const std::shared_ptr<network::tarcap::TaraxaPeer>& peer_filter = {}) const;
+  std::vector<std::shared_ptr<Vote>> getTwoTPlusOneVotedBlockVotes(PbftPeriod period, PbftRound round,
+                                                                   TwoTPlusOneVotedBlockType type) const;
 
   /**
    * Get all 2t+1 voted block next votes(both for null block as well as specific block) for specific period and round
    *
    * @param period
    * @param round
-   * @param peer_filter if specified, get only votes that are unknown for peer
    * @return vector of next votes if 2t+1 voted block votes found, otherwise empty vector
    */
-  std::vector<std::shared_ptr<Vote>> getAllTwoTPlusOneNextVotes(
-      PbftPeriod period, PbftRound round, const std::shared_ptr<network::tarcap::TaraxaPeer>& peer_filter = {}) const;
+  std::vector<std::shared_ptr<Vote>> getAllTwoTPlusOneNextVotes(PbftPeriod period, PbftRound round) const;
 
   /**
    * @brief Sets current pbft period & round. It also checks if we dont alredy have 2t+1 vote bundles(pf any type) for

--- a/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
+++ b/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
@@ -871,9 +871,8 @@ std::optional<blk_hash_t> VoteManager::getTwoTPlusOneVotedBlock(PbftPeriod perio
   return two_t_plus_one_voted_block_it->second.first;
 }
 
-std::vector<std::shared_ptr<Vote>> VoteManager::getTwoTPlusOneVotedBlockVotes(
-    PbftPeriod period, PbftRound round, TwoTPlusOneVotedBlockType type,
-    const std::shared_ptr<network::tarcap::TaraxaPeer>& peer_filter) const {
+std::vector<std::shared_ptr<Vote>> VoteManager::getTwoTPlusOneVotedBlockVotes(PbftPeriod period, PbftRound round,
+                                                                              TwoTPlusOneVotedBlockType type) const {
   std::shared_lock lock(verified_votes_access_);
 
   const auto found_period_it = verified_votes_.find(period);
@@ -909,23 +908,17 @@ std::vector<std::shared_ptr<Vote>> VoteManager::getTwoTPlusOneVotedBlockVotes(
   std::vector<std::shared_ptr<Vote>> votes;
   votes.reserve(found_verified_votes_it->second.second.size());
   for (const auto& vote : found_verified_votes_it->second.second) {
-    if (peer_filter && peer_filter->isVoteKnown(vote.first)) {
-      continue;
-    }
-
     votes.push_back(vote.second);
   }
 
   return votes;
 }
 
-std::vector<std::shared_ptr<Vote>> VoteManager::getAllTwoTPlusOneNextVotes(
-    PbftPeriod period, PbftRound round, const std::shared_ptr<network::tarcap::TaraxaPeer>& peer_filter) const {
-  auto next_votes =
-      getTwoTPlusOneVotedBlockVotes(period, round, TwoTPlusOneVotedBlockType::NextVotedBlock, peer_filter);
+std::vector<std::shared_ptr<Vote>> VoteManager::getAllTwoTPlusOneNextVotes(PbftPeriod period, PbftRound round) const {
+  auto next_votes = getTwoTPlusOneVotedBlockVotes(period, round, TwoTPlusOneVotedBlockType::NextVotedBlock);
 
   auto null_block_next_vote =
-      getTwoTPlusOneVotedBlockVotes(period, round, TwoTPlusOneVotedBlockType::NextVotedNullBlock, peer_filter);
+      getTwoTPlusOneVotedBlockVotes(period, round, TwoTPlusOneVotedBlockType::NextVotedNullBlock);
   if (!null_block_next_vote.empty()) {
     next_votes.reserve(next_votes.size() + null_block_next_vote.size());
     next_votes.insert(next_votes.end(), std::make_move_iterator(null_block_next_vote.begin()),

--- a/tests/vote_test.cpp
+++ b/tests/vote_test.cpp
@@ -168,7 +168,6 @@ TEST_F(VoteTest, vote_broadcast) {
     WAIT_EXPECT_EQ(ctx, vote_mgr2->getVerifiedVotesSize(), 1)
     WAIT_EXPECT_EQ(ctx, vote_mgr3->getVerifiedVotesSize(), 1)
   });
-  EXPECT_EQ(vote_mgr1->getVerifiedVotesSize(), 0);
 }
 
 TEST_F(VoteTest, two_t_plus_one_votes) {


### PR DESCRIPTION
On testnet these error logs often appear:
Taraxa_N1_02242023_053224_00045.log:0x00007ff33affd640 18551e35… GET_NEXT_VOTES_SYNC_PH [2023-02-24 06:49:07.223596] ERROR: No next votes returned for period 76723, round 1
Taraxa_N1_02242023_053224_00045.log:0x00007ff342ffd640 18551e35… GET_NEXT_VOTES_SYNC_PH [2023-02-24 06:49:07.393348] ERROR: No next votes returned for period 76723, round 1

This can happen when vote sync is done for votes which might have just been gossiped. Now we log an error only if votes are missing but if they are already known to peer only a debug log is written.

The change in vote_test was done because this check was never correct to begin with and test could fail. If node 0 is sending vote to nodes 1 and 2, there is no guarantee that the node 0 will not get this vote in this scenario:
- node 0 sends the vote to node 1
- node 1 will not send it back to node 0 but it sends it to node 2
- node 2 will send the vote to node 0 if it receives it from node 1 sooner than from node 0
