### PR TITLE
chore: improve dag propose probability

### DIFF
--- a/libraries/core_libs/consensus/include/dag/dag_block_proposer.hpp
+++ b/libraries/core_libs/consensus/include/dag/dag_block_proposer.hpp
@@ -38,7 +38,8 @@ class DagBlockProposer {
   DagBlockProposer(const DagBlockProposerConfig& bp_config, std::shared_ptr<DagManager> dag_mgr,
                    std::shared_ptr<TransactionManager> trx_mgr, std::shared_ptr<final_chain::FinalChain> final_chain,
                    std::shared_ptr<DbStorage> db, std::shared_ptr<KeyManager> key_manager, addr_t node_addr,
-                   secret_t node_sk, vrf_wrapper::vrf_sk_t vrf_sk, uint64_t pbft_gas_limit, uint64_t dag_gas_limit);
+                   secret_t node_sk, vrf_wrapper::vrf_sk_t vrf_sk, uint64_t pbft_gas_limit, uint64_t dag_gas_limit,
+                   const state_api::Config& state_config);
   ~DagBlockProposer() { stop(); }
   DagBlockProposer(const DagBlockProposer&) = delete;
   DagBlockProposer(DagBlockProposer&&) = delete;
@@ -148,6 +149,9 @@ class DagBlockProposer {
 
   const uint64_t kPbftGasLimit;
   const uint64_t kDagGasLimit;
+
+  const HardforksConfig kHardforks;
+  const uint64_t kValidatorMaxVote;
 
   LOG_OBJECTS_DEFINE
 };

--- a/libraries/core_libs/consensus/include/dag/dag_manager.hpp
+++ b/libraries/core_libs/consensus/include/dag/dag_manager.hpp
@@ -48,8 +48,8 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
                       const DagConfig &dag_config, std::shared_ptr<TransactionManager> trx_mgr,
                       std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<FinalChain> final_chain,
                       std::shared_ptr<DbStorage> db, std::shared_ptr<KeyManager> key_manager, uint64_t pbft_gas_limit,
-                      bool is_light_node = false, uint64_t light_node_history = 0,
-                      uint32_t max_levels_per_period = kMaxLevelsPerPeriod,
+                      const state_api::Config &state_config, bool is_light_node = false,
+                      uint64_t light_node_history = 0, uint32_t max_levels_per_period = kMaxLevelsPerPeriod,
                       uint32_t dag_expiry_limit = kDagExpiryLevelLimit);
 
   DagManager(const DagManager &) = delete;
@@ -282,6 +282,8 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
   ExpirationCacheMap<blk_hash_t, DagBlock> seen_blocks_;
   std::shared_ptr<FinalChain> final_chain_;
   const uint64_t kPbftGasLimit;
