### PR TITLE
chore: improve discovery ping handling

### DIFF
--- a/libraries/aleth/libp2p/NodeTable.cpp
+++ b/libraries/aleth/libp2p/NodeTable.cpp
@@ -697,7 +697,12 @@ void NodeTable::doHandleTimeouts() {
       if (chrono::steady_clock::now() > it->second.pingSentTime + m_requestTimeToLive) {
         if (auto node = nodeEntry(it->second.nodeID)) {
           if (node->lastPongReceivedTime < RLPXDatagramFace::secondsSinceEpoch() - m_requestTimeToLive.count()) {
-            dropNode(std::move(node));
+            if (it->first == node->endpoint()) {
+              dropNode(std::move(node));
+            } else {
+              LOG(m_logger) << "Not dropping node " << it->second.nodeID << " on ping timeout for " << it->first << " "
+                            << " as previous endpoint still valid " << node->endpoint();
+            }
           } else {
             LOG(m_logger) << "Not dropping node " << it->second.nodeID << " " << it->first << " as it was updated";
           }


### PR DESCRIPTION
Scenario easily reproducible on the devnet:
- node is discovered with correct endpoint(IP/port) A. It is pinged and successfully added to the NodeTable with endpoint A.
- same node is discovered again with incorrect endpoint IP/port B. Node is pinged to this incorrect endpoint B and no pong response is received
-  In doHandletimeout node is removed from the NodeTable even though node contains correct endpoint A

This fix only removes the node from the NodeTable if it was actually pinged to the same address which is in the NodeTable.

Example log of this case:
0x00007f5feffff640  discov [2023-08-24 13:20:45.536576] : Not dropping node ##1755f430… on ping timeout for 34.134.242.50:4731  as previous endpoint still valid 34.134.242.50:32002
