### PR TITLE
chore: improve dag sync packet processing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(TARAXA_PATCH_VERSION 1)
 set(TARAXA_VERSION ${TARAXA_MAJOR_VERSION}.${TARAXA_MINOR_VERSION}.${TARAXA_PATCH_VERSION})
 
 # Any time a change in the network protocol is introduced this version should be increased
-set(TARAXA_NET_VERSION 2)
+set(TARAXA_NET_VERSION 3)
 # Major version is modified when DAG blocks, pbft blocks and any basic building blocks of our blockchain is modified
 # in the db
 set(TARAXA_DB_MAJOR_VERSION 1)

--- a/libraries/cli/include/cli/config_jsons/devnet/devnet_config.json
+++ b/libraries/cli/include/cli/config_jsons/devnet/devnet_config.json
@@ -28,7 +28,7 @@
     },
     "listen_ip": "0.0.0.0",
     "listen_port": 10002,
-    "transaction_interval_ms": 150,
+    "transaction_interval_ms": 300,
     "ideal_peer_count": 15,
     "max_peer_count": 30,
     "sync_level_size": 25,

--- a/libraries/cli/include/cli/config_jsons/devnet/devnet_config.json
+++ b/libraries/cli/include/cli/config_jsons/devnet/devnet_config.json
@@ -28,7 +28,7 @@
     },
     "listen_ip": "0.0.0.0",
     "listen_port": 10002,
-    "transaction_interval_ms": 100,
+    "transaction_interval_ms": 150,
     "ideal_peer_count": 15,
     "max_peer_count": 30,
     "sync_level_size": 25,

--- a/libraries/cli/include/cli/config_jsons/devnet/devnet_genesis.json
+++ b/libraries/cli/include/cli/config_jsons/devnet/devnet_genesis.json
@@ -237,13 +237,13 @@
     "dag_blocks_size": "0x32",
     "ghost_path_move_back": "0x0",
     "lambda_ms": "0x5DC",
