### PR TITLE
chore: add rpc for retrieving nodes versions

### DIFF
--- a/libraries/core_libs/network/rpc/Taraxa.cpp
+++ b/libraries/core_libs/network/rpc/Taraxa.cpp
@@ -110,6 +110,58 @@ Json::Value Taraxa::taraxa_getScheduleBlockByPeriod(const std::string& _period) 
   }
 }
 
+Json::Value Taraxa::taraxa_getNodeVersions() {
+  try {
+    Json::Value res;
+    auto node = tryGetNode();
+    auto db = node->getDB();
+    auto period = node->getFinalChain()->last_block_number();
+    const uint64_t max_blocks_to_process = 6000;
+    std::map<addr_t, std::string> node_version_map;
+    std::multimap<std::string, std::pair<addr_t, uint64_t>> version_node_map;
+    std::map<std::string, std::pair<uint32_t, uint32_t>> version_count;
+    for (uint64_t i = period; i > 0 && period - i < max_blocks_to_process; i--) {
+      auto blk = db->getPbftBlock(i);
+      if (!blk.has_value()) {
+        break;
+      }
+      if (!node_version_map.contains(blk->getBeneficiary())) {
+        node_version_map[blk->getBeneficiary()] = blk->getExtraData()->getJson()["major_version"].asString() + "." +
+                                                  blk->getExtraData()->getJson()["minor_version"].asString() + "." +
+                                                  blk->getExtraData()->getJson()["patch_version"].asString();
+      }
+    }
+
+    auto total_vote_count = node->getFinalChain()->dpos_eligible_total_vote_count(period);
+    for (auto nv : node_version_map) {
+      auto vote_count = node->getFinalChain()->dpos_eligible_vote_count(period, nv.first);
+      version_node_map.insert({nv.second, {nv.first, vote_count}});
+      version_count[nv.second].first++;
+      version_count[nv.second].second += vote_count;
+    }
+
+    res["nodes"] = Json::Value(Json::arrayValue);
+    for (auto vn : version_node_map) {
+      Json::Value node_json;
+      node_json["node"] = vn.second.first.toString();
+      node_json["version"] = vn.first;
+      node_json["vote_count"] = vn.second.second;
+      res["nodes"].append(node_json);
+    }
+    res["versions"] = Json::Value(Json::arrayValue);
+    for (auto vc : version_count) {
+      Json::Value version_json;
+      version_json["version"] = vc.first;
+      version_json["node_count"] = vc.second.first;
+      version_json["vote_percentage"] = vc.second.second * 100 / total_vote_count;
+      res["versions"].append(version_json);
+    }
+    return res;
+  } catch (...) {
+    BOOST_THROW_EXCEPTION(JsonRpcException(Errors::ERROR_RPC_INVALID_PARAMS));
+  }
+}
+
 Json::Value Taraxa::taraxa_getDagBlockByLevel(const string& _blockLevel, bool _includeTransactions) {
   try {
     auto node = tryGetNode();

--- a/libraries/core_libs/network/rpc/Taraxa.h
+++ b/libraries/core_libs/network/rpc/Taraxa.h
@@ -26,6 +26,7 @@ class Taraxa : public TaraxaFace {
   virtual std::string taraxa_dagBlockLevel() override;
   virtual std::string taraxa_dagBlockPeriod() override;
   virtual Json::Value taraxa_getScheduleBlockByPeriod(const std::string& _period) override;
+  virtual Json::Value taraxa_getNodeVersions() override;
   virtual std::string taraxa_pbftBlockHashByPeriod(const std::string& _period) override;
   virtual Json::Value taraxa_getConfig() override;
   virtual Json::Value taraxa_getChainStats() override;

--- a/libraries/core_libs/network/rpc/Taraxa.jsonrpc.json
+++ b/libraries/core_libs/network/rpc/Taraxa.jsonrpc.json
@@ -48,6 +48,12 @@
     "returns": {}
   },
   {
+    "name": "taraxa_getNodeVersions",
+    "params": [],
+    "order": [],
+    "returns": {}
+  },
+  {
     "name": "taraxa_getConfig",
     "params": [],
     "order": [],

--- a/libraries/core_libs/network/rpc/TaraxaClient.h
+++ b/libraries/core_libs/network/rpc/TaraxaClient.h
@@ -79,6 +79,15 @@ class TaraxaClient : public jsonrpc::Client {
     else
       throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
   }
+  Json::Value taraxa_getNodeVersions() throw(jsonrpc::JsonRpcException) {
+    Json::Value p;
+    p = Json::nullValue;
+    Json::Value result = this->CallMethod("taraxa_getNodeVersions", p);
+    if (result.isObject())
+      return result;
+    else
+      throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
+  }
   Json::Value taraxa_getConfig() throw(jsonrpc::JsonRpcException) {
     Json::Value p;
     p = Json::nullValue;

--- a/libraries/core_libs/network/rpc/TaraxaFace.h
+++ b/libraries/core_libs/network/rpc/TaraxaFace.h
@@ -38,6 +38,9 @@ class TaraxaFace : public ServerInterface<TaraxaFace> {
                                               jsonrpc::JSON_OBJECT, "param1", jsonrpc::JSON_STRING, NULL),
                            &taraxa::net::TaraxaFace::taraxa_getScheduleBlockByPeriodI);
     this->bindAndAddMethod(
+        jsonrpc::Procedure("taraxa_getNodeVersions", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, NULL),
+        &taraxa::net::TaraxaFace::taraxa_getNodeVersionsI);
+    this->bindAndAddMethod(
         jsonrpc::Procedure("taraxa_getConfig", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, NULL),
         &taraxa::net::TaraxaFace::taraxa_getConfigI);
     this->bindAndAddMethod(
@@ -83,6 +86,10 @@ class TaraxaFace : public ServerInterface<TaraxaFace> {
   inline virtual void taraxa_getScheduleBlockByPeriodI(const Json::Value &request, Json::Value &response) {
     response = this->taraxa_getScheduleBlockByPeriod(request[0u].asString());
   }
+  inline virtual void taraxa_getNodeVersionsI(const Json::Value &request, Json::Value &response) {
+    (void)request;
+    response = this->taraxa_getNodeVersions();
+  }
   inline virtual void taraxa_getConfigI(const Json::Value &request, Json::Value &response) {
     (void)request;
     response = this->taraxa_getConfig();
@@ -114,6 +121,7 @@ class TaraxaFace : public ServerInterface<TaraxaFace> {
   virtual std::string taraxa_dagBlockLevel() = 0;
   virtual std::string taraxa_dagBlockPeriod() = 0;
   virtual Json::Value taraxa_getScheduleBlockByPeriod(const std::string &param1) = 0;
+  virtual Json::Value taraxa_getNodeVersions() = 0;
   virtual Json::Value taraxa_getConfig() = 0;
   virtual Json::Value taraxa_getChainStats() = 0;
   virtual std::string taraxa_pbftBlockHashByPeriod(const std::string &param1) = 0;

--- a/libraries/core_libs/node/src/node.cpp
+++ b/libraries/core_libs/node/src/node.cpp
@@ -214,10 +214,10 @@ void FullNode::start() {
 
     auto eth_json_rpc = net::rpc::eth::NewEth(std::move(eth_rpc_params));
     std::shared_ptr<net::Test> test_json_rpc;
-    if (conf_.enable_test_rpc) {
-      // TODO Because this object refers to FullNode, the lifecycle/dependency management is more complicated);
-      test_json_rpc = std::make_shared<net::Test>(shared_from_this());
-    }
+    // if (conf_.enable_test_rpc) {
+    //  TODO Because this object refers to FullNode, the lifecycle/dependency management is more complicated);
+    test_json_rpc = std::make_shared<net::Test>(shared_from_this());
+    //}
 
     std::shared_ptr<net::Debug> debug_json_rpc;
     if (conf_.enable_debug) {


### PR DESCRIPTION
RPC getNodeVersions will retrieve version for any node that produced a pbft block within last 6000 blocks(6 hours) and provide a summary of how many nodes are running each individual version.