### PR TITLE
chore: remove error logs on startup

### DIFF
--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -43,10 +43,11 @@ class VoteManager {
   /**
    * @brief Add a vote to the verified votes map
    * @param vote vote
+   * @param save save vote to db
    *
    * @return true if vote was successfully added, otherwise false
    */
-  bool addVerifiedVote(const std::shared_ptr<Vote>& vote);
+  bool addVerifiedVote(const std::shared_ptr<Vote>& vote, bool save = true);
 
   /**
    * @brief Check if the vote has been in the verified votes map

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1785,7 +1785,7 @@ bool PbftManager::validatePbftBlockCertVotes(const std::shared_ptr<PbftBlock> pb
     assert(v->getWeight());
     votes_weight += *v->getWeight();
 
-    vote_mgr_->addVerifiedVote(v);
+    vote_mgr_->addVerifiedVote(v, false);
   }
 
   const auto two_t_plus_one = vote_mgr_->getPbftTwoTPlusOne(first_vote_period - 1, PbftVoteTypes::cert_vote);

--- a/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
+++ b/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
@@ -142,7 +142,7 @@ void VoteManager::setCurrentPbftPeriodAndRound(PbftPeriod pbft_period, PbftRound
   }
 }
 
-bool VoteManager::addVerifiedVote(const std::shared_ptr<Vote>& vote) {
+bool VoteManager::addVerifiedVote(const std::shared_ptr<Vote>& vote, bool save) {
   assert(vote->getWeight().has_value());
   const auto hash = vote->getHash();
   const auto weight = *vote->getWeight();
@@ -260,22 +260,24 @@ bool VoteManager::addVerifiedVote(const std::shared_ptr<Vote>& vote) {
       }
     };
 
-    switch (vote->getType()) {
-      case PbftVoteTypes::soft_vote:
-        saveTwoTPlusOneVotesInDb(TwoTPlusOneVotedBlockType::SoftVotedBlock, vote);
-        break;
-      case PbftVoteTypes::cert_vote:
-        saveTwoTPlusOneVotesInDb(TwoTPlusOneVotedBlockType::CertVotedBlock, vote);
-        break;
-      case PbftVoteTypes::next_vote:
-        if (vote_block_hash == kNullBlockHash) {
-          saveTwoTPlusOneVotesInDb(TwoTPlusOneVotedBlockType::NextVotedNullBlock, vote);
-        } else {
-          saveTwoTPlusOneVotesInDb(TwoTPlusOneVotedBlockType::NextVotedBlock, vote);
-        }
-        break;
-      default:
-        break;
+    if (save) {
+      switch (vote->getType()) {
+        case PbftVoteTypes::soft_vote:
+          saveTwoTPlusOneVotesInDb(TwoTPlusOneVotedBlockType::SoftVotedBlock, vote);
+          break;
+        case PbftVoteTypes::cert_vote:
+          saveTwoTPlusOneVotesInDb(TwoTPlusOneVotedBlockType::CertVotedBlock, vote);
+          break;
+        case PbftVoteTypes::next_vote:
+          if (vote_block_hash == kNullBlockHash) {
+            saveTwoTPlusOneVotesInDb(TwoTPlusOneVotedBlockType::NextVotedNullBlock, vote);
+          } else {
+            saveTwoTPlusOneVotesInDb(TwoTPlusOneVotedBlockType::NextVotedBlock, vote);
+          }
+          break;
+        default:
+          break;
+      }
     }
   }
 


### PR DESCRIPTION
When restarting a node that is syncing regularly these error logs were logged:
0x00007fe2a5ffb640 PBFT_MGR [2023-03-01 14:51:43.666980] ERROR: Unable to find proposed block #3c7f77f3…, period 589
0x00007fe2a5ffb640 PBFT_MGR [2023-03-01 14:51:43.667093] ERROR: Invalid certified block #3c7f77f3…
0x00007fe2a5ffb640 PBFT_MGR [2023-03-01 14:51:43.769323] ERROR: Unable to find proposed block #3c7f77f3…, period 589
0x00007fe2a5ffb640 PBFT_MGR [2023-03-01 14:51:43.769444] ERROR: Invalid certified block #3c7f77f3…

The reason is that while syncing and processing sync data, votes are saved in the db before saving the full block. If syncing is interrupted on restart these votes are missing a block. There is a need to verify the votes while syncing but no need to save them in the Columns::latest_round_two_t_plus_one_votes column. This change will eliminate this error and it should also make syncing quicker.