+  const HardforksConfig kHardforks;
+  const uint64_t kValidatorMaxVote;
 
   LOG_OBJECTS_DEFINE
 };

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -307,7 +307,7 @@ bool PbftManager::advancePeriod() {
   // Cleanup proposed blocks
   proposed_blocks_.cleanupProposedPbftBlocksByPeriod(new_period);
 
-  LOG(log_er_) << "Period advanced to: " << new_period << ", round and step reset to 1";
+  LOG(log_nf_) << "Period advanced to: " << new_period << ", round and step reset to 1";
 
   // Restart while loop...
   return true;

--- a/libraries/core_libs/node/src/node.cpp
+++ b/libraries/core_libs/node/src/node.cpp
@@ -123,10 +123,10 @@ void FullNode::init() {
   }
 
   pbft_chain_ = std::make_shared<PbftChain>(node_addr, db_);
-  dag_mgr_ = std::make_shared<DagManager>(conf_.genesis.dag_genesis_block, node_addr, conf_.genesis.sortition,
-                                          conf_.genesis.dag, trx_mgr_, pbft_chain_, final_chain_, db_, key_manager_,
-                                          conf_.genesis.pbft.gas_limit, conf_.is_light_node, conf_.light_node_history,
-                                          conf_.max_levels_per_period, conf_.dag_expiry_limit);
+  dag_mgr_ = std::make_shared<DagManager>(
+      conf_.genesis.dag_genesis_block, node_addr, conf_.genesis.sortition, conf_.genesis.dag, trx_mgr_, pbft_chain_,
+      final_chain_, db_, key_manager_, conf_.genesis.pbft.gas_limit, conf_.genesis.state, conf_.is_light_node,
+      conf_.light_node_history, conf_.max_levels_per_period, conf_.dag_expiry_limit);
   auto slashing_manager = std::make_shared<SlashingManager>(final_chain_, trx_mgr_, gas_pricer_, conf_, kp_.secret());
   vote_mgr_ = std::make_shared<VoteManager>(node_addr, conf_.genesis.pbft, kp_.secret(), conf_.vrf_secret, db_,
                                             pbft_chain_, final_chain_, key_manager_, slashing_manager);
@@ -135,7 +135,7 @@ void FullNode::init() {
                                     pbft_chain_, vote_mgr_, dag_mgr_, trx_mgr_, final_chain_, kp_.secret());
   dag_block_proposer_ = std::make_shared<DagBlockProposer>(
       conf_.genesis.dag.block_proposer, dag_mgr_, trx_mgr_, final_chain_, db_, key_manager_, node_addr, getSecretKey(),
-      getVrfSecretKey(), conf_.genesis.pbft.gas_limit, conf_.genesis.dag.gas_limit);
+      getVrfSecretKey(), conf_.genesis.pbft.gas_limit, conf_.genesis.dag.gas_limit, conf_.genesis.state);
 
   network_ = std::make_shared<Network>(conf_, genesis_hash, conf_.net_file_path().string(), kp_, db_, pbft_mgr_,
                                        pbft_chain_, vote_mgr_, dag_mgr_, trx_mgr_, std::move(slashing_manager));

