### PR TITLE
chore: transactions and dag blocks processing improvements

### DIFF
--- a/libraries/common/include/common/constants.hpp
+++ b/libraries/common/include/common/constants.hpp
@@ -32,6 +32,8 @@ constexpr uint32_t kDefaultTransactionPoolSize{200000};
 
 const size_t kV2NetworkVersion = 2;
 
+const uint32_t kRecentlyFinalizedTransactionsFactor = 2;
+
 // The various denominations; here for ease of use where needed within code.
 static const u256 kOneTara = dev::exp10<18>();
 // static const u256 kFinney = exp10<15>();

--- a/libraries/config/src/network.cpp
+++ b/libraries/config/src/network.cpp
@@ -130,6 +130,13 @@ void dec_json(const Json::Value &json, NetworkConfig &network) {
   network.max_peer_count = getConfigDataAsUInt(json, {"max_peer_count"});
   network.sync_level_size = getConfigDataAsUInt(json, {"sync_level_size"});
   network.packets_processing_threads = getConfigDataAsUInt(json, {"packets_processing_threads"});
+
+  // Packets processing threads performance is heart by too many threads processing same data from multiple peers, limit
+  // concurrency to hardware concurrency
+  if (network.packets_processing_threads > std::thread::hardware_concurrency()) {
+    network.packets_processing_threads = std::max(std::thread::hardware_concurrency(), 3u);
+  }
+
   network.peer_blacklist_timeout =
       getConfigDataAsUInt(json, {"peer_blacklist_timeout"}, true, NetworkConfig::kBlacklistTimeoutDefaultInSeconds);
   network.disable_peer_blacklist = getConfigDataAsBoolean(json, {"disable_peer_blacklist"}, true, false);

--- a/libraries/core_libs/consensus/include/dag/dag_manager.hpp
+++ b/libraries/core_libs/consensus/include/dag/dag_manager.hpp
@@ -77,9 +77,11 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
   /**
    * @brief Verifies new DAG block
    * @param blk Block to verify
-   * @return verification result
+   * @param transactions Optional block transactions
+   * @return verification result and all the transactions which are part of the block
    */
-  VerifyBlockReturnType verifyBlock(const DagBlock &blk);
+  std::pair<VerifyBlockReturnType, SharedTransactions> verifyBlock(
+      const DagBlock &blk, const std::unordered_map<trx_hash_t, std::shared_ptr<Transaction>> &trxs = {});
 
   /**
    * @brief Checks if block pivot and tips are in DAG
@@ -90,8 +92,7 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
 
   /**
    * @brief adds verified DAG block in the DAG
-   * @param trxs Block transactions which are part of the pool, transactions that are already present in a previous DAG
-   * block are excluded
+   * @param trxs Block transactions
    * @param proposed if this node proposed the block
    * @param save if true save block and transactions to database
    * @return true if block added successfully, false with the hash of missing tips/pivot

--- a/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
+++ b/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
@@ -15,10 +15,9 @@ namespace taraxa {
  */
 
 /**
- * @brief TransactionStatus enum class defines current transaction status. All states except Forced are result of
- * verification. Forced status is used when trx is part of synced dag block which is about to be added to DAG
+ * @brief TransactionStatus enum class defines current transaction status
  */
-enum class TransactionStatus { Verified = 0, Invalid, LowNonce, InsufficentBalance, Forced };
+enum class TransactionStatus { Inserted = 0, InsertedNonProposable, Known, Overflow };
 
 class DagBlock;
 class DagManager;
@@ -47,7 +46,7 @@ class FullNode;
  * Transaction transition to finalized block state is done with call to updateFinalizedTransactionsStatus
  *
  * Class is thread safe in general with exception of two special methods: updateFinalizedTransactionsStatus and
- * moveNonFinalizedTransactionsToTransactionsPool. See details in function descriptions.
+ * removeNonFinalizedTransactions. See details in function descriptions.
  */
 class TransactionManager : public std::enable_shared_from_this<TransactionManager> {
  public:
@@ -101,10 +100,10 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
    *
    * @note transaction might be already processed -> they are not processed and inserted again
    * @param tx transaction to be processed
-   * @param status transaction status
-   * @return true if successfully inserted unseen transactions
+   * @param insert_non_proposable insert non proposable transactions
+   * @return transaction status
    */
-  bool insertValidatedTransaction(std::shared_ptr<Transaction> &&tx, const TransactionStatus status);
+  TransactionStatus insertValidatedTransaction(std::shared_ptr<Transaction> &&tx, bool insert_non_proposable = true);
 
   /**
    * @param trx_hash transaction hash
@@ -153,17 +152,19 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
    * @brief Get the block transactions
    *
    * @param blk
+   * @param proposal_period
    * @return transactions retrieved from pool/db
    */
-  std::optional<SharedTransactions> getBlockTransactions(const DagBlock &blk);
+  SharedTransactions getBlockTransactions(const DagBlock &blk, PbftPeriod proposal_period);
 
   /**
-   * @brief Get the  transactions
+   * @brief Get the transactions
    *
-   * @param blk
+   * @param trxs_hashes
+   * @param proposal_period
    * @return transactions retrieved from pool/db
    */
-  std::optional<SharedTransactions> getTransactions(const vec_trx_t &trxs_hashes);
+  SharedTransactions getTransactions(const vec_trx_t &trxs_hashes, PbftPeriod proposal_period);
 
   /**
    * @brief Updates the status of transactions to finalized
@@ -176,13 +177,20 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
   void updateFinalizedTransactionsStatus(const PeriodData &period_data);
 
   /**
-   * @brief Moves non-finalized transactions from discarded old dag blocks back to transactions pool
+   * @brief Initialize recenty finalized transactions
+   *
+   * @param period_data period data
+   */
+  void initializeRecentlyFinalizedTransactions(const PeriodData &period_data);
+
+  /**
+   * @brief Removes non-finalized transactions from discarded old dag blocks
    * IMPORTANT: This method is invoked on finalizing a pbft block, it needs to be protected with transactions_mutex_ but
    * the mutex is locked from pbft manager for the entire pbft finalization process to make the finalization atomic
    *
-   * @param transactions transactions to move
+   * @param transactions transactions to remove
    */
-  void moveNonFinalizedTransactionsToTransactionsPool(std::unordered_set<trx_hash_t> &&transactions);
+  void removeNonFinalizedTransactions(std::unordered_set<trx_hash_t> &&transactions);
 
   /**
    * @brief Retrieves transactions mutex, only to be used when finalizing pbft block
@@ -212,7 +220,7 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
   std::shared_ptr<Transaction> getNonFinalizedTransaction(const trx_hash_t &hash) const;
   unsigned long getTransactionCount() const;
   void recoverNonfinalizedTransactions();
-  std::pair<TransactionStatus, std::string> verifyTransaction(const std::shared_ptr<Transaction> &trx) const;
+  std::pair<bool, std::string> verifyTransaction(const std::shared_ptr<Transaction> &trx) const;
 
  private:
   addr_t getFullNodeAddress() const;
@@ -229,6 +237,7 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
   TransactionQueue transactions_pool_;
   std::unordered_map<trx_hash_t, std::shared_ptr<Transaction>> nonfinalized_transactions_in_dag_;
   std::unordered_map<trx_hash_t, std::shared_ptr<Transaction>> recently_finalized_transactions_;
+  std::unordered_map<PbftPeriod, std::vector<trx_hash_t>> recently_finalized_transactions_per_period_;
   uint64_t trx_count_ = 0;
 
   const uint64_t kDagBlockGasLimit;

--- a/libraries/core_libs/consensus/include/transaction/transaction_queue.hpp
+++ b/libraries/core_libs/consensus/include/transaction/transaction_queue.hpp
@@ -11,6 +11,9 @@ namespace taraxa {
  */
 
 enum class TransactionStatus;
+namespace final_chain {
+class FinalChain;
+}
 /**
  * @brief TransactionQueue keeps transactions in memory sorted by priority to be included in a proposed DAG block or
  * which might be required by an incoming DAG block
@@ -26,18 +29,16 @@ enum class TransactionStatus;
  */
 class TransactionQueue {
  public:
-  TransactionQueue(size_t max_size = kMinTransactionPoolSize);
+  TransactionQueue(std::shared_ptr<final_chain::FinalChain> final_chain, size_t max_size = kMinTransactionPoolSize);
 
   /**
    * @brief insert a transaction into the queue, sorted by priority
    *
    * @param transaction
    * @param last_block_number
-   * @return true
-   * @return false
+   * @return TransactionStatus
    */
-  bool insert(std::shared_ptr<Transaction>&& transaction, const TransactionStatus status,
-              uint64_t last_block_number = 0);
+  TransactionStatus insert(std::shared_ptr<Transaction>&& transaction, bool proposable, uint64_t last_block_number = 0);
 
   /**
    * @brief remove transaction from queue
@@ -94,6 +95,13 @@ class TransactionQueue {
    * @param block_number block number finalized
    */
   void blockFinalized(uint64_t block_number);
+
+  /**
+   * @brief Removes any transactions that are no longer proposable
+   *
+   * @param final_chain
+   */
+  void purge();
 
   /**
    * @brief Marks transaction as known (was successfully pushed into the tx pool)
@@ -163,6 +171,8 @@ class TransactionQueue {
 
   // Maximum size of single account transactions
   const size_t kMaxSingleAccountTransactionsSize;
+
+  std::shared_ptr<final_chain::FinalChain> final_chain_;
 };
 
 /** @}*/

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -71,6 +71,22 @@ PbftManager::PbftManager(const PbftConfig &conf, const blk_hash_t &dag_genesis_b
     finalize_(std::move(period_data), db_->getFinalizedDagBlockHashesByPeriod(period), period == curr_period);
   }
 
+  PbftPeriod start_period = 1;
+  const auto recently_finalized_transactions_periods =
+      kRecentlyFinalizedTransactionsFactor * final_chain_->delegation_delay();
+  if (pbft_chain_->getPbftChainSize() > recently_finalized_transactions_periods) {
+    start_period = pbft_chain_->getPbftChainSize() - recently_finalized_transactions_periods;
+  }
+  for (PbftPeriod period = start_period; period <= pbft_chain_->getPbftChainSize(); period++) {
+    auto period_raw = db_->getPeriodDataRaw(period);
+    if (period_raw.size() == 0) {
+      LOG(log_er_) << "DB corrupted - Cannot find PBFT block in period " << period << " in PBFT chain DB pbft_blocks.";
+      assert(false);
+    }
+    PeriodData period_data(period_raw);
+    trx_mgr_->initializeRecentlyFinalizedTransactions(period_data);
+  }
+
   // Initialize PBFT status
   initialState();
 }

--- a/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
+++ b/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
@@ -12,7 +12,7 @@ namespace taraxa {
 TransactionManager::TransactionManager(FullNodeConfig const &conf, std::shared_ptr<DbStorage> db,
                                        std::shared_ptr<FinalChain> final_chain, addr_t node_addr)
     : kConf(conf),
-      transactions_pool_(kConf.transactions_pool_size),
+      transactions_pool_(final_chain, kConf.transactions_pool_size),
       kDagBlockGasLimit(kConf.genesis.dag.gas_limit),
       db_(std::move(db)),
       final_chain_(std::move(final_chain)) {
@@ -46,48 +46,34 @@ uint64_t TransactionManager::estimateTransactionGas(std::shared_ptr<Transaction>
   return result.gas_used;
 }
 
-std::pair<TransactionStatus, std::string> TransactionManager::verifyTransaction(
-    const std::shared_ptr<Transaction> &trx) const {
+std::pair<bool, std::string> TransactionManager::verifyTransaction(const std::shared_ptr<Transaction> &trx) const {
   // ONLY FOR TESTING
   if (!final_chain_) [[unlikely]] {
-    return {TransactionStatus::Verified, ""};
+    return {true, ""};
   }
 
   if (trx->getChainID() != kConf.genesis.chain_id) {
-    return {TransactionStatus::Invalid,
+    return {false,
             "chain_id mismatch " + std::to_string(trx->getChainID()) + " " + std::to_string(kConf.genesis.chain_id)};
   }
 
   // Ensure the transaction doesn't exceed the current block limit gas.
   if (kDagBlockGasLimit < trx->getGas()) {
-    return {TransactionStatus::Invalid, "invalid gas"};
+    return {false, "invalid gas"};
   }
 
   try {
     trx->getSender();
   } catch (Transaction::InvalidSignature const &) {
-    return {TransactionStatus::Invalid, "invalid signature"};
+    return {false, "invalid signature"};
   }
 
   // gas_price in transaction must be greater than or equal to minimum value from config
   if (kConf.genesis.gas_price.minimum_price > trx->getGasPrice()) {
-    return {TransactionStatus::Invalid, "gas_price too low"};
+    return {false, "gas_price too low"};
   }
 
-  const auto account = final_chain_->get_account(trx->getSender()).value_or(taraxa::state_api::ZeroAccount);
-
-  // Ensure the transaction adheres to nonce ordering
-  if (account.nonce > trx->getNonce()) {
-    return {TransactionStatus::LowNonce, "nonce too low"};
-  }
-
-  // Transactor should have enough funds to cover the costs
-  // cost == V + GP * GL
-  if (account.balance < trx->getCost()) {
-    return {TransactionStatus::InsufficentBalance, "insufficient balance"};
-  }
-
-  return {TransactionStatus::Verified, ""};
+  return {true, ""};
 }
 
 bool TransactionManager::isTransactionKnown(const trx_hash_t &trx_hash) {
@@ -99,14 +85,14 @@ std::pair<bool, std::string> TransactionManager::insertTransaction(const std::sh
     return {false, "Transaction already in transactions pool"};
   }
 
-  const auto [status, reason] = verifyTransaction(trx);
-  if (status != TransactionStatus::Verified) {
+  const auto [verified, reason] = verifyTransaction(trx);
+  if (!verified) {
     return {false, reason};
   }
 
   const auto trx_hash = trx->getHash();
   auto trx_copy = trx;
-  if (insertValidatedTransaction(std::move(trx_copy), status)) {
+  if (insertValidatedTransaction(std::move(trx_copy), false) == TransactionStatus::Inserted) {
     return {true, ""};
   } else {
     const auto period = db_->getTransactionPeriod(trx_hash);
@@ -118,19 +104,46 @@ std::pair<bool, std::string> TransactionManager::insertTransaction(const std::sh
   }
 }
 
-bool TransactionManager::insertValidatedTransaction(std::shared_ptr<Transaction> &&tx, const TransactionStatus status) {
+TransactionStatus TransactionManager::insertValidatedTransaction(std::shared_ptr<Transaction> &&tx,
+                                                                 bool insert_non_proposable) {
   const auto trx_hash = tx->getHash();
 
   // This lock synchronizes inserting and removing transactions from transactions memory pool.
   // It is very important to lock transaction pool checking to be
   // protected from new DAG block and Period data transactions insertions.
   std::unique_lock transactions_lock(transactions_mutex_);
+
   if (nonfinalized_transactions_in_dag_.contains(trx_hash)) {
-    return false;
+    return TransactionStatus::Known;
   }
+
+  if (recently_finalized_transactions_.contains(trx_hash)) {
+    return TransactionStatus::Known;
+  }
+
+  const auto account = final_chain_->get_account(tx->getSender()).value_or(taraxa::state_api::ZeroAccount);
+  bool proposable = true;
+
+  // Ensure the transaction adheres to nonce ordering
+  if (account.nonce > tx->getNonce()) {
+    if (!insert_non_proposable) {
+      return TransactionStatus::Known;
+    }
+    proposable = false;
+  }
+
+  // Transactor should have enough funds to cover the costs
+  // cost == V + GP * GL
+  if (account.balance < tx->getCost()) {
+    if (!insert_non_proposable) {
+      return TransactionStatus::Known;
+    }
+    proposable = false;
+  }
+
   const auto last_block_number = final_chain_->last_block_number();
   LOG(log_dg_) << "Transaction " << trx_hash << " inserted in trx pool";
-  return transactions_pool_.insert(std::move(tx), status, last_block_number);
+  return transactions_pool_.insert(std::move(tx), proposable, last_block_number);
 }
 
 unsigned long TransactionManager::getTransactionCount() const {
@@ -175,19 +188,25 @@ void TransactionManager::saveTransactionsFromDagBlock(SharedTransactions const &
     // Unique lock here makes sure that transactions we are removing are not reinserted in transactions_pool_
     std::unique_lock transactions_lock(transactions_mutex_);
 
-    auto trx_in_db = db_->transactionsInDb(trx_hashes);
-    for (uint64_t i = 0; i < trxs.size(); i++) {
-      auto const &trx_hash = trx_hashes[i];
-      // We only save transaction if it has not already been saved
-      if (!trx_in_db[i]) {
-        db_->addTransactionToBatch(*trxs[i], write_batch);
-        nonfinalized_transactions_in_dag_.emplace(trx_hash, trxs[i]);
-      }
-      if (transactions_pool_.erase(trx_hash)) {
-        LOG(log_dg_) << "Transaction " << trx_hash << " removed from trx pool ";
-        // Transactions are counted when included in DAG
-        trx_count_++;
-        accepted_transactions.emplace_back(trx_hash);
+    for (auto t : trxs) {
+      const auto account = final_chain_->get_account(t->getSender()).value_or(taraxa::state_api::ZeroAccount);
+      const auto tx_hash = t->getHash();
+
+      // Cheacking nonce in cheaper than checking db, verify with nonce if possible
+      bool trx_not_executed = account.nonce < t->getNonce() || !db_->transactionFinalized(tx_hash);
+
+      if (trx_not_executed) {
+        if (!recently_finalized_transactions_.contains(tx_hash) &&
+            !nonfinalized_transactions_in_dag_.contains(tx_hash)) {
+          db_->addTransactionToBatch(*t, write_batch);
+          nonfinalized_transactions_in_dag_.emplace(tx_hash, t);
+          if (transactions_pool_.erase(tx_hash)) {
+            LOG(log_dg_) << "Transaction " << tx_hash << " removed from trx pool ";
+            // Transactions are counted when included in DAG
+            trx_count_++;
+            accepted_transactions.emplace_back(tx_hash);
+          }
+        }
       }
     }
     db_->addStatusFieldToBatch(StatusDbField::TrxCount, trx_count_, write_batch);
@@ -302,18 +321,36 @@ std::vector<SharedTransactions> TransactionManager::getAllPoolTrxs() {
   return transactions_pool_.getAllTransactions();
 }
 
+void TransactionManager::initializeRecentlyFinalizedTransactions(const PeriodData &period_data) {
+  std::unique_lock transactions_lock(transactions_mutex_);
+  for (auto const &trx : period_data.transactions) {
+    const auto hash = trx->getHash();
+    recently_finalized_transactions_[hash] = trx;
+    recently_finalized_transactions_per_period_[period_data.pbft_blk->getPeriod()].push_back(hash);
+  }
+}
+
 /**
  * Update transaction counters and state, it only has effect when PBFT syncing
  */
 void TransactionManager::updateFinalizedTransactionsStatus(PeriodData const &period_data) {
   // !!! There is no lock because it is called under std::unique_lock trx_lock(trx_mgr_->getTransactionsMutex());
+  const auto recently_finalized_transactions_periods =
+      kRecentlyFinalizedTransactionsFactor * final_chain_->delegation_delay();
   if (period_data.transactions.size() > 0) {
-    if (period_data.transactions.size() + recently_finalized_transactions_.size() > kRecentlyFinalizedTransactionsMax) {
-      recently_finalized_transactions_.clear();
+    // Delete transactions older than recently_finalized_transactions_periods
+    if (period_data.pbft_blk->getPeriod() > recently_finalized_transactions_periods) {
+      for (auto hash : recently_finalized_transactions_per_period_[period_data.pbft_blk->getPeriod() -
+                                                                   recently_finalized_transactions_periods]) {
+        recently_finalized_transactions_.erase(hash);
+      }
+      recently_finalized_transactions_per_period_.erase(period_data.pbft_blk->getPeriod() -
+                                                        recently_finalized_transactions_periods);
     }
     for (auto const &trx : period_data.transactions) {
       const auto hash = trx->getHash();
       recently_finalized_transactions_[hash] = trx;
+      recently_finalized_transactions_per_period_[period_data.pbft_blk->getPeriod()].push_back(hash);
       // we should mark trx as know just in case it was only synchronized from the period data
       transactions_pool_.markTransactionKnown(hash);
       if (!nonfinalized_transactions_in_dag_.erase(hash)) {
@@ -327,72 +364,70 @@ void TransactionManager::updateFinalizedTransactionsStatus(PeriodData const &per
     }
     db_->saveStatusField(StatusDbField::TrxCount, trx_count_);
   }
+
+  // Sometimes transactions which nonce was skipped and will never be included in a block might remain in the
+  // transaction pool, remove them each 100 block
+  const uint32_t transaction_purge_interval = 100;
+  if (period_data.pbft_blk->getPeriod() % transaction_purge_interval == 0) {
+    transactions_pool_.purge();
+  }
 }
 
-void TransactionManager::moveNonFinalizedTransactionsToTransactionsPool(std::unordered_set<trx_hash_t> &&transactions) {
+void TransactionManager::removeNonFinalizedTransactions(std::unordered_set<trx_hash_t> &&transactions) {
   // !!! There is no lock because it is called under std::unique_lock trx_lock(trx_mgr_->getTransactionsMutex());
   auto write_batch = db_->createWriteBatch();
   for (auto const &trx_hash : transactions) {
     auto trx = nonfinalized_transactions_in_dag_.find(trx_hash);
     if (trx != nonfinalized_transactions_in_dag_.end()) {
       db_->removeTransactionToBatch(trx_hash, write_batch);
-      transactions_pool_.insert(std::move(trx->second), TransactionStatus::Verified);
       nonfinalized_transactions_in_dag_.erase(trx);
     }
   }
   db_->commitWriteBatch(write_batch);
 }
 
-// Verify all block transactions are present
-std::optional<SharedTransactions> TransactionManager::getBlockTransactions(const DagBlock &blk) {
-  vec_trx_t const &all_block_trx_hashes = blk.getTrxs();
-  if (all_block_trx_hashes.empty()) {
-    LOG(log_er_) << "Ignore block " << blk.getHash() << " since it has no transactions";
-    return std::nullopt;
-  }
-  auto transactions = getTransactions(all_block_trx_hashes);
-  if (!transactions.has_value()) {
-    LOG(log_nf_) << "Block " << blk.getHash() << " has missing transaction";
-  }
-  return transactions;
+SharedTransactions TransactionManager::getBlockTransactions(const DagBlock &blk, PbftPeriod proposal_period) {
+  return getTransactions(blk.getTrxs(), proposal_period);
 }
 
-std::optional<SharedTransactions> TransactionManager::getTransactions(const vec_trx_t &trxs_hashes) {
+SharedTransactions TransactionManager::getTransactions(const vec_trx_t &trxs_hashes, PbftPeriod proposal_period) {
   vec_trx_t finalized_trx_hashes;
   SharedTransactions transactions;
   transactions.reserve(trxs_hashes.size());
-
-  {
+  for (auto const &tx_hash : trxs_hashes) {
     std::shared_lock transactions_lock(transactions_mutex_);
-    for (auto const &tx_hash : trxs_hashes) {
-      auto trx = transactions_pool_.get(tx_hash);
-      if (trx != nullptr) {
-        transactions.emplace_back(std::move(trx));
+    auto trx = transactions_pool_.get(tx_hash);
+    if (trx != nullptr) {
+      transactions.emplace_back(std::move(trx));
+    } else {
+      auto trx_it = nonfinalized_transactions_in_dag_.find(tx_hash);
+      if (trx_it != nonfinalized_transactions_in_dag_.end()) {
+        transactions.emplace_back(trx_it->second);
       } else {
-        auto trx_it = nonfinalized_transactions_in_dag_.find(tx_hash);
-        if (trx_it != nonfinalized_transactions_in_dag_.end()) {
+        trx_it = recently_finalized_transactions_.find(tx_hash);
+        if (trx_it != recently_finalized_transactions_.end()) {
           transactions.emplace_back(trx_it->second);
         } else {
-          trx_it = recently_finalized_transactions_.find(tx_hash);
-          if (trx_it != recently_finalized_transactions_.end()) {
-            transactions.emplace_back(trx_it->second);
-          } else {
-            finalized_trx_hashes.emplace_back(tx_hash);
-          }
+          finalized_trx_hashes.emplace_back(tx_hash);
         }
       }
     }
   }
-  auto finalizedTransactions = db_->getFinalizedTransactions(finalized_trx_hashes);
-  if (finalizedTransactions.first.has_value()) {
-    for (auto trx : *finalizedTransactions.first) {
-      transactions.emplace_back(std::move(trx));
-    }
-  } else {
-    LOG(log_nf_) << "getTransactions has missing transaction " << finalizedTransactions.second;
-    return std::nullopt;
-  }
 
+  // This should be an extremely rare case since transactions should be found in the caches
+  auto finalizedTransactions = db_->getFinalizedTransactions(finalized_trx_hashes);
+
+  for (auto trx : finalizedTransactions) {
+    // Only include transactions with valid nonce at proposal period
+    auto acc = final_chain_->get_account(trx->getSender(), proposal_period);
+    if (acc.has_value()) {
+      if (acc->nonce > trx->getNonce()) {
+        LOG(log_nf_) << "Old transaction: " << trx->getHash();
+      } else {
+        transactions.emplace_back(std::move(trx));
+      }
+    }
+  }
   return transactions;
 }
 

--- a/libraries/core_libs/consensus/src/transaction/transaction_queue.cpp
+++ b/libraries/core_libs/consensus/src/transaction/transaction_queue.cpp
@@ -4,11 +4,12 @@
 
 namespace taraxa {
 
-TransactionQueue::TransactionQueue(size_t max_size)
+TransactionQueue::TransactionQueue(std::shared_ptr<FinalChain> final_chain, size_t max_size)
     : known_txs_(max_size * 2, max_size / 5),
       kNonProposableTransactionsMaxSize(max_size * kNonProposableTransactionsLimitPercentage / 100),
       kMaxSize(max_size),
-      kMaxSingleAccountTransactionsSize(max_size * kSingleAccountTransactionsLimitPercentage / 100) {
+      kMaxSingleAccountTransactionsSize(max_size * kSingleAccountTransactionsLimitPercentage / 100),
+      final_chain_(final_chain) {
   queue_transactions_.reserve(max_size);
 }
 
@@ -106,83 +107,74 @@ bool TransactionQueue::erase(const trx_hash_t &hash) {
   return true;
 }
 
-bool TransactionQueue::insert(std::shared_ptr<Transaction> &&transaction, const TransactionStatus status,
-                              uint64_t last_block_number) {
+TransactionStatus TransactionQueue::insert(std::shared_ptr<Transaction> &&transaction, bool proposable,
+                                           uint64_t last_block_number) {
   assert(transaction);
   const auto tx_hash = transaction->getHash();
 
   if (contains(tx_hash)) {
-    return false;
+    return TransactionStatus::Known;
   }
 
-  switch (status) {
-    case TransactionStatus::Verified: {
-      const auto &account_it = account_nonce_transactions_.find(transaction->getSender());
-      if (account_it == account_nonce_transactions_.end()) {
+  if (proposable) {
+    const auto &account_it = account_nonce_transactions_.find(transaction->getSender());
+    if (account_it == account_nonce_transactions_.end()) {
+      account_nonce_transactions_[transaction->getSender()][transaction->getNonce()] = transaction;
+      queue_transactions_[tx_hash] = transaction;
+    } else {
+      if (account_it->second.size() == kMaxSingleAccountTransactionsSize) {
+        transaction_overflow_time_ = std::chrono::system_clock::now();
+        return TransactionStatus::Overflow;
+      }
+      const auto &nonce_it = account_it->second.find(transaction->getNonce());
+      if (nonce_it == account_it->second.end()) {
         account_nonce_transactions_[transaction->getSender()][transaction->getNonce()] = transaction;
         queue_transactions_[tx_hash] = transaction;
       } else {
-        if (account_it->second.size() == kMaxSingleAccountTransactionsSize) {
-          transaction_overflow_time_ = std::chrono::system_clock::now();
-          return false;
-        }
-        const auto &nonce_it = account_it->second.find(transaction->getNonce());
-        if (nonce_it == account_it->second.end()) {
+        // It should not be possible that transaction is already inside due to verification done before
+        assert(nonce_it->second->getHash() != tx_hash);
+        // Replace transaction if gas price higher
+        if (transaction->getGasPrice() > nonce_it->second->getGasPrice()) {
+          // Place same nonce transaction with lower gas price in non propsable transactions since it could be
+          // possible that some dag block might contain it
+          non_proposable_transactions_[nonce_it->second->getHash()] = {last_block_number, nonce_it->second};
+          queue_transactions_.erase(nonce_it->second->getHash());
           account_nonce_transactions_[transaction->getSender()][transaction->getNonce()] = transaction;
           queue_transactions_[tx_hash] = transaction;
         } else {
-          // It should not be possible that transaction is already inside due to verification done before
-          assert(nonce_it->second->getHash() != tx_hash);
-          // Replace transaction if gas price higher
-          if (transaction->getGasPrice() > nonce_it->second->getGasPrice()) {
-            // Place same nonce transaction with lower gas price in non propsable transactions since it could be
-            // possible that some dag block might contain it
-            non_proposable_transactions_[nonce_it->second->getHash()] = {last_block_number, nonce_it->second};
-            queue_transactions_.erase(nonce_it->second->getHash());
-            account_nonce_transactions_[transaction->getSender()][transaction->getNonce()] = transaction;
-            queue_transactions_[tx_hash] = transaction;
-          } else {
-            non_proposable_transactions_[tx_hash] = {last_block_number, transaction};
-          }
+          non_proposable_transactions_[tx_hash] = {last_block_number, transaction};
         }
       }
+    }
 
-      const auto queue_size = size();
-      // This check if priority_queue_ is not bigger than max size if so we delete 1% of transactions
-      if (queue_size > kMaxSize) [[unlikely]] {
-        auto ordered_transactions = getOrderedTransactions(queue_size);
-        uint32_t counter = 0;
-        for (auto it = ordered_transactions.rbegin(); it != ordered_transactions.rend(); it++) {
-          transaction_overflow_time_ = std::chrono::system_clock::now();
-          erase((*it)->getHash());
-          known_txs_.erase((*it)->getHash());
-          counter++;
-          if (counter >= queue_size / 100) break;
-        }
-        if (!queue_transactions_.contains(tx_hash)) {
-          return false;
-        }
-      }
-      known_txs_.insert(tx_hash);
-    } break;
-    case TransactionStatus::LowNonce:
-    case TransactionStatus::InsufficentBalance:
-      if (non_proposable_transactions_.size() <= kNonProposableTransactionsMaxSize) {
-        non_proposable_transactions_[tx_hash] = {last_block_number, transaction};
-        known_txs_.insert(tx_hash);
-      } else {
+    const auto queue_size = size();
+    // This check if priority_queue_ is not bigger than max size if so we delete 1% of transactions
+    if (queue_size > kMaxSize) [[unlikely]] {
+      auto ordered_transactions = getOrderedTransactions(queue_size);
+      uint32_t counter = 0;
+      for (auto it = ordered_transactions.rbegin(); it != ordered_transactions.rend(); it++) {
         transaction_overflow_time_ = std::chrono::system_clock::now();
-        return false;
+        erase((*it)->getHash());
+        known_txs_.erase((*it)->getHash());
+        counter++;
+        if (counter >= queue_size / 100) break;
       }
-      break;
-    case TransactionStatus::Forced:
+      if (!queue_transactions_.contains(tx_hash)) {
+        return TransactionStatus::Overflow;
+      }
+    }
+    known_txs_.insert(tx_hash);
+  } else {
+    if (non_proposable_transactions_.size() <= kNonProposableTransactionsMaxSize) {
       non_proposable_transactions_[tx_hash] = {last_block_number, transaction};
       known_txs_.insert(tx_hash);
-      break;
-    default:
-      assert(false);
+      return TransactionStatus::InsertedNonProposable;
+    } else {
+      transaction_overflow_time_ = std::chrono::system_clock::now();
+      return TransactionStatus::Overflow;
+    }
   }
-  return true;
+  return TransactionStatus::Inserted;
 }
 
 void TransactionQueue::blockFinalized(uint64_t block_number) {
@@ -192,6 +184,28 @@ void TransactionQueue::blockFinalized(uint64_t block_number) {
       it = non_proposable_transactions_.erase(it);
     } else {
       ++it;
+    }
+  }
+}
+
+void TransactionQueue::purge() {
+  for (auto account_it = account_nonce_transactions_.begin(); account_it != account_nonce_transactions_.end();) {
+    const auto account = final_chain_->get_account(account_it->first);
+    if (account.has_value()) {
+      for (auto nonce_it = account_it->second.begin(); nonce_it != account_it->second.end();) {
+        if (nonce_it->first < account->nonce) {
+          queue_transactions_.erase(nonce_it->second->getHash());
+          nonce_it = account_it->second.erase(nonce_it);
+        } else {
+          break;
+        }
+      }
+
+      if (account_it->second.size() == 0) {
+        account_it = account_nonce_transactions_.erase(account_it);
+      } else {
+        account_it++;
+      }
     }
   }
 }

--- a/libraries/core_libs/network/include/network/tarcap/packets_handlers/latest/dag_block_packet_handler.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/packets_handlers/latest/dag_block_packet_handler.hpp
@@ -17,10 +17,12 @@ class DagBlockPacketHandler : public ExtSyncingPacketHandler {
                         std::shared_ptr<PbftSyncingState> pbft_syncing_state, std::shared_ptr<PbftChain> pbft_chain,
                         std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<DagManager> dag_mgr,
                         std::shared_ptr<TransactionManager> trx_mgr, std::shared_ptr<DbStorage> db,
-                        const addr_t &node_addr, const std::string &logs_prefix = "");
+                        bool trxs_in_dag_packet, const addr_t &node_addr, const std::string &logs_prefix = "");
 
   void sendBlock(dev::p2p::NodeID const &peer_id, DagBlock block, const SharedTransactions &trxs);
-  void onNewBlockReceived(DagBlock &&block, const std::shared_ptr<TaraxaPeer> &peer = nullptr);
+  void sendBlockWithTransactions(dev::p2p::NodeID const &peer_id, DagBlock block, const SharedTransactions &trxs);
+  void onNewBlockReceived(DagBlock &&block, const std::shared_ptr<TaraxaPeer> &peer = nullptr,
+                          const std::unordered_map<trx_hash_t, std::shared_ptr<Transaction>> &trxs = {});
   void onNewBlockVerified(const DagBlock &block, bool proposed, const SharedTransactions &trxs);
 
   // Packet type that is processed by this handler
@@ -32,6 +34,7 @@ class DagBlockPacketHandler : public ExtSyncingPacketHandler {
 
  protected:
   std::shared_ptr<TransactionManager> trx_mgr_{nullptr};
+  const bool kTrxsInDagPacket;
 };
 
 }  // namespace taraxa::network::tarcap

--- a/libraries/core_libs/network/include/network/threadpool/packets_blocking_mask.hpp
+++ b/libraries/core_libs/network/include/network/threadpool/packets_blocking_mask.hpp
@@ -32,6 +32,7 @@ class PacketsBlockingMask {
   bool isPacketPeerOrderBlocked(const PacketData& packet_data) const;
   bool isDagBlockPacketBlockedByLevel(const PacketData& packet_data) const;
   bool isDagBlockPacketBlockedBySameDagBlock(const PacketData& packet_data) const;
+  dev::RLP dagBlockFromDagPacket(const PacketData& packet_data) const;
 
   std::optional<taraxa::level_t> getSmallestDagLevelBeingProcessed() const;
 
@@ -67,6 +68,10 @@ class PacketsBlockingMask {
   // concurrently, to reduce perofrmance impact only one packet/block will be processsed and others will be waiting.
   //  This map contains dag blocks that are currently processed with the associated packet id
   std::map<taraxa::sig_t, PacketData::PacketId> processing_dag_blocks_;
+
+  static constexpr size_t kRequiredDagPacketSizeV3 = 2;
+  static constexpr size_t kDagBlockPosV3 = 1;
+  static constexpr size_t kRequiredDagPacketSizeV2 = 8;
 };
 
 }  // namespace taraxa::network::threadpool

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/latest/dag_block_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/latest/dag_block_packet_handler.cpp
@@ -13,22 +13,45 @@ DagBlockPacketHandler::DagBlockPacketHandler(const FullNodeConfig &conf, std::sh
                                              std::shared_ptr<PbftChain> pbft_chain,
                                              std::shared_ptr<PbftManager> pbft_mgr, std::shared_ptr<DagManager> dag_mgr,
                                              std::shared_ptr<TransactionManager> trx_mgr, std::shared_ptr<DbStorage> db,
-                                             const addr_t &node_addr, const std::string &logs_prefix)
+                                             bool trxs_in_dag_packet, const addr_t &node_addr,
+                                             const std::string &logs_prefix)
     : ExtSyncingPacketHandler(conf, std::move(peers_state), std::move(packets_stats), std::move(pbft_syncing_state),
                               std::move(pbft_chain), std::move(pbft_mgr), std::move(dag_mgr), std::move(db), node_addr,
                               logs_prefix + "DAG_BLOCK_PH"),
-      trx_mgr_(std::move(trx_mgr)) {}
+      trx_mgr_(std::move(trx_mgr)),
+      kTrxsInDagPacket(trxs_in_dag_packet) {}
 
 void DagBlockPacketHandler::validatePacketRlpFormat(const threadpool::PacketData &packet_data) const {
+  constexpr size_t required_size_v2 = 8;
+  constexpr size_t required_size = 2;
   // Only one dag block can be received
-  if (constexpr size_t required_size = 8; packet_data.rlp_.itemCount() != required_size) {
+  if (kTrxsInDagPacket && packet_data.rlp_.itemCount() != required_size) {
     throw InvalidRlpItemsCountException(packet_data.type_str_, packet_data.rlp_.itemCount(), required_size);
+  } else if (!kTrxsInDagPacket && packet_data.rlp_.itemCount() != required_size_v2) {
+    throw InvalidRlpItemsCountException(packet_data.type_str_, packet_data.rlp_.itemCount(), required_size_v2);
   }
 }
 
 void DagBlockPacketHandler::process(const threadpool::PacketData &packet_data,
                                     const std::shared_ptr<TaraxaPeer> &peer) {
-  DagBlock block(packet_data.rlp_);
+  std::unordered_map<trx_hash_t, std::shared_ptr<Transaction>> transactions;
+  auto dag_rlp = packet_data.rlp_;
+  if (packet_data.rlp_.itemCount() == 2) {
+    const auto trx_count = packet_data.rlp_[0].itemCount();
+    transactions.reserve(trx_count);
+
+    for (const auto tx_rlp : packet_data.rlp_[0]) {
+      try {
+        auto trx = std::make_shared<Transaction>(tx_rlp);
+        peer->markTransactionAsKnown(trx->getHash());
+        transactions.emplace(trx->getHash(), std::move(trx));
+      } catch (const Transaction::InvalidTransaction &e) {
+        throw MaliciousPeerException("Unable to parse transaction: " + std::string(e.what()));
+      }
+    }
+    dag_rlp = packet_data.rlp_[1];
+  }
+  DagBlock block(dag_rlp);
   blk_hash_t const hash = block.getHash();
 
   peer->markDagBlockAsKnown(hash);
@@ -43,7 +66,7 @@ void DagBlockPacketHandler::process(const threadpool::PacketData &packet_data,
     return;
   }
 
-  onNewBlockReceived(std::move(block), peer);
+  onNewBlockReceived(std::move(block), peer, transactions);
 }
 
 void DagBlockPacketHandler::sendBlock(dev::p2p::NodeID const &peer_id, taraxa::DagBlock block,
@@ -91,10 +114,45 @@ void DagBlockPacketHandler::sendBlock(dev::p2p::NodeID const &peer_id, taraxa::D
   }
 }
 
-void DagBlockPacketHandler::onNewBlockReceived(DagBlock &&block, const std::shared_ptr<TaraxaPeer> &peer) {
+void DagBlockPacketHandler::sendBlockWithTransactions(dev::p2p::NodeID const &peer_id, taraxa::DagBlock block,
+                                                      const SharedTransactions &trxs) {
+  std::shared_ptr<TaraxaPeer> peer = peers_state_->getPeer(peer_id);
+  if (!peer) {
+    LOG(log_wr_) << "Send dag block " << block.getHash() << ". Failed to obtain peer " << peer_id;
+    return;
+  }
+
+  dev::RLPStream s(2);
+
+  // This lock prevents race condition between syncing and gossiping dag blocks
+  std::unique_lock lock(peer->mutex_for_sending_dag_blocks_);
+
+  taraxa::bytes trx_bytes;
+  for (uint32_t i = 0; i < trxs.size(); i++) {
+    auto trx_data = trxs[i]->rlp();
+    trx_bytes.insert(trx_bytes.end(), std::begin(trx_data), std::end(trx_data));
+  }
+
+  s.appendList(trxs.size());
+  s.appendRaw(trx_bytes, trxs.size());
+
+  s.appendRaw(block.rlp(true));
+
+  if (!sealAndSend(peer_id, DagBlockPacket, std::move(s))) {
+    LOG(log_wr_) << "Sending DagBlock " << block.getHash() << " failed to " << peer_id;
+    return;
+  }
+
+  // Mark data as known if sending was successful
+  peer->markDagBlockAsKnown(block.getHash());
+}
+
+void DagBlockPacketHandler::onNewBlockReceived(
+    DagBlock &&block, const std::shared_ptr<TaraxaPeer> &peer,
+    const std::unordered_map<trx_hash_t, std::shared_ptr<Transaction>> &trxs) {
   const auto block_hash = block.getHash();
-  const auto verified = dag_mgr_->verifyBlock(block);
-  switch (verified) {
+  auto verified = dag_mgr_->verifyBlock(block, trxs);
+  switch (verified.first) {
     case DagManager::VerifyBlockReturnType::IncorrectTransactionsEstimation:
     case DagManager::VerifyBlockReturnType::BlockTooBig:
     case DagManager::VerifyBlockReturnType::FailedVdfVerification:
@@ -102,7 +160,7 @@ void DagBlockPacketHandler::onNewBlockReceived(DagBlock &&block, const std::shar
     case DagManager::VerifyBlockReturnType::FailedTipsVerification: {
       std::ostringstream err_msg;
       err_msg << "DagBlock " << block_hash << " failed verification with error code "
-              << static_cast<uint32_t>(verified);
+              << static_cast<uint32_t>(verified.first);
       throw MaliciousPeerException(err_msg.str());
     }
     case DagManager::VerifyBlockReturnType::MissingTransaction:
@@ -155,8 +213,7 @@ void DagBlockPacketHandler::onNewBlockReceived(DagBlock &&block, const std::shar
       }
       break;
     case DagManager::VerifyBlockReturnType::Verified: {
-      auto transactions = trx_mgr_->getPoolTransactions(block.getTrxs()).first;
-      auto status = dag_mgr_->addDagBlock(std::move(block), std::move(transactions));
+      auto status = dag_mgr_->addDagBlock(std::move(block), std::move(verified.second));
       if (!status.first) {
         LOG(log_dg_) << "Received DagBlockPacket " << block_hash << "from: " << peer->getId();
         // Ignore new block packets when pbft syncing
@@ -201,18 +258,6 @@ void DagBlockPacketHandler::onNewBlockVerified(const DagBlock &block, bool propo
     }
   }
 
-  // trxs contains only transaction that were not already in some previous DAG block,
-  // block_trxs will contain hashes of transactions which were already in DAG
-  std::unordered_set<trx_hash_t> block_trxs;
-  block_trxs.reserve(block.getTrxs().size());
-  for (const auto &trx_hash : block.getTrxs()) {
-    block_trxs.insert(trx_hash);
-  }
-  // Exclude transactions from trxs
-  for (const auto &trx : trxs) {
-    block_trxs.erase(trx->getHash());
-  }
-
   std::string peer_and_transactions_to_log;
   // Sending it in same order favours some peers over others, always start with a different position
   const auto peers_to_send_count = peers_to_send.size();
@@ -235,8 +280,6 @@ void DagBlockPacketHandler::onNewBlockVerified(const DagBlock &block, bool propo
           peer_and_transactions_to_log += trx_hash.abridged();
         }
 
-        std::vector<trx_hash_t> block_trxs_vec(block_trxs.begin(), block_trxs.end());
-        const auto trxs_to_gossip = trx_mgr_->getTransactions(block_trxs_vec);
         for (const auto &trx : trxs) {
           assert(trx != nullptr);
           const auto trx_hash = trx->getHash();
@@ -247,8 +290,11 @@ void DagBlockPacketHandler::onNewBlockVerified(const DagBlock &block, bool propo
           transactions_to_send.push_back(trx);
           peer_and_transactions_to_log += trx_hash.abridged();
         }
-
-        sendBlock(peer_id, block, transactions_to_send);
+        if (kTrxsInDagPacket) {
+          sendBlockWithTransactions(peer_id, block, transactions_to_send);
+        } else {
+          sendBlock(peer_id, block, transactions_to_send);
+        }
         peer->markDagBlockAsKnown(block_hash);
       }
     }

--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -225,8 +225,8 @@ const TaraxaCapability::InitPacketsHandlers TaraxaCapability::kInitLatestVersion
 
       // Standard packets with mid processing priority
       packets_handlers->registerHandler<DagBlockPacketHandler>(config, peers_state, packets_stats, pbft_syncing_state,
-                                                               pbft_chain, pbft_mgr, dag_mgr, trx_mgr, db, node_addr,
-                                                               logs_prefix);
+                                                               pbft_chain, pbft_mgr, dag_mgr, trx_mgr, db,
+                                                               version > kV2NetworkVersion, node_addr, logs_prefix);
 
       // Support for transaition from V2 to V3, once all nodes update to V3 post next hardfork, V2 support can be
       // removed

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -210,11 +210,9 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
    *
    * @param trx_hashes
    *
-   * @return Returns transactions found if all transactions are present. If there is a transaction missing, no
-   * transaction is returned and missing trx hash is returned
+   * @return Returns transactions
    */
-  std::pair<std::optional<SharedTransactions>, trx_hash_t> getFinalizedTransactions(
-      std::vector<trx_hash_t> const& trx_hashes) const;
+  SharedTransactions getFinalizedTransactions(std::vector<trx_hash_t> const& trx_hashes) const;
 
   // DAG
   void saveDagBlock(DagBlock const& blk, Batch* write_batch_p = nullptr);

--- a/libraries/core_libs/storage/src/storage.cpp
+++ b/libraries/core_libs/storage/src/storage.cpp
@@ -797,18 +797,15 @@ uint64_t DbStorage::getTransactionCount(PbftPeriod period) const {
   return 0;
 }
 
-std::pair<std::optional<SharedTransactions>, trx_hash_t> DbStorage::getFinalizedTransactions(
-    std::vector<trx_hash_t> const& trx_hashes) const {
+SharedTransactions DbStorage::getFinalizedTransactions(std::vector<trx_hash_t> const& trx_hashes) const {
+  SharedTransactions trxs;
   // Map of period to position of transactions within a period
   std::map<PbftPeriod, std::set<uint32_t>> period_map;
-  SharedTransactions transactions;
-  transactions.reserve(trx_hashes.size());
+  trxs.reserve(trx_hashes.size());
   for (auto const& tx_hash : trx_hashes) {
     auto trx_period = getTransactionPeriod(tx_hash);
     if (trx_period.has_value()) {
       period_map[trx_period->first].insert(trx_period->second);
-    } else {
-      return {std::nullopt, tx_hash};
     }
   }
   for (auto it : period_map) {
@@ -819,11 +816,11 @@ std::pair<std::optional<SharedTransactions>, trx_hash_t> DbStorage::getFinalized
 
     auto const transactions_rlp = dev::RLP(period_data)[TRANSACTIONS_POS_IN_PERIOD_DATA];
     for (auto pos : it.second) {
-      transactions.emplace_back(std::make_shared<Transaction>(transactions_rlp[pos]));
+      trxs.emplace_back(std::make_shared<Transaction>(transactions_rlp[pos]));
     }
   }
 
-  return {transactions, {}};
+  return trxs;
 }
 
 std::vector<std::shared_ptr<Vote>> DbStorage::getPeriodCertVotes(PbftPeriod period) const {

--- a/tests/dag_block_test.cpp
+++ b/tests/dag_block_test.cpp
@@ -231,14 +231,14 @@ TEST_F(DagBlockMgrTest, incorrect_tx_estimation) {
   // transactions.size and estimations size is not equal
   {
     DagBlock blk(dag_genesis, propose_level, {}, {trx->getHash()}, {}, vdf1, node->getSecretKey());
-    EXPECT_EQ(node->getDagManager()->verifyBlock(std::move(blk)),
+    EXPECT_EQ(node->getDagManager()->verifyBlock(std::move(blk)).first,
               DagManager::VerifyBlockReturnType::IncorrectTransactionsEstimation);
   }
 
   // wrong estimated tx
   {
     DagBlock blk(dag_genesis, propose_level, {}, {trx->getHash()}, 100, vdf1, node->getSecretKey());
-    EXPECT_EQ(node->getDagManager()->verifyBlock(std::move(blk)),
+    EXPECT_EQ(node->getDagManager()->verifyBlock(std::move(blk)).first,
               DagManager::VerifyBlockReturnType::IncorrectTransactionsEstimation);
   }
 }
@@ -267,7 +267,7 @@ TEST_F(DagBlockMgrTest, dag_block_tips_verification) {
 
     DagBlock blk(dag_genesis, propose_level, {}, {trx->getHash()}, 100000, vdf, node->getSecretKey());
     dag_blocks_hashes.push_back(blk.getHash());
-    EXPECT_EQ(node->getDagManager()->verifyBlock(blk), DagManager::VerifyBlockReturnType::Verified);
+    EXPECT_EQ(node->getDagManager()->verifyBlock(blk).first, DagManager::VerifyBlockReturnType::Verified);
     EXPECT_TRUE(node->getDagManager()->addDagBlock(std::move(blk), {trx}).first);
   }
 
@@ -277,20 +277,20 @@ TEST_F(DagBlockMgrTest, dag_block_tips_verification) {
   // Verify block over the kDagBlockMaxTips is rejected
   DagBlock blk_over_limit(dag_genesis, propose_level, dag_blocks_hashes, {trxs[0]->getHash()}, 100000, vdf,
                           node->getSecretKey());
-  EXPECT_EQ(node->getDagManager()->verifyBlock(blk_over_limit),
+  EXPECT_EQ(node->getDagManager()->verifyBlock(blk_over_limit).first,
             DagManager::VerifyBlockReturnType::FailedTipsVerification);
 
   // Verify block at kDagBlockMaxTips is accepted
   dag_blocks_hashes.resize(kDagBlockMaxTips);
   DagBlock blk_at_limit(dag_genesis, propose_level, dag_blocks_hashes, {trxs[0]->getHash()}, 100000, vdf,
                         node->getSecretKey());
-  EXPECT_EQ(node->getDagManager()->verifyBlock(blk_at_limit), DagManager::VerifyBlockReturnType::Verified);
+  EXPECT_EQ(node->getDagManager()->verifyBlock(blk_at_limit).first, DagManager::VerifyBlockReturnType::Verified);
 
   // Verify block below kDagBlockMaxTips is accepted
   dag_blocks_hashes.resize(kDagBlockMaxTips - 1);
   DagBlock blk_under_limit(dag_genesis, propose_level, dag_blocks_hashes, {trxs[0]->getHash()}, 100000, vdf,
                            node->getSecretKey());
-  EXPECT_EQ(node->getDagManager()->verifyBlock(blk_under_limit), DagManager::VerifyBlockReturnType::Verified);
+  EXPECT_EQ(node->getDagManager()->verifyBlock(blk_under_limit).first, DagManager::VerifyBlockReturnType::Verified);
 
   auto dag_blocks_hashes_with_duplicate_pivot = dag_blocks_hashes;
   dag_blocks_hashes_with_duplicate_pivot.push_back(dag_genesis);
@@ -301,13 +301,13 @@ TEST_F(DagBlockMgrTest, dag_block_tips_verification) {
   // Verify block with duplicate pivot is rejected
   DagBlock blk_with_duplicate_pivot(dag_genesis, propose_level, dag_blocks_hashes_with_duplicate_pivot,
                                     {trxs[0]->getHash()}, 100000, vdf, node->getSecretKey());
-  EXPECT_EQ(node->getDagManager()->verifyBlock(blk_with_duplicate_pivot),
+  EXPECT_EQ(node->getDagManager()->verifyBlock(blk_with_duplicate_pivot).first,
             DagManager::VerifyBlockReturnType::FailedTipsVerification);
 
   // Verify block with duplicate tip is rejected
   DagBlock blk_with_duplicate_tip(dag_genesis, propose_level, dag_blocks_hashes_with_duplicate_tip,
                                   {trxs[0]->getHash()}, 100000, vdf, node->getSecretKey());
-  EXPECT_EQ(node->getDagManager()->verifyBlock(blk_with_duplicate_tip),
+  EXPECT_EQ(node->getDagManager()->verifyBlock(blk_with_duplicate_tip).first,
             DagManager::VerifyBlockReturnType::FailedTipsVerification);
 }
 
@@ -336,7 +336,7 @@ TEST_F(DagBlockMgrTest, dag_block_tips_proposal) {
 
     DagBlock blk(dag_genesis, propose_level, {}, {trx->getHash()}, dag_block_gas, vdf, node->getSecretKey());
     dag_blocks_hashes.push_back(blk.getHash());
-    EXPECT_EQ(node->getDagManager()->verifyBlock(blk), DagManager::VerifyBlockReturnType::Verified);
+    EXPECT_EQ(node->getDagManager()->verifyBlock(blk).first, DagManager::VerifyBlockReturnType::Verified);
     EXPECT_TRUE(node->getDagManager()->addDagBlock(std::move(blk), {trx}).first);
   }
 
@@ -368,7 +368,7 @@ TEST_F(DagBlockMgrTest, dag_block_tips_proposal) {
 
     DagBlock blk(dag_blocks_hashes[0], propose_level, {}, {trx->getHash()}, 100000, vdf, node->getSecretKey());
     dag_blocks_hashes.push_back(blk.getHash());
-    EXPECT_EQ(node->getDagManager()->verifyBlock(blk), DagManager::VerifyBlockReturnType::Verified);
+    EXPECT_EQ(node->getDagManager()->verifyBlock(blk).first, DagManager::VerifyBlockReturnType::Verified);
     EXPECT_TRUE(node->getDagManager()->addDagBlock(std::move(blk), {trx}).first);
   }
 
@@ -435,7 +435,7 @@ TEST_F(DagBlockMgrTest, too_big_dag_block) {
 
   {
     DagBlock blk(dag_genesis, propose_level, {}, hashes, estimations, vdf1, node->getSecretKey());
-    EXPECT_EQ(node->getDagManager()->verifyBlock(std::move(blk)), DagManager::VerifyBlockReturnType::BlockTooBig);
+    EXPECT_EQ(node->getDagManager()->verifyBlock(std::move(blk)).first, DagManager::VerifyBlockReturnType::BlockTooBig);
   }
 }
 

--- a/tests/network_test.cpp
+++ b/tests/network_test.cpp
@@ -125,10 +125,10 @@ TEST_F(NetworkTest, transfer_lot_of_blocks) {
 
   for (auto trx : trxs) {
     auto tx = trx;
-    node1->getTransactionManager()->insertValidatedTransaction(std::move(tx), TransactionStatus::Verified);
+    node1->getTransactionManager()->insertValidatedTransaction(std::move(tx));
   }
   for (size_t i = 0; i < dag_blocks.size(); i++) {
-    if (dag_mgr1->verifyBlock(*dag_blocks[i]) == DagManager::VerifyBlockReturnType::Verified)
+    if (dag_mgr1->verifyBlock(*dag_blocks[i]).first == DagManager::VerifyBlockReturnType::Verified)
       dag_mgr1->addDagBlock(DagBlock(*dag_blocks[i]), {trxs[i]});
   }
   wait({1s, 200ms}, [&](auto& ctx) { WAIT_EXPECT_NE(ctx, dag_mgr1->getDagBlock(block_hash), nullptr) });
@@ -478,8 +478,8 @@ TEST_F(NetworkTest, node_sync) {
   blks.push_back(std::make_pair(blk6, g_signed_trx_samples[6]));
 
   for (size_t i = 0; i < blks.size(); ++i) {
-    node1->getTransactionManager()->insertValidatedTransaction(std::move(blks[i].second), TransactionStatus::Verified);
-    EXPECT_EQ(node1->getDagManager()->verifyBlock(blks[i].first), DagManager::VerifyBlockReturnType::Verified);
+    node1->getTransactionManager()->insertValidatedTransaction(std::move(blks[i].second));
+    EXPECT_EQ(node1->getDagManager()->verifyBlock(blks[i].first).first, DagManager::VerifyBlockReturnType::Verified);
     node1->getDagManager()->addDagBlock(std::move(blks[i].first));
   }
 
@@ -527,10 +527,8 @@ TEST_F(NetworkTest, node_pbft_sync) {
   vdf1.computeVdfSolution(vdf_config, vdf_msg1, false);
   DagBlock blk1(dag_genesis, 1, {}, {g_signed_trx_samples[0]->getHash(), g_signed_trx_samples[1]->getHash()}, 0, vdf1,
                 sk);
-  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr<Transaction>(g_signed_trx_samples[0]),
-                                                             TransactionStatus::Verified);
-  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr<Transaction>(g_signed_trx_samples[1]),
-                                                             TransactionStatus::Verified);
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr<Transaction>(g_signed_trx_samples[0]));
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr<Transaction>(g_signed_trx_samples[1]));
   node1->getDagManager()->verifyBlock(DagBlock(blk1));
   node1->getDagManager()->addDagBlock(DagBlock(blk1));
 
@@ -581,10 +579,8 @@ TEST_F(NetworkTest, node_pbft_sync) {
   vdf2.computeVdfSolution(vdf_config, vdf_msg2, false);
   DagBlock blk2(blk1.getHash(), 2, {}, {g_signed_trx_samples[2]->getHash(), g_signed_trx_samples[3]->getHash()}, 0,
                 vdf2, sk);
-  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[2]),
-                                                             TransactionStatus::Verified);
-  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[3]),
-                                                             TransactionStatus::Verified);
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[2]));
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[3]));
   node1->getDagManager()->verifyBlock(DagBlock(blk2));
   node1->getDagManager()->addDagBlock(DagBlock(blk2));
 
@@ -678,10 +674,8 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   vdf1.computeVdfSolution(vdf_config, vdf_msg1, false);
   DagBlock blk1(dag_genesis, 1, {}, {g_signed_trx_samples[0]->getHash(), g_signed_trx_samples[1]->getHash()}, 0, vdf1,
                 sk);
-  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[0]),
-                                                             TransactionStatus::Verified);
-  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[1]),
-                                                             TransactionStatus::Verified);
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[0]));
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[1]));
   node1->getDagManager()->verifyBlock(DagBlock(blk1));
   node1->getDagManager()->addDagBlock(DagBlock(blk1));
 
@@ -721,10 +715,8 @@ TEST_F(NetworkTest, node_pbft_sync_without_enough_votes) {
   vdf2.computeVdfSolution(vdf_config, vdf_msg2, false);
   DagBlock blk2(blk1.getHash(), 2, {}, {g_signed_trx_samples[2]->getHash(), g_signed_trx_samples[3]->getHash()}, 0,
                 vdf2, sk);
-  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[2]),
-                                                             TransactionStatus::Verified);
-  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[3]),
-                                                             TransactionStatus::Verified);
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[2]));
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[3]));
   node1->getDagManager()->verifyBlock(DagBlock(blk2));
   node1->getDagManager()->addDagBlock(DagBlock(blk2));
 
@@ -900,8 +892,6 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
   vdf1.computeVdfSolution(vdf_config, vdf_msg1, false);
   DagBlock blk1(dag_genesis, propose_level, {},
                 {g_signed_trx_samples[0]->getHash(), g_signed_trx_samples[1]->getHash()}, 2 * estimation, vdf1, sk);
-  std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> tr1{
-      {g_signed_trx_samples[0], TransactionStatus::Verified}, {g_signed_trx_samples[1], TransactionStatus::Verified}};
 
   propose_level = 2;
   vdf_sortition::VdfSortition vdf2(vdf_config, vrf_sk, VrfSortitionBase::makeVrfInput(propose_level, period_block_hash),
@@ -909,8 +899,6 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
   dev::bytes vdf_msg2 = DagManager::getVdfMessage(blk1.getHash(), {g_signed_trx_samples[2]});
   vdf2.computeVdfSolution(vdf_config, vdf_msg2, false);
   DagBlock blk2(blk1.getHash(), propose_level, {}, {g_signed_trx_samples[2]->getHash()}, estimation, vdf2, sk);
-  std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> tr2{
-      {g_signed_trx_samples[2], TransactionStatus::Verified}};
 
   propose_level = 3;
   vdf_sortition::VdfSortition vdf3(vdf_config, vrf_sk, VrfSortitionBase::makeVrfInput(propose_level, period_block_hash),
@@ -918,8 +906,6 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
   dev::bytes vdf_msg3 = DagManager::getVdfMessage(blk2.getHash(), {g_signed_trx_samples[3]});
   vdf3.computeVdfSolution(vdf_config, vdf_msg3, false);
   DagBlock blk3(blk2.getHash(), propose_level, {}, {g_signed_trx_samples[3]->getHash()}, estimation, vdf3, sk);
-  std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> tr3{
-      {g_signed_trx_samples[3], TransactionStatus::Verified}};
 
   propose_level = 4;
   vdf_sortition::VdfSortition vdf4(vdf_config, vrf_sk, VrfSortitionBase::makeVrfInput(propose_level, period_block_hash),
@@ -927,8 +913,6 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
   dev::bytes vdf_msg4 = DagManager::getVdfMessage(blk3.getHash(), {g_signed_trx_samples[4]});
   vdf4.computeVdfSolution(vdf_config, vdf_msg4, false);
   DagBlock blk4(blk3.getHash(), propose_level, {}, {g_signed_trx_samples[4]->getHash()}, estimation, vdf4, sk);
-  std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> tr4{
-      {g_signed_trx_samples[4], TransactionStatus::Verified}};
 
   propose_level = 5;
   vdf_sortition::VdfSortition vdf5(vdf_config, vrf_sk, VrfSortitionBase::makeVrfInput(propose_level, period_block_hash),
@@ -940,11 +924,6 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
                 {g_signed_trx_samples[5]->getHash(), g_signed_trx_samples[6]->getHash(),
                  g_signed_trx_samples[7]->getHash(), g_signed_trx_samples[8]->getHash()},
                 4 * estimation, vdf5, sk);
-  std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> tr5{
-      {g_signed_trx_samples[5], TransactionStatus::Verified},
-      {g_signed_trx_samples[6], TransactionStatus::Verified},
-      {g_signed_trx_samples[7], TransactionStatus::Verified},
-      {g_signed_trx_samples[8], TransactionStatus::Verified}};
 
   propose_level = 6;
   vdf_sortition::VdfSortition vdf6(vdf_config, vrf_sk, VrfSortitionBase::makeVrfInput(propose_level, period_block_hash),
@@ -953,40 +932,28 @@ TEST_F(NetworkTest, node_sync_with_transactions) {
   vdf6.computeVdfSolution(vdf_config, vdf_msg6, false);
   DagBlock blk6(blk5.getHash(), propose_level, {blk4.getHash(), blk3.getHash()}, {g_signed_trx_samples[9]->getHash()},
                 estimation, vdf6, sk);
-  std::vector<std::pair<std::shared_ptr<Transaction>, TransactionStatus>> tr6{
-      {g_signed_trx_samples[9], TransactionStatus::Verified}};
 
-  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[0]),
-                                                             TransactionStatus::Verified);
-  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[1]),
-                                                             TransactionStatus::Verified);
-  EXPECT_EQ(node1->getDagManager()->verifyBlock(std::move(blk1)), DagManager::VerifyBlockReturnType::Verified);
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[0]));
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[1]));
+  EXPECT_EQ(node1->getDagManager()->verifyBlock(std::move(blk1)).first, DagManager::VerifyBlockReturnType::Verified);
   node1->getDagManager()->addDagBlock(DagBlock(blk1));
-  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[2]),
-                                                             TransactionStatus::Verified);
-  EXPECT_EQ(node1->getDagManager()->verifyBlock(std::move(blk2)), DagManager::VerifyBlockReturnType::Verified);
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[2]));
+  EXPECT_EQ(node1->getDagManager()->verifyBlock(std::move(blk2)).first, DagManager::VerifyBlockReturnType::Verified);
   node1->getDagManager()->addDagBlock(DagBlock(blk2));
-  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[3]),
-                                                             TransactionStatus::Verified);
-  EXPECT_EQ(node1->getDagManager()->verifyBlock(std::move(blk3)), DagManager::VerifyBlockReturnType::Verified);
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[3]));
+  EXPECT_EQ(node1->getDagManager()->verifyBlock(std::move(blk3)).first, DagManager::VerifyBlockReturnType::Verified);
   node1->getDagManager()->addDagBlock(DagBlock(blk3));
-  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[4]),
-                                                             TransactionStatus::Verified);
-  EXPECT_EQ(node1->getDagManager()->verifyBlock(std::move(blk4)), DagManager::VerifyBlockReturnType::Verified);
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[4]));
+  EXPECT_EQ(node1->getDagManager()->verifyBlock(std::move(blk4)).first, DagManager::VerifyBlockReturnType::Verified);
   node1->getDagManager()->addDagBlock(DagBlock(blk4));
-  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[5]),
-                                                             TransactionStatus::Verified);
-  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[6]),
-                                                             TransactionStatus::Verified);
-  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[7]),
-                                                             TransactionStatus::Verified);
-  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[8]),
-                                                             TransactionStatus::Verified);
-  EXPECT_EQ(node1->getDagManager()->verifyBlock(std::move(blk5)), DagManager::VerifyBlockReturnType::Verified);
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[5]));
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[6]));
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[7]));
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[8]));
+  EXPECT_EQ(node1->getDagManager()->verifyBlock(std::move(blk5)).first, DagManager::VerifyBlockReturnType::Verified);
   node1->getDagManager()->addDagBlock(DagBlock(blk5));
