### PR TITLE
feat: add option to change rewards distribution frequency with hardfork

### DIFF
--- a/libraries/cli/include/cli/config_jsons/devnet/devnet_genesis.json
+++ b/libraries/cli/include/cli/config_jsons/devnet/devnet_genesis.json
@@ -226,6 +226,10 @@
     "7e4aa664f71de4e9d0b4a6473d796372639bdcde": "0x1027e72f1f12813088000000",
     "ee1326fbf7d9322e5ea02c6fe5eb63535fceccd1": "0x52b7d2dcc80cd2e4000000"
   },
+  "hardforks": {
+    "rewards_distribution_frequency": {
+    }
+  },
   "gas_price": {
     "blocks": 200,
     "percentile": 60,

--- a/libraries/cli/include/cli/config_jsons/mainnet/mainnet_genesis.json
+++ b/libraries/cli/include/cli/config_jsons/mainnet/mainnet_genesis.json
@@ -243,6 +243,10 @@
       }
     ]
   },
+  "hardforks": {
+    "rewards_distribution_frequency": {
+    }
+  },
   "initial_balances": {
     "723304d1357a2334fcf902aa3d232f5139080a1b": "0xd53323b7ca3737afbb45000",
     "b0800c7af0a6aec0ff8dbe01708bd8e300c6305b": "0x208b1d135e4a8000",

--- a/libraries/cli/include/cli/config_jsons/testnet/testnet_genesis.json
+++ b/libraries/cli/include/cli/config_jsons/testnet/testnet_genesis.json
@@ -1698,6 +1698,10 @@
     "a903715b57d3bf62e098a6a643c6924d9bdacec4": "0x170a0f5040e50400000",
     "5bd47fef8e8dcb6677c2957ecd78b8232354f145": "0x191cf61eb2bec223400"
   },
