### PR TITLE
feat: change how we process db versions changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(TARAXA_NET_VERSION 1)
 set(TARAXA_DB_MAJOR_VERSION 1)
 # Minor version should be modified when changes to the database are made in the tables that can be rebuilt from the
 # basic tables
-set(TARAXA_DB_MINOR_VERSION 0)
+set(TARAXA_DB_MINOR_VERSION 1)
 
 # Defines Taraxa library target.
 project(taraxa-node VERSION ${TARAXA_VERSION})

--- a/libraries/core_libs/node/src/node.cpp
+++ b/libraries/core_libs/node/src/node.cpp
@@ -67,8 +67,8 @@ void FullNode::init() {
                                       conf_.db_config.db_max_open_files, conf_.db_config.db_max_snapshots,
                                       conf_.db_config.db_revert_to_period, node_addr, false);
 
-    if (db_->hasMinorVersionChanged()) {
-      LOG(log_si_) << "Minor DB version has changed. Rebuilding Db";
+    if (db_->hasMajorVersionChanged()) {
+      LOG(log_si_) << "Major DB version has changed. Rebuilding Db";
       conf_.db_config.rebuild_db = true;
       db_ = nullptr;
       old_db_ = std::make_shared<DbStorage>(conf_.db_path, conf_.db_config.db_snapshot_each_n_pbft_block,
@@ -77,12 +77,12 @@ void FullNode::init() {
       db_ = std::make_shared<DbStorage>(conf_.db_path, conf_.db_config.db_snapshot_each_n_pbft_block,
                                         conf_.db_config.db_max_open_files, conf_.db_config.db_max_snapshots,
                                         conf_.db_config.db_revert_to_period, node_addr);
+    } else if (db_->hasMinorVersionChanged()) {
+      storage::migration::Manager(db_).applyAll();
     }
     if (db_->getDagBlocksCount() == 0) {
       db_->setGenesisHash(conf_.genesis.genesisHash());
     }
-
-    storage::migration::Manager(db_).applyAll();
   }
   LOG(log_nf_) << "DB initialized ...";
 

--- a/libraries/core_libs/node/src/node.cpp
+++ b/libraries/core_libs/node/src/node.cpp
@@ -80,6 +80,8 @@ void FullNode::init() {
     } else if (db_->hasMinorVersionChanged()) {
       storage::migration::Manager(db_).applyAll();
     }
+    db_->updateDbVersions();
+
     if (db_->getDagBlocksCount() == 0) {
       db_->setGenesisHash(conf_.genesis.genesisHash());
     }

--- a/libraries/core_libs/storage/include/storage/migration/migration_base.hpp
+++ b/libraries/core_libs/storage/include/storage/migration/migration_base.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "logger/logger.hpp"
 #include "storage/storage.hpp"
 
 namespace taraxa::storage::migration {
@@ -11,8 +12,11 @@ class Base {
   virtual uint32_t dbVersion() = 0;
 
   bool isApplied() { return db_->lookup_int<bool>(id(), DB::Columns::migrations).has_value(); }
-  void apply() {
+  void apply(logger::Logger& log) {
     if (db_->getMajorVersion() != dbVersion()) {
+      LOG(log) << id()
+               << ": skip migration as it was made for different major db version. Could be removed from the code"
+               << std::endl;
       return;
     }
     migrate();

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -176,6 +176,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   void loadSnapshots();
   void disableSnapshots();
   void enableSnapshots();
+  void updateDbVersions();
 
   uint32_t getMajorVersion() const;
   std::unique_ptr<rocksdb::Iterator> getColumnIterator(const Column& c);

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -144,6 +144,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   std::set<PbftPeriod> snapshots_;
 
   uint32_t kMajorVersion_;
+  bool major_version_changed_ = false;
   bool minor_version_changed_ = false;
 
   auto handle(Column const& col) const { return handles_[col.ordinal_]; }
@@ -307,6 +308,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   void addProposalPeriodDagLevelsMapToBatch(uint64_t level, PbftPeriod period, Batch& write_batch);
 
   bool hasMinorVersionChanged() { return minor_version_changed_; }
+  bool hasMajorVersionChanged() { return major_version_changed_; }
 
   void compactColumn(Column const& column) { db_->CompactRange({}, handle(column), nullptr, nullptr); }
 

--- a/libraries/core_libs/storage/src/migration/migration_manager.cpp
+++ b/libraries/core_libs/storage/src/migration/migration_manager.cpp
@@ -11,9 +11,9 @@ Manager::Manager(std::shared_ptr<DbStorage> db, const addr_t& node_addr) : db_(d
 void Manager::applyAll() {
   for (const auto& m : migrations_) {
     if (!m->isApplied()) {
-      LOG(log_nf_) << "Applying migration " << m->id();
-      m->apply();
-      LOG(log_nf_) << "Migration applied " << m->id();
+      LOG(log_si_) << "Applying migration " << m->id();
+      m->apply(log_si_);
+      LOG(log_si_) << "Migration applied " << m->id();
     }
   }
 }

--- a/libraries/core_libs/storage/src/storage.cpp
+++ b/libraries/core_libs/storage/src/storage.cpp
@@ -79,21 +79,16 @@ DbStorage::DbStorage(fs::path const& path, uint32_t db_snapshot_each_n_pbft_bloc
 
   kMajorVersion_ = getStatusField(StatusDbField::DbMajorVersion);
   uint32_t minor_version = getStatusField(StatusDbField::DbMinorVersion);
-  auto save_db_versions = [&]() {
-    saveStatusField(StatusDbField::DbMajorVersion, TARAXA_DB_MAJOR_VERSION);
-    saveStatusField(StatusDbField::DbMinorVersion, TARAXA_DB_MINOR_VERSION);
-  };
-  if (kMajorVersion_ == 0 && minor_version == 0) {
-    save_db_versions();
-  } else {
-    if (kMajorVersion_ != TARAXA_DB_MAJOR_VERSION) {
-      major_version_changed_ = true;
-      save_db_versions();
-    } else if (minor_version != TARAXA_DB_MINOR_VERSION) {
-      minor_version_changed_ = true;
-      save_db_versions();
-    }
+  if (kMajorVersion_ != 0 && kMajorVersion_ != TARAXA_DB_MAJOR_VERSION) {
+    major_version_changed_ = true;
+  } else if (minor_version != TARAXA_DB_MINOR_VERSION) {
+    minor_version_changed_ = true;
   }
+}
+
+void DbStorage::updateDbVersions() {
+  saveStatusField(StatusDbField::DbMajorVersion, TARAXA_DB_MAJOR_VERSION);
+  saveStatusField(StatusDbField::DbMinorVersion, TARAXA_DB_MINOR_VERSION);
 }
 
 void DbStorage::rebuildColumns(const rocksdb::Options& options) {

--- a/libraries/core_libs/storage/src/storage.cpp
+++ b/libraries/core_libs/storage/src/storage.cpp
@@ -79,16 +79,19 @@ DbStorage::DbStorage(fs::path const& path, uint32_t db_snapshot_each_n_pbft_bloc
 
   kMajorVersion_ = getStatusField(StatusDbField::DbMajorVersion);
   uint32_t minor_version = getStatusField(StatusDbField::DbMinorVersion);
-  if (kMajorVersion_ == 0 && minor_version == 0) {
+  auto save_db_versions = [&]() {
     saveStatusField(StatusDbField::DbMajorVersion, TARAXA_DB_MAJOR_VERSION);
     saveStatusField(StatusDbField::DbMinorVersion, TARAXA_DB_MINOR_VERSION);
+  };
+  if (kMajorVersion_ == 0 && minor_version == 0) {
+    save_db_versions();
   } else {
     if (kMajorVersion_ != TARAXA_DB_MAJOR_VERSION) {
-      throw DbException(string("Database version mismatch. Version on disk ") +
-                        getFormattedVersion({kMajorVersion_, minor_version}) +
-                        " Node version:" + getFormattedVersion({TARAXA_DB_MAJOR_VERSION, TARAXA_DB_MINOR_VERSION}));
+      major_version_changed_ = true;
+      save_db_versions();
     } else if (minor_version != TARAXA_DB_MINOR_VERSION) {
       minor_version_changed_ = true;
+      save_db_versions();
     }
   }
 }


### PR DESCRIPTION
Change the way we are processing db versions change. 
So after this change we are applying migrations on minor version change and rebuilding db on major version change