### PR TITLE
chore: queue limit improvements

### DIFF
--- a/libraries/config/include/config/network.hpp
+++ b/libraries/config/include/config/network.hpp
@@ -53,6 +53,12 @@ struct DdosProtectionConfig {
   // Max packets queue size, 0 means unlimited
   uint64_t max_packets_queue_size{0};
 
+  // Time of allowed queue over the limit
+  std::chrono::milliseconds queue_limit_time{5000};
+
+  // Time period between disconnecting peers
+  std::chrono::milliseconds peer_disconnect_interval{5000};
+
   void validate(uint32_t delegation_delay) const;
 };
 

--- a/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
+++ b/libraries/core_libs/network/include/network/tarcap/taraxa_capability.hpp
@@ -93,6 +93,7 @@ class TaraxaCapability final : public dev::p2p::CapabilityFace {
 
  private:
   bool filterSyncIrrelevantPackets(SubprotocolPacketType packet_type) const;
+  void handlePacketQueueOverLimit(std::shared_ptr<dev::p2p::Host> host, dev::p2p::NodeID node_id, size_t tp_queue_size);
 
  private:
   // Capability version
@@ -115,6 +116,12 @@ class TaraxaCapability final : public dev::p2p::CapabilityFace {
 
   // Main Threadpool for processing packets
   std::shared_ptr<threadpool::PacketsThreadPool> thread_pool_;
+
+  // Last disconnect time and number of peers
+  std::chrono::_V2::system_clock::time_point last_ddos_disconnect_time_ = {};
+  std::chrono::_V2::system_clock::time_point queue_over_limit_start_time_ = {};
+  bool queue_over_limit_ = false;
+  uint32_t last_disconnect_number_of_peers_ = 0;
 
   LOG_OBJECTS_DEFINE
 };

--- a/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
+++ b/libraries/core_libs/network/src/tarcap/taraxa_capability.cpp
@@ -77,6 +77,13 @@ void TaraxaCapability::onConnect(std::weak_ptr<dev::p2p::Session> session, u256 
     return;
   }
 
+  // If queue is over the limit do not allow new nodes to connect until queue size is reduced
+  if (queue_over_limit_ && peers_state_->getPeersCount() >= last_disconnect_number_of_peers_) {
+    session_p->disconnect(dev::p2p::UserReason);
+    LOG(log_wr_) << "Node " << node_id << " connection dropped - queue over limit";
+    return;
+  }
+
   peers_state_->addPendingPeer(node_id, session_p->info().host + ":" + std::to_string(session_p->info().port));
   LOG(log_nf_) << "Node " << node_id << " connected";
 
@@ -166,33 +173,55 @@ void TaraxaCapability::interpretCapabilityPacket(std::weak_ptr<dev::p2p::Session
   // Check max allowed packets queue size
   if (kConf.network.ddos_protection.max_packets_queue_size &&
       tp_queue_size > kConf.network.ddos_protection.max_packets_queue_size) {
-    const auto connected_peers = peers_state_->getAllPeers();
-    // Always keep at least 5 connected peers
-    if (connected_peers.size() > 5) {
-      // Find peer with the highest processing time and disconnect him
-      std::pair<std::chrono::microseconds, dev::p2p::NodeID> peer_max_processing_time{std::chrono::microseconds(0),
-                                                                                      dev::p2p::NodeID()};
-
-      for (const auto &connected_peer : connected_peers) {
-        const auto peer_packets_stats = connected_peer.second->getAllPacketsStatsCopy();
-
-        if (peer_packets_stats.second.processing_duration_ > peer_max_processing_time.first) {
-          peer_max_processing_time = {peer_packets_stats.second.processing_duration_, connected_peer.first};
-        }
-      }
-
-      // Disconnect peer with the highest processing time
-      LOG(log_er_) << "Max allowed packets queue size " << kConf.network.ddos_protection.max_packets_queue_size
-                   << " exceeded: " << tp_queue_size << ". Peer with the highest processing time "
-                   << peer_max_processing_time.second << " will be disconnected";
-      host->disconnect(node_id, dev::p2p::UserReason);
-      return;
-    }
+    // Queue size is over the limit
+    handlePacketQueueOverLimit(host, node_id, tp_queue_size);
+  } else {
+    queue_over_limit_ = false;
+    last_disconnect_number_of_peers_ = 0;
   }
 
   // TODO: we are making a copy here for each packet bytes(toBytes()), which is pretty significant. Check why RLP does
   //       not support move semantics so we can take advantage of it...
   thread_pool_->push({version(), threadpool::PacketData(packet_type, node_id, _r.data().toBytes())});
+}
+
+void TaraxaCapability::handlePacketQueueOverLimit(std::shared_ptr<dev::p2p::Host> host, dev::p2p::NodeID node_id,
+                                                  size_t tp_queue_size) {
+  if (!queue_over_limit_) {
+    queue_over_limit_start_time_ = std::chrono::system_clock::now();
+    queue_over_limit_ = true;
+  }
+
+  // Check if Queue is over the limit for queue_limit_time
+  if ((std::chrono::system_clock::now() - queue_over_limit_start_time_) >
+      kConf.network.ddos_protection.queue_limit_time) {
+    // Only disconnect if there is more than peer_disconnect_interval since last disconnect
+    if ((std::chrono::system_clock::now() - last_ddos_disconnect_time_) >
+        kConf.network.ddos_protection.peer_disconnect_interval) {
+      auto connected_peers = peers_state_->getAllPeers();
+      last_disconnect_number_of_peers_ = connected_peers.size();
+      last_ddos_disconnect_time_ = std::chrono::system_clock::now();
+      // Always keep at least 5 connected peers
+      if (connected_peers.size() > 5) {
+        // Find peers with the highest processing time and disconnect
+        std::pair<std::chrono::microseconds, dev::p2p::NodeID> peer_max_processing_time{std::chrono::microseconds(0),
+                                                                                        dev::p2p::NodeID()};
+        for (const auto &connected_peer : connected_peers) {
+          const auto peer_packets_stats = connected_peer.second->getAllPacketsStatsCopy();
+          if (peer_packets_stats.second.processing_duration_ > peer_max_processing_time.first) {
+            peer_max_processing_time = {peer_packets_stats.second.processing_duration_, connected_peer.first};
+          }
+        }
+
+        // Disconnect peer with the highest processing time
+        LOG(log_er_) << "Max allowed packets queue size " << kConf.network.ddos_protection.max_packets_queue_size
+                     << " exceeded: " << tp_queue_size << ". Peer with the highest processing time "
+                     << peer_max_processing_time.second << " will be disconnected";
+        host->disconnect(node_id, dev::p2p::UserReason);
+        connected_peers.erase(node_id);
+      }
+    }
+  }
 }
 
 inline bool TaraxaCapability::filterSyncIrrelevantPackets(SubprotocolPacketType packet_type) const {


### PR DESCRIPTION
Improved algorithm for disconnecting nodes on packets queue limit reached:

- Only disconnect if limit is reached for certain time amount and not if there is only a short term burst in queue size
- Disconnect nodes in intervals not to disconnect too many nodes at once
- Drop any new connections if queue is over the limit

These changes improve that we do not disconnect when there is no need to disconnect, not disconnect too many nodes, not allow new connections to keep filling up the queue