### PR TITLE
[helm-chart]: labels for kube-monkey

### DIFF
--- a/charts/taraxa-node/CHANGELOG.md
+++ b/charts/taraxa-node/CHANGELOG.md
@@ -3,6 +3,13 @@
 This file documents all notable changes to `taraxa-node` Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v0.3.6
+
+### Minor changes
+
+* Added labels into `StatefulSets` for [kube-monkey](https://github.com/asobti/kube-monkey)
+
+
 ## v0.3.5
 
 ### Minor changes

--- a/charts/taraxa-node/Chart.yaml
+++ b/charts/taraxa-node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Kubernetes helm chart for Taraxa blockchain full node implementation.
 name: taraxa-node
-version: 0.3.5
+version: 0.3.6
 keywords:
   - blockchain
   - taraxa

--- a/charts/taraxa-node/templates/bootnode.yaml
+++ b/charts/taraxa-node/templates/bootnode.yaml
@@ -9,6 +9,13 @@ metadata:
     helm.sh/chart: {{ include "taraxa-node.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{ if .Values.kubemonkey.enabled }}
+    kube-monkey/enabled: enabled
+    kube-monkey/identifier: monkey-victim
+    kube-monkey/mtbf: '2'
+    kube-monkey/kill-mode: "fixed"
+    kube-monkey/kill-value: '1'
+    {{ end }}
 spec:
   replicas: {{ .Values.bootnode.replicaCount }}
   serviceName: {{ include "taraxa-boot-node.fullname" . }}
@@ -29,6 +36,13 @@ spec:
         partition: a
         app.kubernetes.io/name: {{ .Release.Name }}-boot-node
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{ if .Values.kubemonkey.enabled }}
+        kube-monkey/enabled: enabled
+        kube-monkey/identifier: monkey-victim
+        kube-monkey/mtbf: '2'
+        kube-monkey/kill-mode: "fixed"
+        kube-monkey/kill-value: '1'
+        {{ end }}
       annotations:
         kubernetes.io/change-cause: "Configuration through configmaps."
     spec:

--- a/charts/taraxa-node/templates/bootnode.yaml
+++ b/charts/taraxa-node/templates/bootnode.yaml
@@ -13,8 +13,8 @@ metadata:
     kube-monkey/enabled: enabled
     kube-monkey/identifier: {{ include "taraxa-boot-node.fullname" . }}
     kube-monkey/mtbf: {{ .Values.kubemonkey.mtbf }}
-    kube-monkey/kill-mode: {{ .Values.kubemonkey.kill-mode }}
-    kube-monkey/kill-value: {{ .Values.kubemonkey.kill-value }}
+    kube-monkey/kill-mode: {{ .Values.kubemonkey.killMode }}
+    kube-monkey/kill-value: {{ .Values.kubemonkey.killValue }}
     {{ end }}
 spec:
   replicas: {{ .Values.bootnode.replicaCount }}
@@ -40,8 +40,8 @@ spec:
         kube-monkey/enabled: enabled
         kube-monkey/identifier: {{ include "taraxa-boot-node.fullname" . }}
         kube-monkey/mtbf: {{ .Values.kubemonkey.mtbf }}
-        kube-monkey/kill-mode: {{ .Values.kubemonkey.kill-mode }}
-        kube-monkey/kill-value: {{ .Values.kubemonkey.kill-value }}
+        kube-monkey/kill-mode: {{ .Values.kubemonkey.killMode }}
+        kube-monkey/kill-value: {{ .Values.kubemonkey.killValue }}
         {{ end }}
       annotations:
         kubernetes.io/change-cause: "Configuration through configmaps."

--- a/charts/taraxa-node/templates/bootnode.yaml
+++ b/charts/taraxa-node/templates/bootnode.yaml
@@ -11,10 +11,10 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     {{ if .Values.kubemonkey.enabled }}
     kube-monkey/enabled: enabled
-    kube-monkey/identifier: monkey-victim
-    kube-monkey/mtbf: '2'
-    kube-monkey/kill-mode: "fixed"
-    kube-monkey/kill-value: '1'
+    kube-monkey/identifier: {{ include "taraxa-boot-node.fullname" . }}
+    kube-monkey/mtbf: {{ .Values.kubemonkey.mtbf }}
+    kube-monkey/kill-mode: {{ .Values.kubemonkey.kill-mode }}
+    kube-monkey/kill-value: {{ .Values.kubemonkey.kill-value }}
     {{ end }}
 spec:
   replicas: {{ .Values.bootnode.replicaCount }}
@@ -38,10 +38,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         {{ if .Values.kubemonkey.enabled }}
         kube-monkey/enabled: enabled
-        kube-monkey/identifier: monkey-victim
-        kube-monkey/mtbf: '2'
-        kube-monkey/kill-mode: "fixed"
-        kube-monkey/kill-value: '1'
+        kube-monkey/identifier: {{ include "taraxa-boot-node.fullname" . }}
+        kube-monkey/mtbf: {{ .Values.kubemonkey.mtbf }}
+        kube-monkey/kill-mode: {{ .Values.kubemonkey.kill-mode }}
+        kube-monkey/kill-value: {{ .Values.kubemonkey.kill-value }}
         {{ end }}
       annotations:
         kubernetes.io/change-cause: "Configuration through configmaps."

--- a/charts/taraxa-node/templates/bootnode.yaml
+++ b/charts/taraxa-node/templates/bootnode.yaml
@@ -12,9 +12,9 @@ metadata:
     {{ if .Values.kubemonkey.enabled }}
     kube-monkey/enabled: enabled
     kube-monkey/identifier: {{ include "taraxa-boot-node.fullname" . }}
-    kube-monkey/mtbf: {{ .Values.kubemonkey.mtbf }}
-    kube-monkey/kill-mode: {{ .Values.kubemonkey.killMode }}
-    kube-monkey/kill-value: {{ .Values.kubemonkey.killValue }}
+    kube-monkey/mtbf: {{ .Values.kubemonkey.mtbf | quote }}
+    kube-monkey/kill-mode: {{ .Values.kubemonkey.killMode | quote }}
+    kube-monkey/kill-value: {{ .Values.kubemonkey.killValue | quote }}
     {{ end }}
 spec:
   replicas: {{ .Values.bootnode.replicaCount }}
@@ -39,9 +39,9 @@ spec:
         {{ if .Values.kubemonkey.enabled }}
         kube-monkey/enabled: enabled
         kube-monkey/identifier: {{ include "taraxa-boot-node.fullname" . }}
-        kube-monkey/mtbf: {{ .Values.kubemonkey.mtbf }}
-        kube-monkey/kill-mode: {{ .Values.kubemonkey.killMode }}
-        kube-monkey/kill-value: {{ .Values.kubemonkey.killValue }}
+        kube-monkey/mtbf: {{ .Values.kubemonkey.mtbf | quote }}
+        kube-monkey/kill-mode: {{ .Values.kubemonkey.killMode | quote }}
+        kube-monkey/kill-value: {{ .Values.kubemonkey.killValue | quote }}
         {{ end }}
       annotations:
         kubernetes.io/change-cause: "Configuration through configmaps."

--- a/charts/taraxa-node/templates/consensus-node.yaml
+++ b/charts/taraxa-node/templates/consensus-node.yaml
@@ -13,8 +13,8 @@ metadata:
     kube-monkey/enabled: enabled
     kube-monkey/identifier: {{ include "taraxa-consensus-node.fullname" . }}
     kube-monkey/mtbf: {{ .Values.kubemonkey.mtbf }}
-    kube-monkey/kill-mode: {{ .Values.kubemonkey.kill-mode }}
-    kube-monkey/kill-value: {{ .Values.kubemonkey.kill-value }}
+    kube-monkey/kill-mode: {{ .Values.kubemonkey.killMode }}
+    kube-monkey/kill-value: {{ .Values.kubemonkey.killValue }}
     {{ end }}
 spec:
   replicas: {{ .Values.consensusnode.replicaCount }}
@@ -40,8 +40,8 @@ spec:
         kube-monkey/enabled: enabled
         kube-monkey/identifier: {{ include "taraxa-consensus-node.fullname" . }}
         kube-monkey/mtbf: {{ .Values.kubemonkey.mtbf }}
-        kube-monkey/kill-mode: {{ .Values.kubemonkey.kill-mode }}
-        kube-monkey/kill-value: {{ .Values.kubemonkey.kill-value }}
+        kube-monkey/kill-mode: {{ .Values.kubemonkey.killMode }}
+        kube-monkey/kill-value: {{ .Values.kubemonkey.killValue }}
         {{ end }}
       annotations:
         kubernetes.io/change-cause: "Configuration through configmaps."

--- a/charts/taraxa-node/templates/consensus-node.yaml
+++ b/charts/taraxa-node/templates/consensus-node.yaml
@@ -12,9 +12,9 @@ metadata:
     {{ if .Values.kubemonkey.enabled }}
     kube-monkey/enabled: enabled
     kube-monkey/identifier: {{ include "taraxa-consensus-node.fullname" . }}
-    kube-monkey/mtbf: {{ .Values.kubemonkey.mtbf }}
-    kube-monkey/kill-mode: {{ .Values.kubemonkey.killMode }}
-    kube-monkey/kill-value: {{ .Values.kubemonkey.killValue }}
+    kube-monkey/mtbf: {{ .Values.kubemonkey.mtbf | quote }}
+    kube-monkey/kill-mode: {{ .Values.kubemonkey.killMode | quote }}
+    kube-monkey/kill-value: {{ .Values.kubemonkey.killValue | quote }}
     {{ end }}
 spec:
   replicas: {{ .Values.consensusnode.replicaCount }}
@@ -39,9 +39,9 @@ spec:
         {{ if .Values.kubemonkey.enabled }}
         kube-monkey/enabled: enabled
         kube-monkey/identifier: {{ include "taraxa-consensus-node.fullname" . }}
-        kube-monkey/mtbf: {{ .Values.kubemonkey.mtbf }}
-        kube-monkey/kill-mode: {{ .Values.kubemonkey.killMode }}
-        kube-monkey/kill-value: {{ .Values.kubemonkey.killValue }}
+        kube-monkey/mtbf: {{ .Values.kubemonkey.mtbf | quote }}
+        kube-monkey/kill-mode: {{ .Values.kubemonkey.killMode | quote }}
+        kube-monkey/kill-value: {{ .Values.kubemonkey.killValue | quote }}
         {{ end }}
       annotations:
         kubernetes.io/change-cause: "Configuration through configmaps."

--- a/charts/taraxa-node/templates/consensus-node.yaml
+++ b/charts/taraxa-node/templates/consensus-node.yaml
@@ -9,6 +9,13 @@ metadata:
     helm.sh/chart: {{ include "taraxa-node.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{ if .Values.kubemonkey.enabled }}
+    kube-monkey/enabled: enabled
+    kube-monkey/identifier: monkey-victim
+    kube-monkey/mtbf: '2'
+    kube-monkey/kill-mode: "fixed"
+    kube-monkey/kill-value: '1'
+    {{ end }}
 spec:
   replicas: {{ .Values.consensusnode.replicaCount }}
   serviceName: {{ include "taraxa-consensus-node.fullname" . }}
@@ -29,6 +36,13 @@ spec:
         partition: a
         app.kubernetes.io/name: {{ .Release.Name }}-consensus-node
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{ if .Values.kubemonkey.enabled }}
+        kube-monkey/enabled: enabled
+        kube-monkey/identifier: monkey-victim
+        kube-monkey/mtbf: '2'
+        kube-monkey/kill-mode: "fixed"
+        kube-monkey/kill-value: '1'
+        {{ end }}
       annotations:
         kubernetes.io/change-cause: "Configuration through configmaps."
     spec:

--- a/charts/taraxa-node/templates/consensus-node.yaml
+++ b/charts/taraxa-node/templates/consensus-node.yaml
@@ -11,10 +11,10 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     {{ if .Values.kubemonkey.enabled }}
     kube-monkey/enabled: enabled
-    kube-monkey/identifier: monkey-victim
-    kube-monkey/mtbf: '2'
-    kube-monkey/kill-mode: "fixed"
-    kube-monkey/kill-value: '1'
+    kube-monkey/identifier: {{ include "taraxa-consensus-node.fullname" . }}
+    kube-monkey/mtbf: {{ .Values.kubemonkey.mtbf }}
+    kube-monkey/kill-mode: {{ .Values.kubemonkey.kill-mode }}
+    kube-monkey/kill-value: {{ .Values.kubemonkey.kill-value }}
     {{ end }}
 spec:
   replicas: {{ .Values.consensusnode.replicaCount }}
@@ -38,10 +38,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         {{ if .Values.kubemonkey.enabled }}
         kube-monkey/enabled: enabled
-        kube-monkey/identifier: monkey-victim
-        kube-monkey/mtbf: '2'
-        kube-monkey/kill-mode: "fixed"
-        kube-monkey/kill-value: '1'
+        kube-monkey/identifier: {{ include "taraxa-consensus-node.fullname" . }}
+        kube-monkey/mtbf: {{ .Values.kubemonkey.mtbf }}
+        kube-monkey/kill-mode: {{ .Values.kubemonkey.kill-mode }}
+        kube-monkey/kill-value: {{ .Values.kubemonkey.kill-value }}
         {{ end }}
       annotations:
         kubernetes.io/change-cause: "Configuration through configmaps."

--- a/charts/taraxa-node/templates/taraxa-node.yaml
+++ b/charts/taraxa-node/templates/taraxa-node.yaml
@@ -10,6 +10,13 @@ metadata:
     helm.sh/chart: {{ include "taraxa-node.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{ if .Values.kubemonkey.enabled }}
+    kube-monkey/enabled: enabled
+    kube-monkey/identifier: monkey-victim
+    kube-monkey/mtbf: '2'
+    kube-monkey/kill-mode: "fixed"
+    kube-monkey/kill-value: '1'
+    {{ end }}
 spec:
   replicas: {{ .Values.node.replicaCount }}
   # to launch or terminate all Pods in parallel.
@@ -30,6 +37,13 @@ spec:
         partition: a
         app.kubernetes.io/name: {{ include "taraxa-node.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{ if .Values.kubemonkey.enabled }}
+        kube-monkey/enabled: enabled
+        kube-monkey/identifier: monkey-victim
+        kube-monkey/mtbf: '2'
+        kube-monkey/kill-mode: "fixed"
+        kube-monkey/kill-value: '1'
+        {{ end }}
       annotations:
         kubernetes.io/change-cause: "Configuration through configmaps."
     spec:

--- a/charts/taraxa-node/templates/taraxa-node.yaml
+++ b/charts/taraxa-node/templates/taraxa-node.yaml
@@ -14,8 +14,8 @@ metadata:
     kube-monkey/enabled: enabled
     kube-monkey/identifier: {{ include "taraxa-node.fullname" . }}
     kube-monkey/mtbf: {{ .Values.kubemonkey.mtbf }}
-    kube-monkey/kill-mode: {{ .Values.kubemonkey.kill-mode }}
-    kube-monkey/kill-value: {{ .Values.kubemonkey.kill-value }}
+    kube-monkey/kill-mode: {{ .Values.kubemonkey.killMode }}
+    kube-monkey/kill-value: {{ .Values.kubemonkey.killValue }}
     {{ end }}
 spec:
   replicas: {{ .Values.node.replicaCount }}
@@ -41,8 +41,8 @@ spec:
         kube-monkey/enabled: enabled
         kube-monkey/identifier: {{ include "taraxa-node.fullname" . }}
         kube-monkey/mtbf: {{ .Values.kubemonkey.mtbf }}
-        kube-monkey/kill-mode: {{ .Values.kubemonkey.kill-mode }}
-        kube-monkey/kill-value: {{ .Values.kubemonkey.kill-value }}
+        kube-monkey/kill-mode: {{ .Values.kubemonkey.killMode }}
+        kube-monkey/kill-value: {{ .Values.kubemonkey.killValue }}
         {{ end }}
       annotations:
         kubernetes.io/change-cause: "Configuration through configmaps."

--- a/charts/taraxa-node/templates/taraxa-node.yaml
+++ b/charts/taraxa-node/templates/taraxa-node.yaml
@@ -12,10 +12,10 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     {{ if .Values.kubemonkey.enabled }}
     kube-monkey/enabled: enabled
-    kube-monkey/identifier: monkey-victim
-    kube-monkey/mtbf: '2'
-    kube-monkey/kill-mode: "fixed"
-    kube-monkey/kill-value: '1'
+    kube-monkey/identifier: {{ include "taraxa-node.fullname" . }}
+    kube-monkey/mtbf: {{ .Values.kubemonkey.mtbf }}
+    kube-monkey/kill-mode: {{ .Values.kubemonkey.kill-mode }}
+    kube-monkey/kill-value: {{ .Values.kubemonkey.kill-value }}
     {{ end }}
 spec:
   replicas: {{ .Values.node.replicaCount }}
@@ -39,10 +39,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         {{ if .Values.kubemonkey.enabled }}
         kube-monkey/enabled: enabled
-        kube-monkey/identifier: monkey-victim
-        kube-monkey/mtbf: '2'
-        kube-monkey/kill-mode: "fixed"
-        kube-monkey/kill-value: '1'
+        kube-monkey/identifier: {{ include "taraxa-node.fullname" . }}
+        kube-monkey/mtbf: {{ .Values.kubemonkey.mtbf }}
+        kube-monkey/kill-mode: {{ .Values.kubemonkey.kill-mode }}
+        kube-monkey/kill-value: {{ .Values.kubemonkey.kill-value }}
         {{ end }}
       annotations:
         kubernetes.io/change-cause: "Configuration through configmaps."

--- a/charts/taraxa-node/templates/taraxa-node.yaml
+++ b/charts/taraxa-node/templates/taraxa-node.yaml
@@ -13,9 +13,9 @@ metadata:
     {{ if .Values.kubemonkey.enabled }}
     kube-monkey/enabled: enabled
     kube-monkey/identifier: {{ include "taraxa-node.fullname" . }}
-    kube-monkey/mtbf: {{ .Values.kubemonkey.mtbf }}
-    kube-monkey/kill-mode: {{ .Values.kubemonkey.killMode }}
-    kube-monkey/kill-value: {{ .Values.kubemonkey.killValue }}
+    kube-monkey/mtbf: {{ .Values.kubemonkey.mtbf | quote }}
+    kube-monkey/kill-mode: {{ .Values.kubemonkey.killMode | quote }}
+    kube-monkey/kill-value: {{ .Values.kubemonkey.killValue | quote }}
     {{ end }}
 spec:
   replicas: {{ .Values.node.replicaCount }}
@@ -40,9 +40,9 @@ spec:
         {{ if .Values.kubemonkey.enabled }}
         kube-monkey/enabled: enabled
         kube-monkey/identifier: {{ include "taraxa-node.fullname" . }}
-        kube-monkey/mtbf: {{ .Values.kubemonkey.mtbf }}
-        kube-monkey/kill-mode: {{ .Values.kubemonkey.killMode }}
-        kube-monkey/kill-value: {{ .Values.kubemonkey.killValue }}
+        kube-monkey/mtbf: {{ .Values.kubemonkey.mtbf | quote }}
+        kube-monkey/kill-mode: {{ .Values.kubemonkey.killMode | quote }}
+        kube-monkey/kill-value: {{ .Values.kubemonkey.killValue | quote }}
         {{ end }}
       annotations:
         kubernetes.io/change-cause: "Configuration through configmaps."

--- a/charts/taraxa-node/values.yaml
+++ b/charts/taraxa-node/values.yaml
@@ -294,3 +294,6 @@ test:
 
 kubemonkey:
   enabled: false
+  mtbf: 2
+  kill-mode: "fixed"
+  kill-value: '1'

--- a/charts/taraxa-node/values.yaml
+++ b/charts/taraxa-node/values.yaml
@@ -291,3 +291,6 @@ test:
     repository: gcr.io/jovial-meridian-249123/python
     tag: latest
     pullPolicy: IfNotPresent
+
+kubemonkey:
+  enabled: false

--- a/charts/taraxa-node/values.yaml
+++ b/charts/taraxa-node/values.yaml
@@ -295,5 +295,5 @@ test:
 kubemonkey:
   enabled: false
   mtbf: 2
-  kill-mode: "fixed"
-  kill-value: '1'
+  killMode: "fixed"
+  killValue: '1'


### PR DESCRIPTION
## Purpose
<!-- Provide any information reviewers might need to have context on your changes. -->
We want to be able to opt-in for chaos. Used [chaos-monkey](https://github.com/asobti/kube-monkey)

## How does the solution address the problem
<!-- Describe your solution. -->
Opt-ins for chaos by adding labels to `StatefulSet`s.


## Changes made
<!-- Summary or changes that have been made. -->
Added labels to pod templates (and metamata of `StatefullSep` app as well) in `StatefulSet` of boot, rpc and consensus nodes.
