### PR TITLE
Reward votes round check

### DIFF
--- a/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
@@ -114,6 +114,7 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
     // Process processStandardVote is called with false in case of next votes bundle -> does not check max boundaries
     // for round and step to actually being able to sync the current round in case network is stalled
     bool check_max_round_step = votes_bundle_votes_type == PbftVoteTypes::next_vote ? false : true;
+    if (votes_bundle_votes_type == PbftVoteTypes::cert_vote) check_max_round_step = false;
     processVote(vote, nullptr, peer, check_max_round_step);
     votes.push_back(std::move(vote));
   }


### PR DESCRIPTION
Turn off round check for reward votes since it is normal that reward votes are from old round