### PR TITLE
chore: increase gas limit

### DIFF
--- a/libraries/cli/include/cli/config_jsons/default/default_genesis.json
+++ b/libraries/cli/include/cli/config_jsons/default/default_genesis.json
@@ -120,7 +120,9 @@
       "pillar_blocks_interval": 100,
       "pillar_chain_sync_interval": 25,
       "pbft_inclusion_delay": 6,
-      "bridge_contract_address": "0xcAF2b453FE8382a4B8110356DF0508f6d71F22BF"
+      "bridge_contract_address": "0xcAF2b453FE8382a4B8110356DF0508f6d71F22BF",
+      "dag_gas_limit" : "0x1908B100",
+      "pbft_gas_limit" : "0x7d2b7500"
     }
   }
 }

--- a/libraries/cli/include/cli/config_jsons/devnet/devnet_config.json
+++ b/libraries/cli/include/cli/config_jsons/devnet/devnet_config.json
@@ -24,7 +24,7 @@
       "packets_stats_time_period_ms": 60000,
       "peer_max_packets_processing_time_us": 10000000,
       "peer_max_packets_queue_size_limit": 100000,
-      "max_packets_queue_size": 200000
+      "max_packets_queue_size": 50
     },
     "listen_ip": "0.0.0.0",
     "listen_port": 10002,

--- a/libraries/cli/include/cli/config_jsons/devnet/devnet_genesis.json
+++ b/libraries/cli/include/cli/config_jsons/devnet/devnet_genesis.json
@@ -285,7 +285,9 @@
       "pillar_blocks_interval": 100,
       "pillar_chain_sync_interval": 25,
       "pbft_inclusion_delay": 6,
-      "bridge_contract_address": "0xcAF2b453FE8382a4B8110356DF0508f6d71F22BF"
+      "bridge_contract_address": "0xcAF2b453FE8382a4B8110356DF0508f6d71F22BF",
+      "dag_gas_limit" : "0x1908B100",
+      "pbft_gas_limit" : "0x7d2b7500"
     }
   }
 }

--- a/libraries/cli/include/cli/config_jsons/mainnet/mainnet_genesis.json
+++ b/libraries/cli/include/cli/config_jsons/mainnet/mainnet_genesis.json
@@ -1654,7 +1654,9 @@
       "pillar_blocks_interval": 100,
       "pillar_chain_sync_interval": 25,
       "pbft_inclusion_delay": 6,
-      "bridge_contract_address": "0x0000000000000000000000000000000000000000"
+      "bridge_contract_address": "0x0000000000000000000000000000000000000000",
+      "dag_gas_limit" : "0x1908B100",
+      "pbft_gas_limit" : "0x7d2b7500"
     }
   }
 }

--- a/libraries/cli/include/cli/config_jsons/testnet/testnet_config.json
+++ b/libraries/cli/include/cli/config_jsons/testnet/testnet_config.json
@@ -24,7 +24,7 @@
       "packets_stats_time_period_ms": 60000,
       "peer_max_packets_processing_time_us": 0,
       "peer_max_packets_queue_size_limit": 0,
-      "max_packets_queue_size": 200000
+      "max_packets_queue_size": 50
     },
     "listen_ip": "0.0.0.0",
     "listen_port": 10002,

--- a/libraries/cli/include/cli/config_jsons/testnet/testnet_genesis.json
+++ b/libraries/cli/include/cli/config_jsons/testnet/testnet_genesis.json
@@ -154,7 +154,9 @@
       "pillar_blocks_interval": 100,
       "pillar_chain_sync_interval": 25,
       "pbft_inclusion_delay": 6,
-      "bridge_contract_address": "0x0000000000000000000000000000000000000000"
+      "bridge_contract_address": "0x0000000000000000000000000000000000000000",
+      "dag_gas_limit" : "0x1908B100",
+      "pbft_gas_limit" : "0x7d2b7500"
     }
   }
 }

--- a/libraries/common/include/common/constants.hpp
+++ b/libraries/common/include/common/constants.hpp
@@ -30,6 +30,8 @@ const uint64_t kMinTxGas{21000};
 constexpr uint32_t kMinTransactionPoolSize{30000};
 constexpr uint32_t kDefaultTransactionPoolSize{200000};
 
+constexpr uint32_t kMaxNonFinalizedTransactions{1000000};
+
 const size_t kV2NetworkVersion = 2;
 
 const uint32_t kRecentlyFinalizedTransactionsFactor = 2;

--- a/libraries/config/include/config/hardfork.hpp
+++ b/libraries/config/include/config/hardfork.hpp
@@ -48,6 +48,10 @@ struct FicusHardforkConfig {
       6};  // [periods] how many periods after the pillar block is created it is included in pbft block
   taraxa::addr_t bridge_contract_address;  // [address] of the bridge contract
 
