### PR TITLE
chore: transaction pool overflow improvements

### DIFF
--- a/libraries/core_libs/consensus/include/transaction/transaction_queue.hpp
+++ b/libraries/core_libs/consensus/include/transaction/transaction_queue.hpp
@@ -144,7 +144,7 @@ class TransactionQueue {
 
   // If transactions are dropped within last kTransactionOverflowTimeLimit seconds, dag blocks with missing transactions
   // will not be treated as malicious
-  const std::chrono::seconds kTransactionOverflowTimeLimit{300};
+  const std::chrono::seconds kTransactionOverflowTimeLimit{600};
 
   // Limit when non proposable transactions expire
   const size_t kNonProposableTransactionsPeriodExpiryLimit = 10;

--- a/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
+++ b/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
@@ -380,7 +380,7 @@ std::optional<SharedTransactions> TransactionManager::getBlockTransactions(DagBl
       transactions.emplace_back(std::move(trx));
     }
   } else {
-    LOG(log_er_) << "Block " << blk.getHash() << " has missing transaction " << finalizedTransactions.second;
+    LOG(log_nf_) << "Block " << blk.getHash() << " has missing transaction " << finalizedTransactions.second;
     return std::nullopt;
   }
 

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
@@ -127,7 +127,7 @@ class TaraxaPeer : public boost::noncopyable {
   const uint64_t kMaxSuspiciousPacketPerMinute = 1000;
 
   // Performance extensive dag syncing is only allowed to be requested once each kDagSyncingLimit seconds
-  const uint64_t kDagSyncingLimit = 300;
+  const uint64_t kDagSyncingLimit = 60;
 
   // Packets stats for packets sent by *this TaraxaPeer
   PacketsStats sent_packets_stats_;

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -1396,7 +1396,7 @@ TEST_F(NetworkTest, suspicious_packets) {
 
 TEST_F(NetworkTest, dag_syncing_limit) {
   network::tarcap::TaraxaPeer peer1, peer2;
-  const uint64_t dag_sync_limit = 300;
+  const uint64_t dag_sync_limit = 60;
 
   EXPECT_TRUE(peer1.dagSyncingAllowed());
   peer1.peer_dag_synced_ = true;


### PR DESCRIPTION
With the current DAG and PBFT gas limit we are able to process about 400 transactions per second. Once the transaction pool is filled and some of the transactions are dropped on some of the nodes, those transactions might be included in some DAG block after the time to process full transactions pool. This would take (200000 transactions)/(400 transactions per second) which equals about 500 seconds. Because of this kTransactionOverflowTimeLimit is increased from 300 seconds to 600 seconds. This prevents malicious node exception for this cases while doing stress test on devnet.

Error log in TransactionManager::getBlockTransactions changed to info since there is a normal case when transactions could be missed. The actual error is logged in functions that invoke this one if needed for an actual error.

The recent limitations to dag and pbft gas limit significantly reduces the size of dag blocks. This makes dag syncing less performance extensive so reducing kDagSyncingLimit from 300 seconds to 60 seconds to allow more frequent dag syncing in case transactions are overflown and missing.