### PR TITLE
chore: jail updates

### DIFF
--- a/libraries/cli/include/cli/config_jsons/default/default_config.json
+++ b/libraries/cli/include/cli/config_jsons/default/default_config.json
@@ -2,6 +2,7 @@
   "data_path": "",
   "is_light_node": false,
   "final_chain_cache_in_blocks": 5,
+  "report_malicious_behaviour" : true,
   "network": {
     "rpc": {
       "http_port": 7777,

--- a/libraries/cli/include/cli/config_jsons/devnet/devnet_config.json
+++ b/libraries/cli/include/cli/config_jsons/devnet/devnet_config.json
@@ -2,6 +2,7 @@
   "data_path": "",
   "is_light_node": false,
   "final_chain_cache_in_blocks": 5,
+  "report_malicious_behaviour" : true,
   "network": {
     "rpc": {
       "http_port": 7777,

--- a/libraries/cli/include/cli/config_jsons/devnet/devnet_genesis.json
+++ b/libraries/cli/include/cli/config_jsons/devnet/devnet_genesis.json
@@ -270,7 +270,7 @@
     },
     "magnolia_hf": {
       "block_num": 10000,
-      "jail_time": 163459
+      "jail_time": 1000
     }
   }
 }

--- a/libraries/cli/include/cli/config_jsons/mainnet/mainnet_config.json
+++ b/libraries/cli/include/cli/config_jsons/mainnet/mainnet_config.json
@@ -2,6 +2,7 @@
   "data_path": "",
   "is_light_node": false,
   "final_chain_cache_in_blocks": 5,
+  "report_malicious_behaviour" : true,
   "network": {
     "rpc": {
       "http_port": 7777,

--- a/libraries/cli/include/cli/config_jsons/testnet/testnet_config.json
+++ b/libraries/cli/include/cli/config_jsons/testnet/testnet_config.json
@@ -2,6 +2,7 @@
   "data_path": "",
   "is_light_node": false,
   "final_chain_cache_in_blocks": 5,
+  "report_malicious_behaviour" : true,
   "network": {
     "rpc": {
       "http_port": 7777,

--- a/libraries/cli/include/cli/config_jsons/testnet/testnet_genesis.json
+++ b/libraries/cli/include/cli/config_jsons/testnet/testnet_genesis.json
@@ -137,7 +137,7 @@
     "rewards_distribution_frequency": {},
     "magnolia_hf" : {
       "block_num" : 0,
-      "jail_time": 163459
+      "jail_time": 1000
     }
   }
 }


### PR DESCRIPTION
If we do compounding a user that accidentally started two nodes might get jailed for a very long time if it keeps double voting. I think it should be enough to just keep setting the jail time from current block without compunding.

Jailing is not enabled without report_malicious_behaviour set to true so adding for all networks.

For testnet and devnet reduced jail_time to 1000 which is about an hour to make testing it easier.