+  // New gas limit after the hardfork
+  uint64_t dag_gas_limit{0x1908B100};
+  uint64_t pbft_gas_limit{0x7d2b7500};
+
   bool isFicusHardfork(taraxa::PbftPeriod period) const;
 
   /**

--- a/libraries/config/include/config/network.hpp
+++ b/libraries/config/include/config/network.hpp
@@ -53,6 +53,9 @@ struct DdosProtectionConfig {
   // Max packets queue size, 0 means unlimited
   uint64_t max_packets_queue_size{0};
 
+  // Time period between disconnecting peers
+  std::chrono::milliseconds peer_disconnect_interval{5000};
+
   void validate(uint32_t delegation_delay) const;
 };
 

--- a/libraries/config/src/hardfork.cpp
+++ b/libraries/config/src/hardfork.cpp
@@ -53,7 +53,8 @@ RLP_FIELDS_DEFINE(AspenHardfork, block_num_part_one, block_num_part_two, max_sup
 bool FicusHardforkConfig::isFicusHardfork(taraxa::PbftPeriod period) const { return period >= block_num; }
 
 bool FicusHardforkConfig::isPillarBlockPeriod(taraxa::PbftPeriod period, bool skip_first_pillar_block) const {
-  return period >= block_num && period >= firstPillarBlockPeriod() + (skip_first_pillar_block ? 1 : 0) * pillar_blocks_interval &&
+  return period >= block_num &&
+         period >= firstPillarBlockPeriod() + (skip_first_pillar_block ? 1 : 0) * pillar_blocks_interval &&
          period % pillar_blocks_interval == 0;
 }
 
@@ -96,6 +97,8 @@ Json::Value enc_json(const FicusHardforkConfig& obj) {
   json["pillar_chain_sync_interval"] = dev::toJS(obj.pillar_chain_sync_interval);
   json["pbft_inclusion_delay"] = dev::toJS(obj.pbft_inclusion_delay);
   json["bridge_contract_address"] = dev::toJS(obj.bridge_contract_address);
+  json["dag_gas_limit"] = dev::toJS(obj.dag_gas_limit);
+  json["pbft_gas_limit"] = dev::toJS(obj.pbft_gas_limit);
   return json;
 }
 
@@ -105,6 +108,8 @@ void dec_json(const Json::Value& json, FicusHardforkConfig& obj) {
   obj.pillar_chain_sync_interval = dev::getUInt(json["pillar_chain_sync_interval"]);
   obj.pbft_inclusion_delay = dev::getUInt(json["pbft_inclusion_delay"]);
   obj.bridge_contract_address = taraxa::addr_t(json["bridge_contract_address"].asString());
+  obj.dag_gas_limit = dev::getUInt(json["dag_gas_limit"]);
+  obj.pbft_gas_limit = dev::getUInt(json["pbft_gas_limit"]);
 }
 
 RLP_FIELDS_DEFINE(FicusHardforkConfig, block_num, pillar_blocks_interval, pillar_chain_sync_interval,

--- a/libraries/core_libs/consensus/include/dag/dag_block_proposer.hpp
+++ b/libraries/core_libs/consensus/include/dag/dag_block_proposer.hpp
@@ -93,9 +93,10 @@ class DagBlockProposer {
    * @param trxs transactions to be included in the block
    * @param estimations transactions gas estimation
    * @param vdf vdf with correct difficulty calculation
+   * @param pbft_gas_limit pbft_gas_limit
    */
   DagBlock createDagBlock(DagFrontier&& frontier, level_t level, const SharedTransactions& trxs,
-                          std::vector<uint64_t>&& estimations, VdfSortition&& vdf) const;
+                          std::vector<uint64_t>&& estimations, VdfSortition&& vdf, uint64_t pbft_gas_limit) const;
 
   /**
    * @brief Gets transactions to include in the block - sharding not supported yet

--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -226,9 +226,10 @@ class PbftManager {
   /**
    * @brief Check a block weight of gas estimation
    * @param dag_blocks dag blocks
+   * @param period period
    * @return true if total weight of gas estimation is less or equal to gas limit. Otherwise return false
    */
-  bool checkBlockWeight(const std::vector<DagBlock> &dag_blocks) const;
+  bool checkBlockWeight(const std::vector<DagBlock> &dag_blocks, PbftPeriod period) const;
 
   blk_hash_t getLastPbftBlockHash();
 

