### PR TITLE
chore:fix sync large pbft block test

### DIFF
--- a/libraries/core_libs/network/src/tarcap/packets_handlers/latest/get_pbft_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/latest/get_pbft_sync_packet_handler.cpp
@@ -81,7 +81,7 @@ void GetPbftSyncPacketHandler::sendPbftBlocks(const std::shared_ptr<TaraxaPeer> 
     }
 
     dev::RLPStream s;
-    if (pbft_chain_synced && last_block && block_period > 1) {
+    if (pbft_chain_synced && last_block) {
       s.appendList(3);
       s << last_block;
       s.appendRaw(data);

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/v1/get_pbft_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/v1/get_pbft_sync_packet_handler.cpp
@@ -47,7 +47,7 @@ void GetPbftSyncPacketHandler::sendPbftBlocks(const std::shared_ptr<TaraxaPeer> 
     }
 
     dev::RLPStream s;
-    if (pbft_chain_synced && last_block && block_period > 1) {
+    if (pbft_chain_synced && last_block) {
       s.appendList(3);
       s << last_block;
       s.appendRaw(transformPeriodDataRlpToV1(data));


### PR DESCRIPTION
This is a fix for the NetworkTest.sync_large_pbft_block where the sync would fail for a node where there is only a block with period 1 in the chain
