### PR TITLE
Issue 2318/fix exponential backoff

### DIFF
--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -206,7 +206,7 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
    * @brief Get PBFT lambda. PBFT lambda is a timer clock
    * @return PBFT lambda
    */
-  std::chrono::milliseconds getPbftInitialLambda() const { return LAMBDA_ms_MIN; }
+  std::chrono::milliseconds getPbftInitialLambda() const { return kMinLambda; }
 
   /**
    * @brief Calculate DAG blocks ordering hash
@@ -532,17 +532,14 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   const addr_t node_addr_;
   const secret_t node_sk_;
 
-  const std::chrono::milliseconds LAMBDA_ms_MIN;
-  std::chrono::milliseconds LAMBDA_ms{0};
-  uint64_t LAMBDA_backoff_multiple = 1;
+  const std::chrono::milliseconds kMinLambda; // [ms]
+  std::chrono::milliseconds lambda_{0}; // [ms]
   const std::chrono::milliseconds kMaxLambda{60000};  // in ms, max lambda is 1 minutes
 
   const uint32_t kBroadcastVotesLambdaTime = 20;
   const uint32_t kRebroadcastVotesLambdaTime = 60;
   uint32_t broadcast_votes_counter_ = 1;
   uint32_t rebroadcast_votes_counter_ = 1;
-
-  std::default_random_engine random_engine_{std::random_device{}()};
 
   PbftStates state_ = value_proposal_state;
   std::atomic<PbftRound> round_ = 1;

--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -532,8 +532,8 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   const addr_t node_addr_;
   const secret_t node_sk_;
 
-  const std::chrono::milliseconds kMinLambda; // [ms]
-  std::chrono::milliseconds lambda_{0}; // [ms]
+  const std::chrono::milliseconds kMinLambda;         // [ms]
+  std::chrono::milliseconds lambda_{0};               // [ms]
   const std::chrono::milliseconds kMaxLambda{60000};  // in ms, max lambda is 1 minutes
 
   const uint32_t kBroadcastVotesLambdaTime = 20;

--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -255,11 +255,6 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
   void resume();
 
   /**
-   * @brief Resume PBFT daemon on single state. Only to be used for unit tests
-   */
-  void resumeSingleState();
-
-  /**
    * @brief Get a proposed PBFT block based on specified period and block hash
    * @param period
    * @param block_hash
@@ -330,16 +325,6 @@ class PbftManager : public std::enable_shared_from_this<PbftManager> {
    * @brief Time to sleep for PBFT protocol
    */
   void sleep_();
-
-  /**
-   * @brief Go to next PBFT state. Only to be used for unit tests
-   */
-  void doNextState_();
-
-  /**
-   * @brief Set next PBFT state
-   */
-  void setNextState_();
 
   /**
    * @brief Set PBFT filter state

--- a/libraries/core_libs/consensus/include/vote_manager/verified_votes.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/verified_votes.hpp
@@ -19,6 +19,12 @@ struct VerifiedVotes {
 
   // Step votes
   std::map<PbftStep, StepVotes> step_votes;
+
+  // Greatest step, for which there is at least t+1 next votes - it is used for lambda exponential backoff: Usually
+  // when network gets stalled it is due to lack of 2t+1 voting power and steps keep increasing. When new node joins
+  // the network, it should catch up with the rest of nodes asap so we dont start exponentially backing of its lambda
+  // if it's current step is far behind network_t_plus_one_step (at least 1 third of network is at this step)
+  PbftStep network_t_plus_one_step{0};
 };
 
 }  // namespace taraxa

--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -220,6 +220,17 @@ class VoteManager {
    */
   void setCurrentPbftPeriodAndRound(PbftPeriod pbft_period, PbftRound pbft_round);
 
