### PR TITLE
chore: remove incorrect missing tip log

### DIFF
--- a/libraries/core_libs/consensus/src/dag/dag_manager.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_manager.cpp
@@ -691,8 +691,10 @@ DagManager::VerifyBlockReturnType DagManager::verifyBlock(const DagBlock &blk) {
     if ((blk.getTips().size() + 1) > kPbftGasLimit / getDagConfig().gas_limit) {
       for (const auto &t : blk.getTips()) {
         const auto tip_blk = getDagBlock(t);
-        LOG(log_er_) << "DAG Block " << block_hash << " tip " << t << " not present";
-        if (tip_blk == nullptr) return VerifyBlockReturnType::MissingTip;
+        if (tip_blk == nullptr) {
+          LOG(log_er_) << "DAG Block " << block_hash << " tip " << t << " not present";
+          return VerifyBlockReturnType::MissingTip;
+        }
         block_gas_estimation += tip_blk->getGasEstimation();
       }
       if (block_gas_estimation > kPbftGasLimit) {


### PR DESCRIPTION
Tip not present error log is showing up on all of our networks and it was actually logged even if we had a tip. Fixed by logging this only if the tip is missing.