### PR TITLE
increase minor version + genesis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 3.20)
 
 # Set current version of the project
 set(TARAXA_MAJOR_VERSION 1)
-set(TARAXA_MINOR_VERSION 9)
-set(TARAXA_PATCH_VERSION 3)
+set(TARAXA_MINOR_VERSION 10)
+set(TARAXA_PATCH_VERSION 0)
 set(TARAXA_VERSION ${TARAXA_MAJOR_VERSION}.${TARAXA_MINOR_VERSION}.${TARAXA_PATCH_VERSION})
 
 # Any time a change in the network protocol is introduced this version should be increased

--- a/libraries/cli/include/cli/config_jsons/mainnet/mainnet_genesis.json
+++ b/libraries/cli/include/cli/config_jsons/mainnet/mainnet_genesis.json
@@ -1650,9 +1650,9 @@
       "generated_rewards": "0x105674788D280AE305A6EC0"
     },
     "ficus_hf": {
-      "block_num": -1,
-      "pillar_blocks_interval": 100,
-      "bridge_contract_address": "0x0000000000000000000000000000000000000000"
+      "block_num": 11616000,
+      "pillar_blocks_interval": 4000,
+      "bridge_contract_address": "0xe126E0BaeAE904b8Cfd619Be1A8667A173b763a1"
     }
   }
 }

--- a/libraries/cli/include/cli/config_jsons/testnet/testnet_config.json
+++ b/libraries/cli/include/cli/config_jsons/testnet/testnet_config.json
@@ -38,17 +38,17 @@
     "boot_nodes": [
       {
         "id": "f36f467529fe91a750dfdc8086fd0d2f30bad9f55a5800b6b4aa603c7787501db78dc4ac1bf3cf16e42af7c2ebb53648653013c3da1987494960d751871d598a",
-        "ip": "boot-node-3.testnet.taraxa.io",
+        "ip": "boot-node-0.testnet.taraxa.io",
         "port": 10002
       },
       {
         "id": "d2d445fc3276bdbf2a07628a484baabf45ccb91d6aa078a0dc3aefc11f1941899a923312ec0e664b8e57b63b774c47a006d9d1d16befd2135dcf76067736c688",
-        "ip": "boot-node-4.testnet.taraxa.io",
+        "ip": "boot-node-1.testnet.taraxa.io",
         "port": 10002
       },
       {
         "id": "c6e7263f44d88c0d6cc3b0d5ebdc31cf891908e8fa7e545e137d3ed0bfec1810fa24c1379228afbb53df0d59e716e17138115fd096782a84261718ab77665171",
-        "ip": "boot-node-5.testnet.taraxa.io",
+        "ip": "boot-node-2.testnet.taraxa.io",
         "port": 10002
       }
     ]

--- a/libraries/cli/include/cli/config_jsons/testnet/testnet_genesis.json
+++ b/libraries/cli/include/cli/config_jsons/testnet/testnet_genesis.json
@@ -151,7 +151,7 @@
     },
     "ficus_hf": {
       "block_num": 1000,
-      "pillar_blocks_interval": 100,
+      "pillar_blocks_interval": 1000,
       "bridge_contract_address": "0xcAF2b453FE8382a4B8110356DF0508f6d71F22BF"
     }
   }

--- a/libraries/cli/include/cli/config_jsons/testnet/testnet_genesis.json
+++ b/libraries/cli/include/cli/config_jsons/testnet/testnet_genesis.json
@@ -4,7 +4,7 @@
     "level": "0x0",
     "pivot": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "sig": "0xb7e22d46c1ba94d5e8347b01d137b5c428fcbbeaf0a77fb024cbbf1517656ff00d04f7f25be608c321b0d7483c402c294ff46c49b265305d046a52236c0a363701",
-    "timestamp": "0x66827F92",
+    "timestamp": "0x669f7f20",
     "tips": [],
     "transactions": []
   },


### PR DESCRIPTION
## Purpose
<!-- Provide any information reviewers might need to have context on your changes. -->

- new pillar chain implementation
- node version 1.10.0
- changed boot nodes dns to 0,1,2
- timestamo changed to Tuesday, Jul 23, 2024 10:00:00.000 AM

## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
