### PR TITLE
chore: optimize dag block save

### DIFF
--- a/libraries/core_libs/node/src/node.cpp
+++ b/libraries/core_libs/node/src/node.cpp
@@ -426,6 +426,8 @@ void FullNode::rebuildDb() {
   }
   stop_async = true;
   fut.wait();
+  // Handles the race case if some blocks are still in the queue
+  pbft_mgr_->pushSyncedPbftBlocksIntoChain();
   LOG(log_si_) << "Rebuild completed";
 }
 

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -238,7 +238,6 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   SharedTransactions getAllNonfinalizedTransactions();
   bool transactionInDb(trx_hash_t const& hash);
   bool transactionFinalized(trx_hash_t const& hash);
-  std::vector<bool> transactionsInDb(std::vector<trx_hash_t> const& trx_hashes);
   std::vector<bool> transactionsFinalized(std::vector<trx_hash_t> const& trx_hashes);
   void addTransactionToBatch(Transaction const& trx, Batch& write_batch);
   void removeTransactionToBatch(trx_hash_t const& trx, Batch& write_batch);

--- a/libraries/core_libs/storage/src/storage.cpp
+++ b/libraries/core_libs/storage/src/storage.cpp
@@ -871,17 +871,6 @@ bool DbStorage::transactionFinalized(trx_hash_t const& hash) {
   return exist(toSlice(hash.asBytes()), Columns::trx_period);
 }
 
-std::vector<bool> DbStorage::transactionsInDb(std::vector<trx_hash_t> const& trx_hashes) {
-  std::vector<bool> result(trx_hashes.size(), false);
-  for (size_t i = 0; i < trx_hashes.size(); ++i) {
-    const auto key = trx_hashes[i].asBytes();
-    if (exist(toSlice(key), Columns::transactions) || exist(toSlice(key), Columns::trx_period)) {
-      result[i] = true;
-    }
-  }
-  return result;
-}
-
 uint64_t DbStorage::getStatusField(StatusDbField const& field) {
   auto status = lookup(toSlice((uint8_t)field), Columns::status);
   if (!status.empty()) {

--- a/tests/transaction_test.cpp
+++ b/tests/transaction_test.cpp
@@ -258,10 +258,10 @@ TEST_F(TransactionTest, transaction_concurrency) {
   TransactionManager trx_mgr(cfg, db, NewFinalChain(db, cfg), addr_t());
   bool stopped = false;
   // Insert transactions to memory pool and keep trying to insert them again on separate thread, it should always fail
+  for (auto const& t : *g_signed_trx_samples) {
+    trx_mgr.insertTransaction(t);
+  }
   std::thread insertTrx([&trx_mgr, &stopped]() {
-    for (auto const& t : *g_signed_trx_samples) {
-      trx_mgr.insertTransaction(t);
-    }
     while (!stopped) {
       for (auto const& t : *g_signed_trx_samples) {
         EXPECT_FALSE(trx_mgr.insertTransaction(t).first);


### PR DESCRIPTION
When saving transactions from dag block just added to the DAG there were some unneeded db lookups which were a performance bottleneck. On verifying the DAG block it is ensured that all transactions that are not finalized and not yet part of the DAG are within the transaction pool so there is no need to do additional db lookups.

The PR also includes a fix for the issue in rebuild db which was causing db_rebuild test to intermittently fail.