### PR TITLE
chore: adjust mac building compilation

### DIFF
--- a/doc/building.md
+++ b/doc/building.md
@@ -169,10 +169,10 @@ And optional:
 
 ### Install taraxa-node dependencies:
 
-First you need to get (Brew)[https://brew.sh/] package manager. After that you need tot install dependencies with it. Currently there is no llvm-14 in brew, but it works well with llvm-13
+First you need to get (Brew)[https://brew.sh/] package manager. After that you need tot install dependencies with it. Clang-14 is used for compilation.
 
     brew update
-    brew install coreutils go autoconf automake gflags git libtool llvm@13 make pkg-config cmake conan snappy zstd rapidjson gmp mpfr
+    brew install coreutils go autoconf automake gflags git libtool llvm@14 make pkg-config cmake conan snappy zstd rapidjson gmp mpfr
 
 ### Clone the Repository
 
@@ -186,7 +186,8 @@ First you need to get (Brew)[https://brew.sh/] package manager. After that you n
     # It is recommended to use clang because on other compilers you could face some errors
     conan profile new clang --detect && \
     conan profile update settings.compiler=clang clang && \
-    conan profile update settings.compiler.version=13 clang && \
+    conan profile update settings.compiler.version=14 clang && \
+    conan profile update settings.compiler.compiler.cppstd=14
     conan profile update settings.compiler.libcxx=libc++ clang && \
     conan profile update env.CC=clang clang && \
     conan profile update env.CXX=clang++ clang
@@ -222,28 +223,6 @@ It could be cleaned up with:
 
 ```
 rm -rf ~/.conan/data
-```
-
-#### Project building issue
-
-If you are facing strange errors with project compilation it could be a problem that after install of llvm clang if pointing to a default apple clang. You could check that with `clang --version`. It should not point to `/Library/Developer/CommandLineTools/usr/bin`, but something like `/usr/local/opt/llvm/bin`. So you should specify full paths to a compiler:
-1. Check full path with `brew info llvm`. Search for command that looks like
-```
-    echo 'export PATH="/usr/local/opt/llvm/bin:$PATH"' >> ~/.zshrc
-```
-2. Take bin path from it. In our case this is `/usr/local/opt/llvm/bin` It shouldn't differ for most cases.
-3. Append compiler to it and specify it in conan profile:
-```
-    conan profile update env.CC=/usr/local/opt/llvm/bin/clang clang && \
-    conan profile update env.CXX=/usr/local/opt/llvm/bin/clang++ clang
-```
-4. Specify compiler with full path to cmake:
-```
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ ../
-```
-5. After successfull finish of that command processing compile project with:
-```
-make -j$(nproc)
 ```
 
 ## Building on M1 Macs for x86_64 with Rosetta2


### PR DESCRIPTION
## Purpose
<!-- Provide any information reviewers might need to have context on your changes. -->

1. I was not able to build conan libraries without specifying:
`conan profile update settings.compiler.compiler.cppstd=14`
in clang conan profile

2. Seems like there is already clang14 in brew ?

## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
