### PR TITLE
chore: final chain state

### DIFF
--- a/libraries/core_libs/consensus/src/final_chain/final_chain.cpp
+++ b/libraries/core_libs/consensus/src/final_chain/final_chain.cpp
@@ -42,6 +42,8 @@ class FinalChainImpl final : public FinalChain {
   std::condition_variable finalized_cv_;
   std::mutex finalized_mtx_;
 
+  std::atomic<EthBlockNumber> last_block_number_;
+
   LOG_OBJECTS_DEFINE
 
  public:
@@ -85,6 +87,7 @@ class FinalChainImpl final : public FinalChain {
                                  state_db_descriptor.state_root, u256(0));
 
       block_headers_cache_.append(header->number, header);
+      last_block_number_ = header->number;
       db_->commitWriteBatch(batch);
     } else {
       // We need to recover latest changes as there was shutdown inside finalize function
@@ -106,6 +109,7 @@ class FinalChainImpl final : public FinalChain {
         db_->commitWriteBatch(batch);
         last_blk_num = state_db_descriptor.blk_num;
       }
+      last_block_number_ = *last_blk_num;
 
       int64_t start = 0;
       if (*last_blk_num > 5) {
@@ -234,6 +238,7 @@ class FinalChainImpl final : public FinalChain {
     num_executed_dag_blk_ = num_executed_dag_blk;
     num_executed_trx_ = num_executed_trx;
     block_headers_cache_.append(blk_header->number, blk_header);
+    last_block_number_ = blk_header->number;
     block_finalized_emitter_.emit(result);
     LOG(log_nf_) << " successful finalize block " << result->hash << " with number " << blk_header->number;
 
@@ -319,7 +324,7 @@ class FinalChainImpl final : public FinalChain {
     return blk_header_ptr;
   }
 
-  EthBlockNumber last_block_number() const override { return block_headers_cache_.last()->number; }
+  EthBlockNumber last_block_number() const override { return last_block_number_; }
 
   std::optional<EthBlockNumber> block_number(h256 const& h) const override {
     return db_->lookup_int<EthBlockNumber>(h, DB::Columns::final_chain_blk_number_by_hash);


### PR DESCRIPTION
There is a race condition which can cause an exception on processing packets and other places. Final chain commit is performed before the EVM state commit. In between these two calls this can happen:
1. Caller call getBlock from cache with block_num higher than the last block number, this updates the last block number to be over what is executed in EVM
2. Another thread asks for account from EVM using the last block which is not yet present in the EVM

This causes this exception for instance in processing of transaction packet:
0x00007cc72d7fa640 V2_TRANSACTION_PH [2024-03-21 15:22:17.365802] ERROR: Exception caught during packet processing: Requested blk num:941, last committed:940 .PacketData: {"from_node_id":"53b7010037543c15159d6dc77c7ea8e60c61489a06ebf1a7b0a940332c1ef73d9774e4323da34c327a8cecea001de4cde79d473f14ed61f044f8a6102c6cf7d0","id":1194,"priority":1,"receive_time":"2024-03-21 15:22:17 node local time","rlp_items_count":2,"rlp_size":0,"type":"TransactionPacket"}, disconnect peer: 53b7010037543c15159d6dc77c7ea8e60c61489a06ebf1a7b0a940332c1ef73d9774e4323da34c327a8cecea001de4cde79d473f14ed61f044f8a6102c6cf7d0

Fix is by storing last block number separate from the cache and only updating it after both the final chain and EVM state has been commited