### PR TITLE
chore: optimize peer cache memory usage

### DIFF
--- a/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
@@ -116,11 +116,11 @@ class TaraxaPeer : public boost::noncopyable {
  private:
   dev::p2p::NodeID id_;
 
-  ExpirationCache<blk_hash_t> known_dag_blocks_;
-  ExpirationCache<trx_hash_t> known_transactions_;
+  ExpirationBlockNumberCache<blk_hash_t> known_dag_blocks_;
+  ExpirationBlockNumberCache<trx_hash_t> known_transactions_;
   // PBFT
-  ExpirationCache<blk_hash_t> known_pbft_blocks_;
-  ExpirationCache<vote_hash_t> known_votes_;  // for peers
+  ExpirationBlockNumberCache<blk_hash_t> known_pbft_blocks_;
+  ExpirationBlockNumberCache<vote_hash_t> known_votes_;  // for peers
 
   std::atomic<uint64_t> timestamp_suspicious_packet_ = 0;
   std::atomic<uint64_t> suspicious_packet_count_ = 0;

--- a/libraries/core_libs/network/src/tarcap/taraxa_peer.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_peer.cpp
@@ -3,31 +3,37 @@
 namespace taraxa::network::tarcap {
 
 TaraxaPeer::TaraxaPeer()
-    : known_dag_blocks_(10000, 1000),
-      known_transactions_(100000, 10000),
-      known_pbft_blocks_(10000, 1000),
-      known_votes_(10000, 1000) {}
+    : known_dag_blocks_(10000, 1000, 10),
+      known_transactions_(100000, 10000, 10),
+      known_pbft_blocks_(10000, 1000, 10),
+      known_votes_(10000, 1000, 10) {}
 
 TaraxaPeer::TaraxaPeer(const dev::p2p::NodeID& id, size_t transaction_pool_size)
     : id_(id),
-      known_dag_blocks_(10000, 1000),
-      known_transactions_(transaction_pool_size * 1.2, transaction_pool_size / 10),
-      known_pbft_blocks_(10000, 1000),
-      known_votes_(100000, 1000) {}
+      known_dag_blocks_(10000, 1000, 10),
+      known_transactions_(transaction_pool_size * 1.2, transaction_pool_size / 10, 10),
+      known_pbft_blocks_(10000, 1000, 10),
+      known_votes_(100000, 1000, 10) {}
 
-bool TaraxaPeer::markDagBlockAsKnown(const blk_hash_t& hash) { return known_dag_blocks_.insert(hash); }
+bool TaraxaPeer::markDagBlockAsKnown(const blk_hash_t& hash) {
+  return known_dag_blocks_.insert(hash, pbft_chain_size_);
+}
 
 bool TaraxaPeer::isDagBlockKnown(const blk_hash_t& hash) const { return known_dag_blocks_.contains(hash); }
 
-bool TaraxaPeer::markTransactionAsKnown(const trx_hash_t& hash) { return known_transactions_.insert(hash); }
+bool TaraxaPeer::markTransactionAsKnown(const trx_hash_t& hash) {
+  return known_transactions_.insert(hash, pbft_chain_size_);
+}
 
 bool TaraxaPeer::isTransactionKnown(const trx_hash_t& hash) const { return known_transactions_.contains(hash); }
 
-bool TaraxaPeer::markVoteAsKnown(const vote_hash_t& hash) { return known_votes_.insert(hash); }
+bool TaraxaPeer::markVoteAsKnown(const vote_hash_t& hash) { return known_votes_.insert(hash, pbft_chain_size_); }
 
 bool TaraxaPeer::isVoteKnown(const vote_hash_t& hash) const { return known_votes_.contains(hash); }
 
-bool TaraxaPeer::markPbftBlockAsKnown(const blk_hash_t& hash) { return known_pbft_blocks_.insert(hash); }
+bool TaraxaPeer::markPbftBlockAsKnown(const blk_hash_t& hash) {
+  return known_pbft_blocks_.insert(hash, pbft_chain_size_);
+}
 
 bool TaraxaPeer::isPbftBlockKnown(const blk_hash_t& hash) const { return known_pbft_blocks_.contains(hash); }
 


### PR DESCRIPTION
Cache that previously each TaraxaPeer uses for keeping known transactions, votes and blocks hashes get always fully populated to maximum size. With some nodes configured to have up to 50 connected peers this cache can take significant memory usage.
The change is made that the cache entries expire once they are included in block finalizes 10 periods ago. This makes the cache small when ever network is progressing normally and it will only reach maximum size in case network gets stuck and there is some build up of transactions, dag blocks and votes at the same period.