### PR TITLE
fix: pbft syncing gossip transition

### DIFF
--- a/libraries/cli/include/cli/config_jsons/default/default_config.json
+++ b/libraries/cli/include/cli/config_jsons/default/default_config.json
@@ -34,7 +34,7 @@
     "sync_level_size": 25,
     "packets_processing_threads": 14,
     "peer_blacklist_timeout": 600,
-    "deep_syncing_threshold": 10,
+    "deep_syncing_threshold": 50,
     "boot_nodes": [
     ]
   },

--- a/libraries/cli/include/cli/config_jsons/devnet/devnet_config.json
+++ b/libraries/cli/include/cli/config_jsons/devnet/devnet_config.json
@@ -34,7 +34,7 @@
     "sync_level_size": 25,
     "packets_processing_threads": 14,
     "peer_blacklist_timeout": 600,
-    "deep_syncing_threshold": 10,
+    "deep_syncing_threshold": 50,
     "boot_nodes": [
       {
         "id": "fdcf4c860d9bb1f17608cbf2dd10ac3ae8d0ba41aa20b3e43fb85a72617a356f8609475d68b44e25dd508a0e5b36da75e7ae9aaf93360f4f002464d1d75fd353",

--- a/libraries/cli/include/cli/config_jsons/mainnet/mainnet_config.json
+++ b/libraries/cli/include/cli/config_jsons/mainnet/mainnet_config.json
@@ -34,7 +34,7 @@
     "sync_level_size": 10,
     "packets_processing_threads": 14,
     "peer_blacklist_timeout": 600,
-    "deep_syncing_threshold": 10,
+    "deep_syncing_threshold": 50,
     "boot_nodes": [
       {
         "id": "45949587c9f31f62e802175471c142da1618f4e456a77e51b0fcb3cc14b14bba7f585d44db15417fff96c29967a4778c60584ced00148bc905609a14fa7e538f",

--- a/libraries/cli/include/cli/config_jsons/testnet/testnet_config.json
+++ b/libraries/cli/include/cli/config_jsons/testnet/testnet_config.json
@@ -34,7 +34,7 @@
     "sync_level_size": 10,
     "packets_processing_threads": 14,
     "peer_blacklist_timeout": 600,
-    "deep_syncing_threshold": 10,
+    "deep_syncing_threshold": 50,
     "boot_nodes": [
       {
         "id": "f36f467529fe91a750dfdc8086fd0d2f30bad9f55a5800b6b4aa603c7787501db78dc4ac1bf3cf16e42af7c2ebb53648653013c3da1987494960d751871d598a",

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1444,7 +1444,7 @@ void PbftManager::pushSyncedPbftBlocksIntoChain() {
 
     if (pushPbftBlock_(std::move(period_data.first), std::move(period_data.second))) {
       LOG(log_dg_) << "Pushed synced PBFT block " << pbft_block_hash << " with period " << pbft_block_period;
-      net->setSyncStatePeriod(pbft_block_period);
+      net->setSyncStatePeriod(pbftSyncingPeriod());
     } else {
       LOG(log_er_) << "Failed push PBFT block " << pbft_block_hash << " with period " << pbft_block_period;
       break;

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/latest/pbft_sync_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/latest/pbft_sync_packet_handler.hpp
@@ -30,6 +30,8 @@ class PbftSyncPacketHandler : public ExtSyncingPacketHandler {
   void pbftSyncComplete();
   void delayedPbftSync(int counter);
 
+  static constexpr uint32_t kDelayedPbftSyncDelayMs = 10;
+
   std::shared_ptr<VoteManager> vote_mgr_;
   util::ThreadPool periodic_events_tp_;
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/latest/pbft_sync_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/latest/pbft_sync_packet_handler.cpp
@@ -95,6 +95,12 @@ void PbftSyncPacketHandler::process(const threadpool::PacketData &packet_data,
                  << packet_data.from_node_id_ << " already present in chain";
   } else {
     if (pbft_block_period != pbft_mgr_->pbftSyncingPeriod() + 1) {
+      // This can happen if we just got synced and block was cert voted
+      if (pbft_chain_synced && pbft_block_period == pbft_mgr_->pbftSyncingPeriod()) {
+        pbftSyncComplete();
+        return;
+      }
+
       LOG(log_er_) << "Block " << pbft_blk_hash << " period unexpected: " << pbft_block_period
                    << ". Expected period: " << pbft_mgr_->pbftSyncingPeriod() + 1;
       return;
@@ -207,7 +213,7 @@ void PbftSyncPacketHandler::process(const threadpool::PacketData &packet_data,
       if (pbft_sync_period > pbft_chain_->getPbftChainSize() + (10 * kConf.network.sync_level_size)) {
         LOG(log_tr_) << "Syncing pbft blocks too fast than processing. Has synced period " << pbft_sync_period
                      << ", PBFT chain size " << pbft_chain_->getPbftChainSize();
-        periodic_events_tp_.post(1000, [this] { delayedPbftSync(1); });
+        periodic_events_tp_.post(kDelayedPbftSyncDelayMs, [this] { delayedPbftSync(1); });
       } else {
         if (!syncPeerPbft(pbft_sync_period + 1)) {
           pbft_syncing_state_->setPbftSyncing(false);
@@ -230,7 +236,7 @@ void PbftSyncPacketHandler::pbftSyncComplete() {
   if (pbft_mgr_->periodDataQueueSize()) {
     LOG(log_tr_) << "Syncing pbft blocks faster than processing. Remaining sync size "
                  << pbft_mgr_->periodDataQueueSize();
-    periodic_events_tp_.post(1000, [this] { pbftSyncComplete(); });
+    periodic_events_tp_.post(kDelayedPbftSyncDelayMs, [this] { pbftSyncComplete(); });
   } else {
     LOG(log_dg_) << "Syncing PBFT is completed";
     // We are pbft synced with the node we are connected to but
@@ -259,7 +265,7 @@ void PbftSyncPacketHandler::delayedPbftSync(int counter) {
     if (pbft_sync_period > pbft_chain_->getPbftChainSize() + (10 * kConf.network.sync_level_size)) {
       LOG(log_tr_) << "Syncing pbft blocks faster than processing " << pbft_sync_period << " "
                    << pbft_chain_->getPbftChainSize();
-      periodic_events_tp_.post(1000, [this, counter] { delayedPbftSync(counter + 1); });
+      periodic_events_tp_.post(kDelayedPbftSyncDelayMs, [this, counter] { delayedPbftSync(counter + 1); });
     } else {
       if (!syncPeerPbft(pbft_sync_period + 1)) {
         pbft_syncing_state_->setPbftSyncing(false);


### PR DESCRIPTION
While node is syncing gossiping messages like transactions/dag blocks/votes packets are ignored up to the point of deep_syncing_threshold of being synced. This threshold was set to only 10 blocks. Since 10 blocks are usually very quickly processed we would usually lose the recent votes which would create two problems:
1. Missing reward votes for the cert voted block making us unable to push the cert voted block requiring us to restart the syncing
2. Not processing votes also did not gave us most up to date info about peer pbft chain sizes delaying the actual syncing up to the latest block

Sometimes this behavior can cause long time of nodes restarting syncing and not being able to fully join the consensus.

Fix is done by increasing the deep_syncing_threshold to 50 and threshold using the latest synced and not finalized blocks so that the votes are processed as soon as we receive the blocks in the queue.

When pbft syncing queue gets filled or when pbft sync is complete a delay of 1000ms was used to wait for the downloaded blocks to be processed. This delay was sometimes to large and caused unneeded delay. This is now reduced to 10ms
