### PR TITLE
chore: optimize rewards votes handling

### DIFF
--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -96,13 +96,16 @@ class VoteManager {
   std::optional<PbftRound> determineNewRound(PbftPeriod current_pbft_period, PbftRound current_pbft_round);
 
   /**
-   * @brief Replace current reward votes info with new period, round & block hash based on vote
+   * @brief Replace current reward votes with new period, round & block hash based on vote
    *
    * @param period
    * @param round
+   * @param step
    * @param block_hash
+   * @param batch
    */
-  void resetRewardVotesInfo(PbftPeriod period, PbftRound round, const blk_hash_t& block_hash);
+  void resetRewardVotes(PbftPeriod period, PbftRound round, PbftStep step, const blk_hash_t& block_hash,
+                        DbStorage::Batch& batch);
 
   /**
    * @brief Check reward votes for specified pbft block
@@ -115,11 +118,11 @@ class VoteManager {
                                                                        bool copy_votes);
 
   /**
-   * @brief Get reward votes from reward_votes_ with the round during which was the previous block pushed
+   * @brief Get reward votes with the round during which was the previous block pushed
    *
    * @return vector of reward votes
    */
-  std::vector<std::shared_ptr<Vote>> getProposeRewardVotes();
+  std::vector<std::shared_ptr<Vote>> getRewardVotes();
 
   /**
    * @brief Get current reward votes pbft block period
@@ -280,6 +283,7 @@ class VoteManager {
   blk_hash_t reward_votes_block_hash_;
   PbftRound reward_votes_period_;
   PbftRound reward_votes_round_;
+  std::vector<vote_hash_t> extra_reward_votes_;
   mutable std::shared_mutex reward_votes_info_mutex_;
 
   // Cache for current 2T+1 - <Vote type, <period, two_t_plus_one for period>>

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -555,7 +555,7 @@ void PbftManager::broadcastVotes(bool rebroadcast) {
   }
 
   // Broadcast reward votes - previous round 2t+1 cert votes
-  auto reward_votes = vote_mgr_->getProposeRewardVotes();
+  auto reward_votes = vote_mgr_->getRewardVotes();
   if (!reward_votes.empty()) {
     LOG(log_dg_) << "Broadcast propose reward votes for period " << period << ", round " << round;
     net->getSpecificHandler<network::tarcap::VotesSyncPacketHandler>()->onNewPbftVotesBundle(std::move(reward_votes),
@@ -1013,7 +1013,7 @@ std::optional<std::pair<std::shared_ptr<PbftBlock>, std::vector<std::shared_ptr<
     const blk_hash_t &order_hash) {
   // Reward votes should only include those reward votes with the same round as the round last pbft block was pushed
   // into chain
-  auto reward_votes = vote_mgr_->getProposeRewardVotes();
+  auto reward_votes = vote_mgr_->getRewardVotes();
   if (propose_period > 1) [[likely]] {
     assert(!reward_votes.empty());
     if (reward_votes[0]->getPeriod() != propose_period - 1) {
@@ -1511,8 +1511,8 @@ bool PbftManager::pushPbftBlock_(PeriodData &&period_data, std::vector<std::shar
   db_->savePeriodData(period_data, batch);
 
   // Replace current reward votes
-  vote_mgr_->resetRewardVotesInfo(cert_votes[0]->getPeriod(), cert_votes[0]->getRound(), cert_votes[0]->getBlockHash());
-  db_->replaceRewardVotes(cert_votes, batch);
+  vote_mgr_->resetRewardVotes(cert_votes[0]->getPeriod(), cert_votes[0]->getRound(), cert_votes[0]->getStep(),
+                              cert_votes[0]->getBlockHash(), batch);
 
   // pass pbft with dag blocks and transactions to adjust difficulty
   if (period_data.pbft_blk->getPivotDagBlockHash() != kNullBlockHash) {

--- a/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
+++ b/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
@@ -32,10 +32,18 @@ VoteManager::VoteManager(const addr_t& node_addr, const PbftConfig& pbft_config,
   auto db_votes = db_->getAllTwoTPlusOneVotes();
 
   auto loadVotesFromDb = [this](const std::vector<std::shared_ptr<Vote>>& votes) {
+    bool reward_votes_info_set = false;
     for (const auto& vote : votes) {
       // Check if votes are unique per round, step & voter
       if (!isUniqueVote(vote).first) {
         continue;
+      }
+
+      if (!reward_votes_info_set && vote->getType() == PbftVoteTypes::cert_vote) {
+        reward_votes_info_set = true;
+        reward_votes_block_hash_ = vote->getBlockHash();
+        reward_votes_period_ = vote->getPeriod();
+        reward_votes_round_ = vote->getRound();
       }
 
       addVerifiedVote(vote);
@@ -45,11 +53,9 @@ VoteManager::VoteManager(const addr_t& node_addr, const PbftConfig& pbft_config,
 
   loadVotesFromDb(db_->getAllTwoTPlusOneVotes());
   loadVotesFromDb(db_->getOwnVerifiedVotes());
-
-  if (const auto reward_votes = db_->getRewardVotes(); !reward_votes.empty()) {
-    loadVotesFromDb(reward_votes);
-    resetRewardVotesInfo(reward_votes[0]->getPeriod(), reward_votes[0]->getRound(), reward_votes[0]->getBlockHash());
-  }
+  auto reward_votes = db_->getRewardVotes();
+  for (const auto& vote : reward_votes) extra_reward_votes_.emplace_back(vote->getHash());
+  loadVotesFromDb(reward_votes);
 }
 
 void VoteManager::setNetwork(std::weak_ptr<Network> network) { network_ = std::move(network); }
@@ -227,9 +233,9 @@ bool VoteManager::addVerifiedVote(const std::shared_ptr<Vote>& vote) {
     LOG(log_nf_) << "Added verified vote: " << hash;
     LOG(log_dg_) << "Added verified vote: " << *vote;
 
-    // Save in db only those reward votes that have the same round as round during which we pushed the block into chain
-    if (is_valid_potential_reward_vote && reward_votes_round_ == vote->getRound()) {
-      db_->saveRewardVote(vote);
+    if (is_valid_potential_reward_vote) {
+      extra_reward_votes_.emplace_back(vote->getHash());
+      db_->saveExtraRewardVote(vote);
     }
 
     const auto total_weight = (found_voted_value_it->second.first += weight);
@@ -279,7 +285,9 @@ bool VoteManager::addVerifiedVote(const std::shared_ptr<Vote>& vote) {
           {two_plus_one_voted_block_type, std::make_pair(vote->getBlockHash(), vote->getStep())});
 
       // Save only current pbft period & round 2t+1 votes bundles into db
-      if (vote->getPeriod() == current_pbft_period_ && vote->getRound() == current_pbft_round_) {
+      // Cert votes are saved once the pbft block is pushed in the chain
+      if (vote->getType() != PbftVoteTypes::cert_vote && vote->getPeriod() == current_pbft_period_ &&
+          vote->getRound() == current_pbft_round_) {
         std::vector<std::shared_ptr<Vote>> votes;
         votes.reserve(found_voted_value_it->second.second.size());
         for (const auto& tmp_vote : found_voted_value_it->second.second) {
@@ -541,14 +549,63 @@ PbftPeriod VoteManager::getRewardVotesPbftBlockPeriod() {
   return reward_votes_period_;
 }
 
-void VoteManager::resetRewardVotesInfo(PbftPeriod period, PbftRound round, const blk_hash_t& block_hash) {
+void VoteManager::resetRewardVotes(PbftPeriod period, PbftRound round, PbftStep step, const blk_hash_t& block_hash,
+                                   DbStorage::Batch& batch) {
+  // Save 2t+1 cert votes to database, remove old reward votes
   {
     std::scoped_lock lock(reward_votes_info_mutex_);
-
     reward_votes_block_hash_ = block_hash;
     reward_votes_period_ = period;
     reward_votes_round_ = round;
   }
+
+  std::scoped_lock lock(verified_votes_access_);
+  auto found_period_it = verified_votes_.find(period);
+  if (found_period_it == verified_votes_.end()) {
+    LOG(log_er_) << "resetRewardVotes missing period";
+    assert(false);
+    return;
+  }
+  auto found_round_it = found_period_it->second.find(round);
+  if (found_round_it == found_period_it->second.end()) {
+    LOG(log_er_) << "resetRewardVotes missing round" << round;
+    assert(false);
+    return;
+  }
+  auto found_step_it = found_round_it->second.step_votes.find(step);
+  if (found_step_it == found_round_it->second.step_votes.end()) {
+    LOG(log_er_) << "resetRewardVotes missing step" << step;
+    assert(false);
+    return;
+  }
+  auto found_two_t_plus_one_voted_block =
+      found_round_it->second.two_t_plus_one_voted_blocks_.find(TwoTPlusOneVotedBlockType::CertVotedBlock);
+  if (found_two_t_plus_one_voted_block == found_round_it->second.two_t_plus_one_voted_blocks_.end()) {
+    LOG(log_er_) << "resetRewardVotes missing cert voted block";
+    assert(false);
+    return;
+  }
+  if (found_two_t_plus_one_voted_block->second.first != block_hash) {
+    LOG(log_er_) << "resetRewardVotes incorrect block " << found_two_t_plus_one_voted_block->second.first
+                 << " expected " << block_hash;
+    assert(false);
+    return;
+  }
+  auto found_voted_value_it = found_step_it->second.votes.find(block_hash);
+  if (found_voted_value_it == found_step_it->second.votes.end()) {
+    LOG(log_er_) << "resetRewardVotes missing vote block " << block_hash;
+    assert(false);
+    return;
+  }
+  std::vector<std::shared_ptr<Vote>> votes;
+  votes.reserve(found_voted_value_it->second.second.size());
+  for (const auto& tmp_vote : found_voted_value_it->second.second) {
+    votes.push_back(tmp_vote.second);
+  }
+
+  db_->replaceTwoTPlusOneVotesToBatch(TwoTPlusOneVotedBlockType::CertVotedBlock, votes, batch);
+  db_->removeExtraRewardVotes(extra_reward_votes_, batch);
+  extra_reward_votes_.clear();
 
   LOG(log_dg_) << "Reward votes info reset to: block_hash: " << block_hash << ", period: " << period
                << ", round: " << round;
@@ -556,7 +613,6 @@ void VoteManager::resetRewardVotesInfo(PbftPeriod period, PbftRound round, const
 
 bool VoteManager::isValidRewardVote(const std::shared_ptr<Vote>& vote) const {
   std::shared_lock lock(reward_votes_info_mutex_);
-
   if (vote->getType() != PbftVoteTypes::cert_vote) {
     LOG(log_tr_) << "Invalid reward vote: type " << static_cast<uint64_t>(vote->getType())
                  << " is different from cert type";
@@ -637,19 +693,27 @@ std::pair<bool, std::vector<std::shared_ptr<Vote>>> VoteManager::checkRewardVote
     }
   };
 
-  std::shared_lock reward_votes_info_lock(reward_votes_info_mutex_);
+  blk_hash_t reward_votes_block_hash;
+  PbftRound reward_votes_period;
+  PbftRound reward_votes_round;
+  {
+    std::shared_lock reward_votes_info_lock(reward_votes_info_mutex_);
+    reward_votes_block_hash = reward_votes_block_hash_;
+    reward_votes_period = reward_votes_period_;
+    reward_votes_round = reward_votes_round_;
+  }
   std::shared_lock verified_votes_lock(verified_votes_access_);
 
-  const auto found_period_it = verified_votes_.find(reward_votes_period_);
+  const auto found_period_it = verified_votes_.find(reward_votes_period);
   if (found_period_it == verified_votes_.end()) {
-    LOG(log_er_) << "No reward votes found for period " << reward_votes_period_;
+    LOG(log_er_) << "No reward votes found for period " << reward_votes_period;
     assert(false);
     return {false, {}};
   }
 
-  const auto found_round_it = found_period_it->second.find(reward_votes_round_);
+  const auto found_round_it = found_period_it->second.find(reward_votes_round);
   if (found_round_it == found_period_it->second.end()) {
-    LOG(log_er_) << "No reward votes found for round " << reward_votes_round_;
+    LOG(log_er_) << "No reward votes found for round " << reward_votes_round;
     assert(false);
     return {false, {}};
   }
@@ -657,7 +721,7 @@ std::pair<bool, std::vector<std::shared_ptr<Vote>>> VoteManager::checkRewardVote
   const auto reward_votes_hashes = pbft_block->getRewardVotes();
 
   // Most of the time we should get the reward votes based on reward_votes_period_ and reward_votes_round_
-  auto reward_votes = getRewardVotes(found_round_it, reward_votes_hashes, reward_votes_block_hash_, copy_votes);
+  auto reward_votes = getRewardVotes(found_round_it, reward_votes_hashes, reward_votes_block_hash, copy_votes);
   if (reward_votes.first) [[likely]] {
     return {true, std::move(reward_votes.second)};
   }
@@ -666,13 +730,13 @@ std::pair<bool, std::vector<std::shared_ptr<Vote>>> VoteManager::checkRewardVote
   // and when they included the reward votes in new block, these votes have different round than what saved in
   // reward_votes_round_ -> therefore we have to iterate over all rounds and find the correct round
   for (auto round_it = found_period_it->second.begin(); round_it != found_period_it->second.end(); round_it++) {
-    const auto tmp_reward_votes = getRewardVotes(round_it, reward_votes_hashes, reward_votes_block_hash_, copy_votes);
+    const auto tmp_reward_votes = getRewardVotes(round_it, reward_votes_hashes, reward_votes_block_hash, copy_votes);
     if (!tmp_reward_votes.first) {
       LOG(log_dg_) << "No (or not enough) reward votes found for block " << pbft_block->getBlockHash()
                    << ", period: " << pbft_block->getPeriod()
                    << ", prev. block hash: " << pbft_block->getPrevBlockHash()
-                   << ", reward_votes_period_: " << reward_votes_period_ << ", reward_votes_round_: " << round_it->first
-                   << ", reward_votes_block_hash_: " << reward_votes_block_hash_;
+                   << ", reward_votes_period: " << reward_votes_period << ", reward_votes_round_: " << round_it->first
+                   << ", reward_votes_block_hash: " << reward_votes_block_hash;
       continue;
     }
 
@@ -681,19 +745,28 @@ std::pair<bool, std::vector<std::shared_ptr<Vote>>> VoteManager::checkRewardVote
 
   LOG(log_er_) << "No (or not enough) reward votes found for block " << pbft_block->getBlockHash()
                << ", period: " << pbft_block->getPeriod() << ", prev. block hash: " << pbft_block->getPrevBlockHash()
-               << ", reward_votes_period_: " << reward_votes_period_ << ", reward_votes_round_: " << reward_votes_round_
-               << ", reward_votes_block_hash_: " << reward_votes_block_hash_;
+               << ", reward_votes_period: " << reward_votes_period << ", reward_votes_round_: " << reward_votes_round
+               << ", reward_votes_block_hash: " << reward_votes_block_hash;
   return {false, {}};
 }
 
-std::vector<std::shared_ptr<Vote>> VoteManager::getProposeRewardVotes() {
-  std::shared_lock lock(reward_votes_info_mutex_);
-  const auto reward_votes = getTwoTPlusOneVotedBlockVotes(reward_votes_period_, reward_votes_round_,
-                                                          TwoTPlusOneVotedBlockType::CertVotedBlock);
+std::vector<std::shared_ptr<Vote>> VoteManager::getRewardVotes() {
+  blk_hash_t reward_votes_block_hash;
+  PbftRound reward_votes_period;
+  PbftRound reward_votes_round;
+  {
+    std::shared_lock reward_votes_info_lock(reward_votes_info_mutex_);
+    reward_votes_block_hash = reward_votes_block_hash_;
+    reward_votes_period = reward_votes_period_;
+    reward_votes_round = reward_votes_round_;
+  }
+  std::shared_lock lock(verified_votes_access_);
+  auto reward_votes =
+      getTwoTPlusOneVotedBlockVotes(reward_votes_period, reward_votes_round, TwoTPlusOneVotedBlockType::CertVotedBlock);
 
-  if (!reward_votes.empty() && reward_votes[0]->getBlockHash() != reward_votes_block_hash_) {
+  if (!reward_votes.empty() && reward_votes[0]->getBlockHash() != reward_votes_block_hash) {
     // This should never happen
-    LOG(log_er_) << "Proposal reward votes block hash mismatch. reward_votes_block_hash_ " << reward_votes_block_hash_
+    LOG(log_er_) << "Proposal reward votes block hash mismatch. reward_votes_block_hash " << reward_votes_block_hash
                  << ", reward_votes[0]->getBlockHash() " << reward_votes[0]->getBlockHash();
     assert(false);
     return {};
@@ -904,7 +977,6 @@ std::optional<blk_hash_t> VoteManager::getTwoTPlusOneVotedBlock(PbftPeriod perio
 std::vector<std::shared_ptr<Vote>> VoteManager::getTwoTPlusOneVotedBlockVotes(PbftPeriod period, PbftRound round,
                                                                               TwoTPlusOneVotedBlockType type) const {
   std::shared_lock lock(verified_votes_access_);
-
   const auto found_period_it = verified_votes_.find(period);
   if (found_period_it == verified_votes_.end()) {
     return {};

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_pbft_sync_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_pbft_sync_packet_handler.hpp
@@ -5,6 +5,7 @@
 namespace taraxa {
 class PbftChain;
 class DbStorage;
+class VoteManager;
 }  // namespace taraxa
 
 namespace taraxa::network::tarcap {
@@ -16,7 +17,8 @@ class GetPbftSyncPacketHandler final : public PacketHandler {
   GetPbftSyncPacketHandler(const FullNodeConfig& conf, std::shared_ptr<PeersState> peers_state,
                            std::shared_ptr<TimePeriodPacketsStats> packets_stats,
                            std::shared_ptr<PbftSyncingState> pbft_syncing_state, std::shared_ptr<PbftChain> pbft_chain,
-                           std::shared_ptr<DbStorage> db, const addr_t& node_addr);
+                           std::shared_ptr<VoteManager> vote_mgr, std::shared_ptr<DbStorage> db,
+                           const addr_t& node_addr);
 
   void sendPbftBlocks(dev::p2p::NodeID const& peer_id, PbftPeriod from_period, size_t blocks_to_transfer,
                       bool pbft_chain_synced);
@@ -30,6 +32,7 @@ class GetPbftSyncPacketHandler final : public PacketHandler {
 
   std::shared_ptr<PbftSyncingState> pbft_syncing_state_;
   std::shared_ptr<PbftChain> pbft_chain_;
+  std::shared_ptr<VoteManager> vote_mgr_;
   std::shared_ptr<DbStorage> db_;
 };
 

--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -237,7 +237,7 @@ void TaraxaCapability::registerPacketHandlers(
 
   // TODO there is additional logic, that should be moved outside process function
   packets_handlers_->registerHandler<GetPbftSyncPacketHandler>(kConf, peers_state_, packets_stats, pbft_syncing_state_,
-                                                               pbft_chain, db, node_addr);
+                                                               pbft_chain, vote_mgr, db, node_addr);
 
   packets_handlers_->registerHandler<PbftSyncPacketHandler>(kConf, peers_state_, packets_stats, pbft_syncing_state_,
                                                             pbft_chain, pbft_mgr, dag_mgr, vote_mgr,

--- a/libraries/core_libs/node/src/node.cpp
+++ b/libraries/core_libs/node/src/node.cpp
@@ -347,8 +347,8 @@ void FullNode::rebuildDb() {
   // Read pbft blocks one by one
   PbftPeriod period = 1;
   std::shared_ptr<PeriodData> period_data, next_period_data;
-  std::vector<std::shared_ptr<Vote>> cert_votes;
   while (true) {
+    std::vector<std::shared_ptr<Vote>> cert_votes;
     if (next_period_data != nullptr) {
       period_data = next_period_data;
     } else {
@@ -359,8 +359,11 @@ void FullNode::rebuildDb() {
     auto data = old_db_->getPeriodDataRaw(period + 1);
     if (data.size() == 0) {
       next_period_data = nullptr;
-      // Latest finalized block cert votes are saved in db as reward votes for new blocks
-      cert_votes = old_db_->getRewardVotes();
+      // Latest finalized block cert votes are saved in db as 2t+1 cert votes
+      auto votes = old_db_->getAllTwoTPlusOneVotes();
+      for (auto v : votes) {
+        if (v->getType() == PbftVoteTypes::cert_vote) cert_votes.push_back(v);
+      }
     } else {
       next_period_data = std::make_shared<PeriodData>(std::move(data));
       cert_votes = next_period_data->previous_block_cert_votes;

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -105,7 +105,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
     COLUMN(pbft_head);
     COLUMN(latest_round_own_votes);             // own votes of any type for the latest round
     COLUMN(latest_round_two_t_plus_one_votes);  // 2t+1 votes bundles of any type for the latest round
-    COLUMN(latest_reward_votes);                // extra reward votes on top of 2t+1 cert votes bundle from
+    COLUMN(extra_reward_votes);                 // extra reward votes on top of 2t+1 cert votes bundle from
                                                 // latest_round_two_t_plus_one_votes
     COLUMN(pbft_block_period);
     COLUMN(dag_block_period);
@@ -269,11 +269,13 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
 
   // 2t+1 votes bundles for the latest round
   void replaceTwoTPlusOneVotes(TwoTPlusOneVotedBlockType type, const std::vector<std::shared_ptr<Vote>>& votes);
+  void replaceTwoTPlusOneVotesToBatch(TwoTPlusOneVotedBlockType type, const std::vector<std::shared_ptr<Vote>>& votes,
+                                      Batch& write_batch);
   std::vector<std::shared_ptr<Vote>> getAllTwoTPlusOneVotes();
 
   // Reward votes - cert votes for the latest finalized block
-  void replaceRewardVotes(const std::vector<std::shared_ptr<Vote>>& votes, Batch& write_batch);
-  void saveRewardVote(const std::shared_ptr<Vote>& vote);
+  void removeExtraRewardVotes(const std::vector<vote_hash_t>& votes, Batch& write_batch);
+  void saveExtraRewardVote(const std::shared_ptr<Vote>& vote);
   std::vector<std::shared_ptr<Vote>> getRewardVotes();
 
   // period_pbft_block

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -615,7 +615,7 @@ TEST_F(NetworkTest, node_pbft_sync) {
                         beneficiary, node1->getSecretKey(), {});
   std::vector<std::shared_ptr<Vote>> votes_for_pbft_blk2;
   votes_for_pbft_blk2.emplace_back(
-      node1->getVoteManager()->generateVote(pbft_block2.getBlockHash(), PbftVoteTypes::cert_vote, 2, 2, 3));
+      node1->getVoteManager()->generateVoteWithWeight(pbft_block2.getBlockHash(), PbftVoteTypes::cert_vote, 2, 1, 3));
   std::cout << "Generate 1 vote for second PBFT block" << std::endl;
   // node1 put block2 into pbft chain and store into DB
   // Add cert votes in DB
@@ -629,7 +629,9 @@ TEST_F(NetworkTest, node_pbft_sync) {
   period_data2.transactions.push_back(g_signed_trx_samples[3]);
 
   db1->savePeriodData(period_data2, batch);
-  db1->replaceRewardVotes(votes_for_pbft_blk2, batch);
+  node1->getVoteManager()->addVerifiedVote(votes_for_pbft_blk2[0]);
+  db1->replaceTwoTPlusOneVotesToBatch(TwoTPlusOneVotedBlockType::CertVotedBlock, votes_for_pbft_blk2, batch);
+  node1->getVoteManager()->resetRewardVotes(2, 1, 3, pbft_block2.getBlockHash(), batch);
 
   // Update pbft chain
   pbft_chain1->updatePbftChain(pbft_block2.getBlockHash(), pbft_block2.getPivotDagBlockHash());


### PR DESCRIPTION
The goal of this optimization was to avoid saving cert votes twice in the db, once as a cert vote when cert voting a block and second time when treating the same votes as reward votes.

- 2t+1 cert votes are no longer saved once node receives 2t+1 votes but only a short time later when we actually push a pbft block to the chain. They are saved in a db batch as part of an atomic db operation when moving to the next period.
- Additional reward votes that come after pushing the pbft block into chain is saved in reward_votes column
- Total reward votes will consists of votes bundle saved as 2t+1 cert votes and additional reward votes saved individually
