### PR TITLE
chore: increase gas limit on devnet

### DIFF
--- a/libraries/cli/include/cli/config_jsons/devnet/devnet_genesis.json
+++ b/libraries/cli/include/cli/config_jsons/devnet/devnet_genesis.json
@@ -237,13 +237,13 @@
     "dag_blocks_size": "0x32",
     "ghost_path_move_back": "0x0",
     "lambda_ms": "0x5DC",
-    "gas_limit": "0x12C684C0"
+    "gas_limit": "0x3E95BA80"
   },
   "dag": {
     "block_proposer": {
       "shard": 1
     },
-    "gas_limit": "0x1E0A6E0"
+    "gas_limit": "0x6422C40"
   },
   "sortition": {
     "changes_count_for_average": 10,


### PR DESCRIPTION
gas_limit for DAG and Pbft blocks was reduced as part of this PR: https://github.com/Taraxa-project/taraxa-node/pull/2424
The gas limit basically limits how many transactions we can execute per second together with the other parameters. With the current settings we produce just a little over 1 dag block per second. With aiming for dag block efficiency of 50% only half of transactions in dag blocks are unique transactions. This means that the gas limit in practice allows us to put max of 1500 transactions in dag block and is basically limiting us to not have over 750 transactions per second.

Increased the limit to support 5000 transactions in DAG block and 50000 in PBFT block on devnet to be able to perform high TPS testing.

Reverting transactions check that was removed as part of syncing optimization. This code is reverted because removing it opens a possibility of malicious node sending incorrect transactions leading to an incorrect state root and corrupted db.