### PR TITLE
chore: prune state_db manually

### DIFF
--- a/libraries/cli/include/cli/config.hpp
+++ b/libraries/cli/include/cli/config.hpp
@@ -42,6 +42,7 @@ class Config {
   static constexpr const char* HELP = "help";
   static constexpr const char* VERSION = "version";
   static constexpr const char* WALLET = "wallet";
+  static constexpr const char* PRUNE_STATE_DB = "prune-state-db";
 
   static constexpr const char* NODE_COMMAND = "node";
   static constexpr const char* ACCOUNT_COMMAND = "account";

--- a/libraries/cli/src/config.cpp
+++ b/libraries/cli/src/config.cpp
@@ -38,6 +38,8 @@ Config::Config(int argc, const char* argv[]) {
   bool destroy_db = false;
   bool rebuild_network = false;
   bool rebuild_db = false;
+  bool prune_state_db = false;
+
   bool light_node = false;
   bool version = false;
   uint64_t rebuild_db_period = 0;
@@ -129,6 +131,7 @@ Config::Config(int argc, const char* argv[]) {
                                      "Enables Test JsonRPC. Disabled by default");
   node_command_options.add_options()(ENABLE_DEBUG, bpo::bool_switch(&enable_debug),
                                      "Enables Debug RPC interface. Disabled by default");
+  node_command_options.add_options()(PRUNE_STATE_DB, bpo::bool_switch(&prune_state_db), "Prune state_db");
 
   allowed_options.add(main_options);
 
@@ -261,6 +264,7 @@ Config::Config(int argc, const char* argv[]) {
     }
     node_config_.db_config.db_revert_to_period = revert_to_period;
     node_config_.db_config.rebuild_db = rebuild_db;
+    node_config_.db_config.prune_state_db = prune_state_db;
     node_config_.db_config.rebuild_db_period = rebuild_db_period;
 
     node_config_.enable_test_rpc = enable_test_rpc;

--- a/libraries/config/include/config/config.hpp
+++ b/libraries/config/include/config/config.hpp
@@ -15,6 +15,7 @@ struct DBConfig {
   uint32_t db_max_open_files = 0;
   PbftPeriod db_revert_to_period = 0;
   bool rebuild_db = false;
+  bool prune_state_db = false;
   PbftPeriod rebuild_db_period = 0;
 };
 

--- a/libraries/config/src/config.cpp
+++ b/libraries/config/src/config.cpp
@@ -98,13 +98,11 @@ FullNodeConfig::FullNodeConfig(const Json::Value &string_or_object, const Json::
   }
 
   is_light_node = getConfigDataAsBoolean(root, {"is_light_node"}, true, is_light_node);
-  if (is_light_node) {
-    const auto min_light_node_history = (genesis.state.dpos.blocks_per_year * kDefaultLightNodeHistoryDays) / 365;
-    light_node_history = getConfigDataAsUInt(root, {"light_node_history"}, true, min_light_node_history);
-    if (light_node_history < min_light_node_history) {
-      throw ConfigException("Min. required light node history is " + std::to_string(min_light_node_history) +
-                            " blocks (" + std::to_string(kDefaultLightNodeHistoryDays) + " days)");
-    }
+  const auto min_light_node_history = (genesis.state.dpos.blocks_per_year * kDefaultLightNodeHistoryDays) / 365;
+  light_node_history = getConfigDataAsUInt(root, {"light_node_history"}, true, min_light_node_history);
+  if (light_node_history < min_light_node_history) {
+    throw ConfigException("Min. required light node history is " + std::to_string(min_light_node_history) +
+                          " blocks (" + std::to_string(kDefaultLightNodeHistoryDays) + " days)");
   }
 
   try {


### PR DESCRIPTION
Pruning state_db in a light node requires deleting very large number of db entries in the state_db which can take a long time. Running this synchronously while running a node makes this even slower and node is unable to progress while doing this. Running it asynchronously also slows done the node and causes some crashes that are still being investigated. It is questionable it is feasible and practical to do this while node is running.
This probably would not be a problem is state_db is not growing at the rate it is now.
This change will make state_db prune run only manually on cmd line argument prune-state-db.
Deleting old period_data is fast so this still works in a light node same as before with data being deleted while running the node.