### PR TITLE
fix: make gas limits smaller for all of our networks

### DIFF
--- a/libraries/cli/include/cli/config_jsons/devnet/devnet_genesis.json
+++ b/libraries/cli/include/cli/config_jsons/devnet/devnet_genesis.json
@@ -237,13 +237,13 @@
     "dag_blocks_size": "0x32",
     "ghost_path_move_back": "0x0",
     "lambda_ms": "0x5DC",
-    "gas_limit": "0x7d2b7500"
+    "gas_limit": "0x12C684C0"
   },
   "dag": {
     "block_proposer": {
       "shard": 1
     },
-    "gas_limit": "0xc845880"
+    "gas_limit": "0x1E0A6E0"
   },
   "sortition": {
     "changes_count_for_average": 10,

--- a/libraries/cli/include/cli/config_jsons/mainnet/mainnet_genesis.json
+++ b/libraries/cli/include/cli/config_jsons/mainnet/mainnet_genesis.json
@@ -259,13 +259,13 @@
     "dag_blocks_size": "0x32",
     "ghost_path_move_back": "0x0",
     "lambda_ms": "0x5DC",
-    "gas_limit": "0x7d2b7500"
+    "gas_limit": "0x12C684C0"
   },
   "dag": {
     "block_proposer": {
       "shard": 1
     },
-    "gas_limit": "0xc845880"
+    "gas_limit": "0x1E0A6E0"
   },
   "sortition": {
     "changes_count_for_average": 10,

--- a/libraries/cli/include/cli/config_jsons/testnet/testnet_genesis.json
+++ b/libraries/cli/include/cli/config_jsons/testnet/testnet_genesis.json
@@ -1709,13 +1709,13 @@
     "dag_blocks_size": "0x32",
     "ghost_path_move_back": "0x0",
     "lambda_ms": "0x5DC",
-    "gas_limit": "0x7d2b7500"
+    "gas_limit": "0x12C684C0"
   },
   "dag": {
     "block_proposer": {
       "shard": 1
     },
-    "gas_limit": "0xc845880"
+    "gas_limit": "0x1E0A6E0"
   },
   "sortition": {
     "changes_count_for_average": 10,


### PR DESCRIPTION
Make gas limits smaller. For dag it will be equal to 31.5M which is equal to 1500 basic transfer transactions. And 315M for pbft block, but this is not a hard cap and actual pbft block could be larger in some situations 