### PR TITLE
fix: cpp-check warnings on build

### DIFF
--- a/CMakeModules/cppcheck.cmake
+++ b/CMakeModules/cppcheck.cmake
@@ -32,9 +32,12 @@ else ()
             # exclude graphql generated
             -i ${PROJECT_SOURCE_DIR}/libraries/core_libs/network/graphql/gen/
             # messy files
+            --suppress=unmatchedSuppression:${PROJECT_SOURCE_DIR}/*/vector_ref.h
+            --suppress=unmatchedSuppression:${PROJECT_SOURCE_DIR}/*/Common.h
             --suppress=cstyleCast:${PROJECT_SOURCE_DIR}/*/vector_ref.h
             --suppress=cstyleCast:${PROJECT_SOURCE_DIR}/*/Common.h
-
+            #not an issue here 
+            --suppress=virtualCallInConstructor:${PROJECT_SOURCE_DIR}/*/final_chain.cpp
             # Only show found errors
             "--quiet"
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/transaction_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/transaction_packet_handler.cpp
@@ -127,11 +127,7 @@ void TransactionPacketHandler::periodicSendTransactions(SharedTransactions &&tra
   std::vector<std::pair<dev::p2p::NodeID, SharedTransactions>> peers_with_transactions_to_send;
 
   auto peers = peers_state_->getAllPeers();
-  std::string transactions_to_log;
   std::string peers_to_log;
-  for (auto const &trx : transactions) {
-    transactions_to_log += trx->getHash().abridged();
-  }
   for (const auto &peer : peers) {
     // Confirm that status messages were exchanged otherwise message might be ignored and node would
     // incorrectly markTransactionAsKnown
@@ -150,6 +146,9 @@ void TransactionPacketHandler::periodicSendTransactions(SharedTransactions &&tra
   }
   const auto peers_to_send_count = peers_with_transactions_to_send.size();
   if (peers_to_send_count > 0) {
+    auto transactions_to_log =
+        std::accumulate(transactions.begin(), transactions.end(), std::string{},
+                        [](const auto &r, const auto &trx) { return r + trx->getHash().abridged(); });
     LOG(log_tr_) << "Sending Transactions " << transactions_to_log << " to " << peers_to_log;
     // Sending it in same order favours some peers over others, always start with a different position
     uint32_t start_with = rand() % peers_to_send_count;


### PR DESCRIPTION
Fix cpp check errors that I saw on latest develop build 