### PR TITLE
chore: refactor reward votes saving

### DIFF
--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -203,6 +203,16 @@ class VoteManager {
                                                                    TwoTPlusOneVotedBlockType type) const;
 
   /**
+   * Get 2t+1 voted block votes for first round with specific period and type, e.g. soft/cert/next voted block
+   *
+   * @param period
+   * @param type
+   * @return vector of votes if 2t+1 voted block votes found, otherwise empty vector
+   */
+  std::vector<std::shared_ptr<Vote>> getTwoTPlusOneVotedBlockVotes(PbftPeriod period,
+                                                                   TwoTPlusOneVotedBlockType type) const;
+
+  /**
    * Get all 2t+1 voted block next votes(both for null block as well as specific block) for specific period and round
    *
    * @param period
@@ -267,8 +277,8 @@ class VoteManager {
 
   // Reward votes related info
   blk_hash_t reward_votes_block_hash_;
-  PbftRound reward_votes_period_;
-  PbftRound reward_votes_round_;
+  PbftRound reward_votes_period_ = 0;
+  PbftRound reward_votes_round_ = 0;
   mutable std::shared_mutex reward_votes_info_mutex_;
 
   // Cache for current 2T+1 - <Vote type, <period, two_t_plus_one for period>>

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1589,7 +1589,6 @@ bool PbftManager::pushPbftBlock_(PeriodData &&period_data, std::vector<std::shar
 
   // Replace current reward votes
   vote_mgr_->resetRewardVotesInfo(cert_votes[0]->getPeriod(), cert_votes[0]->getRound(), cert_votes[0]->getBlockHash());
-  db_->replaceRewardVotes(cert_votes, batch);
 
   // pass pbft with dag blocks and transactions to adjust difficulty
   if (period_data.pbft_blk->getPivotDagBlockHash() != kNullBlockHash) {

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_pbft_sync_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/get_pbft_sync_packet_handler.hpp
@@ -4,6 +4,7 @@
 
 namespace taraxa {
 class PbftChain;
+class VoteManager;
 class DbStorage;
 }  // namespace taraxa
 
@@ -16,7 +17,8 @@ class GetPbftSyncPacketHandler final : public PacketHandler {
   GetPbftSyncPacketHandler(const FullNodeConfig& conf, std::shared_ptr<PeersState> peers_state,
                            std::shared_ptr<TimePeriodPacketsStats> packets_stats,
                            std::shared_ptr<PbftSyncingState> pbft_syncing_state, std::shared_ptr<PbftChain> pbft_chain,
-                           std::shared_ptr<DbStorage> db, const addr_t& node_addr);
+                           std::shared_ptr<VoteManager> vote_mgr, std::shared_ptr<DbStorage> db,
+                           const addr_t& node_addr);
 
   void sendPbftBlocks(dev::p2p::NodeID const& peer_id, PbftPeriod from_period, size_t blocks_to_transfer,
                       bool pbft_chain_synced);
@@ -30,6 +32,7 @@ class GetPbftSyncPacketHandler final : public PacketHandler {
 
   std::shared_ptr<PbftSyncingState> pbft_syncing_state_;
   std::shared_ptr<PbftChain> pbft_chain_;
+  std::shared_ptr<VoteManager> vote_mgr_;
   std::shared_ptr<DbStorage> db_;
 };
 

--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -237,7 +237,7 @@ void TaraxaCapability::registerPacketHandlers(
 
   // TODO there is additional logic, that should be moved outside process function
   packets_handlers_->registerHandler<GetPbftSyncPacketHandler>(kConf, peers_state_, packets_stats, pbft_syncing_state_,
-                                                               pbft_chain, db, node_addr);
+                                                               pbft_chain, vote_mgr, db, node_addr);
 
   packets_handlers_->registerHandler<PbftSyncPacketHandler>(kConf, peers_state_, packets_stats, pbft_syncing_state_,
                                                             pbft_chain, pbft_mgr, dag_mgr, vote_mgr,

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -105,8 +105,6 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
     COLUMN(pbft_head);
     COLUMN(latest_round_own_votes);             // own votes of any type for the latest round
     COLUMN(latest_round_two_t_plus_one_votes);  // 2t+1 votes bundles of any type for the latest round
-    COLUMN(latest_reward_votes);                // extra reward votes on top of 2t+1 cert votes bundle from
-                                                // latest_round_two_t_plus_one_votes
     COLUMN(pbft_block_period);
     COLUMN(dag_block_period);
     COLUMN_W_COMP(proposal_period_levels_map, getIntComparator<uint64_t>());
@@ -272,11 +270,6 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   // 2t+1 votes bundles for the latest round
   void replaceTwoTPlusOneVotes(TwoTPlusOneVotedBlockType type, const std::vector<std::shared_ptr<Vote>>& votes);
   std::vector<std::shared_ptr<Vote>> getAllTwoTPlusOneVotes();
-
-  // Reward votes - cert votes for the latest finalized block
-  void replaceRewardVotes(const std::vector<std::shared_ptr<Vote>>& votes, Batch& write_batch);
-  void saveRewardVote(const std::shared_ptr<Vote>& vote);
-  std::vector<std::shared_ptr<Vote>> getRewardVotes();
 
   // period_pbft_block
   void addPbftBlockPeriodToBatch(PbftPeriod period, taraxa::blk_hash_t const& pbft_block_hash, Batch& write_batch);

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -284,32 +284,6 @@ TEST_F(FullNodeTest, db_test) {
     verified_votes_map[vote->getHash()] = vote;
   }
 
-  EXPECT_TRUE(db.getRewardVotes().empty());
-  batch = db.createWriteBatch();
-  db.replaceRewardVotes(verified_votes, batch);
-  db.commitWriteBatch(batch);
-
-  const auto db_reward_votes = db.getRewardVotes();
-  EXPECT_EQ(db_reward_votes.size(), verified_votes_map.size());
-  for (const auto &db_vote : db_reward_votes) {
-    EXPECT_EQ(db_vote->rlp(true, true), verified_votes_map[db_vote->getHash()]->rlp(true, true));
-  }
-
-  const auto new_reward_vote = genVote(PbftVoteTypes::cert_vote, 10, 10, 3);
-  verified_votes_map[new_reward_vote->getHash()] = new_reward_vote;
-  db.saveRewardVote(new_reward_vote);
-
-  const auto new_db_reward_votes = db.getRewardVotes();
-  EXPECT_EQ(new_db_reward_votes.size(), verified_votes_map.size());
-  for (const auto &db_vote : new_db_reward_votes) {
-    EXPECT_EQ(db_vote->rlp(true, true), verified_votes_map[db_vote->getHash()]->rlp(true, true));
-  }
-
-  batch = db.createWriteBatch();
-  db.replaceRewardVotes({}, batch);
-  db.commitWriteBatch(batch);
-  EXPECT_TRUE(db.getRewardVotes().empty());
-
   // period_pbft_block
   batch = db.createWriteBatch();
   db.addPbftBlockPeriodToBatch(3, blk_hash_t(1), batch);

--- a/tests/pbft_manager_test.cpp
+++ b/tests/pbft_manager_test.cpp
@@ -636,7 +636,8 @@ TEST_F(PbftManagerTest, propose_block_and_vote_broadcast) {
   blk_hash_t prev_block_hash = node1->getPbftChain()->getLastPbftBlockHash();
 
   // Node1 generate a PBFT block sample
-  auto reward_votes = node1->getDB()->getRewardVotes();
+  auto reward_votes = node1->getVoteManager()->getTwoTPlusOneVotedBlockVotes(
+      node1->getPbftChain()->getPbftChainSize() - 1, TwoTPlusOneVotedBlockType::CertVotedBlock);
   std::vector<vote_hash_t> reward_votes_hashes;
   std::transform(reward_votes.begin(), reward_votes.end(), std::back_inserter(reward_votes_hashes),
                  [](const auto &v) { return v->getHash(); });
@@ -903,7 +904,9 @@ TEST_F(PbftManagerWithDagCreation, DISABLED_pbft_block_is_overweighted) {
     auto order_hash = node->getPbftManager()->calculateOrderHash(dag_block_order);
 
     const auto &last_hash = node->getPbftChain()->getLastPbftBlockHash();
-    auto reward_votes = node->getDB()->getRewardVotes();
+    auto reward_votes = node->getVoteManager()->getTwoTPlusOneVotedBlockVotes(
+        node->getPbftChain()->getPbftChainSize() - 1, TwoTPlusOneVotedBlockType::CertVotedBlock);
+
     std::vector<vote_hash_t> reward_votes_hashes;
     std::transform(reward_votes.begin(), reward_votes.end(), std::back_inserter(reward_votes_hashes),
                    [](const auto &v) { return v->getHash(); });


### PR DESCRIPTION
Reward votes are no longer saved separately from cert_votes. All the need for reward votes is handled from verified_votes cache and db. This saves both space and makes processing votes and syncing simple and faster.