### PR TITLE
chore: improve ping timeout handling on discovery

### DIFF
--- a/libraries/aleth/libp2p/NodeTable.cpp
+++ b/libraries/aleth/libp2p/NodeTable.cpp
@@ -461,6 +461,14 @@ shared_ptr<NodeEntry> NodeTable::handlePong(bi::udp::endpoint const& _from, Disc
   }
 
   m_sentPings.erase(_from);
+  // Remove any other sent pings which was sent to other endpoints for the same nodeID
+  for (auto it = m_sentPings.begin(); it != m_sentPings.end();) {
+    if (nodeValidation.nodeID == it->second.nodeID) {
+      it = m_sentPings.erase(it);
+    } else {
+      ++it;
+    }
+  }
 
   // update our external endpoint address and UDP port
   if (m_endpointTracker.addEndpointStatement(_from, pong.destination) >= c_minEndpointTrackStatements) {
@@ -695,13 +703,10 @@ void NodeTable::doHandleTimeouts() {
     for (auto it = m_sentPings.begin(); it != m_sentPings.end();) {
       if (chrono::steady_clock::now() > it->second.pingSentTime + m_requestTimeToLive) {
         if (auto node = nodeEntry(it->second.nodeID)) {
-          if (node->endpoint() == it->first) {
-            dropNode(std::move(node));
+          dropNode(std::move(node));
 
-            // save the replacement node that should be activated
-            if (it->second.replacementNodeEntry)
-              nodesToActivate.emplace_back(std::move(it->second.replacementNodeEntry));
-          }
+          // save the replacement node that should be activated
+          if (it->second.replacementNodeEntry) nodesToActivate.emplace_back(std::move(it->second.replacementNodeEntry));
         }
 
         it = m_sentPings.erase(it);


### PR DESCRIPTION
With the current approach a node that never responds stays in the nodetable if it is being pinged constantly to different endpoints.  With this change such node will be removed after the ping timeout to make room for other nodes. Once a node responds with a pong all other pings to other endpoints are removed.