### PR TITLE
chore: light node optimizations and fix

### DIFF
--- a/libraries/core_libs/consensus/include/dag/dag_manager.hpp
+++ b/libraries/core_libs/consensus/include/dag/dag_manager.hpp
@@ -239,7 +239,7 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
   bool validateBlockNotExpired(const std::shared_ptr<DagBlock> &dag_block,
                                std::unordered_map<blk_hash_t, std::shared_ptr<DagBlock>> &expired_dag_blocks_to_remove);
   void handleExpiredDagBlocksTransactions(const std::vector<trx_hash_t> &transactions_from_expired_dag_blocks) const;
-  void clearLightNodeHistory();
+  void clearLightNodeHistory(bool force = false);
 
   std::pair<blk_hash_t, std::vector<blk_hash_t>> getFrontier() const;  // return pivot and tips
   void updateFrontier();

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -96,7 +96,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
     COLUMN_W_COMP(period_data, getIntComparator<PbftPeriod>());
     COLUMN(genesis);
     COLUMN(dag_blocks);
-    COLUMN(dag_blocks_index);
+    COLUMN_W_COMP(dag_blocks_level, getIntComparator<uint64_t>());
     COLUMN(transactions);
     COLUMN(trx_period);
     COLUMN(status);
@@ -199,7 +199,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
 
   // Period data
   void savePeriodData(const PeriodData& period_data, Batch& write_batch);
-  void clearPeriodDataHistory(PbftPeriod period);
+  void clearPeriodDataHistory(PbftPeriod period, uint64_t dag_level_to_keep);
   dev::bytes getPeriodDataRaw(PbftPeriod period) const;
   std::optional<PbftBlock> getPbftBlock(PbftPeriod period) const;
   std::vector<std::shared_ptr<Vote>> getPeriodCertVotes(PbftPeriod period) const;

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -1477,9 +1477,8 @@ TEST_F(FullNodeTest, clear_period_data) {
   for (uint64_t i = 0; i < nodes[1]->getPbftChain()->getPbftChainSize(); i++) {
     const auto pbft_block = nodes[1]->getDB()->getPbftBlock(i);
     if (pbft_block && pbft_block->getPivotDagBlockHash() != kNullBlockHash) {
-      if (nodes[1]->getDB()->getDagBlock(pbft_block->getPivotDagBlockHash())->getLevel() +
-              node_cfgs[0].dag_expiry_limit >=
-          last_anchor_level) {
+      auto dag_block = nodes[1]->getDB()->getDagBlock(pbft_block->getPivotDagBlockHash());
+      if (dag_block && (dag_block->getLevel() + node_cfgs[0].dag_expiry_limit >= last_anchor_level)) {
         first_over_limit = i;
         break;
       }


### PR DESCRIPTION
- Clear light node history on startup
- dag_blocks_level column created based on dag_blocks_index which is removed to have column ordered by level to support deleting by level for light node
- Fix issue with incorrect transaction hash used to delete old transactions on light node
- Delete additional columns data for light node: old transactions data in trx_period and old dag blocks in dag_block_period and dag_block_level