--- a/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
+++ b/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
@@ -28,6 +28,10 @@ uint64_t TransactionManager::estimateTransactionGas(std::shared_ptr<Transaction>
   if (trx->getGas() <= kEstimateGasLimit) {
     return trx->getGas();
   }
+  auto gas_limit = kDagBlockGasLimit;
+  if (kConf.genesis.state.hardforks.ficus_hf.isFicusHardfork(*proposal_period)) {
+    gas_limit = kConf.genesis.state.hardforks.ficus_hf.dag_gas_limit;
+  }
   const auto &result = final_chain_->call(
       state_api::EVMTransaction{
           trx->getSender(),
@@ -35,7 +39,7 @@ uint64_t TransactionManager::estimateTransactionGas(std::shared_ptr<Transaction>
           trx->getReceiver(),
           trx->getNonce(),
           trx->getValue(),
-          kDagBlockGasLimit,
+          gas_limit,
           trx->getData(),
       },
       proposal_period);

--- a/libraries/core_libs/network/include/network/network.hpp
+++ b/libraries/core_libs/network/include/network/network.hpp
@@ -77,6 +77,13 @@ class Network {
    */
   void requestPillarBlockVotesBundle(PbftPeriod period, const blk_hash_t &pillar_block_hash);
 
+  /**
+   * @brief Get packets queue status
+   *
+   * @return true if packets queue is over the limit
+   */
+  bool packetQueueOverLimit() const;
+
   // METHODS USED IN TESTS ONLY
   template <typename PacketHandlerType>
   std::shared_ptr<PacketHandlerType> getSpecificHandler() const;

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
@@ -116,6 +116,9 @@ class TaraxaCapability final : public dev::p2p::CapabilityFace {
   // Main Threadpool for processing packets
   std::shared_ptr<threadpool::PacketsThreadPool> thread_pool_;
 
+  // Last disconnect time
+  std::chrono::_V2::system_clock::time_point last_ddos_disconnect_time_;
+
   LOG_OBJECTS_DEFINE
 };
 

--- a/libraries/core_libs/network/src/network.cpp
+++ b/libraries/core_libs/network/src/network.cpp
@@ -129,6 +129,12 @@ void Network::start() {
 
 bool Network::isStarted() { return tp_.is_running(); }
 
+bool Network::packetQueueOverLimit() const {
+  auto [hp_queue_size, mp_queue_size, lp_queue_size] = packets_tp_->getQueueSize();
+  auto total_size = hp_queue_size + mp_queue_size + lp_queue_size;
+  return total_size > kConf.network.ddos_protection.max_packets_queue_size;
+}
+
 std::list<dev::p2p::NodeEntry> Network::getAllNodes() const { return host_->getNodes(); }
 
 size_t Network::getPeerCount() { return host_->peer_count(); }

--- a/tests/dag_block_test.cpp
+++ b/tests/dag_block_test.cpp
@@ -406,6 +406,7 @@ TEST_F(DagBlockMgrTest, too_big_dag_block) {
   // make config
   auto node_cfgs = make_node_cfgs(1, 1, 20);
   node_cfgs.front().genesis.dag.gas_limit = 500000;
+  node_cfgs.front().genesis.state.hardforks.ficus_hf.block_num = 2;
 
   auto node = create_nodes(node_cfgs).front();
   auto db = node->getDB();
@@ -419,7 +420,7 @@ TEST_F(DagBlockMgrTest, too_big_dag_block) {
     auto [ok, err_msg] = node->getTransactionManager()->insertTransaction(create_trx);
     EXPECT_EQ(ok, true);
     hashes.emplace_back(create_trx->getHash());
-    const auto& e = node->getTransactionManager()->estimateTransactionGas(create_trx, std::nullopt);
+    const auto& e = node->getTransactionManager()->estimateTransactionGas(create_trx, 0);
     estimations += e;
   }
 

--- a/tests/pbft_manager_test.cpp
+++ b/tests/pbft_manager_test.cpp
@@ -539,6 +539,7 @@ TEST_F(PbftManagerWithDagCreation, dag_generation) {
 TEST_F(PbftManagerWithDagCreation, limit_dag_block_size) {
   auto node_cfgs = make_node_cfgs(1, 1, 5, true);
   node_cfgs.front().genesis.dag.gas_limit = 500000;
+  node_cfgs.front().genesis.state.hardforks.ficus_hf.block_num = 100;
   makeNodeFromConfig(node_cfgs);
   deployContract();
 
@@ -631,6 +632,7 @@ TEST_F(PbftManagerWithDagCreation, produce_overweighted_block) {
   auto node_cfgs = make_node_cfgs(1, 1, 5, true);
   auto dag_gas_limit = node_cfgs.front().genesis.dag.gas_limit = 500000;
   node_cfgs.front().genesis.pbft.gas_limit = 1100000;
+  node_cfgs.front().genesis.state.hardforks.ficus_hf.block_num = 100;
   makeNodeFromConfig(node_cfgs);
 
   deployContract();
@@ -666,7 +668,7 @@ TEST_F(PbftManagerWithDagCreation, produce_overweighted_block) {
   auto period_raw = node->getDB()->getPeriodDataRaw(period);
   ASSERT_FALSE(period_raw.empty());
   PeriodData period_data(period_raw);
-  EXPECT_FALSE(node->getPbftManager()->checkBlockWeight(period_data.dag_blocks));
+  EXPECT_FALSE(node->getPbftManager()->checkBlockWeight(period_data.dag_blocks, period));
 }
 
 TEST_F(PbftManagerWithDagCreation, proposed_blocks) {


### PR DESCRIPTION
- Increase dag and pbft gas limit on testnet and mainnet as part of ficus HF
- As soon as the packets queue go over 50 start disconnecting peers since any delay in queue processing basically makes node useless. Disconnecting peers is now done one by one in intervals of 5 seconds
- Do not produce DAG blocks if non finalized transactions are over the limit (protection for memory not to grow too large with large DAG blocks)
- Do not produce DAG blocks if queue is over the limit since the queue contains DAG blocks
