### PR TITLE
chore: light node size optimization

### DIFF
--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -313,6 +313,8 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
 
   std::vector<blk_hash_t> getFinalizedDagBlockHashesByPeriod(PbftPeriod period);
   std::vector<std::shared_ptr<DagBlock>> getFinalizedDagBlockByPeriod(PbftPeriod period);
+  std::pair<blk_hash_t, std::vector<std::shared_ptr<DagBlock>>> getLastPbftblockHashAndFinalizedDagBlockByPeriod(
+      PbftPeriod period);
 
   // DPOS level to proposal period map
   std::optional<uint64_t> getProposalPeriodForDagLevel(uint64_t level);


### PR DESCRIPTION
- Delete data from trx_period, pbft_block_period and final_chain_log_blooms_index columns older than light node history
- dag_block_period column was not correctly deleted, fixed

With these changes size of the db snapshot columns with 7 days history:
period_data 3.2GB
final_chain_receipt_by_trx_hash 413MB
trx_period 371MB

All other columns smaller than 100MB