### PR TITLE
chore: allow dag resyncing after node is out of pbft sync

### DIFF
--- a/libraries/core_libs/network/src/tarcap/shared_states/pbft_syncing_state.cpp
+++ b/libraries/core_libs/network/src/tarcap/shared_states/pbft_syncing_state.cpp
@@ -35,6 +35,8 @@ bool PbftSyncingState::setPbftSyncing(bool syncing, PbftPeriod current_period,
     peer_ = std::move(peer);
 
     if (syncing) {
+      // If pbft syncing, set dag synced state to false
+      peer_->peer_dag_synced_ = false;
       deep_pbft_syncing_ = (peer_->pbft_chain_size_ - current_period >= kDeepSyncingThreshold);
       // Reset last sync packet time when syncing is restarted/fresh syncing flag is set
       setLastSyncPacketTime();


### PR DESCRIPTION
If a node gets out of sync (this is known to happen while deleting old period_data blocks in a light node which blocks us from pbft progressing) and pbft syncing is restarted, a malicious peer exception can happen once pbft blocks are synced but dag blocks are not. Allow dag re-syncing once pbft syncing completes.