### PR TITLE
fix: add revert reason to execution error

### DIFF
--- a/tests/rpc_test.cpp
+++ b/tests/rpc_test.cpp
@@ -58,13 +58,6 @@ TEST_F(RPCTest, eth_estimateGas) {
   }
 }
 
-#define EXPECT_THROW_WITH(statement, expected_exception, msg) \
-  try {                                                       \
-    statement;                                                \
-  } catch (const expected_exception& e) {                     \
-    ASSERT_EQ(std::string(msg), std::string(e.what()));       \
-  }
-
 TEST_F(RPCTest, eth_call) {
   auto node_cfg = make_node_cfgs(1);
   auto nodes = launch_nodes(node_cfg);

--- a/tests/test_util/include/test_util/test_util.hpp
+++ b/tests/test_util/include/test_util/test_util.hpp
@@ -122,6 +122,14 @@ bool wait(const wait_opts& opts, const std::function<void(wait_ctx&)>& poller);
     EXPECT_GE(o1, o2);                      \
   }
 
+#define EXPECT_THROW_WITH(statement, expected_exception, msg) \
+  try {                                                       \
+    statement;                                                \
+    EXPECT_TRUE("No exception thrown" && false);              \
+  } catch (const expected_exception& e) {                     \
+    EXPECT_EQ(std::string(msg), std::string(e.what()));       \
+  }
+
 struct TransactionClient {
   enum class TransactionStage {
     created,


### PR DESCRIPTION
Add revert reason to execution error in result of dry_run_transaction. This is how it work in geth and will make debugging on contracts much easier