### PR TITLE
chore: trxs gossip improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(TARAXA_PATCH_VERSION 2)
 set(TARAXA_VERSION ${TARAXA_MAJOR_VERSION}.${TARAXA_MINOR_VERSION}.${TARAXA_PATCH_VERSION})
 
 # Any time a change in the network protocol is introduced this version should be increased
-set(TARAXA_NET_VERSION 2)
+set(TARAXA_NET_VERSION 3)
 # Major version is modified when DAG blocks, pbft blocks and any basic building blocks of our blockchain is modified
 # in the db
 set(TARAXA_DB_MAJOR_VERSION 1)

--- a/libraries/cli/include/cli/config_jsons/devnet/devnet_genesis.json
+++ b/libraries/cli/include/cli/config_jsons/devnet/devnet_genesis.json
@@ -237,13 +237,13 @@
     "dag_blocks_size": "0x32",
     "ghost_path_move_back": "0x0",
     "lambda_ms": "0x5DC",
-    "gas_limit": "0x3E95BA80"
+    "gas_limit": "0x7d2b7500"
   },
   "dag": {
     "block_proposer": {
       "shard": 1
     },
-    "gas_limit": "0x6422C40"
+    "gas_limit": "0x1908B100"
   },
   "sortition": {
     "changes_count_for_average": 10,

--- a/libraries/common/include/common/constants.hpp
+++ b/libraries/common/include/common/constants.hpp
@@ -21,6 +21,7 @@ constexpr uint32_t kDagExpiryLevelLimit = 1000;
 constexpr uint32_t kDagBlockMaxTips = 16;
 
 const uint32_t kMaxTransactionsInPacket{500};
+const uint32_t kMaxHashesInPacket{5000};
 
 const uint32_t kPeriodicEventsThreadCount{2};
 
@@ -28,6 +29,8 @@ const uint64_t kMinTxGas{21000};
 
 constexpr uint32_t kMinTransactionPoolSize{30000};
 constexpr uint32_t kDefaultTransactionPoolSize{200000};
+
+const size_t kV2NetworkVersion = 2;
 
 // The various denominations; here for ease of use where needed within code.
 static const u256 kOneTara = dev::exp10<18>();

--- a/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
+++ b/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
@@ -71,10 +71,10 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
   std::pair<SharedTransactions, std::vector<uint64_t>> packTrxs(PbftPeriod proposal_period, uint64_t weight_limit);
 
   /**
-   * @brief Gets all transactions from pool
+   * @brief Gets all transactions from pool grouped per account
    * @return transactions
    */
-  SharedTransactions getAllPoolTrxs();
+  std::vector<SharedTransactions> getAllPoolTrxs();
 
   /**
    * Saves transactions from dag block which was added to the DAG. Removes transactions from memory pool

--- a/libraries/core_libs/consensus/include/transaction/transaction_queue.hpp
+++ b/libraries/core_libs/consensus/include/transaction/transaction_queue.hpp
@@ -66,11 +66,11 @@ class TransactionQueue {
   std::vector<std::shared_ptr<Transaction>> getOrderedTransactions(uint64_t count) const;
 
   /**
-   * @brief returns all transactions
+   * @brief returns all transactions grouped by transactions author
    *
-   * @return std::vector<std::shared_ptr<Transaction>>
+   * @return std::vector<SharedTransactions>
    */
-  std::vector<std::shared_ptr<Transaction>> getAllTransactions() const;
+  std::vector<SharedTransactions> getAllTransactions() const;
 
   /**
    * @brief returns true/false if the transaction is in the queue
@@ -152,11 +152,17 @@ class TransactionQueue {
   // Maximum number of non proposable transactions in percentage of kMaxSize
   const size_t kNonProposableTransactionsLimitPercentage = 20;
 
+  // Maximum number of single account transactions in percentage of kMaxSize
+  const size_t kSingleAccountTransactionsLimitPercentage = 5;
+
   // Maximum number of non proposable transactions
   const size_t kNonProposableTransactionsMaxSize;
 
   // Maximum size of transactions pool
   const size_t kMaxSize;
+
+  // Maximum size of single account transactions
+  const size_t kMaxSingleAccountTransactionsSize;
 };
 
 /** @}*/

--- a/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
+++ b/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
@@ -297,7 +297,7 @@ std::pair<SharedTransactions, std::vector<uint64_t>> TransactionManager::packTrx
   return {trxs, estimations};
 }
 
