### PR TITLE
Fix clang format check and formatting 

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,5 +2,5 @@
 Language: Cpp
 BasedOnStyle: Google
 ColumnLimit: 120
-...
+---
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@
 !CMakeModules
 !tests
 !clang-format
+!.clang-format
 !.gitmodules
 !CMakeLists.txt
 !LICENSE

--- a/libraries/core_libs/network/rpc/EthFace.h
+++ b/libraries/core_libs/network/rpc/EthFace.h
@@ -111,9 +111,10 @@ class EthFace : public ServerInterface<EthFace> {
                            &taraxa::net::EthFace::eth_sendRawTransactionI);
     this->bindAndAddMethod(jsonrpc::Procedure("eth_syncing", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, NULL),
                            &taraxa::net::EthFace::eth_syncingI);
-    this->bindAndAddMethod(jsonrpc::Procedure("eth_estimateGas", jsonrpc::PARAMS_BY_POSITION_WITH_OPTIONAL, jsonrpc::JSON_STRING,
-                                              "param1", jsonrpc::JSON_OBJECT, "param2", JSON_ANY, NULL),
-                           &taraxa::net::EthFace::eth_estimateGasI);
+    this->bindAndAddMethod(
+        jsonrpc::Procedure("eth_estimateGas", jsonrpc::PARAMS_BY_POSITION_WITH_OPTIONAL, jsonrpc::JSON_STRING, "param1",
+                           jsonrpc::JSON_OBJECT, "param2", JSON_ANY, NULL),
+        &taraxa::net::EthFace::eth_estimateGasI);
     this->bindAndAddMethod(jsonrpc::Procedure("eth_chainId", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, NULL),
                            &taraxa::net::EthFace::eth_chainIdI);
   }


### PR DESCRIPTION
`!.clang-format` added to `.dockerignore`, so `COPY` command in the Dockerfile will actually copy this config and formatting will be checked properly 
