### PR TITLE
fix: gas estimations for transactions with internal calls

### DIFF
--- a/libraries/core_libs/network/rpc/eth/Eth.cpp
+++ b/libraries/core_libs/network/rpc/eth/Eth.cpp
@@ -152,14 +152,50 @@ class EthImpl : public Eth, EthParams {
     const auto block_number = get_block_number_from_json(_jsonBlock);
     auto t = toTransactionSkeleton(_json);
     prepare_transaction_for_call(t, block_number);
-    return toJS(call(block_number, t).code_retval);
+    auto ret = call(block_number, t);
+    if (!ret.consensus_err.empty() || !ret.code_err.empty()) {
+      throw std::runtime_error(ret.consensus_err.empty() ? ret.code_err : ret.consensus_err);
+    }
+    return toJS(ret.code_retval);
   }
 
   string eth_estimateGas(const Json::Value& _json) override {
     auto t = toTransactionSkeleton(_json);
     auto blk_n = final_chain->last_block_number();
     prepare_transaction_for_call(t, blk_n);
-    return toJS(call(blk_n, t).gas_used);
+
+    auto is_enough_gas = [&](gas_t gas) -> bool {
+      t.gas = gas;
+      auto res = call(blk_n, t);
+      if (!res.consensus_err.empty()) {
+        throw std::runtime_error(res.consensus_err);
+      }
+      if (!res.code_err.empty()) {
+        return false;
+      }
+      return true;
+    };
+    // couldn't be lower than execution gas_used. So we should start with this value
+    auto call_result = call(blk_n, t);
+    if (!call_result.consensus_err.empty() || !call_result.code_err.empty()) {
+      throw std::runtime_error(call_result.consensus_err.empty() ? call_result.code_err : call_result.consensus_err);
+    }
+    gas_t low = call_result.gas_used;
+    gas_t hi = *t.gas;
+    if (low > hi) {
+      throw std::runtime_error("out of gas");
+    }
+    // precision is 5%(1/20) of higher gas_used value
+    while (hi - low > hi / 20) {
+      auto mid = low + ((hi - low) / 2);
+
+      if (is_enough_gas(mid)) {
+        hi = mid;
+      } else {
+        low = mid;
+      }
+    }
+    return toJS(hi);
   }
 
   string eth_getTransactionCount(const string& _address, const Json::Value& _json) override {
@@ -362,10 +398,7 @@ class EthImpl : public Eth, EthParams {
         },
         blk_n);
 
-    if (result.consensus_err.empty() && result.code_err.empty()) {
-      return result;
-    }
-    throw std::runtime_error(result.consensus_err.empty() ? result.code_err : result.consensus_err);
+    return result;
   }
 
   // this should be used only in eth_call and eth_estimateGas

--- a/tests/rpc_test.cpp
+++ b/tests/rpc_test.cpp
@@ -21,13 +21,20 @@ TEST_F(RPCTest, eth_estimateGas) {
   auto eth_json_rpc = net::rpc::eth::NewEth(std::move(eth_rpc_params));
 
   const auto from = dev::toHex(dev::toAddress(node_cfg.front().node_secret));
+  auto check_estimation_is_in_range = [&](const Json::Value& trx, const std::string& e) {
+    auto estimate = dev::jsToInt(eth_json_rpc->eth_estimateGas(trx));
+    auto expected = dev::jsToInt(e);
+    EXPECT_GE(estimate, expected);
+    EXPECT_GE(expected / 20, estimate - expected);
+  };
+
   // Contract creation estimations with author + without author
   {
     Json::Value trx(Json::objectValue);
     trx["data"] = samples::greeter_contract_code;
-    EXPECT_EQ(eth_json_rpc->eth_estimateGas(trx), "0x5ccc5");
+    check_estimation_is_in_range(trx, "0x5ccc5");
     trx["from"] = from;
-    EXPECT_EQ(eth_json_rpc->eth_estimateGas(trx), "0x5ccc5");
+    check_estimation_is_in_range(trx, "0x5ccc5");
   }
 
   // Contract creation with value
@@ -35,7 +42,7 @@ TEST_F(RPCTest, eth_estimateGas) {
     Json::Value trx(Json::objectValue);
     trx["value"] = 1;
     trx["data"] = samples::greeter_contract_code;
-    EXPECT_EQ(eth_json_rpc->eth_estimateGas(trx), "0x5ccc5");
+    check_estimation_is_in_range(trx, "0x5ccc5");
   }
 
   // Simple transfer estimations with author + without author
@@ -43,9 +50,9 @@ TEST_F(RPCTest, eth_estimateGas) {
     Json::Value trx(Json::objectValue);
     trx["value"] = 1;
     trx["to"] = dev::toHex(addr_t::random());
-    EXPECT_EQ(eth_json_rpc->eth_estimateGas(trx), "0x5208");  // 21k
+    check_estimation_is_in_range(trx, "0x5208");  // 21k
     trx["from"] = from;
-    EXPECT_EQ(eth_json_rpc->eth_estimateGas(trx), "0x5208");  // 21k
+    check_estimation_is_in_range(trx, "0x5208");  // 21k
   }
 
   // Test throw on failed transaction


### PR DESCRIPTION
Fix for transactions estimation. Before this fix some transactions with internal calls to other contracts(and maybe in some other cases) was running out of gas. So estimations wasn't correct