-  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[9]),
-                                                             TransactionStatus::Verified);
-  EXPECT_EQ(node1->getDagManager()->verifyBlock(std::move(blk6)), DagManager::VerifyBlockReturnType::Verified);
+  node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(g_signed_trx_samples[9]));
+  EXPECT_EQ(node1->getDagManager()->verifyBlock(std::move(blk6)).first, DagManager::VerifyBlockReturnType::Verified);
   node1->getDagManager()->addDagBlock(DagBlock(blk6));
   // To make sure blocks are stored before starting node 2
   taraxa::thisThreadSleepForMilliSeconds(1000);
@@ -1157,8 +1124,7 @@ TEST_F(NetworkTest, node_sync2) {
   trxs.push_back(tr12);
 
   for (size_t i = 0; i < blks.size(); ++i) {
-    for (auto t : trxs[i])
-      node1->getTransactionManager()->insertValidatedTransaction(std::move(t), TransactionStatus::Verified);
+    for (auto t : trxs[i]) node1->getTransactionManager()->insertValidatedTransaction(std::move(t));
     node1->getDagManager()->verifyBlock(std::move(blks[i]));
     node1->getDagManager()->addDagBlock(DagBlock(blks[i]));
   }
@@ -1186,8 +1152,7 @@ TEST_F(NetworkTest, node_transaction_sync) {
   auto& node1 = nodes[0];
   auto& node2 = nodes[1];
 
-  for (auto t : *g_signed_trx_samples)
-    node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(t), TransactionStatus::Verified);
+  for (auto t : *g_signed_trx_samples) node1->getTransactionManager()->insertValidatedTransaction(std::shared_ptr(t));
 
   std::cout << "Waiting Sync for 2000 milliseconds ..." << std::endl;
   taraxa::thisThreadSleepForMilliSeconds(2000);
@@ -1612,8 +1577,7 @@ TEST_F(NetworkTest, node_full_sync) {
   int num_of_trxs = 50;
   auto trxs = samples::createSignedTrxSamples(0, num_of_trxs, g_secret);
   for (auto i = 0; i < num_of_trxs; ++i) {
-    nodes[distNodes(rng)]->getTransactionManager()->insertValidatedTransaction(std::move(trxs[i]),
-                                                                               TransactionStatus::Verified);
+    nodes[distNodes(rng)]->getTransactionManager()->insertValidatedTransaction(std::move(trxs[i]));
     thisThreadSleepForMilliSeconds(distTransactions(rng));
   }
   ASSERT_EQ(num_of_trxs, 50);  // 50 transactions


### PR DESCRIPTION
Various improvements in processing:

Verification of DAG blocks was retrieving all the transactions from pool/caches/db and than the same transactions were retrieved again when adding the block to the DAG and changing transactions statuses. Now transactions retrieved from the verification are returned from DagManager::VerifyBlock and used in adding the DAG block which speeds up DAG block/transactions processing.

Any transactions received in the dag block and dag sync packet is processed directly in adding the dag block packet without previously being saved in transactions pool. This makes processing dag blocks with transactions faster.

DagBlockPacket is modified to include any transactions not already sent to the peer.

Recently finalized transaction is enforced to always contain all the transactions that are pushed in the pbft chain but might not yet be executed. Using this by confirming that a transaction nonce is valid and transaction is not a part of the recently finalized transactions cache, this ensures that this is a new transactions without having to check all the history of transactions. This rule is applied when verifying and inserting new transactions with additional minor improvements to improve performance on transactions insertions.

Single account transactions size in memory pool is limited to 5% of max size.

Scheduled removal of transactions from memory pool is added to avoid skip nonce transactions to remain in the pool forever.

Limit packets processing threads to hardware concurrency. Large number of threads impacts performance because of same data being processed in parallel on too many threads received from multiple peers at the same time causing packets queue to grow in size.