### PR TITLE
chore: async clear light node history

### DIFF
--- a/libraries/core_libs/consensus/src/dag/dag_manager.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_manager.cpp
@@ -290,7 +290,6 @@ void DagManager::clearLightNodeHistory(bool initial) {
   bool period_over_history_condition = period_ > light_node_history_;
   if (((period_ % clear_interval == 0) || initial) && period_over_history_condition && dag_expiry_level_condition) {
     // This will happen at most once a day so log a silent log
-    LOG(log_si_) << "Clear light node history";
     const auto proposal_period = db_->getProposalPeriodForDagLevel(dag_expiry_level_ - max_levels_per_period_ - 1);
     assert(proposal_period);
 
@@ -307,7 +306,6 @@ void DagManager::clearLightNodeHistory(bool initial) {
       dag_level_to_keep = dag_expiry_level_ - max_levels_per_period_;
     }
     db_->clearPeriodDataHistory(end, dag_level_to_keep, initial);
-    LOG(log_si_) << "Clear light node history completed";
   }
 }
 

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -145,7 +145,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   std::atomic<bool> snapshots_enabled_ = true;
   const uint32_t kDbSnapshotsMaxCount = 0;
   std::set<PbftPeriod> snapshots_;
-  std::unique_ptr<std::thread> clear_history_thread_;
+  std::unique_ptr<std::future<void>> clear_history_future_;
 
   uint32_t kMajorVersion_;
   bool major_version_changed_ = false;

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -145,6 +145,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   std::atomic<bool> snapshots_enabled_ = true;
   const uint32_t kDbSnapshotsMaxCount = 0;
   std::set<PbftPeriod> snapshots_;
+  std::unique_ptr<std::thread> clear_history_thread_;
 
   uint32_t kMajorVersion_;
   bool major_version_changed_ = false;


### PR DESCRIPTION
Even with some latest optimizations getting transactions from period data to be able to delete old data from Columns::final_chain_receipt_by_trx_hash can sometimes take up to 20 seconds. With DagManager::clearLightNodeHistory running synchronously blocking the node from pushing new blocks to the chain this causes node to get out of synced state.

Change is made that clearing light node history is now done on a separate thread. Since this is done once an hour, a new thread is always created since there is no need to have an active thread in thread pool which is only utilized once an hour for a light node.