-SharedTransactions TransactionManager::getAllPoolTrxs() {
+std::vector<SharedTransactions> TransactionManager::getAllPoolTrxs() {
   std::shared_lock transactions_lock(transactions_mutex_);
   return transactions_pool_.getAllTransactions();
 }

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/latest/transaction_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/latest/transaction_packet_handler.hpp
@@ -17,7 +17,7 @@ class TransactionPacketHandler : public PacketHandler {
  public:
   TransactionPacketHandler(const FullNodeConfig& conf, std::shared_ptr<PeersState> peers_state,
                            std::shared_ptr<TimePeriodPacketsStats> packets_stats,
-                           std::shared_ptr<TransactionManager> trx_mgr, const addr_t& node_addr,
+                           std::shared_ptr<TransactionManager> trx_mgr, const addr_t& node_addr, bool hash_gossip,
                            const std::string& logs_prefix = "TRANSACTION_PH");
 
   /**
@@ -27,7 +27,8 @@ class TransactionPacketHandler : public PacketHandler {
    * @param transactions serialized transactions
    *
    */
-  void sendTransactions(std::shared_ptr<TaraxaPeer> peer, std::vector<std::shared_ptr<Transaction>>&& transactions);
+  void sendTransactions(std::shared_ptr<TaraxaPeer> peer,
+                        std::pair<SharedTransactions, std::vector<trx_hash_t>>&& transactions);
 
   /**
    * @brief Sends batch of transactions to all connected peers
@@ -35,7 +36,7 @@ class TransactionPacketHandler : public PacketHandler {
    *
    * @param transactions to be sent
    */
-  void periodicSendTransactions(SharedTransactions&& transactions);
+  void periodicSendTransactions(std::vector<SharedTransactions>&& transactions);
 
   // Packet type that is processed by this handler
   static constexpr SubprotocolPacketType kPacketType_ = SubprotocolPacketType::TransactionPacket;
@@ -48,10 +49,41 @@ class TransactionPacketHandler : public PacketHandler {
   virtual void process(const threadpool::PacketData& packet_data, const std::shared_ptr<TaraxaPeer>& peer) override;
 
  protected:
+  /**
+   * @brief Sends batch of transactions to all connected peers
+   * @note Support of the old V2 version, remove once most of the network is updated or after a hardfork. This method is
+   * used as periodic event to broadcast transactions to the other peers in network
+   *
+   * @param transactions to be sent
+   */
+  void periodicSendTransactionsWithoutHashGossip(std::vector<SharedTransactions>&& transactions);
+
+  /**
+   * @brief select which transactions and hashes to send to which connected peer
+   *
+   * @param transactions to be sent
+   * @return selected transactions and hashes to be sent per peer
+   */
+  std::vector<std::pair<std::shared_ptr<TaraxaPeer>, std::pair<SharedTransactions, std::vector<trx_hash_t>>>>
+  transactionsToSendToPeers(std::vector<SharedTransactions>&& transactions);
+
+  /**
+   * @brief select which transactions and hashes to send to peer
+   *
+   * @param peer
+   * @param transactions grouped per account to be sent
+   * @param account_start_index which account to start with
+   * @return index of the next account to continue and selected transactions and hashes to be sent per peer
+   */
+  std::pair<uint32_t, std::pair<SharedTransactions, std::vector<trx_hash_t>>> transactionsToSendToPeer(
+      std::shared_ptr<TaraxaPeer> peer, const std::vector<SharedTransactions>& transactions,
+      uint32_t account_start_index);
+
   std::shared_ptr<TransactionManager> trx_mgr_;
 
   std::atomic<uint64_t> received_trx_count_{0};
   std::atomic<uint64_t> unique_received_trx_count_{0};
+  const bool kHashGossip = true;
 };
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
@@ -46,7 +46,7 @@ class TaraxaCapability final : public dev::p2p::CapabilityFace {
       const std::shared_ptr<PbftManager> &pbft_mgr, const std::shared_ptr<PbftChain> &pbft_chain,
       const std::shared_ptr<VoteManager> &vote_mgr, const std::shared_ptr<DagManager> &dag_mgr,
       const std::shared_ptr<TransactionManager> &trx_mgr, const std::shared_ptr<SlashingManager> &slashing_manager,
-      const addr_t &node_addr)>;
+      TarcapVersion version, const addr_t &node_addr)>;
 
   /**
    * @brief Default InitPacketsHandlers function definition with the latest version of packets handlers

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
@@ -95,6 +95,11 @@ class TaraxaPeer : public boost::noncopyable {
    */
   void resetPacketsStats();
 
+  /**
+   * @brief Resets known caches - used for testing
+   */
+  void resetKnownCaches();
+
  public:
   std::atomic<bool> syncing_ = false;
   std::atomic<uint64_t> dag_level_ = 0;
@@ -125,7 +130,7 @@ class TaraxaPeer : public boost::noncopyable {
 
   std::atomic<uint64_t> timestamp_suspicious_packet_ = 0;
   std::atomic<uint64_t> suspicious_packet_count_ = 0;
-  const uint64_t kMaxSuspiciousPacketPerMinute = 1000;
+  const uint64_t kMaxSuspiciousPacketPerMinute = 50000;
 
   // Performance extensive dag syncing is only allowed to be requested once each kDagSyncingLimit seconds
   const uint64_t kDagSyncingLimit = 60;

--- a/libraries/core_libs/network/src/network.cpp
+++ b/libraries/core_libs/network/src/network.cpp
@@ -70,7 +70,16 @@ Network::Network(const FullNodeConfig &config, const h256 &genesis_hash, std::fi
   // Create taraxa capabilities
   dev::p2p::Host::CapabilitiesFactory constructCapabilities = [&](std::weak_ptr<dev::p2p::Host> host) {
     assert(!host.expired());
+
+    assert(kV2NetworkVersion < TARAXA_NET_VERSION);
+
     dev::p2p::Host::CapabilityList capabilities;
+
+    // Register old version (V2) of taraxa capability
+    auto v2_tarcap = std::make_shared<network::tarcap::TaraxaCapability>(
+        kV2NetworkVersion, config, genesis_hash, host, key, packets_tp_, all_packets_stats_, pbft_syncing_state_, db,
+        pbft_mgr, pbft_chain, vote_mgr, dag_mgr, trx_mgr, slashing_manager);
+    capabilities.emplace_back(v2_tarcap);
 
     // Register latest version of taraxa capability
     auto latest_tarcap = std::make_shared<network::tarcap::TaraxaCapability>(

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/latest/transaction_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/latest/transaction_packet_handler.cpp
@@ -10,9 +10,10 @@ namespace taraxa::network::tarcap {
 TransactionPacketHandler::TransactionPacketHandler(const FullNodeConfig &conf, std::shared_ptr<PeersState> peers_state,
                                                    std::shared_ptr<TimePeriodPacketsStats> packets_stats,
                                                    std::shared_ptr<TransactionManager> trx_mgr, const addr_t &node_addr,
-                                                   const std::string &logs_prefix)
+                                                   bool hash_gossip, const std::string &logs_prefix)
     : PacketHandler(conf, std::move(peers_state), std::move(packets_stats), node_addr, logs_prefix + "TRANSACTION_PH"),
-      trx_mgr_(std::move(trx_mgr)) {}
+      trx_mgr_(std::move(trx_mgr)),
+      kHashGossip(hash_gossip) {}
 
 void TransactionPacketHandler::validatePacketRlpFormat(const threadpool::PacketData &packet_data) const {
   auto items = packet_data.rlp_.itemCount();
@@ -22,11 +23,16 @@ void TransactionPacketHandler::validatePacketRlpFormat(const threadpool::PacketD
   auto hashes_count = packet_data.rlp_[0].itemCount();
   auto trx_count = packet_data.rlp_[1].itemCount();
 
-  if (hashes_count != trx_count) {
+  if (hashes_count < trx_count) {
     throw InvalidRlpItemsCountException(packet_data.type_str_, hashes_count, trx_count);
   }
-  if (hashes_count == 0 || hashes_count > kMaxTransactionsInPacket) {
-    throw InvalidRlpItemsCountException(packet_data.type_str_, hashes_count, kMaxTransactionsInPacket);
+  if (hashes_count == 0 || hashes_count > kMaxTransactionsInPacket + kMaxHashesInPacket) {
+    throw InvalidRlpItemsCountException(packet_data.type_str_, hashes_count,
+                                        kMaxTransactionsInPacket + kMaxHashesInPacket);
+  }
+
+  if (trx_count > kMaxTransactionsInPacket) {
+    throw InvalidRlpItemsCountException(packet_data.type_str_, trx_count, kMaxTransactionsInPacket);
   }
 }
 
@@ -34,11 +40,12 @@ inline void TransactionPacketHandler::process(const threadpool::PacketData &pack
                                               const std::shared_ptr<TaraxaPeer> &peer) {
   std::vector<trx_hash_t> received_transactions;
 
-  const auto transaction_count = packet_data.rlp_[0].itemCount();
+  const auto transaction_hashes_count = packet_data.rlp_[0].itemCount();
+  const auto transaction_count = packet_data.rlp_[1].itemCount();
   received_transactions.reserve(transaction_count);
 
   std::vector<trx_hash_t> trx_hashes;
-  trx_hashes.reserve(transaction_count);
+  trx_hashes.reserve(transaction_hashes_count);
 
   // First extract only transaction hashes
   for (const auto trx_hash_rlp : packet_data.rlp_[0]) {
@@ -104,33 +111,37 @@ inline void TransactionPacketHandler::process(const threadpool::PacketData &pack
   }
 }
 
-void TransactionPacketHandler::periodicSendTransactions(SharedTransactions &&transactions) {
-  std::vector<std::pair<dev::p2p::NodeID, SharedTransactions>> peers_with_transactions_to_send;
+void TransactionPacketHandler::periodicSendTransactionsWithoutHashGossip(
+    std::vector<SharedTransactions> &&transactions) {
+  std::vector<std::pair<dev::p2p::NodeID, std::pair<SharedTransactions, std::vector<trx_hash_t>>>>
+      peers_with_transactions_to_send;
 
   auto peers = peers_state_->getAllPeers();
-  std::string peers_to_log;
   for (const auto &peer : peers) {
     // Confirm that status messages were exchanged otherwise message might be ignored and node would
     // incorrectly markTransactionAsKnown
     if (!peer.second->syncing_) {
-      peers_to_log += peer.first.abridged();
       SharedTransactions peer_trxs;
-      for (auto const &trx : transactions) {
-        auto trx_hash = trx->getHash();
-        if (peer.second->isTransactionKnown(trx_hash)) {
-          continue;
+      for (auto const &account_trx : transactions) {
+        for (auto const &trx : account_trx) {
+          auto trx_hash = trx->getHash();
+          if (peer.second->isTransactionKnown(trx_hash)) {
+            continue;
+          }
+          peer_trxs.push_back(trx);
+          if (peer_trxs.size() == kMaxTransactionsInPacket) {
+            peers_with_transactions_to_send.push_back({peer.first, {peer_trxs, {}}});
+            peer_trxs.clear();
+          };
         }
-        peer_trxs.push_back(trx);
       }
-      peers_with_transactions_to_send.push_back({peer.first, peer_trxs});
+      if (peer_trxs.size() > 0) {
+        peers_with_transactions_to_send.push_back({peer.first, {peer_trxs, {}}});
+      }
     }
   }
   const auto peers_to_send_count = peers_with_transactions_to_send.size();
   if (peers_to_send_count > 0) {
-    auto transactions_to_log =
-        std::accumulate(transactions.begin(), transactions.end(), std::string{},
-                        [](const auto &r, const auto &trx) { return r + trx->getHash().abridged(); });
-    LOG(log_tr_) << "Sending Transactions " << transactions_to_log << " to " << peers_to_log;
     // Sending it in same order favours some peers over others, always start with a different position
     uint32_t start_with = rand() % peers_to_send_count;
     for (uint32_t i = 0; i < peers_to_send_count; i++) {
@@ -140,35 +151,129 @@ void TransactionPacketHandler::periodicSendTransactions(SharedTransactions &&tra
   }
 }
 
-void TransactionPacketHandler::sendTransactions(std::shared_ptr<TaraxaPeer> peer,
-                                                std::vector<std::shared_ptr<Transaction>> &&transactions) {
-  if (!peer) return;
-  const auto peer_id = peer->getId();
-  LOG(log_tr_) << "sendTransactions " << transactions.size() << " to " << peer_id;
+std::pair<uint32_t, std::pair<SharedTransactions, std::vector<trx_hash_t>>>
+TransactionPacketHandler::transactionsToSendToPeer(std::shared_ptr<TaraxaPeer> peer,
+                                                   const std::vector<SharedTransactions> &transactions,
+                                                   uint32_t account_start_index) {
+  const auto accounts_size = transactions.size();
+  bool trx_max_reached = false;
+  auto account_iterator = account_start_index;
+  std::pair<SharedTransactions, std::vector<trx_hash_t>> result;
+  // Next peer should continue after the last account of the current peer
+  uint32_t next_peer_account_index = (account_start_index + 1) % accounts_size;
 
-  uint32_t index = 0;
-  while (index < transactions.size()) {
-    uint32_t trx_count_to_send = std::min(static_cast<size_t>(kMaxTransactionsInPacket), transactions.size() - index);
-
-    dev::RLPStream s(kTransactionPacketItemCount);
-    s.appendList(trx_count_to_send);
-    for (uint32_t i = index; i < index + trx_count_to_send; i++) {
-      s << transactions[i]->getHash();
-    }
-    s.appendList(trx_count_to_send);
-
-    for (uint32_t i = index; i < index + trx_count_to_send; i++) {
-      const auto &transaction = transactions[i];
-      s.appendRaw(transaction->rlp());
-    }
-
-    if (sealAndSend(peer_id, TransactionPacket, std::move(s))) {
-      for (auto &trx : transactions) {
-        peer->markTransactionAsKnown(trx->getHash());
+  while (true) {
+    // Iterate over transactions from single account
+    for (auto const &trx : transactions[account_iterator]) {
+      auto trx_hash = trx->getHash();
+      if (peer->isTransactionKnown(trx_hash)) {
+        continue;
+      }
+      // If max number of transactions to be sent is already reached include hashes to be sent
+      if (trx_max_reached) {
+        result.second.push_back(trx_hash);
+        if (result.second.size() == kMaxHashesInPacket) {
+          // If both transactions and hashes reached max nothing to do for this peer, return
+          return {next_peer_account_index, std::move(result)};
+        }
+      } else {
+        result.first.push_back(trx);
+        if (result.first.size() == kMaxTransactionsInPacket) {
+          // Max number of transactions reached, save next_peer_account_index for next peer to continue to avoid
+          // sending same transactions to multiple peers
+          trx_max_reached = true;
+          next_peer_account_index = (account_iterator + 1) % accounts_size;
+        }
       }
     }
 
-    index += trx_count_to_send;
+    account_iterator = (account_iterator + 1) % accounts_size;
+    if (account_iterator == account_start_index) {
+      // Iterated through all of the transactions, return
+      return {next_peer_account_index, std::move(result)};
+    }
+  }
+}
+
+std::vector<std::pair<std::shared_ptr<TaraxaPeer>, std::pair<SharedTransactions, std::vector<trx_hash_t>>>>
+TransactionPacketHandler::transactionsToSendToPeers(std::vector<SharedTransactions> &&transactions) {
+  // Main goal of the algorithm below is to send different transactions and hashes to different peers but still follow
+  // nonce ordering for single account and not send higher nonces without sending low nonces first
+  const auto accounts_size = transactions.size();
+  if (!accounts_size) {
+    return {};
+  }
+  std::vector<std::pair<std::shared_ptr<TaraxaPeer>, std::pair<SharedTransactions, std::vector<trx_hash_t>>>>
+      peers_with_transactions_to_send;
+  auto peers = peers_state_->getAllPeers();
+
+  // account_index keeps current account index so that different peers will receive
+  // transactions from different accounts
+  uint32_t account_index = 0;
+  for (const auto &peer : peers) {
+    if (peer.second->syncing_) {
+      continue;
+    }
+
+    std::pair<SharedTransactions, std::vector<trx_hash_t>> peer_transactions;
+    std::tie(account_index, peer_transactions) = transactionsToSendToPeer(peer.second, transactions, account_index);
+
+    if (peer_transactions.first.size() > 0) {
+      peers_with_transactions_to_send.push_back({peer.second, std::move(peer_transactions)});
+    }
+  }
+
+  return peers_with_transactions_to_send;
+}
+
+void TransactionPacketHandler::periodicSendTransactions(std::vector<SharedTransactions> &&transactions) {
+  // Support of old v2 net version. Remove once network is fully updated
+  if (!kHashGossip) {
+    periodicSendTransactionsWithoutHashGossip(std::move(transactions));
+    return;
+  }
+
+  auto peers_with_transactions_to_send = transactionsToSendToPeers(std::move(transactions));
+  const auto peers_to_send_count = peers_with_transactions_to_send.size();
+  if (peers_to_send_count > 0) {
+    // Sending it in same order favours some peers over others, always start with a different position
+    uint32_t start_with = rand() % peers_to_send_count;
+    for (uint32_t i = 0; i < peers_to_send_count; i++) {
+      auto peer_to_send = peers_with_transactions_to_send[(start_with + i) % peers_to_send_count];
+      sendTransactions(peer_to_send.first, std::move(peer_to_send.second));
+    }
+  }
+}
+
+void TransactionPacketHandler::sendTransactions(std::shared_ptr<TaraxaPeer> peer,
+                                                std::pair<SharedTransactions, std::vector<trx_hash_t>> &&transactions) {
+  if (!peer) return;
+  const auto peer_id = peer->getId();
+  const auto transactions_size = transactions.first.size();
+  const auto hashes_size = transactions.second.size();
+
+  LOG(log_tr_) << "sendTransactions " << transactions.first.size() << " to " << peer_id;
+
+  dev::RLPStream s(kTransactionPacketItemCount);
+  s.appendList(transactions_size + hashes_size);
+  for (const auto &trx : transactions.first) {
+    s << trx->getHash();
+  }
+
+  for (const auto &trx_hash : transactions.second) {
+    s << trx_hash;
+  }
+
+  s.appendList(transactions_size);
+
+  for (const auto &trx : transactions.first) {
+    s.appendRaw(trx->rlp());
+  }
+
+  if (sealAndSend(peer_id, TransactionPacket, std::move(s))) {
+    for (const auto &trx : transactions.first) {
+      peer->markTransactionAsKnown(trx->getHash());
+    }
   }
 }
 

--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -48,7 +48,7 @@ TaraxaCapability::TaraxaCapability(TarcapVersion version, const FullNodeConfig &
   peers_state_ = std::make_shared<PeersState>(host, kConf);
   packets_handlers_ =
       init_packets_handlers(logs_prefix, conf, genesis_hash, peers_state_, pbft_syncing_state_, all_packets_stats_, db,
-                            pbft_mgr, pbft_chain, vote_mgr, dag_mgr, trx_mgr, slashing_manager, node_addr);
+                            pbft_mgr, pbft_chain, vote_mgr, dag_mgr, trx_mgr, slashing_manager, version, node_addr);
 
   // Must be called after init_packets_handlers
   thread_pool_->setPacketsHandlers(version, packets_handlers_);
@@ -213,7 +213,7 @@ const TaraxaCapability::InitPacketsHandlers TaraxaCapability::kInitLatestVersion
        const std::shared_ptr<PbftManager> &pbft_mgr, const std::shared_ptr<PbftChain> &pbft_chain,
        const std::shared_ptr<VoteManager> &vote_mgr, const std::shared_ptr<DagManager> &dag_mgr,
        const std::shared_ptr<TransactionManager> &trx_mgr, const std::shared_ptr<SlashingManager> &slashing_manager,
-       const addr_t &node_addr) {
+       TarcapVersion version, const addr_t &node_addr) {
       auto packets_handlers = std::make_shared<PacketsHandler>();
       // Consensus packets with high processing priority
       packets_handlers->registerHandler<VotePacketHandler>(config, peers_state, packets_stats, pbft_mgr, pbft_chain,
@@ -228,8 +228,10 @@ const TaraxaCapability::InitPacketsHandlers TaraxaCapability::kInitLatestVersion
                                                                pbft_chain, pbft_mgr, dag_mgr, trx_mgr, db, node_addr,
                                                                logs_prefix);
 
+      // Support for transaition from V2 to V3, once all nodes update to V3 post next hardfork, V2 support can be
+      // removed
       packets_handlers->registerHandler<TransactionPacketHandler>(config, peers_state, packets_stats, trx_mgr,
-                                                                  node_addr, logs_prefix);
+                                                                  node_addr, version > kV2NetworkVersion, logs_prefix);
 
       // Non critical packets with low processing priority
       packets_handlers->registerHandler<StatusPacketHandler>(config, peers_state, packets_stats, pbft_syncing_state,

--- a/libraries/core_libs/network/src/tarcap/taraxa_peer.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_peer.cpp
@@ -77,4 +77,11 @@ std::pair<std::chrono::system_clock::time_point, PacketStats> TaraxaPeer::getAll
 
 void TaraxaPeer::resetPacketsStats() { sent_packets_stats_.resetStats(); }
 
+void TaraxaPeer::resetKnownCaches() {
+  known_transactions_.clear();
+  known_dag_blocks_.clear();
+  known_votes_.clear();
+  known_pbft_blocks_.clear();
+}
+
 }  // namespace taraxa::network::tarcap


### PR DESCRIPTION
In a single transaction send interval which is 100ms only one packet of max of 500 transactions is sent to another peer.
Different connected peers will be sent different packet of 500 transactions grouped by account so that transactions are gossiped more evenly around the network.

Each packet will also contain up to additional 5000 transactions hashes to notify the other peers of the transactions in transaction pool to avoid receiving same transactions back and forth between nodes.

These changes significantly reduces the network data by reducing the number of times same transaction is shared between nodes which improves performance. This also increases dag efficiency by spreading transactions out more evenly around the network.

This change only applies if we have high transactions load. If transaction per second is small and transaction pool size is small all of the transactions are sent immediately to all nodes.

Single account transactions are now limited to 5% of the max size of transactions pool. So for trx pool of max size of 200000, only 10000 transactions from the same account can be accepted to the pool.

Part of this change is also increasing the gas_limit on devnet to allow testing with high transactions per second.  