### PR TITLE
fix: RLP InvalidEncodingSize inherits from RLPException

### DIFF
--- a/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/votes_sync_packet_handler.cpp
@@ -113,7 +113,7 @@ void VotesSyncPacketHandler::process(const PacketData &packet_data, const std::s
 
     // Process processStandardVote is called with false in case of next votes bundle -> does not check max boundaries
     // for round and step to actually being able to sync the current round in case network is stalled
-    bool check_max_round_step =  true;
+    bool check_max_round_step = true;
     if (votes_bundle_votes_type == PbftVoteTypes::cert_vote || votes_bundle_votes_type == PbftVoteTypes::next_vote) {
       check_max_round_step = false;
     }


### PR DESCRIPTION
 InvalidEncodingSize was inherited from std::invalid_argument exception, so we was incorrectly processing this RLP related exception(we wasn't marking sender node as malicious). 