--- a/tests/dag_test.cpp
+++ b/tests/dag_test.cpp
@@ -135,9 +135,9 @@ TEST_F(DagTest, compute_epoch) {
   auto trx_mgr = std::make_shared<TransactionManager>(FullNodeConfig(), db_ptr, nullptr, addr_t());
   auto pbft_chain = std::make_shared<PbftChain>(addr_t(), db_ptr);
   const blk_hash_t GENESIS = node_cfgs[0].genesis.dag_genesis_block.getHash();
-  auto mgr =
-      std::make_shared<DagManager>(node_cfgs[0].genesis.dag_genesis_block, addr_t(), node_cfgs[0].genesis.sortition,
-                                   node_cfgs[0].genesis.dag, trx_mgr, pbft_chain, nullptr, db_ptr, nullptr, 100000);
+  auto mgr = std::make_shared<DagManager>(node_cfgs[0].genesis.dag_genesis_block, addr_t(),
+                                          node_cfgs[0].genesis.sortition, node_cfgs[0].genesis.dag, trx_mgr, pbft_chain,
+                                          nullptr, db_ptr, nullptr, 100000, node_cfgs[0].genesis.state);
 
   DagBlock blkA(GENESIS, 1, {}, {trx_hash_t(2)}, sig_t(1), blk_hash_t(2), addr_t(1));
   DagBlock blkB(GENESIS, 1, {}, {trx_hash_t(3), trx_hash_t(4)}, sig_t(1), blk_hash_t(3), addr_t(1));
@@ -228,9 +228,9 @@ TEST_F(DagTest, dag_expiry) {
   auto trx_mgr = std::make_shared<TransactionManager>(FullNodeConfig(), db_ptr, nullptr, addr_t());
   auto pbft_chain = std::make_shared<PbftChain>(addr_t(), db_ptr);
   const blk_hash_t GENESIS = node_cfgs[0].genesis.dag_genesis_block.getHash();
-  auto mgr = std::make_shared<DagManager>(node_cfgs[0].genesis.dag_genesis_block, addr_t(),
-                                          node_cfgs[0].genesis.sortition, node_cfgs[0].genesis.dag, trx_mgr, pbft_chain,
-                                          nullptr, db_ptr, nullptr, 100000, false, 0, 3, EXPIRY_LIMIT);
+  auto mgr = std::make_shared<DagManager>(
+      node_cfgs[0].genesis.dag_genesis_block, addr_t(), node_cfgs[0].genesis.sortition, node_cfgs[0].genesis.dag,
+      trx_mgr, pbft_chain, nullptr, db_ptr, nullptr, 100000, node_cfgs[0].genesis.state, false, 0, 3, EXPIRY_LIMIT);
 
   DagBlock blkA(GENESIS, 1, {}, {trx_hash_t(2)}, sig_t(1), blk_hash_t(2), addr_t(1));
   DagBlock blkB(GENESIS, 1, {}, {trx_hash_t(3), trx_hash_t(4)}, sig_t(1), blk_hash_t(3), addr_t(1));
@@ -304,9 +304,9 @@ TEST_F(DagTest, receive_block_in_order) {
   auto pbft_chain = std::make_shared<PbftChain>(addr_t(), db_ptr);
   auto trx_mgr = std::make_shared<TransactionManager>(FullNodeConfig(), db_ptr, nullptr, addr_t());
   const blk_hash_t GENESIS = node_cfgs[0].genesis.dag_genesis_block.getHash();
-  auto mgr =
-      std::make_shared<DagManager>(node_cfgs[0].genesis.dag_genesis_block, addr_t(), node_cfgs[0].genesis.sortition,
-                                   node_cfgs[0].genesis.dag, trx_mgr, pbft_chain, nullptr, db_ptr, nullptr, 100000);
+  auto mgr = std::make_shared<DagManager>(node_cfgs[0].genesis.dag_genesis_block, addr_t(),
+                                          node_cfgs[0].genesis.sortition, node_cfgs[0].genesis.dag, trx_mgr, pbft_chain,
+                                          nullptr, db_ptr, nullptr, 100000, node_cfgs[0].genesis.state);
 
   DagBlock blk1(GENESIS, 1, {}, {}, sig_t(777), blk_hash_t(1), addr_t(15));
   DagBlock blk2(blk_hash_t(1), 2, {}, {}, sig_t(777), blk_hash_t(2), addr_t(15));
@@ -336,9 +336,9 @@ TEST_F(DagTest, compute_epoch_2) {
   auto pbft_chain = std::make_shared<PbftChain>(addr_t(), db_ptr);
   auto trx_mgr = std::make_shared<TransactionManager>(FullNodeConfig(), db_ptr, nullptr, addr_t());
   const blk_hash_t GENESIS = node_cfgs[0].genesis.dag_genesis_block.getHash();
-  auto mgr =
-      std::make_shared<DagManager>(node_cfgs[0].genesis.dag_genesis_block, addr_t(), node_cfgs[0].genesis.sortition,
-                                   node_cfgs[0].genesis.dag, trx_mgr, pbft_chain, nullptr, db_ptr, nullptr, 100000);
+  auto mgr = std::make_shared<DagManager>(node_cfgs[0].genesis.dag_genesis_block, addr_t(),
+                                          node_cfgs[0].genesis.sortition, node_cfgs[0].genesis.dag, trx_mgr, pbft_chain,
+                                          nullptr, db_ptr, nullptr, 100000, node_cfgs[0].genesis.state);
 
   DagBlock blkA(GENESIS, 1, {}, {trx_hash_t(2)}, sig_t(1), blk_hash_t(2), addr_t(1));
   DagBlock blkB(GENESIS, 1, {}, {trx_hash_t(3), trx_hash_t(4)}, sig_t(1), blk_hash_t(3), addr_t(1));
@@ -419,9 +419,9 @@ TEST_F(DagTest, get_latest_pivot_tips) {
   auto trx_mgr = std::make_shared<TransactionManager>(FullNodeConfig(), db_ptr, nullptr, addr_t());
   auto pbft_chain = std::make_shared<PbftChain>(addr_t(), db_ptr);
   const blk_hash_t GENESIS = node_cfgs[0].genesis.dag_genesis_block.getHash();
-  auto mgr =
-      std::make_shared<DagManager>(node_cfgs[0].genesis.dag_genesis_block, addr_t(), node_cfgs[0].genesis.sortition,
-                                   node_cfgs[0].genesis.dag, trx_mgr, pbft_chain, nullptr, db_ptr, nullptr, 100000);
+  auto mgr = std::make_shared<DagManager>(node_cfgs[0].genesis.dag_genesis_block, addr_t(),
+                                          node_cfgs[0].genesis.sortition, node_cfgs[0].genesis.dag, trx_mgr, pbft_chain,
+                                          nullptr, db_ptr, nullptr, 100000, node_cfgs[0].genesis.state);
 
   DagBlock blk2(GENESIS, 1, {}, {}, sig_t(1), blk_hash_t(2), addr_t(15));
   DagBlock blk3(blk_hash_t(2), 2, {}, {}, sig_t(1), blk_hash_t(3), addr_t(15));
@@ -446,9 +446,9 @@ TEST_F(DagTest, initial_pivot) {
   auto db_ptr = std::make_shared<DbStorage>(data_dir / "db");
   auto trx_mgr = std::make_shared<TransactionManager>(FullNodeConfig(), db_ptr, nullptr, addr_t());
   auto pbft_chain = std::make_shared<PbftChain>(addr_t(), db_ptr);
-  auto mgr =
-      std::make_shared<DagManager>(node_cfgs[0].genesis.dag_genesis_block, addr_t(), node_cfgs[0].genesis.sortition,
-                                   node_cfgs[0].genesis.dag, trx_mgr, pbft_chain, nullptr, db_ptr, nullptr, 100000);
+  auto mgr = std::make_shared<DagManager>(node_cfgs[0].genesis.dag_genesis_block, addr_t(),
+                                          node_cfgs[0].genesis.sortition, node_cfgs[0].genesis.dag, trx_mgr, pbft_chain,
+                                          nullptr, db_ptr, nullptr, 100000, node_cfgs[0].genesis.state);
 
   auto pt = mgr->getLatestPivotAndTips();
 

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -1433,11 +1433,17 @@ TEST_F(FullNodeTest, light_node) {
       non_empty_counter++;
     }
   }
+
+  uint32_t non_empty_counter_full_node = 0;
+  for (uint64_t i = 0; i < nodes[0]->getPbftChain()->getPbftChainSize(); i++) {
+    const auto pbft_block = nodes[0]->getDB()->getPbftBlock(i);
+    if (pbft_block) {
+      non_empty_counter_full_node++;
+    }
+  }
   // Verify light node keeps at least light_node_history and it deletes old blocks
   EXPECT_GE(non_empty_counter, node_cfgs[1].light_node_history);
-  // Actual history size will be between 100% and 110% of light_node_history_ to
-  // avoid deleting on every period
-  EXPECT_LE(non_empty_counter, node_cfgs[1].light_node_history * 1.1 + node_cfgs[1].dag_expiry_limit);
+  EXPECT_LT(non_empty_counter, non_empty_counter_full_node);
 }
 
 TEST_F(FullNodeTest, clear_period_data) {

--- a/tests/state_api_test.cpp
+++ b/tests/state_api_test.cpp
@@ -235,7 +235,7 @@ TEST_F(StateAPITest, slashing) {
   ASSERT_EQ(true, slashing_manager->submitDoubleVotingProof(vote_a, vote_b));
 
   // After few blocks malicious validator should be jailed
-  ASSERT_HAPPENS({5s, 100ms}, [&](auto& ctx) {
+  ASSERT_HAPPENS({10s, 100ms}, [&](auto& ctx) {
     WAIT_EXPECT_EQ(
         ctx, false,
         node->getFinalChain()->dpos_is_eligible(node->getFinalChain()->last_block_number(), node->getAddress()))


### PR DESCRIPTION
Probability to create a DAG block for a eligible proposer was determined by node vote_count/total_vote_count expressed in 1/1000 units and used in DAG difficulty threshold calculation.

On current mainnet total vote count is 2M votes and minimal validator vote is 50 votes. With 1/1000 of 2M being 200 votes, current algorithm gives validators which are at minimum 50 votes much higher yield that any validator above that.

To fix this the base value for these calculation post magnolia hardfork is changed from total_vote_count to a maximum vote count per validator. For the current mainnet this means a change from 2M to 80k. With the base value being 80k, 1/1000 of 80k is only 8 votes which is significantly smaller than the current minimal delegation for a validator.

At the time of the hardfork there should be an increase in dag block generation but difficulty adjustment will fix this in a couple of hundred pbft blocks.