+  /**
+   * @brief Returns greatest step (in specified period & round), for which there is at least t+1 voting power
+   *        from all nodes
+   * @note It is used for triggering lambda exponential backoff
+   *
+   * @param period
+   * @param round
+   * @return greatest network 2t+1 next voting step
+   */
+  PbftStep getNetworkTplusOneNextVotingStep(PbftPeriod period, PbftRound round) const;
+
  private:
   /**
    * @param vote

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -532,6 +532,7 @@ void PbftManager::setFinishPollingState_() {
   already_next_voted_value_ = false;
   already_next_voted_null_block_hash_ = false;
   second_finish_step_start_datetime_ = std::chrono::system_clock::now();
+  next_step_time_ms_ += kPollingIntervalMs;
 }
 
 void PbftManager::loopBackFinishState_() {

--- a/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
+++ b/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
@@ -142,6 +142,22 @@ void VoteManager::setCurrentPbftPeriodAndRound(PbftPeriod pbft_period, PbftRound
   }
 }
 
+PbftStep VoteManager::getNetworkTplusOneNextVotingStep(PbftPeriod period, PbftRound round) const {
+  std::shared_lock lock(verified_votes_access_);
+
+  const auto found_period_it = verified_votes_.find(period);
+  if (found_period_it == verified_votes_.end()) {
+    return 0;
+  }
+
+  const auto found_round_it = found_period_it->second.find(round);
+  if (found_round_it == found_period_it->second.end()) {
+    return 0;
+  }
+
+  return found_round_it->second.network_t_plus_one_step;
+}
+
 bool VoteManager::addVerifiedVote(const std::shared_ptr<Vote>& vote) {
   assert(vote->getWeight().has_value());
   const auto hash = vote->getHash();
@@ -218,9 +234,22 @@ bool VoteManager::addVerifiedVote(const std::shared_ptr<Vote>& vote) {
 
     const auto total_weight = (found_voted_value_it->second.first += weight);
 
-    // Not enough votes - do not set 2t+1 voted block for period,round and step
+    // Unable to get 2t+1
     const auto two_t_plus_one = getPbftTwoTPlusOne(vote->getPeriod() - 1, vote->getType());
-    if (total_weight < two_t_plus_one) {
+    if (!two_t_plus_one.has_value()) [[unlikely]] {
+      return true;
+    }
+
+    // Calculate t+1
+    const auto t_plus_one = ((*two_t_plus_one - 1) / 2) + 1;
+    // Set network_t_plus_one_step - used for triggering exponential backoff
+    if (vote->getType() == PbftVoteTypes::next_vote && total_weight >= t_plus_one &&
+        vote->getStep() > found_round_it->second.network_t_plus_one_step) {
+      found_round_it->second.network_t_plus_one_step = vote->getStep();
+    }
+
+    // Not enough votes - do not set 2t+1 voted block for period,round and step
+    if (total_weight < *two_t_plus_one) {
       return true;
     }
 

--- a/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
+++ b/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
@@ -237,6 +237,7 @@ bool VoteManager::addVerifiedVote(const std::shared_ptr<Vote>& vote) {
     // Unable to get 2t+1
     const auto two_t_plus_one = getPbftTwoTPlusOne(vote->getPeriod() - 1, vote->getType());
     if (!two_t_plus_one.has_value()) [[unlikely]] {
+      LOG(log_er_) << "Cannot set(or not) 2t+1 voted block as 2t+1 threshold is unavailable, vote " << vote->getHash();
       return true;
     }
 


### PR DESCRIPTION
## Purpose
<!-- Provide any information reviewers might need to have context on your changes. -->


New mechanism for lambda exponential backoff:
- it should fix the issue when we have to wait very long time until new nodes catch up with the rest of the network 
- network gets stalled when we dont have 2t+1 voting power in next voting steps so I keep track of the network_t_plus_one_step for which there is at least t+1 voting power in the network and I consider this step as reference step, which network is at
- if node's current step is more than kMaxSteps(13) behind network_t_plus_one_step, it's lambda stays at initial value
- once the node is less than kMaxSteps(13) behind network_t_plus_one_step, it starts exponentially backing off it's lambda
- this should make sure all nodes eventually catch up with the rest of the network in relatively small amount of time - the outdated nodes keep their lambdas at 600ms while the rest of the network has it at 60s


## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
