### PR TITLE
chore: light node clearing on restart only

### DIFF
--- a/libraries/core_libs/consensus/include/dag/dag_manager.hpp
+++ b/libraries/core_libs/consensus/include/dag/dag_manager.hpp
@@ -239,7 +239,7 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
   bool validateBlockNotExpired(const std::shared_ptr<DagBlock> &dag_block,
                                std::unordered_map<blk_hash_t, std::shared_ptr<DagBlock>> &expired_dag_blocks_to_remove);
   void handleExpiredDagBlocksTransactions(const std::vector<trx_hash_t> &transactions_from_expired_dag_blocks) const;
-  void clearLightNodeHistory(bool initial = false);
+  void clearLightNodeHistory();
 
   std::pair<blk_hash_t, std::vector<blk_hash_t>> getFrontier() const;  // return pivot and tips
   void updateFrontier();

--- a/libraries/core_libs/consensus/src/dag/dag_manager.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_manager.cpp
@@ -54,7 +54,7 @@ DagManager::DagManager(const DagBlock &dag_genesis_block, addr_t node_addr, cons
   }
   recoverDag();
   if (is_light_node_) {
-    clearLightNodeHistory(true);
+    clearLightNodeHistory();
   }
 } catch (std::exception &e) {
   std::cerr << e.what() << std::endl;
@@ -282,14 +282,10 @@ std::vector<blk_hash_t> DagManager::getDagBlockOrder(blk_hash_t const &anchor, P
   return blk_orders;
 }
 
-void DagManager::clearLightNodeHistory(bool initial) {
-  // Delete once size 1% over the light_node_history_, by default light node history is a week of data so this condition
-  // will pass once an hour
-  uint64_t clear_interval = std::max(light_node_history_ / 100, (uint64_t)1);
+void DagManager::clearLightNodeHistory() {
   bool dag_expiry_level_condition = dag_expiry_level_ > max_levels_per_period_ + 1;
   bool period_over_history_condition = period_ > light_node_history_;
-  if (((period_ % clear_interval == 0) || initial) && period_over_history_condition && dag_expiry_level_condition) {
-    // This will happen at most once a day so log a silent log
+  if (period_over_history_condition && dag_expiry_level_condition) {
     const auto proposal_period = db_->getProposalPeriodForDagLevel(dag_expiry_level_ - max_levels_per_period_ - 1);
     assert(proposal_period);
 
@@ -305,7 +301,7 @@ void DagManager::clearLightNodeHistory(bool initial) {
     if (dag_expiry_level_ > max_levels_per_period_) {
       dag_level_to_keep = dag_expiry_level_ - max_levels_per_period_;
     }
-    db_->clearPeriodDataHistory(end, dag_level_to_keep, initial);
+    db_->clearPeriodDataHistory(end, dag_level_to_keep);
   }
 }
 

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -145,7 +145,6 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   std::atomic<bool> snapshots_enabled_ = true;
   const uint32_t kDbSnapshotsMaxCount = 0;
   std::set<PbftPeriod> snapshots_;
-  std::unique_ptr<std::future<void>> clear_history_future_;
 
   uint32_t kMajorVersion_;
   bool major_version_changed_ = false;
@@ -199,7 +198,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
 
   // Period data
   void savePeriodData(const PeriodData& period_data, Batch& write_batch);
-  void clearPeriodDataHistory(PbftPeriod period, uint64_t dag_level_to_keep, bool initial);
+  void clearPeriodDataHistory(PbftPeriod period, uint64_t dag_level_to_keep);
   dev::bytes getPeriodDataRaw(PbftPeriod period) const;
   std::optional<PbftBlock> getPbftBlock(PbftPeriod period) const;
   std::vector<std::shared_ptr<Vote>> getPeriodCertVotes(PbftPeriod period) const;

--- a/libraries/core_libs/storage/src/storage.cpp
+++ b/libraries/core_libs/storage/src/storage.cpp
@@ -374,7 +374,6 @@ std::optional<h256> DbStorage::getGenesisHash() {
 }
 
 DbStorage::~DbStorage() {
-  if (clear_history_future_) clear_history_future_->wait();
   for (auto cf : handles_) {
     checkStatus(db_->DestroyColumnFamilyHandle(cf));
   }
@@ -564,7 +563,7 @@ std::optional<SortitionParamsChange> DbStorage::getParamsChangeForPeriod(PbftPer
   return SortitionParamsChange::from_rlp(dev::RLP(it->value().ToString()));
 }
 
-void DbStorage::clearPeriodDataHistory(PbftPeriod end_period, uint64_t dag_level_to_keep, bool initial) {
+void DbStorage::clearPeriodDataHistory(PbftPeriod end_period, uint64_t dag_level_to_keep) {
   LOG(log_si_) << "Clear light node history";
   auto it = std::unique_ptr<rocksdb::Iterator>(db_->NewIterator(read_options_, handle(Columns::period_data)));
   // Find the first non-deleted period
@@ -577,73 +576,61 @@ void DbStorage::clearPeriodDataHistory(PbftPeriod end_period, uint64_t dag_level
     if (it->Valid()) {
       uint64_t start_level;
       memcpy(&start_level, it->key().data(), sizeof(uint64_t));
-      if (clear_history_future_) clear_history_future_->wait();
-      clear_history_future_ = std::make_unique<std::future<void>>(
-          std::async(std::launch::async, [this, start_period, start_level, initial, dag_level_to_keep, end_period]() {
-            if (start_period < end_period) {
-              auto write_batch = createWriteBatch();
-              // Delete up to max 10000 period at once
-              const uint32_t max_batch_delete = 10000;
-              auto start_slice = toSlice(start_period);
-              auto end_slice = toSlice(end_period);
+      if (start_period < end_period) {
+        auto write_batch = createWriteBatch();
+        // Delete up to max 10000 period at once
+        const uint32_t max_batch_delete = 10000;
+        auto start_slice = toSlice(start_period);
+        auto end_slice = toSlice(end_period);
 
-              for (auto period = start_period; period < end_period; period++) {
-                // Find transactions included in the old blocks and delete data related to these transactions to free
-                // disk space
-                const auto& dag_blocks = getFinalizedDagBlockByPeriod(period);
+        for (auto period = start_period; period < end_period; period++) {
+          // Find transactions included in the old blocks and delete data related to these transactions to free
+          // disk space
+          const auto& dag_blocks = getFinalizedDagBlockByPeriod(period);
 
-                for (const auto& dag_block : dag_blocks) {
-                  for (const auto& trx_hash : dag_block->getTrxs()) {
-                    remove(write_batch, Columns::final_chain_receipt_by_trx_hash, trx_hash);
-                  }
-                }
-                if ((period - start_period + 1) % max_batch_delete == 0) {
-                  commitWriteBatch(write_batch);
-                  write_batch = createWriteBatch();
-                }
-              }
-
-              commitWriteBatch(write_batch);
-              db_->DeleteRange(write_options_, handle(Columns::period_data), start_slice, end_slice);
-
-              if (initial) {
-                // Deletion alone does not guarantee that the disk space is freed, CompactRange  actually compacts
-                // the data in the database and free disk space
-                db_->CompactRange({}, handle(Columns::period_data), &start_slice, &end_slice);
-                db_->CompactRange({}, handle(Columns::final_chain_receipt_by_trx_hash), nullptr, nullptr);
-              }
+          for (const auto& dag_block : dag_blocks) {
+            for (const auto& trx_hash : dag_block->getTrxs()) {
+              remove(write_batch, Columns::final_chain_receipt_by_trx_hash, trx_hash);
             }
+          }
+          if ((period - start_period + 1) % max_batch_delete == 0) {
+            commitWriteBatch(write_batch);
+            write_batch = createWriteBatch();
+          }
+        }
 
-            if (start_level < dag_level_to_keep) {
-              auto write_batch = createWriteBatch();
-              // Delete up to max 10000 period at once
-              const uint32_t max_batch_delete = 10000;
-              auto start_slice = toSlice(start_level);
-              auto end_slice = toSlice(dag_level_to_keep - 1);
-              for (auto level = start_level; level < dag_level_to_keep; level++) {
-                // Find old dag blocks and delete data related to these blocks to free disk space
-                auto dag_block_hashes = getBlocksByLevel(start_level);
-                for (auto dag_block_hash : dag_block_hashes) {
-                  remove(write_batch, Columns::dag_block_period, dag_block_hash);
-                }
-                if ((dag_level_to_keep - start_level + 1) % max_batch_delete == 0) {
-                  commitWriteBatch(write_batch);
-                  write_batch = createWriteBatch();
-                }
-              }
-              commitWriteBatch(write_batch);
-              db_->DeleteRange(write_options_, handle(Columns::dag_blocks_level), start_slice, end_slice);
+        commitWriteBatch(write_batch);
+        db_->DeleteRange(write_options_, handle(Columns::period_data), start_slice, end_slice);
 
-              if (initial) {
-                db_->CompactRange({}, handle(Columns::dag_block_period), nullptr, nullptr);
-                db_->CompactRange({}, handle(Columns::dag_blocks_level), nullptr, nullptr);
-              }
-              LOG(log_si_) << "Clear light node history completed";
-            }
-          }));
-      if (initial) {
-        clear_history_future_->wait();
-        clear_history_future_ = nullptr;
+        // Deletion alone does not guarantee that the disk space is freed, CompactRange  actually compacts
+        // the data in the database and free disk space
+        db_->CompactRange({}, handle(Columns::period_data), &start_slice, &end_slice);
+        db_->CompactRange({}, handle(Columns::final_chain_receipt_by_trx_hash), nullptr, nullptr);
+      }
+
+      if (start_level < dag_level_to_keep) {
+        auto write_batch = createWriteBatch();
+        // Delete up to max 10000 period at once
+        const uint32_t max_batch_delete = 10000;
+        auto start_slice = toSlice(start_level);
+        auto end_slice = toSlice(dag_level_to_keep - 1);
+        for (auto level = start_level; level < dag_level_to_keep; level++) {
+          // Find old dag blocks and delete data related to these blocks to free disk space
+          auto dag_block_hashes = getBlocksByLevel(start_level);
+          for (auto dag_block_hash : dag_block_hashes) {
+            remove(write_batch, Columns::dag_block_period, dag_block_hash);
+          }
+          if ((dag_level_to_keep - start_level + 1) % max_batch_delete == 0) {
+            commitWriteBatch(write_batch);
+            write_batch = createWriteBatch();
+          }
+        }
+        commitWriteBatch(write_batch);
+        db_->DeleteRange(write_options_, handle(Columns::dag_blocks_level), start_slice, end_slice);
+
+        db_->CompactRange({}, handle(Columns::dag_block_period), nullptr, nullptr);
+        db_->CompactRange({}, handle(Columns::dag_blocks_level), nullptr, nullptr);
+        LOG(log_si_) << "Clear light node history completed";
       }
     }
   }


### PR DESCRIPTION
Since clearing light node data while running the node resulted in node getting out of sync, this is now only done on restarting the node.