### PR TITLE
chore: dag block proposal limit

### DIFF
--- a/libraries/cli/include/cli/config_jsons/default/default_config.json
+++ b/libraries/cli/include/cli/config_jsons/default/default_config.json
@@ -24,7 +24,7 @@
       "packets_stats_time_period_ms": 60000,
       "peer_max_packets_processing_time_us": 10000000,
       "peer_max_packets_queue_size_limit": 100000,
-      "max_packets_queue_size": 200000
+      "max_packets_queue_size": 100
     },
     "listen_ip": "0.0.0.0",
     "listen_port": 10002,

--- a/libraries/cli/include/cli/config_jsons/devnet/devnet_config.json
+++ b/libraries/cli/include/cli/config_jsons/devnet/devnet_config.json
@@ -24,7 +24,7 @@
       "packets_stats_time_period_ms": 60000,
       "peer_max_packets_processing_time_us": 10000000,
       "peer_max_packets_queue_size_limit": 100000,
-      "max_packets_queue_size": 200000
+      "max_packets_queue_size": 100
     },
     "listen_ip": "0.0.0.0",
     "listen_port": 10002,

--- a/libraries/cli/include/cli/config_jsons/mainnet/mainnet_config.json
+++ b/libraries/cli/include/cli/config_jsons/mainnet/mainnet_config.json
@@ -24,7 +24,7 @@
       "packets_stats_time_period_ms": 60000,
       "peer_max_packets_processing_time_us": 0,
       "peer_max_packets_queue_size_limit": 0,
-      "max_packets_queue_size": 200000
+      "max_packets_queue_size": 100
     },
     "listen_ip": "0.0.0.0",
     "listen_port": 10002,

--- a/libraries/cli/include/cli/config_jsons/testnet/testnet_config.json
+++ b/libraries/cli/include/cli/config_jsons/testnet/testnet_config.json
@@ -24,7 +24,7 @@
       "packets_stats_time_period_ms": 60000,
       "peer_max_packets_processing_time_us": 0,
       "peer_max_packets_queue_size_limit": 0,
-      "max_packets_queue_size": 200000
+      "max_packets_queue_size": 100
     },
     "listen_ip": "0.0.0.0",
     "listen_port": 10002,

--- a/libraries/common/include/common/constants.hpp
+++ b/libraries/common/include/common/constants.hpp
@@ -29,6 +29,7 @@ const uint64_t kMinTxGas{21000};
 
 constexpr uint32_t kMinTransactionPoolSize{30000};
 constexpr uint32_t kDefaultTransactionPoolSize{200000};
+constexpr uint32_t kMaxNonFinalizedTransactions{1000000};
 
 const size_t kV2NetworkVersion = 2;
 

--- a/libraries/core_libs/network/include/network/network.hpp
+++ b/libraries/core_libs/network/include/network/network.hpp
@@ -77,6 +77,13 @@ class Network {
    */
   void requestPillarBlockVotesBundle(PbftPeriod period, const blk_hash_t &pillar_block_hash);
 
+  /**
+   * @brief Get packets queue status
+   *
+   * @return true if packets queue is over the limit
+   */
+  bool packetQueueOverLimit() const;
+
   // METHODS USED IN TESTS ONLY
   template <typename PacketHandlerType>
   std::shared_ptr<PacketHandlerType> getSpecificHandler() const;

--- a/libraries/core_libs/network/src/network.cpp
+++ b/libraries/core_libs/network/src/network.cpp
@@ -132,6 +132,12 @@ void Network::start() {
 
 bool Network::isStarted() { return tp_.is_running(); }
 
+bool Network::packetQueueOverLimit() const {
+  auto [hp_queue_size, mp_queue_size, lp_queue_size] = packets_tp_->getQueueSize();
+  auto total_size = hp_queue_size + mp_queue_size + lp_queue_size;
+  return total_size > kConf.network.ddos_protection.max_packets_queue_size;
+}
+
 std::list<dev::p2p::NodeEntry> Network::getAllNodes() const { return host_->getNodes(); }
 
 size_t Network::getPeerCount() { return host_->peer_count(); }


### PR DESCRIPTION
On high transactions per second load on the network dag block and transactions packets start queueing up in the packet queue. This causes delays in receiving DAG block packets which makes nodes propose dag blocks with high difficulty or even stale since the low difficulty dag blocks are not received in time. This causes a chain reaction with more dag block being produced it is less likely for the network to digest it in time. At the same time this causes a large build up of non-finalized dag blocks ans transations.
To prevent this:
Node is not to produce a dag block if the queue is over the queue limit
Node is not to produce a dag block if total non finalized transactions are over the limit

