### PR TITLE
chore: handle transactions with no account

### DIFF
--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -371,6 +371,8 @@ TEST_F(FullNodeTest, sync_five_nodes) {
       }
     }
 
+    void dummy_initial_transfer() { coin_transfer(0, dummy_client.getAddress(), 1000000, true); }
+
     auto getIssuedTrxCount() {
       shared_lock l(m);
       return issued_trx_count;
@@ -455,8 +457,9 @@ TEST_F(FullNodeTest, sync_five_nodes) {
 
   std::vector<trx_hash_t> all_transactions;
   // transfer some coins to your friends ...
-  auto init_bal = own_effective_genesis_bal(nodes[0]->getConfig()) / nodes.size();
+  auto init_bal = own_effective_genesis_bal(nodes[0]->getConfig()) / (nodes.size() + 1);
 
+  context.dummy_initial_transfer();
   {
     for (size_t i(1); i < nodes.size(); ++i) {
       // we shouldn't wait for transaction execution because it could be in alternative dag
@@ -982,7 +985,7 @@ TEST_F(FullNodeTest, sync_two_nodes2) {
   // send 1000 trxs
   try {
     std::cout << "Sending 1000 trxs ..." << std::endl;
-    sendTrx(1000, 7778);
+    sendTrx(1000, 7778, nodes[0]->getSecretKey());
     std::cout << "1000 trxs sent ..." << std::endl;
 
   } catch (std::exception &e) {
@@ -1109,7 +1112,7 @@ TEST_F(FullNodeTest, receive_send_transaction) {
   auto node = create_nodes(node_cfgs, true /*start*/).front();
 
   try {
-    sendTrx(1000, 7778);
+    sendTrx(1000, 7778, node->getSecretKey());
   } catch (std::exception &e) {
     std::cerr << e.what() << std::endl;
   }

--- a/tests/test_util/include/test_util/samples.hpp
+++ b/tests/test_util/include/test_util/samples.hpp
@@ -99,7 +99,7 @@ class TxGenerator {
 
 inline auto const TX_GEN = Lazy([] { return TxGenerator(); });
 
-bool sendTrx(uint64_t count, unsigned port);
+bool sendTrx(uint64_t count, unsigned port, dev::Secret secret);
 
 SharedTransactions createSignedTrxSamples(unsigned start, unsigned num, secret_t const &sk,
                                           bytes data = dev::fromHex("00FEDCBA9876543210000000"));

--- a/tests/test_util/include/test_util/test_util.hpp
+++ b/tests/test_util/include/test_util/test_util.hpp
@@ -151,6 +151,8 @@ struct TransactionClient {
   Context process(const std::shared_ptr<Transaction>& trx, bool wait_executed = true) const;
 
   Context coinTransfer(const addr_t& to, const val_t& val, bool wait_executed = true);
+
+  addr_t getAddress() const { return dev::KeyPair(secret_).address(); }
 };
 
 SharedTransaction make_dpos_trx(const FullNodeConfig& sender_node_cfg, const u256& value = 0, uint64_t nonce = 0,

--- a/tests/test_util/src/samples.cpp
+++ b/tests/test_util/src/samples.cpp
@@ -1,7 +1,7 @@
 #include "test_util/samples.hpp"
 
 namespace taraxa::core_tests::samples {
-bool sendTrx(uint64_t count, unsigned port) {
+bool sendTrx(uint64_t count, unsigned port, dev::Secret secret) {
   auto pattern = R"(
       curl --silent -m 10 --output /dev/null -d \
       '{
@@ -21,9 +21,8 @@ bool sendTrx(uint64_t count, unsigned port) {
       }' 0.0.0.0:%s
     )";
   for (uint64_t i = 0; i < count; ++i) {
-    auto retcode = system(fmt(pattern, i + 1, val_t(TEST_TX_GAS_LIMIT), val_t(0), addr_t::random(),
-                              samples::TX_GEN->getRandomUniqueSenderSecret().makeInsecure(), port)
-                              .c_str());
+    auto retcode = system(
+        fmt(pattern, i + 1, val_t(TEST_TX_GAS_LIMIT), val_t(0), addr_t::random(), secret.makeInsecure(), port).c_str());
     if (retcode != 0) {
       return false;
     }


### PR DESCRIPTION
Transactions with no account were not handled correctly. They could end up both in proposable and unproposable transactions since undefined balance ZeroAccount was used for it. Fixed by correclt handling it with transaction never placed in proposable transaction pool