+  "hardforks": {
+    "rewards_distribution_frequency": {
+    }
+  },
   "gas_price": {
     "blocks": 200,
     "percentile": 60,

--- a/libraries/config/CMakeLists.txt
+++ b/libraries/config/CMakeLists.txt
@@ -7,7 +7,7 @@ set(HEADERS
     include/config/dag_config.hpp
     include/config/pbft_config.hpp
     include/config/state_config.hpp
-    # include/config/hardfork.hpp
+    include/config/hardfork.hpp
 )
 
 set(SOURCES
@@ -18,7 +18,7 @@ set(SOURCES
     src/dag_config.cpp
     src/pbft_config.cpp
     src/state_config.cpp
-    # src/hardfork.cpp
+    src/hardfork.cpp
 )
 
 # Configure file with version

--- a/libraries/config/include/config/hardfork.hpp
+++ b/libraries/config/include/config/hardfork.hpp
@@ -5,7 +5,18 @@
 #include "common/encoding_rlp.hpp"
 
 struct Hardforks {
-  uint64_t fix_genesis_fork_block = 0;
+  /*
+   * @brief key is block number at which change is applied and value is new distribution interval.
+   * Default distribution frequency is every block
+   * To change rewards distribution frequency we should add a new element in map below.
+   * For example {{101, 20}, {201, 10}} means:
+   * 1. for blocks [1,100] we are distributing rewards every block
+   * 2. for blocks [101, 200] rewards are distributed every 20 block. On blocks 120, 140, etc.
+   * 3. for blocks after 201 rewards are distributed every 10 block. On blocks 210, 220, etc.
+   */
+  using RewardsDistributionMap = std::map<uint64_t, uint32_t>;
+  RewardsDistributionMap rewards_distribution_frequency;
+
   HAS_RLP_FIELDS
 };
 

--- a/libraries/config/include/config/state_config.hpp
+++ b/libraries/config/include/config/state_config.hpp
@@ -6,7 +6,7 @@
 #include "common/encoding_rlp.hpp"
 #include "common/types.hpp"
 #include "common/vrf_wrapper.hpp"
-// #include "config/hardfork.hpp"
+#include "config/hardfork.hpp"
 
 namespace taraxa::state_api {
 
@@ -61,7 +61,7 @@ struct Config {
   EVMChainConfig evm_chain_config;
   BalanceMap initial_balances;
   DPOSConfig dpos;
-  // Hardforks hardforks;
+  Hardforks hardforks;
 
   HAS_RLP_FIELDS
 };

--- a/libraries/config/src/hardfork.cpp
+++ b/libraries/config/src/hardfork.cpp
@@ -2,14 +2,23 @@
 
 Json::Value enc_json(const Hardforks& obj) {
   Json::Value json(Json::objectValue);
-  json["fix_genesis_fork_block"] = dev::toJS(obj.fix_genesis_fork_block);
+
+  auto& rewards = json["rewards_distribution_frequency"];
+  rewards = Json::objectValue;
+  for (auto i = obj.rewards_distribution_frequency.begin(); i != obj.rewards_distribution_frequency.end(); ++i) {
+    rewards[std::to_string(i->first)] = i->second;
+  }
   return json;
 }
 
 void dec_json(const Json::Value& json, Hardforks& obj) {
-  if (auto const& e = json["fix_genesis_fork_block"]) {
-    obj.fix_genesis_fork_block = dev::getUInt(e);
+  if (const auto& e = json["rewards_distribution_frequency"]) {
+    assert(e.isObject());
+
+    for (auto itr = e.begin(); itr != e.end(); ++itr) {
+      obj.rewards_distribution_frequency[itr.key().asUInt64()] = itr->asUInt64();
+    }
   }
 }
 
-RLP_FIELDS_DEFINE(Hardforks, fix_genesis_fork_block)
+RLP_FIELDS_DEFINE(Hardforks, rewards_distribution_frequency)

--- a/libraries/config/src/state_config.cpp
+++ b/libraries/config/src/state_config.cpp
@@ -22,14 +22,14 @@ void dec_json(const Json::Value& /*json*/, uint64_t chain_id, EVMChainConfig& ob
 void append_json(Json::Value& json, const Config& obj) {
   json["evm_chain_config"] = enc_json(obj.evm_chain_config);
   json["initial_balances"] = enc_json(obj.initial_balances);
-  // json["hardforks"] = enc_json(obj.hardforks);
+  json["hardforks"] = enc_json(obj.hardforks);
   json["dpos"] = enc_json(obj.dpos);
 }
 
 void dec_json(const Json::Value& json, Config& obj) {
   dec_json(json["evm_chain_config"], json["chain_id"].asUInt(), obj.evm_chain_config);
   dec_json(json["initial_balances"], obj.initial_balances);
-  // dec_json(json["hardforks"], obj.hardforks);
+  dec_json(json["hardforks"], obj.hardforks);
   dec_json(json["dpos"], obj.dpos);
 }
 

--- a/libraries/core_libs/consensus/include/rewards/block_stats.hpp
+++ b/libraries/core_libs/consensus/include/rewards/block_stats.hpp
@@ -15,6 +15,8 @@ namespace taraxa::rewards {
  */
 class BlockStats {
  public:
+  // Needed for RLP
+  BlockStats() = default;
   /**
    * @brief setting block_author_, max_votes_weight_ and calls processStats function
    *
@@ -58,7 +60,7 @@ class BlockStats {
    */
   bool addVote(const std::shared_ptr<Vote>& vote);
 
- private:
+ protected:
   struct ValidatorStats {
     // count of rewardable(with 1 or more unique transactions) DAG blocks produced by this validator
     uint32_t dag_blocks_count_ = 0;

--- a/libraries/core_libs/consensus/include/rewards/rewards_stats.hpp
+++ b/libraries/core_libs/consensus/include/rewards/rewards_stats.hpp
@@ -1,17 +1,54 @@
 #include "config/hardfork.hpp"
 #include "rewards/block_stats.hpp"
+#include "storage/storage.hpp"
 
 namespace taraxa::rewards {
+/*
+ * @brief class that is managing rewards stats processing and hardforks(intervals changes)
+ * So intermediate blocks stats are stored in the vector in data(to restore on the node restart)
+ * and full list of interval stats is returned in the end of interval
+ */
 class Stats {
  public:
-  Stats(uint32_t committee_size, std::function<uint64_t(EthBlockNumber)>&& dpos_eligible_total_vote_count);
+  Stats(uint32_t committee_size, const Hardforks::RewardsDistributionMap& rdm, std::shared_ptr<DB> db,
+        std::function<uint64_t(EthBlockNumber)>&& dpos_eligible_total_vote_count);
 
-  std::vector<BlockStats> getStats(const PeriodData& current_blk);
+  /*
+   * @brief processing passed block and returns stats that should be processed at this block
+   * @param current_blk block to process
+   * @return vector<BlockStats> that should be processed at current block
+   */
+  std::vector<BlockStats> processStats(const PeriodData& current_blk);
 
- private:
+ protected:
+  /*
+   * @brief load current interval stats from database
+   */
+  void loadFromDb();
+  /*
+   * @brief returns rewards distribution frequency for specified period
+   */
+  uint32_t getCurrentDistributionFrequency(uint64_t current_period) const;
+  /*
+   * @brief gets all needed data and makes(processes) BlocksStats
+   * @param current_blk block to process
+   * @return block statistics needed for rewards distribution
+   */
   BlockStats getBlockStats(const PeriodData& current_blk);
+  /*
+   * @brief saves stats to database to not lose this data in case of node restart
+   */
+  void saveBlockStats(uint64_t number, const BlockStats& stats);
+  /*
+   * @brief called on start of new rewards interval. clears blocks_stats_ collection
+   * and removes all data saved in db column
+   */
+  void clear();
 
   const uint32_t kCommitteeSize;
+  const Hardforks::RewardsDistributionMap kRewardsDistributionFrequency;
+  std::shared_ptr<DB> db_;
   const std::function<uint64_t(EthBlockNumber)> dpos_eligible_total_vote_count_;
+  std::vector<BlockStats> blocks_stats_;
 };
 }  // namespace taraxa::rewards

--- a/libraries/core_libs/consensus/src/final_chain/final_chain.cpp
+++ b/libraries/core_libs/consensus/src/final_chain/final_chain.cpp
@@ -59,7 +59,7 @@ class FinalChainImpl final : public FinalChain {
         kLightNode(config.is_light_node),
         kLightNodeHistory(config.light_node_history),
         kMaxLevelsPerPeriod(config.max_levels_per_period),
-        rewards_(config.genesis.pbft.committee_size,
+        rewards_(config.genesis.pbft.committee_size, config.genesis.state.hardforks.rewards_distribution_frequency, db_,
                  [this](EthBlockNumber n) { return dpos_eligible_total_vote_count(n); }),
         block_headers_cache_(config.final_chain_cache_in_blocks,
                              [this](uint64_t blk) { return get_block_header(blk); }),
@@ -151,7 +151,7 @@ class FinalChainImpl final : public FinalChain {
                                                       std::shared_ptr<DagBlock>&& anchor) {
     auto batch = db_->createWriteBatch();
 
-    auto rewards_stats = rewards_.getStats(new_blk);
+    auto rewards_stats = rewards_.processStats(new_blk);
 
     block_applying_emitter_.emit(block_header()->number + 1);
 

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -121,6 +121,8 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
     COLUMN(final_chain_log_blooms_index);
     COLUMN_W_COMP(sortition_params_change, getIntComparator<PbftPeriod>());
 
+    COLUMN_W_COMP(block_rewards_stats, getIntComparator<uint64_t>());
+
 #undef COLUMN
 #undef COLUMN_W_COMP
   };
@@ -177,6 +179,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   void disableSnapshots();
   void enableSnapshots();
   void updateDbVersions();
+  void deleteColumnData(const Column& c);
 
   uint32_t getMajorVersion() const;
   std::unique_ptr<rocksdb::Iterator> getColumnIterator(const Column& c);

--- a/libraries/core_libs/storage/src/storage.cpp
+++ b/libraries/core_libs/storage/src/storage.cpp
@@ -91,6 +91,16 @@ void DbStorage::updateDbVersions() {
   saveStatusField(StatusDbField::DbMinorVersion, TARAXA_DB_MINOR_VERSION);
 }
 
+void DbStorage::deleteColumnData(const Column& c) {
+  checkStatus(db_->DropColumnFamily(handle(c)));
+
+  auto options = rocksdb::ColumnFamilyOptions();
+  if (c.comparator_) {
+    options.comparator = c.comparator_;
+  }
+  checkStatus(db_->CreateColumnFamily(options, c.name(), &handles_[c.ordinal_]));
+}
+
 void DbStorage::rebuildColumns(const rocksdb::Options& options) {
   std::unique_ptr<rocksdb::DB> db;
   std::vector<std::string> column_families;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,6 +69,9 @@ add_executable(vote_test vote_test.cpp)
 target_link_libraries(vote_test test_util)
 add_test(vote_test ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/vote_test)
 
+add_executable(rewards_stats_test rewards_stats_test.cpp)
+target_link_libraries(rewards_stats_test test_util)
+add_test(rewards_stats_test ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/rewards_stats_test)
 
 add_executable(tarcap_threadpool_test tarcap_threadpool_test.cpp)
 target_link_libraries(tarcap_threadpool_test test_util)

--- a/tests/rewards_stats_test.cpp
+++ b/tests/rewards_stats_test.cpp
@@ -1,0 +1,185 @@
+#include "rewards/rewards_stats.hpp"
+
+#include <gtest/gtest.h>
+#include <libdevcore/Address.h>
+#include <libdevcore/Common.h>
+#include <libdevcore/CommonJS.h>
+
+#include "test_util/gtest.hpp"
+#include "test_util/samples.hpp"
+
+namespace taraxa::core_tests {
+
+auto g_secret = dev::Secret("3800b2875669d9b2053c1aff9224ecfdc411423aac5b5a73d7a45ced1c3b9dcd",
+                            dev::Secret::ConstructFromStringType::FromHex);
+auto g_key_pair = Lazy([] { return dev::KeyPair(g_secret); });
+
+struct RewardsStatsTest : NodesTest {};
+
+class TestableRewardsStats : public rewards::Stats {
+ public:
+  TestableRewardsStats(const Hardforks::RewardsDistributionMap& rdm, std::shared_ptr<DB> db)
+      : rewards::Stats(100, rdm, db, [](auto) { return 100; }) {}
+  std::vector<rewards::BlockStats> getStats() { return blocks_stats_; }
+};
+
+class TestableBlockStats : public rewards::BlockStats {
+ public:
+  const addr_t& getAuthor() const { return block_author_; }
+};
+
+TEST_F(RewardsStatsTest, defaultDistribution) {
+  auto db = std::make_shared<DbStorage>(data_dir / "db");
+
+  std::vector<std::shared_ptr<Vote>> empty_votes;
+  auto rewards_stats = TestableRewardsStats({}, db);
+
+  for (auto i = 1; i < 5; ++i) {
+    PeriodData block(make_simple_pbft_block(blk_hash_t(i), i), empty_votes);
+    auto stats = rewards_stats.processStats(block);
+    ASSERT_EQ(stats.size(), 1);
+    ASSERT_TRUE(rewards_stats.getStats().empty());
+  }
+}
+
+TEST_F(RewardsStatsTest, statsSaving) {
+  auto db = std::make_shared<DbStorage>(data_dir / "db");
+
+  // distribute every 5 blocks
+  Hardforks::RewardsDistributionMap distribution{{0, 5}};
+
+  std::vector<std::shared_ptr<Vote>> empty_votes;
+  std::vector<addr_t> block_authors;
+  {
+    auto rewards_stats = TestableRewardsStats(distribution, db);
+
+    for (auto i = 1; i < 5; ++i) {
+      auto kp = dev::KeyPair::create();
+      block_authors.push_back(kp.address());
+
+      PeriodData block(make_simple_pbft_block(blk_hash_t(i), i, kp.secret()), empty_votes);
+      auto stats = rewards_stats.processStats(block);
+      ASSERT_EQ(rewards_stats.getStats().size(), block_authors.size());
+      ASSERT_TRUE(stats.empty());
+    }
+  }
+  {
+    // Load from db
+    auto rewards_stats = TestableRewardsStats(distribution, db);
+    auto stats = rewards_stats.getStats();
+    ASSERT_EQ(rewards_stats.getStats().size(), block_authors.size());
+
+    for (size_t i = 0; i < stats.size(); ++i) {
+      auto stats_with_get = reinterpret_cast<TestableBlockStats*>(&stats[i]);
+      ASSERT_EQ(stats_with_get->getAuthor(), block_authors[i]);
+    }
+  }
+}
+
+TEST_F(RewardsStatsTest, statsCleaning) {
+  auto db = std::make_shared<DbStorage>(data_dir / "db");
+
+  // distribute every 5 blocks
+  Hardforks::RewardsDistributionMap distribution{{0, 5}};
+
+  std::vector<std::shared_ptr<Vote>> empty_votes;
+  std::vector<addr_t> block_authors;
+  {
+    auto rewards_stats = TestableRewardsStats(distribution, db);
+
+    for (auto i = 1; i < 5; ++i) {
+      auto kp = dev::KeyPair::create();
+      block_authors.push_back(kp.address());
+
+      PeriodData block(make_simple_pbft_block(blk_hash_t(i), i, kp.secret()), empty_votes);
+      auto stats = rewards_stats.processStats(block);
+      ASSERT_EQ(rewards_stats.getStats().size(), block_authors.size());
+      ASSERT_TRUE(stats.empty());
+    }
+
+    // Process block 5 after which we should have no stats elements in db
+    PeriodData block(make_simple_pbft_block(blk_hash_t(5), 5), empty_votes);
+    rewards_stats.processStats(block);
+  }
+
+  // Load from db
+  auto rewards_stats = TestableRewardsStats(distribution, db);
+  ASSERT_TRUE(rewards_stats.getStats().empty());
+}
+
+TEST_F(RewardsStatsTest, statsProcessing) {
+  auto db = std::make_shared<DbStorage>(data_dir / "db");
+  // distribute every 10 blocks
+  auto rewards_stats = TestableRewardsStats({{0, 10}}, db);
+
+  std::vector<std::shared_ptr<Vote>> empty_votes;
+  std::vector<addr_t> block_authors;
+
+  // make blocks [1,9] and process them. output of processStats should be empty
+  for (auto i = 1; i < 10; ++i) {
+    auto kp = dev::KeyPair::create();
+    block_authors.push_back(kp.address());
+
+    PeriodData block(make_simple_pbft_block(blk_hash_t(i), i, kp.secret()), empty_votes);
+    auto stats = rewards_stats.processStats(block);
+    ASSERT_TRUE(stats.empty());
+    ASSERT_EQ(rewards_stats.getStats().size(), block_authors.size());
+  }
+
+  auto kp = dev::KeyPair::create();
+  block_authors.push_back(kp.address());
+
+  PeriodData block(make_simple_pbft_block(blk_hash_t(10), 10, kp.secret()), empty_votes);
+  auto stats = rewards_stats.processStats(block);
+  ASSERT_EQ(stats.size(), block_authors.size());
+
+  for (size_t i = 0; i < stats.size(); ++i) {
+    auto stats_with_get = reinterpret_cast<TestableBlockStats*>(&stats[i]);
+    ASSERT_EQ(stats_with_get->getAuthor(), block_authors[i]);
+  }
+  ASSERT_TRUE(rewards_stats.getStats().empty());
+}
+
+TEST_F(RewardsStatsTest, distributionChange) {
+  auto db = std::make_shared<DbStorage>(data_dir / "db");
+
+  Hardforks::RewardsDistributionMap distribution{{6, 5}, {11, 2}};
+
+  auto rewards_stats = TestableRewardsStats(distribution, db);
+
+  std::vector<std::shared_ptr<Vote>> empty_votes;
+  uint64_t period = 1;
+  for (; period <= 5; ++period) {
+    PeriodData block(make_simple_pbft_block(blk_hash_t(period), period), empty_votes);
+    auto stats = rewards_stats.processStats(block);
+    ASSERT_FALSE(stats.empty());
+  }
+  {
+    // make blocks [1,9] and process them. output of processStats should be empty
+    for (; period < 10; ++period) {
+      PeriodData block(make_simple_pbft_block(blk_hash_t(period), period), empty_votes);
+      auto stats = rewards_stats.processStats(block);
+      ASSERT_TRUE(stats.empty());
+    }
+    PeriodData block(make_simple_pbft_block(blk_hash_t(period), period), empty_votes);
+    auto stats = rewards_stats.processStats(block);
+  }
+
+  PeriodData block(make_simple_pbft_block(blk_hash_t(period), period), empty_votes);
+  auto stats = rewards_stats.processStats(block);
+}
+
+}  // namespace taraxa::core_tests
+
+using namespace taraxa;
+int main(int argc, char** argv) {
+  taraxa::static_init();
+
+  auto logging = logger::createDefaultLoggingConfig();
+  logging.verbosity = logger::Verbosity::Error;
+  addr_t node_addr;
+  logging.InitLogging(node_addr);
+
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/test_util/include/test_util/test_util.hpp
+++ b/tests/test_util/include/test_util/test_util.hpp
@@ -169,7 +169,7 @@ state_api::BalanceMap effective_initial_balances(const state_api::Config& cfg);
 u256 own_effective_genesis_bal(const FullNodeConfig& cfg);
 
 std::shared_ptr<PbftBlock> make_simple_pbft_block(const h256& hash, uint64_t period,
-                                                  const h256& anchor_hash = kNullBlockHash);
+                                                  const secret_t& pk = secret_t::random());
 
 std::vector<blk_hash_t> getOrderedDagBlocks(const std::shared_ptr<DbStorage>& db);
 

--- a/tests/test_util/src/test_util.cpp
+++ b/tests/test_util/src/test_util.cpp
@@ -96,10 +96,10 @@ u256 own_effective_genesis_bal(const FullNodeConfig& cfg) {
   return effective_initial_balances(cfg.genesis.state)[dev::toAddress(dev::Secret(cfg.node_secret))];
 }
 
-std::shared_ptr<PbftBlock> make_simple_pbft_block(const h256& hash, uint64_t period, const h256& anchor_hash) {
+std::shared_ptr<PbftBlock> make_simple_pbft_block(const h256& hash, uint64_t period, const secret_t& pk) {
   std::vector<vote_hash_t> reward_votes_hashes;
-  return std::make_shared<PbftBlock>(hash, anchor_hash, kNullBlockHash, kNullBlockHash, period, addr_t(0),
-                                     secret_t::random(), std::move(reward_votes_hashes));
+  return std::make_shared<PbftBlock>(hash, kNullBlockHash, kNullBlockHash, kNullBlockHash, period, addr_t(0), pk,
+                                     std::move(reward_votes_hashes));
 }
 
 std::vector<blk_hash_t> getOrderedDagBlocks(const std::shared_ptr<DbStorage>& db) {


### PR DESCRIPTION
Add option to specify different rewards distribution frequency as a hardfork. Default distribution frequency is every block, so until we will add some record to hardforks this version is still should be compatible with latest release.

So to change rewards distribution frequency we need to add a new element to `rewards_distribution_frequency` in `hardforks`.
For example map with {{101, 20}, {201, 10}} elements means:
1. for blocks [1,100] we are distributing rewards every block
2. for blocks [101, 200] rewards are distributed every 20 block. On blocks 120, 140, etc.
3. for blocks after 201 rewards are distributed every 10 block. On blocks 210, 220, etc.