### PR TITLE
chore: improve syncing speed

### DIFF
--- a/libraries/common/include/common/vrf_wrapper.hpp
+++ b/libraries/common/include/common/vrf_wrapper.hpp
@@ -22,7 +22,8 @@ bool isValidVrfPublicKey(vrf_pk_t const &pk);
 // get proof if public is valid
 std::optional<vrf_proof_t> getVrfProof(vrf_sk_t const &pk, bytes const &msg);
 // get output if proff is valid
-std::optional<vrf_output_t> getVrfOutput(vrf_pk_t const &pk, vrf_proof_t const &proof, bytes const &msg);
+std::optional<vrf_output_t> getVrfOutput(vrf_pk_t const &pk, vrf_proof_t const &proof, bytes const &msg,
+                                         bool strict = true);
 
 class VrfSortitionBase {
  public:
@@ -38,7 +39,7 @@ class VrfSortitionBase {
 
   static dev::bytes makeVrfInput(taraxa::level_t level, const dev::h256 &period_hash);
 
-  bool verify(const vrf_pk_t &pk, const bytes &msg, uint16_t vote_count = 1) const;
+  bool verify(const vrf_pk_t &pk, const bytes &msg, uint16_t vote_count = 1, bool strict = true) const;
 
   bool operator==(VrfSortitionBase const &other) const { return proof_ == other.proof_ && output_ == other.output_; }
 

--- a/libraries/common/src/vrf_wrapper.cpp
+++ b/libraries/common/src/vrf_wrapper.cpp
@@ -29,12 +29,17 @@ std::optional<vrf_proof_t> getVrfProof(vrf_sk_t const &sk, bytes const &msg) {
   return {};
 }
 
-std::optional<vrf_output_t> getVrfOutput(vrf_pk_t const &pk, vrf_proof_t const &proof, bytes const &msg) {
+std::optional<vrf_output_t> getVrfOutput(vrf_pk_t const &pk, vrf_proof_t const &proof, bytes const &msg, bool strict) {
   vrf_output_t output;
-  // crypto_vrf_verify return 0 on success!
-  if (!crypto_vrf_verify(output.data(), const_cast<unsigned char *>(pk.data()),
-                         const_cast<unsigned char *>(proof.data()), const_cast<unsigned char *>(msg.data()),
-                         msg.size())) {
+  if (strict) {
+    // crypto_vrf_verify return 0 on success!
+    if (!crypto_vrf_verify(output.data(), const_cast<unsigned char *>(pk.data()),
+                           const_cast<unsigned char *>(proof.data()), const_cast<unsigned char *>(msg.data()),
+                           msg.size())) {
+      return output;
+    }
+  } else {
+    crypto_vrf_proof_to_hash(output.data(), const_cast<unsigned char *>(proof.data()));
     return output;
   }
   return {};
@@ -47,11 +52,8 @@ dev::bytes VrfSortitionBase::makeVrfInput(taraxa::level_t level, const dev::h256
   return s.invalidate();
 }
 
-bool VrfSortitionBase::verify(const vrf_pk_t &pk, const bytes &msg, uint16_t vote_count) const {
-  if (!isValidVrfPublicKey(pk)) {
-    return false;
-  }
-  auto res = vrf_wrapper::getVrfOutput(pk, proof_, msg);
+bool VrfSortitionBase::verify(const vrf_pk_t &pk, const bytes &msg, uint16_t vote_count, bool strict) const {
+  auto res = vrf_wrapper::getVrfOutput(pk, proof_, msg, strict);
   if (res != std::nullopt) {
     output_ = res.value();
     thresholdFromOutput(vote_count);

--- a/libraries/core_libs/consensus/include/final_chain/final_chain.hpp
+++ b/libraries/core_libs/consensus/include/final_chain/final_chain.hpp
@@ -223,6 +223,11 @@ class FinalChain {
    */
   virtual void prune(EthBlockNumber blk_n) = 0;
 
+  /**
+   * @brief Wait until next block is finalized
+   */
+  virtual void wait_for_finalized() = 0;
+
   virtual std::vector<state_api::ValidatorStake> dpos_validators_total_stakes(EthBlockNumber blk_num) const = 0;
   // TODO move out of here:
 

--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -195,13 +195,6 @@ class PbftManager {
   blk_hash_t lastPbftBlockHashFromQueueOrChain();
 
   /**
-   * @brief Add rebuild DB with provided data
-   * @param block period data
-   * @param current_block_cert_votes cert votes for PeriodData pbft block period
-   */
-  void addRebuildDBPeriodData(PeriodData &&period_data, std::vector<std::shared_ptr<Vote>> &&current_block_cert_votes);
-
-  /**
    * @brief Get PBFT lambda. PBFT lambda is a timer clock
    * @return PBFT lambda
    */
@@ -266,12 +259,6 @@ class PbftManager {
    */
   void testBroadcatVotesFunctionality();
 
- private:
-  /**
-   * @brief Broadcast or rebroadcast 2t+1 soft/reward/previous round next votes + all own votes if needed
-   */
-  void broadcastVotes();
-
   /**
    * @brief Check PBFT blocks syncing queue. If there are synced PBFT blocks in queue, push it to PBFT chain
    */
@@ -282,6 +269,12 @@ class PbftManager {
    * @brief wait for DPOS period finalization
    */
   void waitForPeriodFinalization();
+
+ private:
+  /**
+   * @brief Broadcast or rebroadcast 2t+1 soft/reward/previous round next votes + all own votes if needed
+   */
+  void broadcastVotes();
 
   /**
    * @brief Reset PBFT step to 1

--- a/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
+++ b/libraries/core_libs/consensus/include/vote_manager/vote_manager.hpp
@@ -180,9 +180,10 @@ class VoteManager {
    * @brief Validates vote
    *
    * @param vote to be validated
+   * @param strict strict validation
    * @return <true, ""> vote validation passed, otherwise <false, "err msg">
    */
-  std::pair<bool, std::string> validateVote(const std::shared_ptr<Vote>& vote) const;
+  std::pair<bool, std::string> validateVote(const std::shared_ptr<Vote>& vote, bool strict = true) const;
 
   /**
    * @brief Get 2t+1. 2t+1 is 2/3 of PBFT sortition threshold and plus 1 for a specific period

--- a/libraries/core_libs/consensus/src/final_chain/final_chain.cpp
+++ b/libraries/core_libs/consensus/src/final_chain/final_chain.cpp
@@ -18,7 +18,6 @@ class FinalChainImpl final : public FinalChain {
   const uint64_t kBlockGasLimit;
   StateAPI state_api_;
   const bool kLightNode = false;
-  const uint64_t kLightNodeHistory = 0;
   const uint32_t kMaxLevelsPerPeriod;
   rewards::Stats rewards_;
 
@@ -28,11 +27,6 @@ class FinalChainImpl final : public FinalChain {
   std::atomic<uint64_t> num_executed_dag_blk_ = 0;
   std::atomic<uint64_t> num_executed_trx_ = 0;
 
-  rocksdb::WriteOptions const db_opts_w_ = [] {
-    rocksdb::WriteOptions ret;
-    ret.sync = true;
-    return ret;
-  }();
   EthBlockNumber delegation_delay_;
 
   ValueByBlockCache<std::shared_ptr<const BlockHeader>> block_headers_cache_;
@@ -44,6 +38,9 @@ class FinalChainImpl final : public FinalChain {
   ValueByBlockCache<uint64_t> total_vote_count_cache_;
   MapByBlockCache<addr_t, uint64_t> dpos_vote_count_cache_;
   MapByBlockCache<addr_t, uint64_t> dpos_is_eligible_cache_;
+
+  std::condition_variable finalized_cv_;
+  std::mutex finalized_mtx_;
 
   LOG_OBJECTS_DEFINE
 
@@ -57,7 +54,6 @@ class FinalChainImpl final : public FinalChain {
                        db->stateDbStoragePath().string(),
                    }),
         kLightNode(config.is_light_node),
-        kLightNodeHistory(config.light_node_history),
         kMaxLevelsPerPeriod(config.max_levels_per_period),
         rewards_(config.genesis.pbft.committee_size, config.genesis.state.hardforks, db_,
                  [this](EthBlockNumber n) { return dpos_eligible_total_vote_count(n); }),
@@ -89,7 +85,7 @@ class FinalChainImpl final : public FinalChain {
                                  state_db_descriptor.state_root, u256(0));
 
       block_headers_cache_.append(header->number, header);
-      db_->commitWriteBatch(batch, db_opts_w_);
+      db_->commitWriteBatch(batch);
     } else {
       // We need to recover latest changes as there was shutdown inside finalize function
       if (*last_blk_num != state_db_descriptor.blk_num) [[unlikely]] {
@@ -107,7 +103,7 @@ class FinalChainImpl final : public FinalChain {
         db_->insert(batch, DB::Columns::status, StatusDbField::ExecutedBlkCount, num_executed_dag_blk_.load());
         db_->insert(batch, DB::Columns::status, StatusDbField::ExecutedTrxCount, num_executed_trx_.load());
         db_->insert(batch, DB::Columns::final_chain_meta, DBMetaKeys::LAST_NUMBER, state_db_descriptor.blk_num);
-        db_->commitWriteBatch(batch, db_opts_w_);
+        db_->commitWriteBatch(batch);
         last_blk_num = state_db_descriptor.blk_num;
       }
 
@@ -140,6 +136,7 @@ class FinalChainImpl final : public FinalChain {
                                          finalized_dag_blk_hashes = std::move(finalized_dag_blk_hashes),
                                          anchor_block = std::move(anchor), p]() mutable {
       p->set_value(finalize_(std::move(new_blk), std::move(finalized_dag_blk_hashes), std::move(anchor_block)));
+      finalized_cv_.notify_one();
     });
     return p->get_future();
   }
@@ -231,7 +228,7 @@ class FinalChainImpl final : public FinalChain {
         std::move(receipts),
     });
 
-    db_->commitWriteBatch(batch, db_opts_w_);
+    db_->commitWriteBatch(batch);
     state_api_.transition_state_commit();
 
     num_executed_dag_blk_ = num_executed_dag_blk;
@@ -449,6 +446,11 @@ class FinalChainImpl final : public FinalChain {
 
   std::vector<state_api::ValidatorStake> dpos_validators_total_stakes(EthBlockNumber blk_num) const override {
     return state_api_.dpos_validators_total_stakes(blk_num);
+  }
+
+  void wait_for_finalized() override {
+    std::unique_lock lck(finalized_mtx_);
+    finalized_cv_.wait_for(lck, std::chrono::milliseconds(10));
   }
 
  private:

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1656,7 +1656,7 @@ std::optional<std::pair<PeriodData, std::vector<std::shared_ptr<Vote>>>> PbftMan
       break;
     }
     // If syncing and pbft manager is faster than execution a delay might be needed to allow EVM to catch up
-    thisThreadSleepForMilliSeconds(10);
+    final_chain_->wait_for_finalized();
     if (!retry_logged) {
       LOG(log_wr_) << "PBFT block " << pbft_block_hash
                    << " validation delayed, state root missing, execution is behind";
@@ -1690,41 +1690,18 @@ std::optional<std::pair<PeriodData, std::vector<std::shared_ptr<Vote>>>> PbftMan
     return std::nullopt;
   }
 
-  // Get all the ordered unique non-finalized transactions which should match period_data.transactions
-  std::unordered_set<trx_hash_t> trx_set;
-  std::vector<trx_hash_t> transactions_to_query;
-  for (auto const &dag_block : period_data.dag_blocks) {
-    for (auto const &trx_hash : dag_block.getTrxs()) {
-      if (trx_set.insert(trx_hash).second) {
-        transactions_to_query.emplace_back(trx_hash);
-      }
-    }
-  }
-  auto non_finalized_transactions = trx_mgr_->excludeFinalizedTransactions(transactions_to_query);
-
-  if (non_finalized_transactions.size() != period_data.transactions.size()) {
-    LOG(log_er_) << "Synced PBFT block " << pbft_block_hash << " transactions count " << period_data.transactions.size()
-                 << " incorrect, expected: " << non_finalized_transactions.size();
-    sync_queue_.clear();
-    net->handleMaliciousSyncPeer(node_id);
-    return std::nullopt;
-  }
-  for (uint32_t i = 0; i < period_data.transactions.size(); i++) {
-    if (!non_finalized_transactions.contains(period_data.transactions[i]->getHash())) {
-      LOG(log_er_) << "Synced PBFT block " << pbft_block_hash << " has incorrect transaction "
-                   << period_data.transactions[i]->getHash();
-      sync_queue_.clear();
-      net->handleMaliciousSyncPeer(node_id);
-      return std::nullopt;
-    }
-  }
-
   return std::optional<std::pair<PeriodData, std::vector<std::shared_ptr<Vote>>>>(
       {std::move(period_data), std::move(cert_votes)});
 }
 
 bool PbftManager::validatePbftBlockCertVotes(const std::shared_ptr<PbftBlock> pbft_block,
                                              const std::vector<std::shared_ptr<Vote>> &cert_votes) const {
+  // To speed up syncing/rebuilding full strict vote verification is done for all votes on every
+  // full_vote_validation_interval and for a random vote for each block
+  const uint32_t full_vote_validation_interval = 100;
+  const uint32_t vote_to_validate = std::rand() % cert_votes.size();
+  const bool strict_validation = (pbft_block->getPeriod() % full_vote_validation_interval == 0);
+
   if (cert_votes.empty()) {
     LOG(log_er_) << "No cert votes provided! The synced PBFT block comes from a malicious player";
     return false;
@@ -1739,7 +1716,8 @@ bool PbftManager::validatePbftBlockCertVotes(const std::shared_ptr<PbftBlock> pb
     return false;
   }
 
-  for (const auto &v : cert_votes) {
+  for (uint32_t vote_counter = 0; vote_counter < cert_votes.size(); vote_counter++) {
+    const auto &v = cert_votes[vote_counter];
     // Any info is wrong that can determine the synced PBFT block comes from a malicious player
     if (v->getPeriod() != first_vote_period) {
       LOG(log_er_) << "Invalid cert vote " << v->getHash() << " period " << v->getPeriod() << ", PBFT block "
@@ -1771,7 +1749,9 @@ bool PbftManager::validatePbftBlockCertVotes(const std::shared_ptr<PbftBlock> pb
       return false;
     }
 
-    if (const auto ret = vote_mgr_->validateVote(v); !ret.first) {
+    bool strict = strict_validation || (vote_counter == vote_to_validate);
+
+    if (const auto ret = vote_mgr_->validateVote(v, strict); !ret.first) {
       LOG(log_er_) << "Cert vote " << v->getHash() << " validation failed. Err: " << ret.second << ", pbft block "
                    << pbft_block->getBlockHash();
       return false;
@@ -1851,13 +1831,6 @@ std::shared_ptr<PbftBlock> PbftManager::getPbftProposedBlock(PbftPeriod period, 
   }
 
   return proposed_block->first;
-}
-
-void PbftManager::addRebuildDBPeriodData(PeriodData &&period_data,
-                                         std::vector<std::shared_ptr<Vote>> &&current_block_cert_votes) {
-  periodDataQueuePush(std::move(period_data), dev::p2p::NodeID(), std::move(current_block_cert_votes));
-  pushSyncedPbftBlocksIntoChain();
-  waitForPeriodFinalization();
 }
 
 }  // namespace taraxa

--- a/libraries/core_libs/consensus/src/pbft/period_data_queue.cpp
+++ b/libraries/core_libs/consensus/src/pbft/period_data_queue.cpp
@@ -38,7 +38,9 @@ bool PeriodDataQueue::push(PeriodData &&period_data, const dev::p2p::NodeID &nod
   const auto period = period_data.pbft_blk->getPeriod();
   std::unique_lock lock(queue_access_);
 
-  if (period != std::max(period_, max_pbft_size) + 1) {
+  // It needs to be block after the last block in the queue or max_pbft_size + 1 or max_pbft_size + 2 since it is
+  // possible that block max_pbft_size + 1 is removed from the queue but not yet pushed in the chain
+  if (period != std::max(period_, max_pbft_size) + 1 && (queue_.empty() && period != max_pbft_size + 2)) {
     return false;
   }
   if (max_pbft_size > period_ && !queue_.empty()) queue_.clear();

--- a/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
+++ b/libraries/core_libs/consensus/src/vote_manager/vote_manager.cpp
@@ -872,7 +872,7 @@ std::shared_ptr<Vote> VoteManager::generateVote(const blk_hash_t& blockhash, Pbf
   return std::make_shared<Vote>(kNodeSk, std::move(vrf_sortition), blockhash);
 }
 
-std::pair<bool, std::string> VoteManager::validateVote(const std::shared_ptr<Vote>& vote) const {
+std::pair<bool, std::string> VoteManager::validateVote(const std::shared_ptr<Vote>& vote, bool strict) const {
   std::stringstream err_msg;
   const uint64_t vote_period = vote->getPeriod();
 
@@ -901,7 +901,7 @@ std::pair<bool, std::string> VoteManager::validateVote(const std::shared_ptr<Vot
       return {false, err_msg.str()};
     }
 
-    if (!vote->verifyVrfSortition(*pk)) {
+    if (!vote->verifyVrfSortition(*pk, strict)) {
       err_msg << "Invalid vote " << vote->getHash() << ": invalid vrf proof";
       return {false, err_msg.str()};
     }

--- a/libraries/core_libs/network/include/network/ws_server.hpp
+++ b/libraries/core_libs/network/include/network/ws_server.hpp
@@ -95,6 +95,7 @@ class WsServer : public std::enable_shared_from_this<WsServer>, public jsonrpc::
   void newDagBlockFinalized(const blk_hash_t& blk, uint64_t period);
   void newPbftBlockExecuted(const PbftBlock& sche_blk, const std::vector<blk_hash_t>& finalized_dag_blk_hashes);
   void newPendingTransaction(const trx_hash_t& trx_hash);
+  uint32_t numberOfSessions();
 
   virtual std::shared_ptr<WsSession> createSession(tcp::socket&& socket) = 0;
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/latest/get_pbft_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/latest/get_pbft_sync_packet_handler.cpp
@@ -76,8 +76,9 @@ void GetPbftSyncPacketHandler::sendPbftBlocks(const std::shared_ptr<TaraxaPeer> 
     auto data = db_->getPeriodDataRaw(block_period);
 
     if (data.size() == 0) {
+      // This can happen when switching from light node to full node setting
       LOG(log_er_) << "DB corrupted. Cannot find period " << block_period << " PBFT block in db";
-      assert(false);
+      return;
     }
 
     dev::RLPStream s;

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/v1/get_pbft_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/v1/get_pbft_sync_packet_handler.cpp
@@ -42,8 +42,9 @@ void GetPbftSyncPacketHandler::sendPbftBlocks(const std::shared_ptr<TaraxaPeer> 
     auto data = db_->getPeriodDataRaw(block_period);
 
     if (data.size() == 0) {
+      // This can happen when switching from light node to full node setting
       LOG(log_er_) << "DB corrupted. Cannot find period " << block_period << " PBFT block in db";
-      assert(false);
+      return;
     }
 
     dev::RLPStream s;

--- a/libraries/core_libs/network/src/ws_server.cpp
+++ b/libraries/core_libs/network/src/ws_server.cpp
@@ -333,4 +333,9 @@ void WsServer::newPendingTransaction(trx_hash_t const &trx_hash) {
   }
 }
 
+uint32_t WsServer::numberOfSessions() {
+  boost::shared_lock<boost::shared_mutex> lock(sessions_mtx_);
+  return sessions.size();
+}
+
 }  // namespace taraxa::net

--- a/libraries/core_libs/node/src/node.cpp
+++ b/libraries/core_libs/node/src/node.cpp
@@ -239,23 +239,27 @@ void FullNode::start() {
       jsonrpc_api_->addConnector(jsonrpc_ws_);
       jsonrpc_ws_->run();
     }
-    final_chain_->block_finalized_.subscribe(
-        [eth_json_rpc = as_weak(eth_json_rpc), ws = as_weak(jsonrpc_ws_), db = as_weak(db_)](auto const &res) {
-          if (auto _eth_json_rpc = eth_json_rpc.lock()) {
-            _eth_json_rpc->note_block_executed(*res->final_chain_blk, res->trxs, res->trx_receipts);
-          }
-          if (auto _ws = ws.lock()) {
-            _ws->newEthBlock(*res->final_chain_blk, hashes_from_transactions(res->trxs));
-            if (auto _db = db.lock()) {
-              auto pbft_blk = _db->getPbftBlock(res->hash);
-              if (const auto &hash = pbft_blk->getPivotDagBlockHash(); hash != kNullBlockHash) {
-                _ws->newDagBlockFinalized(hash, pbft_blk->getPeriod());
-              }
-              _ws->newPbftBlockExecuted(*pbft_blk, res->dag_blk_hashes);
+    if (!conf_.db_config.rebuild_db) {
+      final_chain_->block_finalized_.subscribe(
+          [eth_json_rpc = as_weak(eth_json_rpc), ws = as_weak(jsonrpc_ws_), db = as_weak(db_)](auto const &res) {
+            if (auto _eth_json_rpc = eth_json_rpc.lock()) {
+              _eth_json_rpc->note_block_executed(*res->final_chain_blk, res->trxs, res->trx_receipts);
             }
-          }
-        },
-        *rpc_thread_pool_);
+            if (auto _ws = ws.lock()) {
+              if (_ws->numberOfSessions()) {
+                _ws->newEthBlock(*res->final_chain_blk, hashes_from_transactions(res->trxs));
+                if (auto _db = db.lock()) {
+                  auto pbft_blk = _db->getPbftBlock(res->hash);
+                  if (const auto &hash = pbft_blk->getPivotDagBlockHash(); hash != kNullBlockHash) {
+                    _ws->newDagBlockFinalized(hash, pbft_blk->getPeriod());
+                  }
+                  _ws->newPbftBlockExecuted(*pbft_blk, res->dag_blk_hashes);
+                }
+              }
+            }
+          },
+          *rpc_thread_pool_);
+    }
 
     trx_mgr_->transaction_accepted_.subscribe(
         [eth_json_rpc = as_weak(eth_json_rpc), ws = as_weak(jsonrpc_ws_)](auto const &trx_hash) {
@@ -296,22 +300,24 @@ void FullNode::start() {
     }
   }
 
-  // GasPricer updater
-  final_chain_->block_finalized_.subscribe(
-      [gas_pricer = as_weak(gas_pricer_)](auto const &res) {
-        if (auto gp = gas_pricer.lock()) {
-          gp->update(res->trxs);
-        }
-      },
-      subscription_pool_);
+  if (!conf_.db_config.rebuild_db) {
+    // GasPricer updater
+    final_chain_->block_finalized_.subscribe(
+        [gas_pricer = as_weak(gas_pricer_)](auto const &res) {
+          if (auto gp = gas_pricer.lock()) {
+            gp->update(res->trxs);
+          }
+        },
+        subscription_pool_);
 
-  final_chain_->block_finalized_.subscribe(
-      [trx_manager = as_weak(trx_mgr_)](auto const &res) {
-        if (auto trx_mgr = trx_manager.lock()) {
-          trx_mgr->blockFinalized(res->final_chain_blk->number);
-        }
-      },
-      subscription_pool_);
+    final_chain_->block_finalized_.subscribe(
+        [trx_manager = as_weak(trx_mgr_)](auto const &res) {
+          if (auto trx_mgr = trx_manager.lock()) {
+            trx_mgr->blockFinalized(res->final_chain_blk->number);
+          }
+        },
+        subscription_pool_);
+  }
 
   vote_mgr_->setNetwork(network_);
   pbft_mgr_->setNetwork(network_);
@@ -362,6 +368,16 @@ void FullNode::rebuildDb() {
   // Read pbft blocks one by one
   PbftPeriod period = 1;
   std::shared_ptr<PeriodData> period_data, next_period_data;
+  std::atomic_bool stop_async = false;
+
+  std::future<void> fut = std::async(std::launch::async, [this, &stop_async]() {
+    while (!stop_async) {
+      // While rebuilding pushSyncedPbftBlocksIntoChain will stay in its own internal loop
+      pbft_mgr_->pushSyncedPbftBlocksIntoChain();
+      thisThreadSleepForMilliSeconds(1);
+    }
+  });
+
   while (true) {
     std::vector<std::shared_ptr<Vote>> cert_votes;
     if (next_period_data != nullptr) {
@@ -381,24 +397,36 @@ void FullNode::rebuildDb() {
       }
     } else {
       next_period_data = std::make_shared<PeriodData>(std::move(data));
+      // More efficient to get sender(which is expensive) on this thread which is not as busy as the thread that pushes
+      // blocks to chain
+      for (auto &t : next_period_data->transactions) t->getSender();
       cert_votes = next_period_data->previous_block_cert_votes;
     }
 
     LOG(log_nf_) << "Adding PBFT block " << period_data->pbft_blk->getBlockHash().toString()
                  << " from old DB into syncing queue for processing, final chain size: "
                  << final_chain_->last_block_number();
-    pbft_mgr_->addRebuildDBPeriodData(std::move(*period_data), std::move(cert_votes));
+
+    pbft_mgr_->periodDataQueuePush(std::move(*period_data), dev::p2p::NodeID(), std::move(cert_votes));
+    pbft_mgr_->waitForPeriodFinalization();
     period++;
+    if (period % 100 == 0) {
+      while (period - pbft_chain_->getPbftChainSize() > 100) {
+        thisThreadSleepForMilliSeconds(1);
+      }
+    }
 
     if (period - 1 == conf_.db_config.rebuild_db_period) {
       break;
     }
-    while (final_chain_->last_block_number() != period - 1) {
-      thisThreadSleepForMilliSeconds(5);
-      LOG(log_nf_) << "Waiting on PBFT blocks to be processed. PBFT chain size " << pbft_mgr_->pbftSyncingPeriod()
-                   << ", final chain size: " << final_chain_->last_block_number();
+
+    if (period % 10000 == 0) {
+      LOG(log_si_) << "Rebuilding period: " << period;
     }
   }
+  stop_async = true;
+  fut.wait();
+  LOG(log_si_) << "Rebuild completed";
 }
 
 uint64_t FullNode::getProposedBlocksCount() const { return dag_block_proposer_->getProposedBlocksCount(); }

--- a/libraries/types/vote/include/vote/vote.hpp
+++ b/libraries/types/vote/include/vote/vote.hpp
@@ -56,7 +56,7 @@ class Vote {
    * @brief Verify VRF sortition
    * @return true if passed
    */
-  bool verifyVrfSortition(const vrf_pk_t& pk) const { return vrf_sortition_.verify(pk); }
+  bool verifyVrfSortition(const vrf_pk_t& pk, bool strict) const { return vrf_sortition_.verify(pk, strict); }
 
   /**
    * @brief Get VRF sortition

--- a/libraries/types/vote/include/vote/vrf_sortition.hpp
+++ b/libraries/types/vote/include/vote/vrf_sortition.hpp
@@ -94,9 +94,13 @@ class VrfPbftSortition : public vrf_wrapper::VrfSortitionBase {
 
   /**
    * @brief Verify VRF sortition
+   *
+   * @param strict strict validation
    * @return true if passed
    */
-  bool verify(const vrf_pk_t& pk) const { return VrfSortitionBase::verify(pk, pbft_msg_.getRlpBytes()); }
+  bool verify(const vrf_pk_t& pk, bool strict = true) const {
+    return VrfSortitionBase::verify(pk, pbft_msg_.getRlpBytes(), 1, strict);
+  }
 
   bool operator==(VrfPbftSortition const& other) const {
     return pbft_msg_ == other.pbft_msg_ && vrf_wrapper::VrfSortitionBase::operator==(other);

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -1112,7 +1112,7 @@ TEST_F(FullNodeTest, receive_send_transaction) {
 }
 
 TEST_F(FullNodeTest, detect_overlap_transactions) {
-  auto node_cfgs = make_node_cfgs(5, 1, 20);
+  auto node_cfgs = make_node_cfgs(5, 1, 10);
   auto nodes = launch_nodes(node_cfgs);
   const auto expected_balances = effective_initial_balances(node_cfgs[0].genesis.state);
   const auto node_1_genesis_bal = own_effective_genesis_bal(node_cfgs[0]);


### PR DESCRIPTION
Rocksdb options sync which was set to false only in final_chain db operations makes every write very slow because it waits for the data to be written to disk. This is specially noticeable on slower SSD and HDD. Removing it improves syncing speed. I do not see any reason why we ever used this.

When syncing faster than processing the blocks we sync which can happen often, a condition variable is used to notify the waiting blocks once a new block is finalized. This also reduces waiting time and improves syncing speed.