### PR TITLE
fix: setting dag synced state

### DIFF
--- a/libraries/core_libs/network/src/tarcap/shared_states/pbft_syncing_state.cpp
+++ b/libraries/core_libs/network/src/tarcap/shared_states/pbft_syncing_state.cpp
@@ -36,7 +36,9 @@ bool PbftSyncingState::setPbftSyncing(bool syncing, PbftPeriod current_period,
 
     if (syncing) {
       // If pbft syncing, set dag synced state to false
-      peer_->peer_dag_synced_ = false;
+      if (peer_->dagSyncingAllowed()) {
+        peer_->peer_dag_synced_ = false;
+      }
       deep_pbft_syncing_ = (peer_->pbft_chain_size_ - current_period >= kDeepSyncingThreshold);
       // Reset last sync packet time when syncing is restarted/fresh syncing flag is set
       setLastSyncPacketTime();


### PR DESCRIPTION
This is fixing an issue where node we are syncing from marks us as malicious with this error:
Taraxa_N1_12042023_101626_00464.log:0x00007fbca17fa640 10c405dc… V2_GET_DAG_SYNC_PH [2023-12-04 10:23:04.234114] ERROR: Exception caught during packet processing: PacketProcessingException -> MaliciousPeer : Received multiple GetDagSyncPackets from d0dd0540… .PacketData: {"from_node_id":"d0dd0540abbd65d4b63da832afafcf7571ca1b74bfce9ac2b7d22c1a215448a07f6ce6eff0f7e54fb52c8efb8ca64bc6b03a0774f8e2bc4c01ff9e81a1783583","id":61850817,"priority":2,"receive_time":"2023-12-04 10:23:04 node local time","rlp_items_count":2,"rlp_size":0,"type":"GetDagSyncPacket"}, disconnect peer: d0dd0540abbd65d4b63da832afafcf7571ca1b74bfce9ac2b7d22c1a215448a07f6ce6eff0f7e54fb52c8efb8ca64bc6b03a0774f8e2bc4c01ff9e81a1783583

When restarting pbft syncing multiple times from the same node a check is needed if dag syncing is allowed before doing it multiple times.