-    "gas_limit": "0x3E95BA80"
+    "gas_limit": "0x7d2b7500"
   },
   "dag": {
     "block_proposer": {
       "shard": 1
     },
-    "gas_limit": "0x6422C40"
+    "gas_limit": "0x1908B100"
   },
   "sortition": {
     "changes_count_for_average": 10,

--- a/libraries/common/include/common/constants.hpp
+++ b/libraries/common/include/common/constants.hpp
@@ -21,6 +21,7 @@ constexpr uint32_t kDagExpiryLevelLimit = 1000;
 constexpr uint32_t kDagBlockMaxTips = 16;
 
 const uint32_t kMaxTransactionsInPacket{500};
+const uint32_t kMaxHashesInPacket{5000};
 
 const uint32_t kPeriodicEventsThreadCount{2};
 

--- a/libraries/core_libs/consensus/include/dag/dag_manager.hpp
+++ b/libraries/core_libs/consensus/include/dag/dag_manager.hpp
@@ -79,7 +79,8 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
    * @param blk Block to verify
    * @return verification result
    */
-  VerifyBlockReturnType verifyBlock(const DagBlock &blk);
+  VerifyBlockReturnType verifyBlock(const DagBlock &blk,
+                                    const std::unordered_map<blk_hash_t, std::shared_ptr<Transaction>> &trxs = {});
 
   /**
    * @brief Checks if block pivot and tips are in DAG

--- a/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
+++ b/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
@@ -71,10 +71,10 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
   std::pair<SharedTransactions, std::vector<uint64_t>> packTrxs(PbftPeriod proposal_period, uint64_t weight_limit);
 
   /**
-   * @brief Gets all transactions from pool
+   * @brief Gets all transactions from pool grouped per account
    * @return transactions
    */
-  SharedTransactions getAllPoolTrxs();
+  std::vector<SharedTransactions> getAllPoolTrxs();
 
   /**
    * Saves transactions from dag block which was added to the DAG. Removes transactions from memory pool

--- a/libraries/core_libs/consensus/include/transaction/transaction_queue.hpp
+++ b/libraries/core_libs/consensus/include/transaction/transaction_queue.hpp
@@ -66,11 +66,11 @@ class TransactionQueue {
   std::vector<std::shared_ptr<Transaction>> getOrderedTransactions(uint64_t count) const;
 
   /**
-   * @brief returns all transactions
+   * @brief returns all transactions grouped by transactions author
    *
-   * @return std::vector<std::shared_ptr<Transaction>>
+   * @return std::vector<SharedTransactions>
    */
-  std::vector<std::shared_ptr<Transaction>> getAllTransactions() const;
+  std::vector<SharedTransactions> getAllTransactions() const;
 
   /**
    * @brief returns true/false if the transaction is in the queue
@@ -152,11 +152,17 @@ class TransactionQueue {
   // Maximum number of non proposable transactions in percentage of kMaxSize
   const size_t kNonProposableTransactionsLimitPercentage = 20;
 
+  // Maximum number of single account transactions in percentage of kMaxSize
+  const size_t kSingleAccountTransactionsLimitPercentage = 5;
+
   // Maximum number of non proposable transactions
   const size_t kNonProposableTransactionsMaxSize;
 
   // Maximum size of transactions pool
   const size_t kMaxSize;
+
+  // Maximum size of single account transactions
+  const size_t kMaxSingleAccountTransactionsSize;
 };
 
 /** @}*/

--- a/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
+++ b/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
@@ -175,11 +175,11 @@ void TransactionManager::saveTransactionsFromDagBlock(SharedTransactions const &
     // Unique lock here makes sure that transactions we are removing are not reinserted in transactions_pool_
     std::unique_lock transactions_lock(transactions_mutex_);
 
-    auto trx_in_db = db_->transactionsInDb(trx_hashes);
     for (uint64_t i = 0; i < trxs.size(); i++) {
       auto const &trx_hash = trx_hashes[i];
       // We only save transaction if it has not already been saved
-      if (!trx_in_db[i]) {
+      if (!nonfinalized_transactions_in_dag_.contains(trx_hash) &&
+          !recently_finalized_transactions_.contains(trx_hash) && !db_->transactionFinalized(trx_hash)) {
         db_->addTransactionToBatch(*trxs[i], write_batch);
         nonfinalized_transactions_in_dag_.emplace(trx_hash, trxs[i]);
       }

--- a/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
+++ b/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
@@ -297,7 +297,7 @@ std::pair<SharedTransactions, std::vector<uint64_t>> TransactionManager::packTrx
   return {trxs, estimations};
 }
 
-SharedTransactions TransactionManager::getAllPoolTrxs() {
+std::vector<SharedTransactions> TransactionManager::getAllPoolTrxs() {
   std::shared_lock transactions_lock(transactions_mutex_);
   return transactions_pool_.getAllTransactions();
 }

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/latest/transaction_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/latest/transaction_packet_handler.hpp
@@ -17,7 +17,7 @@ class TransactionPacketHandler : public PacketHandler {
  public:
   TransactionPacketHandler(const FullNodeConfig& conf, std::shared_ptr<PeersState> peers_state,
                            std::shared_ptr<TimePeriodPacketsStats> packets_stats,
-                           std::shared_ptr<TransactionManager> trx_mgr, const addr_t& node_addr,
+                           std::shared_ptr<TransactionManager> trx_mgr, const addr_t& node_addr, bool hash_gossip,
                            const std::string& logs_prefix = "TRANSACTION_PH");
 
   /**
@@ -27,7 +27,8 @@ class TransactionPacketHandler : public PacketHandler {
    * @param transactions serialized transactions
    *
    */
-  void sendTransactions(std::shared_ptr<TaraxaPeer> peer, std::vector<std::shared_ptr<Transaction>>&& transactions);
+  void sendTransactions(std::shared_ptr<TaraxaPeer> peer,
+                        std::pair<SharedTransactions, std::vector<trx_hash_t>>&& transactions);
 
   /**
    * @brief Sends batch of transactions to all connected peers
@@ -35,7 +36,7 @@ class TransactionPacketHandler : public PacketHandler {
    *
    * @param transactions to be sent
    */
-  void periodicSendTransactions(SharedTransactions&& transactions);
+  void periodicSendTransactions(std::vector<SharedTransactions>&& transactions);
 
   // Packet type that is processed by this handler
   static constexpr SubprotocolPacketType kPacketType_ = SubprotocolPacketType::TransactionPacket;
@@ -48,10 +49,29 @@ class TransactionPacketHandler : public PacketHandler {
   virtual void process(const threadpool::PacketData& packet_data, const std::shared_ptr<TaraxaPeer>& peer) override;
 
  protected:
+  /**
+   * @brief Sends batch of transactions to all connected peers
+   * @note Support of the old V2 version, remove once most of the network is updated or after a hardfork. This method is
+   * used as periodic event to broadcast transactions to the other peers in network
+   *
+   * @param transactions to be sent
+   */
+  void periodicSendTransactionsWithoutHashGossip(std::vector<SharedTransactions>&& transactions);
+
+  /**
+   * @brief select which transactions and hashes to send to which connected peer
+   *
+   * @param transactions to be sent
+   * @return selected transactions and hashes to be sent per peer
+   */
+  std::vector<std::pair<std::shared_ptr<TaraxaPeer>, std::pair<SharedTransactions, std::vector<trx_hash_t>>>>
+  transactionsToSendToPeers(std::vector<SharedTransactions>&& transactions);
+
   std::shared_ptr<TransactionManager> trx_mgr_;
 
   std::atomic<uint64_t> received_trx_count_{0};
   std::atomic<uint64_t> unique_received_trx_count_{0};
+  bool hash_gossip_ = true;
 };
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
@@ -46,7 +46,7 @@ class TaraxaCapability final : public dev::p2p::CapabilityFace {
       const std::shared_ptr<PbftManager> &pbft_mgr, const std::shared_ptr<PbftChain> &pbft_chain,
       const std::shared_ptr<VoteManager> &vote_mgr, const std::shared_ptr<DagManager> &dag_mgr,
       const std::shared_ptr<TransactionManager> &trx_mgr, const std::shared_ptr<SlashingManager> &slashing_manager,
-      const addr_t &node_addr)>;
+      TarcapVersion version, const addr_t &node_addr)>;
 
   /**
    * @brief Default InitPacketsHandlers function definition with the latest version of packets handlers

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_peer.hpp
@@ -95,6 +95,11 @@ class TaraxaPeer : public boost::noncopyable {
    */
   void resetPacketsStats();
 
+  /**
+   * @brief Resets known caches - used for testing
+   */
+  void resetKnownCaches();
+
  public:
   std::atomic<bool> syncing_ = false;
   std::atomic<uint64_t> dag_level_ = 0;
@@ -125,7 +130,7 @@ class TaraxaPeer : public boost::noncopyable {
 
   std::atomic<uint64_t> timestamp_suspicious_packet_ = 0;
   std::atomic<uint64_t> suspicious_packet_count_ = 0;
-  const uint64_t kMaxSuspiciousPacketPerMinute = 1000;
+  const uint64_t kMaxSuspiciousPacketPerMinute = 50000;
 
   // Performance extensive dag syncing is only allowed to be requested once each kDagSyncingLimit seconds
   const uint64_t kDagSyncingLimit = 60;

--- a/libraries/core_libs/network/src/network.cpp
+++ b/libraries/core_libs/network/src/network.cpp
@@ -70,7 +70,17 @@ Network::Network(const FullNodeConfig &config, const h256 &genesis_hash, std::fi
   // Create taraxa capabilities
   dev::p2p::Host::CapabilitiesFactory constructCapabilities = [&](std::weak_ptr<dev::p2p::Host> host) {
     assert(!host.expired());
+
+    const size_t kV2NetworkVersion = 2;
+    assert(kV2NetworkVersion < TARAXA_NET_VERSION);
+
     dev::p2p::Host::CapabilityList capabilities;
+
+    // Register old version (V2) of taraxa capability
+    auto v2_tarcap = std::make_shared<network::tarcap::TaraxaCapability>(
+        kV2NetworkVersion, config, genesis_hash, host, key, packets_tp_, all_packets_stats_, pbft_syncing_state_, db,
+        pbft_mgr, pbft_chain, vote_mgr, dag_mgr, trx_mgr, slashing_manager);
+    capabilities.emplace_back(v2_tarcap);
 
     // Register latest version of taraxa capability
     auto latest_tarcap = std::make_shared<network::tarcap::TaraxaCapability>(

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/latest/transaction_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/latest/transaction_packet_handler.cpp
@@ -10,9 +10,10 @@ namespace taraxa::network::tarcap {
 TransactionPacketHandler::TransactionPacketHandler(const FullNodeConfig &conf, std::shared_ptr<PeersState> peers_state,
                                                    std::shared_ptr<TimePeriodPacketsStats> packets_stats,
                                                    std::shared_ptr<TransactionManager> trx_mgr, const addr_t &node_addr,
-                                                   const std::string &logs_prefix)
+                                                   bool hash_gossip, const std::string &logs_prefix)
     : PacketHandler(conf, std::move(peers_state), std::move(packets_stats), node_addr, logs_prefix + "TRANSACTION_PH"),
-      trx_mgr_(std::move(trx_mgr)) {}
+      trx_mgr_(std::move(trx_mgr)),
+      hash_gossip_(hash_gossip) {}
 
 void TransactionPacketHandler::validatePacketRlpFormat(const threadpool::PacketData &packet_data) const {
   auto items = packet_data.rlp_.itemCount();
@@ -22,11 +23,16 @@ void TransactionPacketHandler::validatePacketRlpFormat(const threadpool::PacketD
   auto hashes_count = packet_data.rlp_[0].itemCount();
   auto trx_count = packet_data.rlp_[1].itemCount();
 
-  if (hashes_count != trx_count) {
+  if (hashes_count < trx_count) {
     throw InvalidRlpItemsCountException(packet_data.type_str_, hashes_count, trx_count);
   }
-  if (hashes_count == 0 || hashes_count > kMaxTransactionsInPacket) {
-    throw InvalidRlpItemsCountException(packet_data.type_str_, hashes_count, kMaxTransactionsInPacket);
+  if (hashes_count == 0 || hashes_count > kMaxTransactionsInPacket + kMaxHashesInPacket) {
+    throw InvalidRlpItemsCountException(packet_data.type_str_, hashes_count,
+                                        kMaxTransactionsInPacket + kMaxHashesInPacket);
+  }
+
+  if (trx_count > kMaxTransactionsInPacket) {
+    throw InvalidRlpItemsCountException(packet_data.type_str_, trx_count, kMaxTransactionsInPacket);
   }
 }
 
@@ -34,11 +40,12 @@ inline void TransactionPacketHandler::process(const threadpool::PacketData &pack
                                               const std::shared_ptr<TaraxaPeer> &peer) {
   std::vector<trx_hash_t> received_transactions;
 
-  const auto transaction_count = packet_data.rlp_[0].itemCount();
+  const auto transaction_hashes_count = packet_data.rlp_[0].itemCount();
+  const auto transaction_count = packet_data.rlp_[1].itemCount();
   received_transactions.reserve(transaction_count);
 
   std::vector<trx_hash_t> trx_hashes;
-  trx_hashes.reserve(transaction_count);
+  trx_hashes.reserve(transaction_hashes_count);
 
   // First extract only transaction hashes
   for (const auto trx_hash_rlp : packet_data.rlp_[0]) {
@@ -104,33 +111,31 @@ inline void TransactionPacketHandler::process(const threadpool::PacketData &pack
   }
 }
 
-void TransactionPacketHandler::periodicSendTransactions(SharedTransactions &&transactions) {
-  std::vector<std::pair<dev::p2p::NodeID, SharedTransactions>> peers_with_transactions_to_send;
+void TransactionPacketHandler::periodicSendTransactionsWithoutHashGossip(
+    std::vector<SharedTransactions> &&transactions) {
+  std::vector<std::pair<dev::p2p::NodeID, std::pair<SharedTransactions, std::vector<trx_hash_t>>>>
+      peers_with_transactions_to_send;
 
   auto peers = peers_state_->getAllPeers();
-  std::string peers_to_log;
   for (const auto &peer : peers) {
     // Confirm that status messages were exchanged otherwise message might be ignored and node would
     // incorrectly markTransactionAsKnown
     if (!peer.second->syncing_) {
-      peers_to_log += peer.first.abridged();
       SharedTransactions peer_trxs;
-      for (auto const &trx : transactions) {
-        auto trx_hash = trx->getHash();
-        if (peer.second->isTransactionKnown(trx_hash)) {
-          continue;
+      for (auto const &account_trx : transactions) {
+        for (auto const &trx : account_trx) {
+          auto trx_hash = trx->getHash();
+          if (peer.second->isTransactionKnown(trx_hash)) {
+            continue;
+          }
+          peer_trxs.push_back(trx);
         }
-        peer_trxs.push_back(trx);
       }
-      peers_with_transactions_to_send.push_back({peer.first, peer_trxs});
+      peers_with_transactions_to_send.push_back({peer.first, {peer_trxs, {}}});
     }
   }
   const auto peers_to_send_count = peers_with_transactions_to_send.size();
   if (peers_to_send_count > 0) {
-    auto transactions_to_log =
-        std::accumulate(transactions.begin(), transactions.end(), std::string{},
-                        [](const auto &r, const auto &trx) { return r + trx->getHash().abridged(); });
-    LOG(log_tr_) << "Sending Transactions " << transactions_to_log << " to " << peers_to_log;
     // Sending it in same order favours some peers over others, always start with a different position
     uint32_t start_with = rand() % peers_to_send_count;
     for (uint32_t i = 0; i < peers_to_send_count; i++) {
@@ -140,35 +145,125 @@ void TransactionPacketHandler::periodicSendTransactions(SharedTransactions &&tra
   }
 }
 
-void TransactionPacketHandler::sendTransactions(std::shared_ptr<TaraxaPeer> peer,
-                                                std::vector<std::shared_ptr<Transaction>> &&transactions) {
-  if (!peer) return;
-  const auto peer_id = peer->getId();
-  LOG(log_tr_) << "sendTransactions " << transactions.size() << " to " << peer_id;
+std::vector<std::pair<std::shared_ptr<TaraxaPeer>, std::pair<SharedTransactions, std::vector<trx_hash_t>>>>
+TransactionPacketHandler::transactionsToSendToPeers(std::vector<SharedTransactions> &&transactions) {
+  // Main goal of the algorithm below is to send different transactions and hashes to different peers but still follow
+  // nonce ordering for single account and not send higher nonces without sending low nonces first
+  const auto accounts_size = transactions.size();
+  std::vector<std::pair<std::shared_ptr<TaraxaPeer>, std::pair<SharedTransactions, std::vector<trx_hash_t>>>>
+      peers_with_transactions_to_send;
+  auto peers = peers_state_->getAllPeers();
 
-  uint32_t index = 0;
-  while (index < transactions.size()) {
-    uint32_t trx_count_to_send = std::min(static_cast<size_t>(kMaxTransactionsInPacket), transactions.size() - index);
+  if (accounts_size) {
+    // trx_account_index keeps current account start index so that different peers will receive
+    // transactions from different accounts
+    uint32_t trx_account_index = 0;
+    for (const auto &peer : peers) {
+      if (!peer.second->syncing_) {
+        SharedTransactions peer_trxs;
+        std::vector<trx_hash_t> peer_trx_hashes;
+        bool trx_max_reached = false;
+        uint32_t trx_max_reached_index = 0;
+        auto trx_account_index_iterator = trx_account_index;
 
-    dev::RLPStream s(kTransactionPacketItemCount);
-    s.appendList(trx_count_to_send);
-    for (uint32_t i = index; i < index + trx_count_to_send; i++) {
-      s << transactions[i]->getHash();
-    }
-    s.appendList(trx_count_to_send);
-
-    for (uint32_t i = index; i < index + trx_count_to_send; i++) {
-      const auto &transaction = transactions[i];
-      s.appendRaw(transaction->rlp());
-    }
-
-    if (sealAndSend(peer_id, TransactionPacket, std::move(s))) {
-      for (auto &trx : transactions) {
-        peer->markTransactionAsKnown(trx->getHash());
+        while (true) {
+          // Iterate over transactions from single account
+          for (auto const &trx : transactions[trx_account_index_iterator]) {
+            auto trx_hash = trx->getHash();
+            if (peer.second->isTransactionKnown(trx_hash)) {
+              continue;
+            }
+            // If max number of transactions to be sent is already reached include hashes to be sent
+            if (trx_max_reached) {
+              peer_trx_hashes.push_back(trx_hash);
+              if (peer_trx_hashes.size() == kMaxHashesInPacket) {
+                // If both transactions and hashes reached max nothing to do for this peer, break
+                break;
+              }
+            } else {
+              peer_trxs.push_back(trx);
+              if (peer_trxs.size() == kMaxTransactionsInPacket) {
+                // Max number of transactions reached, save trx_max_reached_index for next peer to continue to avoid
+                // sending same transactions to multiple peers
+                trx_max_reached = true;
+                trx_max_reached_index = (trx_account_index_iterator + 1) % accounts_size;
+              }
+            }
+          }
+          if (peer_trx_hashes.size() == kMaxHashesInPacket) {
+            // Max transactions and hashes reached, break and move to next peer
+            break;
+          }
+          trx_account_index_iterator = (trx_account_index_iterator + 1) % accounts_size;
+          if (trx_account_index_iterator == trx_account_index) {
+            // Iterated through all of the transactions, break
+            break;
+          }
+        }
+        if (peer_trxs.size() > 0) {
+          peers_with_transactions_to_send.push_back({peer.second, {std::move(peer_trxs), std::move(peer_trx_hashes)}});
+          if (trx_max_reached) {
+            // If transaction max reached, set trx_account_index to start from the next account
+            trx_account_index = trx_max_reached_index;
+          } else {
+            // Since transaction max is not reached, simply continue where the last peer stopped
+            trx_account_index = trx_account_index_iterator;
+          }
+        }
       }
     }
+  }
+  return peers_with_transactions_to_send;
+}
 
-    index += trx_count_to_send;
+void TransactionPacketHandler::periodicSendTransactions(std::vector<SharedTransactions> &&transactions) {
+  // Support of old v2 net version. Remove once network is fully updated
+  if (!hash_gossip_) {
+    periodicSendTransactionsWithoutHashGossip(std::move(transactions));
+    return;
+  }
+
+  auto peers_with_transactions_to_send = transactionsToSendToPeers(std::move(transactions));
+  const auto peers_to_send_count = peers_with_transactions_to_send.size();
+  if (peers_to_send_count > 0) {
+    // Sending it in same order favours some peers over others, always start with a different position
+    uint32_t start_with = rand() % peers_to_send_count;
+    for (uint32_t i = 0; i < peers_to_send_count; i++) {
+      auto peer_to_send = peers_with_transactions_to_send[(start_with + i) % peers_to_send_count];
+      sendTransactions(peer_to_send.first, std::move(peer_to_send.second));
+    }
+  }
+}
+
+void TransactionPacketHandler::sendTransactions(std::shared_ptr<TaraxaPeer> peer,
+                                                std::pair<SharedTransactions, std::vector<trx_hash_t>> &&transactions) {
+  if (!peer) return;
+  const auto peer_id = peer->getId();
+  const auto &transactions_size = transactions.first.size();
+  const auto &hashes_size = transactions.second.size();
+
+  LOG(log_tr_) << "sendTransactions " << transactions.first.size() << " to " << peer_id;
+
+  dev::RLPStream s(kTransactionPacketItemCount);
+  s.appendList(transactions_size + hashes_size);
+  for (const auto &trx : transactions.first) {
+    s << trx->getHash();
+  }
+
+  for (const auto &trx_hash : transactions.second) {
+    s << trx_hash;
+  }
+
+  s.appendList(transactions_size);
+
+  for (const auto &trx : transactions.first) {
+    s.appendRaw(trx->rlp());
+  }
+
+  if (sealAndSend(peer_id, TransactionPacket, std::move(s))) {
+    for (const auto &trx : transactions.first) {
+      peer->markTransactionAsKnown(trx->getHash());
+    }
   }
 }
 

--- a/libraries/core_libs/network/src/tarcap/taraxa_peer.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_peer.cpp
@@ -77,4 +77,11 @@ std::pair<std::chrono::system_clock::time_point, PacketStats> TaraxaPeer::getAll
 
 void TaraxaPeer::resetPacketsStats() { sent_packets_stats_.resetStats(); }
 
+void TaraxaPeer::resetKnownCaches() {
+  known_transactions_.clear();
+  known_dag_blocks_.clear();
+  known_votes_.clear();
+  known_pbft_blocks_.clear();
+}
+
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -238,7 +238,6 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
   SharedTransactions getAllNonfinalizedTransactions();
   bool transactionInDb(trx_hash_t const& hash);
   bool transactionFinalized(trx_hash_t const& hash);
-  std::vector<bool> transactionsInDb(std::vector<trx_hash_t> const& trx_hashes);
   std::vector<bool> transactionsFinalized(std::vector<trx_hash_t> const& trx_hashes);
   void addTransactionToBatch(Transaction const& trx, Batch& write_batch);
   void removeTransactionToBatch(trx_hash_t const& trx, Batch& write_batch);

--- a/libraries/core_libs/storage/src/storage.cpp
+++ b/libraries/core_libs/storage/src/storage.cpp
@@ -871,17 +871,6 @@ bool DbStorage::transactionFinalized(trx_hash_t const& hash) {
   return exist(toSlice(hash.asBytes()), Columns::trx_period);
 }
 
-std::vector<bool> DbStorage::transactionsInDb(std::vector<trx_hash_t> const& trx_hashes) {
-  std::vector<bool> result(trx_hashes.size(), false);
-  for (size_t i = 0; i < trx_hashes.size(); ++i) {
-    const auto key = trx_hashes[i].asBytes();
-    if (exist(toSlice(key), Columns::transactions) || exist(toSlice(key), Columns::trx_period)) {
-      result[i] = true;
-    }
-  }
-  return result;
-}
-
 uint64_t DbStorage::getStatusField(StatusDbField const& field) {
   auto status = lookup(toSlice((uint8_t)field), Columns::status);
   if (!status.empty()) {


### PR DESCRIPTION
In processing DagSyncPacket on verifying the dag blocks, all the transactions were being retrieved from the local cache/db with:
trx_mgr_->getBlockTransactions

This was inefficient since the packet already contains most of the transactions that are needed. Now we only query for the transactions that did not arrive with the packet which saves considerable processing.

There was no check if dag block is already known, so dag blocks were processed and verified even though there was no need for it.