### PR TITLE
chore: improve prune

### DIFF
--- a/libraries/core_libs/consensus/include/final_chain/state_api.hpp
+++ b/libraries/core_libs/consensus/include/final_chain/state_api.hpp
@@ -48,8 +48,7 @@ class StateAPI {
                                                 const RewardsStats& rewards_stats = {});
   void transition_state_commit();
   void create_snapshot(PbftPeriod period);
-  void prune(const dev::h256& state_root_to_keep, const std::vector<dev::h256>& state_root_to_prune,
-             EthBlockNumber blk_num);
+  void prune(const std::vector<dev::h256>& state_root_to_keep, EthBlockNumber blk_num);
 
   // DPOS
   uint64_t dpos_eligible_total_vote_count(EthBlockNumber blk_num) const;

--- a/libraries/core_libs/consensus/src/dag/dag_manager.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_manager.cpp
@@ -287,6 +287,8 @@ void DagManager::clearLightNodeHistory() {
   // Actual history size will be between 100% and 110% of light_node_history_ to avoid deleting on every period
   if (((period_ % (std::max(light_node_history_ / 10, (uint64_t)1)) == 0)) && period_ > light_node_history_ &&
       dag_expiry_level_ > max_levels_per_period_ + 1) {
+    // This will happen at most once a day so log a silent log
+    LOG(log_si_) << "Clear light node history";
     const auto proposal_period = db_->getProposalPeriodForDagLevel(dag_expiry_level_ - max_levels_per_period_ - 1);
     assert(proposal_period);
 
@@ -299,6 +301,7 @@ void DagManager::clearLightNodeHistory() {
                  << " *proposal_period " << *proposal_period;
     LOG(log_tr_) << "Delete period history from: " << start << " to " << end;
     db_->clearPeriodDataHistory(end);
+    LOG(log_si_) << "Clear light node history completed";
   }
 }
 

--- a/libraries/core_libs/consensus/src/final_chain/state_api.cpp
+++ b/libraries/core_libs/consensus/src/final_chain/state_api.cpp
@@ -204,9 +204,8 @@ void StateAPI::create_snapshot(PbftPeriod period) {
   err_h.check();
 }
 
-void StateAPI::prune(const dev::h256& state_root_to_keep, const std::vector<dev::h256>& state_root_to_prune,
-                     EthBlockNumber blk_num) {
-  return c_method_args_rlp<taraxa_evm_state_api_prune>(this_c_, state_root_to_keep, state_root_to_prune, blk_num);
+void StateAPI::prune(const std::vector<dev::h256>& state_root_to_keep, EthBlockNumber blk_num) {
+  return c_method_args_rlp<taraxa_evm_state_api_prune>(this_c_, state_root_to_keep, blk_num);
 }
 
 uint64_t StateAPI::dpos_eligible_total_vote_count(EthBlockNumber blk_num) const {

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -685,30 +685,12 @@ TEST_F(FullNodeTest, sync_five_nodes) {
 
   // Prune state_db of one node
   auto prune_node = nodes[nodes.size() - 1];
-  const uint32_t min_blocks_to_prune = 50;
+  const uint32_t min_blocks_to_prune = 30;
   // This ensures that we never prune blocks that are over proposal period
-  ASSERT_HAPPENS({20s, 100ms}, [&](auto &ctx) {
-    const auto max_level = prune_node->getDagManager()->getMaxLevel();
-    const auto proposal_period = prune_node->getDB()->getProposalPeriodForDagLevel(max_level);
-    ASSERT_TRUE(proposal_period.has_value());
-    context.dummy_transaction();
-    WAIT_EXPECT_TRUE(ctx, ((*proposal_period) > min_blocks_to_prune))
+  ASSERT_HAPPENS({40s, 100ms}, [&](auto &ctx) {
+    WAIT_EXPECT_TRUE(ctx, (prune_node->getPbftChain()->getPbftChainSize() > min_blocks_to_prune + kMaxLevelsPerPeriod))
   });
   prune_node->getFinalChain()->prune(min_blocks_to_prune);
-  context.assert_balances_synced();
-
-  // transfer some coins to pruned node ...
-  context.coin_transfer(0, prune_node->getAddress(), init_bal, false);
-  context.wait_all_transactions_known();
-
-  std::cout << "Waiting until transaction is executed" << std::endl;
-  auto trx_cnt = context.getIssuedTrxCount();
-  ASSERT_HAPPENS({20s, 500ms}, [&](auto &ctx) {
-    for (size_t i = 0; i < nodes.size(); ++i)
-      WAIT_EXPECT_EQ(ctx, nodes[i]->getDB()->getNumTransactionExecuted(), trx_cnt)
-  });
-
-  // Check balances after prune";
   context.assert_balances_synced();
 }
 


### PR DESCRIPTION
Review this as well:
https://github.com/Taraxa-project/taraxa-evm/pull/165

Main and account node databases are huge with large number of entries. Any prune where deleting these entries one by one is taking a very long time. This is avoided by having prune load the data in memory that is to be kept and than deleting the entire column in the database at once and recreating it and populating it with data stored in memory. This makes the prune run in about 3 minutes for a month of data.

Since the prune is relatively fast it can be started manually but it is also run on restart for a light node.