### PR TITLE
fix: state root validation on syncing

### DIFF
--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -20,6 +20,7 @@ namespace taraxa {
 class FullNode;
 
 enum PbftStates { value_proposal_state = 1, filter_state, certify_state, finish_state, finish_polling_state };
+enum class PbftStateRootValidation { Valid = 0, Missing, Invalid };
 
 /**
  * @brief PbftManager class is a daemon that is used to finalize a bench of directed acyclic graph (DAG) blocks by using
@@ -448,11 +449,11 @@ class PbftManager {
   bool validatePbftBlock(const std::shared_ptr<PbftBlock> &pbft_block) const;
 
   /**
-   * @brief Validates pbft block state root. It checks if:
+   * @brief Validates pbft block state root.
    * @param pbft_block PBFT block
-   * @return true if pbft block is valid, otherwise false
+   * @return validation result
    */
-  bool validatePbftBlockStateRoot(const std::shared_ptr<PbftBlock> &pbft_block) const;
+  PbftStateRootValidation validatePbftBlockStateRoot(const std::shared_ptr<PbftBlock> &pbft_block) const;
 
   /**
    * @brief If there are enough certify votes, push the vote PBFT block in PBFT chain


### PR DESCRIPTION
In case execution was delayed, state root validation would fail in processing synced pbft block which would cause marking the node as malicious when processing the next block in the queue.

This is fixed to separately handle two cases:
- when execution is delayed and state root is missing keep waiting in a loop until state root is present
- when state root is invalid clear the entire queue and mark node as malicious