### PR TITLE
chore: adding version to pbft block

### DIFF
--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -55,10 +55,10 @@ class PbftManager {
  public:
   using time_point = std::chrono::system_clock::time_point;
 
-  PbftManager(const PbftConfig &conf, const blk_hash_t &dag_genesis_block_hash, addr_t node_addr,
-              std::shared_ptr<DbStorage> db, std::shared_ptr<PbftChain> pbft_chain,
-              std::shared_ptr<VoteManager> vote_mgr, std::shared_ptr<DagManager> dag_mgr,
-              std::shared_ptr<TransactionManager> trx_mgr, std::shared_ptr<FinalChain> final_chain, secret_t node_sk);
+  PbftManager(const GenesisConfig &conf, addr_t node_addr, std::shared_ptr<DbStorage> db,
+              std::shared_ptr<PbftChain> pbft_chain, std::shared_ptr<VoteManager> vote_mgr,
+              std::shared_ptr<DagManager> dag_mgr, std::shared_ptr<TransactionManager> trx_mgr,
+              std::shared_ptr<FinalChain> final_chain, secret_t node_sk);
   ~PbftManager();
   PbftManager(const PbftManager &) = delete;
   PbftManager(PbftManager &&) = delete;
@@ -252,7 +252,7 @@ class PbftManager {
    * @brief Get PBFT committee size
    * @return PBFT committee size
    */
-  size_t getPbftCommitteeSize() const { return config_.committee_size; }
+  size_t getPbftCommitteeSize() const { return config_.pbft.committee_size; }
 
   /**
    * @brief Test/enforce broadcastVotes() to actually send votes
@@ -567,7 +567,7 @@ class PbftManager {
 
   const blk_hash_t dag_genesis_block_hash_;
 
-  const PbftConfig &config_;
+  const GenesisConfig &config_;
 
   std::condition_variable stop_cv_;
   std::mutex stop_mtx_;

--- a/libraries/core_libs/node/src/node.cpp
+++ b/libraries/core_libs/node/src/node.cpp
@@ -135,9 +135,8 @@ void FullNode::init() {
   auto slashing_manager = std::make_shared<SlashingManager>(final_chain_, trx_mgr_, gas_pricer_, conf_, kp_.secret());
   vote_mgr_ = std::make_shared<VoteManager>(node_addr, conf_.genesis.pbft, kp_.secret(), conf_.vrf_secret, db_,
                                             pbft_chain_, final_chain_, key_manager_, slashing_manager);
-  pbft_mgr_ =
-      std::make_shared<PbftManager>(conf_.genesis.pbft, conf_.genesis.dag_genesis_block.getHash(), node_addr, db_,
-                                    pbft_chain_, vote_mgr_, dag_mgr_, trx_mgr_, final_chain_, kp_.secret());
+  pbft_mgr_ = std::make_shared<PbftManager>(conf_.genesis, node_addr, db_, pbft_chain_, vote_mgr_, dag_mgr_, trx_mgr_,
+                                            final_chain_, kp_.secret());
   dag_block_proposer_ = std::make_shared<DagBlockProposer>(
       conf_.genesis.dag.block_proposer, dag_mgr_, trx_mgr_, final_chain_, db_, key_manager_, node_addr, getSecretKey(),
       getVrfSecretKey(), conf_.genesis.pbft.gas_limit, conf_.genesis.dag.gas_limit, conf_.genesis.state);

--- a/libraries/types/pbft_block/CMakeLists.txt
+++ b/libraries/types/pbft_block/CMakeLists.txt
@@ -1,9 +1,11 @@
 set(HEADERS
     include/pbft/pbft_block.hpp
+    include/pbft/pbft_block_extra_data.hpp
     include/pbft/period_data.hpp
 )
 set(SOURCES
     src/pbft_block.cpp
+    src/pbft_block_extra_data.cpp
     src/period_data.cpp
 )
 

--- a/libraries/types/pbft_block/include/pbft/pbft_block.hpp
+++ b/libraries/types/pbft_block/include/pbft/pbft_block.hpp
@@ -7,6 +7,7 @@
 
 #include "common/types.hpp"
 #include "dag/dag_block.hpp"
+#include "pbft_block_extra_data.hpp"
 #include "vote/vote.hpp"
 
 namespace taraxa {
@@ -30,11 +31,12 @@ class PbftBlock {
   addr_t beneficiary_;
   sig_t signature_;
   std::vector<vote_hash_t> reward_votes_;  // Cert votes in previous period
+  std::optional<PbftBlockExtraData> extra_data_;
 
  public:
   PbftBlock(const blk_hash_t& prev_blk_hash, const blk_hash_t& dag_blk_hash_as_pivot, const blk_hash_t& order_hash,
             const blk_hash_t& prev_state_root, PbftPeriod period, const addr_t& beneficiary, const secret_t& sk,
-            std::vector<vote_hash_t>&& reward_votes);
+            std::vector<vote_hash_t>&& reward_votes, const PbftBlockExtraData& extra_data = {});
   explicit PbftBlock(const dev::RLP& rlp);
   explicit PbftBlock(const bytes& RLP);
 
@@ -116,6 +118,18 @@ class PbftBlock {
    * @return timestamp
    */
   auto getTimestamp() const { return timestamp_; }
+
+  /**
+   * @brief Get extra data
+   * @return extra data
+   */
+  auto getExtraData() const { return extra_data_; }
+
+  /**
+   * @brief Get extra data rlp
+   * @return extra data rlp
+   */
+  auto getExtraDataRlp() const { return extra_data_.has_value() ? extra_data_->rlp() : bytes(); }
 
   /**
    * @brief Get PBFT block proposer address

--- a/libraries/types/pbft_block/include/pbft/pbft_block_extra_data.hpp
+++ b/libraries/types/pbft_block/include/pbft/pbft_block_extra_data.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <libdevcore/Common.h>
+#include <libdevcore/RLP.h>
+#include <libdevcore/SHA3.h>
+#include <libdevcrypto/Common.h>
+
+#include "common/types.hpp"
+#include "dag/dag_block.hpp"
+#include "vote/vote.hpp"
+
+namespace taraxa {
+
+/** @addtogroup PBFT
+ * @{
+ */
+
+class PbftBlockExtraData {
+ public:
+  PbftBlockExtraData() {}
+  PbftBlockExtraData(const uint16_t major_version, const uint16_t minor_version, const uint16_t patch_version,
+                     const uint16_t net_version, const std::string node_implementation);
+  PbftBlockExtraData(const bytes& data);
+
+  /**
+   * @brief Get rlp
+   * @return rlp
+   */
+  bytes rlp() const;
+
+  /**
+   * @brief Get JSON
+   * @return Json
+   */
+  Json::Value getJson() const;
+
+ protected:
+  uint16_t major_version_;
+  uint16_t minor_version_;
+  uint16_t patch_version_;
+  uint16_t net_version_;
+  std::string node_implementation_;
+  static constexpr uint32_t kExtraDataMaxSize = 1024;
+};
+
+/** @}*/
+
+}  // namespace taraxa

--- a/libraries/types/pbft_block/src/pbft_block.cpp
+++ b/libraries/types/pbft_block/src/pbft_block.cpp
@@ -11,22 +11,32 @@ namespace taraxa {
 PbftBlock::PbftBlock(bytes const& b) : PbftBlock(dev::RLP(b)) {}
 
 PbftBlock::PbftBlock(dev::RLP const& rlp) {
-  util::rlp_tuple(util::RLPDecoderRef(rlp, true), prev_block_hash_, dag_block_hash_as_pivot_, order_hash_,
-                  prev_state_root_hash_, period_, timestamp_, reward_votes_, signature_);
+  if (rlp.itemCount() == 9) {
+    dev::bytes extra_data_bytes;
+    util::rlp_tuple(util::RLPDecoderRef(rlp, true), prev_block_hash_, dag_block_hash_as_pivot_, order_hash_,
+                    prev_state_root_hash_, period_, timestamp_, reward_votes_, extra_data_bytes, signature_);
+    extra_data_ = PbftBlockExtraData(extra_data_bytes);
+  } else {
+    util::rlp_tuple(util::RLPDecoderRef(rlp, true), prev_block_hash_, dag_block_hash_as_pivot_, order_hash_,
+                    prev_state_root_hash_, period_, timestamp_, reward_votes_, signature_);
+  }
+
   calculateHash_();
   checkUniqueRewardVotes();
 }
 
 PbftBlock::PbftBlock(const blk_hash_t& prev_blk_hash, const blk_hash_t& dag_blk_hash_as_pivot,
                      const blk_hash_t& order_hash, const blk_hash_t& prev_state_root, PbftPeriod period,
-                     const addr_t& beneficiary, const secret_t& sk, std::vector<vote_hash_t>&& reward_votes)
+                     const addr_t& beneficiary, const secret_t& sk, std::vector<vote_hash_t>&& reward_votes,
+                     const PbftBlockExtraData& extra_data)
     : prev_block_hash_(prev_blk_hash),
       dag_block_hash_as_pivot_(dag_blk_hash_as_pivot),
       order_hash_(order_hash),
       prev_state_root_hash_(prev_state_root),
       period_(period),
       beneficiary_(beneficiary),
-      reward_votes_(reward_votes) {
+      reward_votes_(reward_votes),
+      extra_data_(extra_data) {
   timestamp_ = dev::utcTime();
   signature_ = dev::sign(sk, sha3(false));
   calculateHash_();
@@ -86,13 +96,16 @@ Json::Value PbftBlock::getJson() const {
   for (const auto& v : reward_votes_) {
     json["reward_votes"].append(v.toString());
   }
+  json["extra_data"] = extra_data_->getJson();
 
   return json;
 }
 
 // Using to setup PBFT block hash
 void PbftBlock::streamRLP(dev::RLPStream& strm, bool include_sig) const {
-  strm.appendList(include_sig ? 8 : 7);
+  uint32_t rlp_count = (include_sig ? 8 : 7);
+  if (extra_data_.has_value()) rlp_count++;
+  strm.appendList(rlp_count);
   strm << prev_block_hash_;
   strm << dag_block_hash_as_pivot_;
   strm << order_hash_;
@@ -100,6 +113,10 @@ void PbftBlock::streamRLP(dev::RLPStream& strm, bool include_sig) const {
   strm << period_;
   strm << timestamp_;
   strm.appendVector(reward_votes_);
+
+  if (extra_data_.has_value()) {
+    strm << extra_data_->rlp();
+  }
   if (include_sig) {
     strm << signature_;
   }

--- a/libraries/types/pbft_block/src/pbft_block_extra_data.cpp
+++ b/libraries/types/pbft_block/src/pbft_block_extra_data.cpp
@@ -1,0 +1,49 @@
+#include "pbft/pbft_block_extra_data.hpp"
+
+#include <iostream>
+
+#include "common/jsoncpp.hpp"
+
+namespace taraxa {
+
+PbftBlockExtraData::PbftBlockExtraData(const uint16_t major_version, const uint16_t minor_version,
+                                       const uint16_t patch_version, const uint16_t net_version,
+                                       const std::string node_implementation)
+    : major_version_(major_version),
+      minor_version_(minor_version),
+      patch_version_(patch_version),
+      net_version_(net_version),
+      node_implementation_(node_implementation) {}
+
+PbftBlockExtraData::PbftBlockExtraData(const bytes& data) {
+  if (data.size() > kExtraDataMaxSize) {
+    throw std::runtime_error("Pbft block invalid, extra data size over the limit");
+  }
+  dev::RLP rlp(data);
+  util::rlp_tuple(util::RLPDecoderRef(rlp, true), major_version_, minor_version_, patch_version_, net_version_,
+                  node_implementation_);
+}
+
+bytes PbftBlockExtraData::rlp() const {
+  dev::RLPStream s;
+  s.appendList(5);
+  s << major_version_;
+  s << minor_version_;
+  s << patch_version_;
+  s << net_version_;
+  s << node_implementation_;
+  return s.invalidate();
+}
+
+Json::Value PbftBlockExtraData::getJson() const {
+  Json::Value json;
+  json["major_version"] = major_version_;
+  json["minor_version"] = minor_version_;
+  json["patch_version"] = patch_version_;
+  json["net_version"] = net_version_;
+  json["node_implementation"] = node_implementation_;
+
+  return json;
+}
+
+}  // namespace taraxa

--- a/tests/final_chain_test.cpp
+++ b/tests/final_chain_test.cpp
@@ -106,7 +106,7 @@ struct FinalChainTest : WithDataDir {
                                        trxs.size(), [&](auto i) { return dev::rlp(i); },
                                        [&](auto i) { return util::rlp_enc(receipts[i]); }));
     EXPECT_EQ(blk_h.gas_limit, cfg.genesis.pbft.gas_limit);
-    EXPECT_EQ(blk_h.extra_data, bytes());
+    EXPECT_EQ(blk_h.extra_data, pbft_block->getExtraData()->rlp());
     EXPECT_EQ(blk_h.nonce(), Nonce());
     EXPECT_EQ(blk_h.difficulty(), 0);
     EXPECT_EQ(blk_h.mix_hash(), h256());

--- a/tests/pbft_chain_test.cpp
+++ b/tests/pbft_chain_test.cpp
@@ -17,7 +17,7 @@ namespace taraxa::core_tests {
 
 struct PbftChainTest : NodesTest {};
 
-TEST_F(PbftChainTest, serialize_desiriablize_pbft_block) {
+TEST_F(PbftChainTest, serialize_deserialize_pbft_block) {
   auto node_cfgs = make_node_cfgs(1);
   dev::Secret sk(node_cfgs[0].node_secret);
   // Generate PBFT block sample


### PR DESCRIPTION
Pbft block after aspen hf part two contains an optional extra field similar to extra_data field in ethereum block. Final chain ethereum block representation contains the field. After aspen hf, this field will contain a version info in format:
{'T', TARAXA_MAJOR_VERSION, TARAXA_MINOR_VERSION, TARAXA_PATCH_VERSION, TARAXA_NET_VERSION})