### PR TITLE
Change final chain hash

### DIFF
--- a/for_devs/local-net
+++ b/for_devs/local-net
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 import click
 import subprocess
 import threading
@@ -313,7 +312,7 @@ def faucet_worker(tps):
     time.sleep(10)
     web3 = Web3(Web3.HTTPProvider('http://127.0.0.1:7017'))
     nonce = web3.eth.get_transaction_count(
-        Web3.to_checksum_address(faucet_public_address))
+        Web3.toChecksumAddress(faucet_public_address))
 
     consensus_nodes = list(consensus_nodes_public_addresses.keys())
 
@@ -323,10 +322,10 @@ def faucet_worker(tps):
             0, len(consensus_nodes)-1)]]
         tx = {
             'nonce': nonce,
-            'to': Web3.to_checksum_address(to),
-            'value': web3.to_wei(100000000, 'gwei'),
+            'to': Web3.toChecksumAddress(to),
+            'value': web3.toWei(100000000, 'gwei'),
             'gas': 21000,
-            'gasPrice': web3.to_wei(1, 'gwei'),
+            'gasPrice': web3.toWei(1, 'gwei'),
             'chainId': int(chain_id)
         }
         nonce = nonce + 1
@@ -338,7 +337,7 @@ def faucet_worker(tps):
         try:
             tx_hash = web3.eth.send_raw_transaction(signed_tx.rawTransaction)
             log_format(
-                'faucet', f'{t} Dripped to {to}, tx_hash: {web3.to_hex(tx_hash)}')
+                'faucet', f'{t} Dripped to {to}, tx_hash: {web3.toHex(tx_hash)}')
         except Exception as e:
             log_format('faucet', f'{t} Failed to drip to {to}. Error: {str(e)}')
             pass

--- a/libraries/cli/include/cli/config_jsons/default/default_genesis.json
+++ b/libraries/cli/include/cli/config_jsons/default/default_genesis.json
@@ -120,6 +120,6 @@
       "pillar_blocks_interval": 10,
       "bridge_contract_address": "0xcAF2b453FE8382a4B8110356DF0508f6d71F22BF"
     },
-    "cornus_hf_block_num": 0
+    "cornus_hf_block_num": 100
   }
 }

--- a/libraries/config/include/config/hardfork.hpp
+++ b/libraries/config/include/config/hardfork.hpp
@@ -133,6 +133,8 @@ struct HardforksConfig {
   // Cornus hf - support multiple undelegations from the same validator at the same time
   uint64_t cornus_hf_block_num{0};
 
+  bool isCornusHardfork(uint64_t block_number) const { return block_number >= cornus_hf_block_num; }
+
   HAS_RLP_FIELDS
 };
 

--- a/libraries/core_libs/consensus/include/final_chain/data.hpp
+++ b/libraries/core_libs/consensus/include/final_chain/data.hpp
@@ -41,12 +41,6 @@ struct BlockHeader : BlockHeaderData {
   BlockHeader() = default;
   BlockHeader(std::string&& raw_header_data);
   BlockHeader(std::string&& raw_header_data, const PbftBlock& pbft, uint64_t gas_limit);
-  h256 hash;
-  Address author;
-  uint64_t gas_limit = 0;
-  uint64_t timestamp = 0;
-  EthBlockNumber number = 0;
-  bytes extra_data;
 
   void setFromPbft(const PbftBlock& pbft);
 
@@ -59,6 +53,13 @@ struct BlockHeader : BlockHeaderData {
   static h256 const& mixHash();
 
   dev::bytes ethereumRlp() const;
+
+  h256 hash;
+  Address author;
+  uint64_t gas_limit = 0;
+  uint64_t timestamp = 0;
+  EthBlockNumber number = 0;
+  bytes extra_data;
 };
 
 static constexpr auto c_bloomIndexSize = 16;

--- a/libraries/core_libs/consensus/include/final_chain/final_chain.hpp
+++ b/libraries/core_libs/consensus/include/final_chain/final_chain.hpp
@@ -89,6 +89,14 @@ class FinalChain {
   std::optional<h256> blockHash(std::optional<EthBlockNumber> n = {}) const;
 
   /**
+   * @brief Method to get the final chain hash by block number
+   *
+   * @param n block number
+   * @return std::optional<h256> final chain hash or nullopt
+   */
+  std::optional<h256> finalChainHash(EthBlockNumber n) const;
+
+  /**
    * @brief Needed if we are changing params with hardfork and it affects Go part of code. For example DPOS contract
    * @param new_config state_api::Config
    */

--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -466,11 +466,11 @@ class PbftManager {
   bool validatePbftBlock(const std::shared_ptr<PbftBlock> &pbft_block) const;
 
   /**
-   * @brief Validates pbft block state root.
+   * @brief Validates pbft block final chain hash.
    * @param pbft_block PBFT block
    * @return validation result
    */
-  PbftStateRootValidation validatePbftBlockStateRoot(const std::shared_ptr<PbftBlock> &pbft_block) const;
+  PbftStateRootValidation validateFinalChainHash(const std::shared_ptr<PbftBlock> &pbft_block) const;
 
   /**
    * @brief Validates pbft block extra data presence:

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -8,10 +8,8 @@
 
 #include "config/version.hpp"
 #include "dag/dag.hpp"
+#include "dag/dag_manager.hpp"
 #include "final_chain/final_chain.hpp"
-#include "network/tarcap/packets_handlers/latest/pbft_sync_packet_handler.hpp"
-#include "network/tarcap/packets_handlers/latest/vote_packet_handler.hpp"
-#include "network/tarcap/packets_handlers/latest/votes_bundle_packet_handler.hpp"
 #include "pbft/period_data.hpp"
 #include "pillar_chain/pillar_chain_manager.hpp"
 #include "vote_manager/vote_manager.hpp"
@@ -1135,17 +1133,17 @@ PbftManager::generatePbftBlock(PbftPeriod propose_period, const blk_hash_t &prev
   std::transform(reward_votes.begin(), reward_votes.end(), std::back_inserter(reward_votes_hashes),
                  [](const auto &v) { return v->getHash(); });
 
-  h256 last_state_root;
+  h256 final_chain_hash;
   if (propose_period > final_chain_->delegationDelay()) {
     if (const auto header = final_chain_->blockHeader(propose_period - final_chain_->delegationDelay())) {
-      last_state_root = header->state_root;
+      final_chain_hash = header->state_root;
     } else {
       LOG(log_wr_) << "Block for period " << propose_period << " could not be proposed as we are behind";
       return {};
     }
   }
   try {
-    auto block = std::make_shared<PbftBlock>(prev_blk_hash, anchor_hash, order_hash, last_state_root, propose_period,
+    auto block = std::make_shared<PbftBlock>(prev_blk_hash, anchor_hash, order_hash, final_chain_hash, propose_period,
                                              node_addr_, node_sk_, std::move(reward_votes_hashes), extra_data);
 
     return {std::make_pair(std::move(block), std::move(reward_votes))};
@@ -1405,8 +1403,8 @@ PbftStateRootValidation PbftManager::validatePbftBlockStateRoot(const std::share
         return PbftStateRootValidation::Missing;
       }
     }
-    if (pbft_block->getPrevStateRoot() != prev_state_root_hash) {
-      LOG(log_er_) << "Block " << pbft_block_hash << " state root " << pbft_block->getPrevStateRoot()
+    if (pbft_block->getFinalChainHash() != prev_state_root_hash) {
+      LOG(log_er_) << "Block " << pbft_block_hash << " state root " << pbft_block->getFinalChainHash()
                    << " isn't matching actual " << prev_state_root_hash;
       return PbftStateRootValidation::Invalid;
     }
@@ -1883,7 +1881,7 @@ std::optional<std::pair<PeriodData, std::vector<std::shared_ptr<PbftVote>>>> Pbf
     if (validation_result != PbftStateRootValidation::Missing) {
       if (validation_result == PbftStateRootValidation::Invalid) {
         LOG(log_er_) << "Failed verifying block " << pbft_block_hash
-                     << " with invalid state root: " << period_data.pbft_blk->getPrevStateRoot()
+                     << " with invalid state root: " << period_data.pbft_blk->getFinalChainHash()
                      << ". Disconnect malicious peer " << node_id.abridged();
         sync_queue_.clear();
         net->handleMaliciousSyncPeer(node_id);

--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1133,18 +1133,15 @@ PbftManager::generatePbftBlock(PbftPeriod propose_period, const blk_hash_t &prev
   std::transform(reward_votes.begin(), reward_votes.end(), std::back_inserter(reward_votes_hashes),
                  [](const auto &v) { return v->getHash(); });
 
-  h256 final_chain_hash;
-  if (propose_period > final_chain_->delegationDelay()) {
-    if (const auto header = final_chain_->blockHeader(propose_period - final_chain_->delegationDelay())) {
-      final_chain_hash = header->state_root;
-    } else {
-      LOG(log_wr_) << "Block for period " << propose_period << " could not be proposed as we are behind";
-      return {};
-    }
+  auto final_chain_hash = final_chain_->finalChainHash(propose_period);
+  if (!final_chain_hash) {
+    LOG(log_wr_) << "Block for period " << propose_period << " could not be proposed as we are behind";
+    return {};
   }
   try {
-    auto block = std::make_shared<PbftBlock>(prev_blk_hash, anchor_hash, order_hash, final_chain_hash, propose_period,
-                                             node_addr_, node_sk_, std::move(reward_votes_hashes), extra_data);
+    auto block =
+        std::make_shared<PbftBlock>(prev_blk_hash, anchor_hash, order_hash, final_chain_hash.value(), propose_period,
+                                    node_addr_, node_sk_, std::move(reward_votes_hashes), extra_data);
 
     return {std::make_pair(std::move(block), std::move(reward_votes))};
   } catch (const std::exception &e) {
@@ -1390,25 +1387,21 @@ std::shared_ptr<PbftBlock> PbftManager::identifyLeaderBlock_(PbftRound round, Pb
   return empty_leader_block;
 }
 
-PbftStateRootValidation PbftManager::validatePbftBlockStateRoot(const std::shared_ptr<PbftBlock> &pbft_block) const {
+PbftStateRootValidation PbftManager::validateFinalChainHash(const std::shared_ptr<PbftBlock> &pbft_block) const {
   auto period = pbft_block->getPeriod();
-  auto const &pbft_block_hash = pbft_block->getBlockHash();
-  {
-    h256 prev_state_root_hash;
-    if (period > final_chain_->delegationDelay()) {
-      if (const auto header = final_chain_->blockHeader(period - final_chain_->delegationDelay())) {
-        prev_state_root_hash = header->state_root;
-      } else {
-        LOG(log_wr_) << "Block " << pbft_block_hash << " could not be validated as we are behind";
-        return PbftStateRootValidation::Missing;
-      }
-    }
-    if (pbft_block->getFinalChainHash() != prev_state_root_hash) {
-      LOG(log_er_) << "Block " << pbft_block_hash << " state root " << pbft_block->getFinalChainHash()
-                   << " isn't matching actual " << prev_state_root_hash;
-      return PbftStateRootValidation::Invalid;
-    }
+  const auto &pbft_block_hash = pbft_block->getBlockHash();
+
+  auto prev_final_chain_hash = final_chain_->finalChainHash(period);
+  if (!prev_final_chain_hash) {
+    LOG(log_wr_) << "Block " << pbft_block_hash << " could not be validated as we are behind";
+    return PbftStateRootValidation::Missing;
   }
+  if (pbft_block->getFinalChainHash() != prev_final_chain_hash) {
+    LOG(log_er_) << "Block " << pbft_block_hash << " state root " << pbft_block->getFinalChainHash()
+                 << " isn't matching actual " << prev_final_chain_hash.value();
+    return PbftStateRootValidation::Invalid;
+  }
+
   return PbftStateRootValidation::Valid;
 }
 
@@ -1481,7 +1474,7 @@ bool PbftManager::validatePbftBlock(const std::shared_ptr<PbftBlock> &pbft_block
 
   auto const &pbft_block_hash = pbft_block->getBlockHash();
 
-  if (validatePbftBlockStateRoot(pbft_block) != PbftStateRootValidation::Valid) {
+  if (validateFinalChainHash(pbft_block) != PbftStateRootValidation::Valid) {
     return false;
   }
 
@@ -1877,7 +1870,7 @@ std::optional<std::pair<PeriodData, std::vector<std::shared_ptr<PbftVote>>>> Pbf
 
   bool retry_logged = false;
   while (true) {
-    auto validation_result = validatePbftBlockStateRoot(period_data.pbft_blk);
+    auto validation_result = validateFinalChainHash(period_data.pbft_blk);
     if (validation_result != PbftStateRootValidation::Missing) {
       if (validation_result == PbftStateRootValidation::Invalid) {
         LOG(log_er_) << "Failed verifying block " << pbft_block_hash

--- a/libraries/core_libs/storage/include/storage/migration/period_dag_blocks.hpp
+++ b/libraries/core_libs/storage/include/storage/migration/period_dag_blocks.hpp
@@ -2,9 +2,9 @@
 #include "storage/migration/migration_base.hpp"
 
 namespace taraxa::storage::migration {
-class PeriodDataDagBlockMigration : public migration::Base {
+class PeriodDagBlocks : public migration::Base {
  public:
-  PeriodDataDagBlockMigration(std::shared_ptr<DbStorage> db);
+  PeriodDagBlocks(std::shared_ptr<DbStorage> db);
   std::string id() override;
   uint32_t dbVersion() override;
   void migrate(logger::Logger& log) override;

--- a/libraries/core_libs/storage/src/migration/migration_manager.cpp
+++ b/libraries/core_libs/storage/src/migration/migration_manager.cpp
@@ -1,12 +1,12 @@
 #include "storage/migration/migration_manager.hpp"
 
-#include "storage/migration/dag_block_period_migration.hpp"
 #include "storage/migration/final_chain_header.hpp"
+#include "storage/migration/period_dag_blocks.hpp"
 #include "storage/migration/transaction_period.hpp"
 namespace taraxa::storage::migration {
 
 Manager::Manager(std::shared_ptr<DbStorage> db, const addr_t& node_addr) : db_(db) {
-  registerMigration<PeriodDataDagBlockMigration>();
+  registerMigration<PeriodDagBlocks>();
   registerMigration<FinalChainHeader>();
   LOG_OBJECTS_CREATE("MIGRATIONS");
 }

--- a/libraries/core_libs/storage/src/migration/period_dag_blocks.cpp
+++ b/libraries/core_libs/storage/src/migration/period_dag_blocks.cpp
@@ -1,4 +1,4 @@
-#include "storage/migration/dag_block_period_migration.hpp"
+#include "storage/migration/period_dag_blocks.hpp"
 
 #include <libdevcore/Common.h>
 
@@ -8,13 +8,13 @@
 
 namespace taraxa::storage::migration {
 
-PeriodDataDagBlockMigration::PeriodDataDagBlockMigration(std::shared_ptr<DbStorage> db) : migration::Base(db) {}
+PeriodDagBlocks::PeriodDagBlocks(std::shared_ptr<DbStorage> db) : migration::Base(db) {}
 
-std::string PeriodDataDagBlockMigration::id() { return "PeriodDataDagBlockMigration"; }
+std::string PeriodDagBlocks::id() { return "PeriodDagBlocks"; }
 
-uint32_t PeriodDataDagBlockMigration::dbVersion() { return 1; }
+uint32_t PeriodDagBlocks::dbVersion() { return 1; }
 
-void PeriodDataDagBlockMigration::migrate(logger::Logger& log) {
+void PeriodDagBlocks::migrate(logger::Logger& log) {
   auto it = db_->getColumnIterator(DbStorage::Columns::period_data);
   it->SeekToFirst();
   if (!it->Valid()) {

--- a/libraries/types/pbft_block/include/pbft/pbft_block.hpp
+++ b/libraries/types/pbft_block/include/pbft/pbft_block.hpp
@@ -23,7 +23,7 @@ class PbftBlock {
   blk_hash_t prev_block_hash_;
   blk_hash_t dag_block_hash_as_pivot_;
   blk_hash_t order_hash_;
-  blk_hash_t prev_state_root_hash_;
+  blk_hash_t final_chain_hash_;
   PbftPeriod period_;  // Block index, PBFT head block is period 0, first PBFT block is period 1
   uint64_t timestamp_;
   addr_t beneficiary_;
@@ -33,7 +33,7 @@ class PbftBlock {
 
  public:
   PbftBlock(const blk_hash_t& prev_blk_hash, const blk_hash_t& dag_blk_hash_as_pivot, const blk_hash_t& order_hash,
-            const blk_hash_t& prev_state_root, PbftPeriod period, const addr_t& beneficiary, const secret_t& sk,
+            const blk_hash_t& final_chain_hash, PbftPeriod period, const addr_t& beneficiary, const secret_t& sk,
             std::vector<vote_hash_t>&& reward_votes, const std::optional<PbftBlockExtraData>& extra_data = {});
   explicit PbftBlock(const dev::RLP& rlp);
   explicit PbftBlock(const bytes& RLP);
@@ -103,7 +103,11 @@ class PbftBlock {
    */
   const auto& getOrderHash() const { return order_hash_; }
 
-  const auto& getPrevStateRoot() const { return prev_state_root_hash_; }
+  /**
+   * @brief Get final chain hash to tie final chain to the PBFT chain
+   * @return final chain hash
+   */
+  const auto& getFinalChainHash() const { return final_chain_hash_; }
 
   /**
    * @brief Get period number

--- a/libraries/types/pbft_block/src/pbft_block.cpp
+++ b/libraries/types/pbft_block/src/pbft_block.cpp
@@ -15,11 +15,11 @@ PbftBlock::PbftBlock(dev::RLP const& rlp) {
   if (rlp.itemCount() == 9) {
     dev::bytes extra_data_bytes;
     util::rlp_tuple(util::RLPDecoderRef(rlp, true), prev_block_hash_, dag_block_hash_as_pivot_, order_hash_,
-                    prev_state_root_hash_, period_, timestamp_, reward_votes_, extra_data_bytes, signature_);
+                    final_chain_hash_, period_, timestamp_, reward_votes_, extra_data_bytes, signature_);
     extra_data_ = PbftBlockExtraData::fromBytes(extra_data_bytes);
   } else {
     util::rlp_tuple(util::RLPDecoderRef(rlp, true), prev_block_hash_, dag_block_hash_as_pivot_, order_hash_,
-                    prev_state_root_hash_, period_, timestamp_, reward_votes_, signature_);
+                    final_chain_hash_, period_, timestamp_, reward_votes_, signature_);
   }
 
   calculateHash_();
@@ -27,13 +27,13 @@ PbftBlock::PbftBlock(dev::RLP const& rlp) {
 }
 
 PbftBlock::PbftBlock(const blk_hash_t& prev_blk_hash, const blk_hash_t& dag_blk_hash_as_pivot,
-                     const blk_hash_t& order_hash, const blk_hash_t& prev_state_root, PbftPeriod period,
+                     const blk_hash_t& order_hash, const blk_hash_t& final_chain_hash, PbftPeriod period,
                      const addr_t& beneficiary, const secret_t& sk, std::vector<vote_hash_t>&& reward_votes,
                      const std::optional<PbftBlockExtraData>& extra_data)
     : prev_block_hash_(prev_blk_hash),
       dag_block_hash_as_pivot_(dag_blk_hash_as_pivot),
       order_hash_(order_hash),
-      prev_state_root_hash_(prev_state_root),
+      final_chain_hash_(final_chain_hash),
       period_(period),
       beneficiary_(beneficiary),
       reward_votes_(reward_votes),
@@ -87,7 +87,7 @@ Json::Value PbftBlock::getJson() const {
   json["prev_block_hash"] = prev_block_hash_.toString();
   json["dag_block_hash_as_pivot"] = dag_block_hash_as_pivot_.toString();
   json["order_hash"] = order_hash_.toString();
-  json["prev_state_root_hash"] = prev_state_root_hash_.toString();
+  json["prev_state_root_hash"] = final_chain_hash_.toString();
   json["period"] = (Json::Value::UInt64)period_;
   json["timestamp"] = (Json::Value::UInt64)timestamp_;
   json["block_hash"] = block_hash_.toString();
@@ -110,7 +110,7 @@ void PbftBlock::streamRLP(dev::RLPStream& strm, bool include_sig) const {
   strm << prev_block_hash_;
   strm << dag_block_hash_as_pivot_;
   strm << order_hash_;
-  strm << prev_state_root_hash_;
+  strm << final_chain_hash_;
   strm << period_;
   strm << timestamp_;
   strm.appendVector(reward_votes_);

--- a/libraries/types/pbft_block/src/pbft_block.cpp
+++ b/libraries/types/pbft_block/src/pbft_block.cpp
@@ -87,7 +87,7 @@ Json::Value PbftBlock::getJson() const {
   json["prev_block_hash"] = prev_block_hash_.toString();
   json["dag_block_hash_as_pivot"] = dag_block_hash_as_pivot_.toString();
   json["order_hash"] = order_hash_.toString();
-  json["prev_state_root_hash"] = final_chain_hash_.toString();
+  json["final_chain_hash"] = final_chain_hash_.toString();
   json["period"] = (Json::Value::UInt64)period_;
   json["timestamp"] = (Json::Value::UInt64)timestamp_;
   json["block_hash"] = block_hash_.toString();

--- a/tests/pbft_manager_test.cpp
+++ b/tests/pbft_manager_test.cpp
@@ -736,11 +736,7 @@ TEST_F(PbftManagerWithDagCreation, state_root_hash) {
   // Check that all produced blocks have correct state_root_hashes
   while (pbft_block.getPeriod() != 1) {
     auto period = pbft_block.getPeriod();
-    h256 state_root;
-    if (period > state_root_delay) {
-      state_root = node->getFinalChain()->blockHeader(period - state_root_delay)->state_root;
-    }
-    EXPECT_EQ(pbft_block.getFinalChainHash(), state_root);
+    EXPECT_EQ(pbft_block.getFinalChainHash(), node->getFinalChain()->finalChainHash(period));
 
     pbft_block = node->getPbftChain()->getPbftBlockInChain(pbft_block.getPrevBlockHash());
   }

--- a/tests/pbft_manager_test.cpp
+++ b/tests/pbft_manager_test.cpp
@@ -740,7 +740,7 @@ TEST_F(PbftManagerWithDagCreation, state_root_hash) {
     if (period > state_root_delay) {
       state_root = node->getFinalChain()->blockHeader(period - state_root_delay)->state_root;
     }
-    EXPECT_EQ(pbft_block.getPrevStateRoot(), state_root);
+    EXPECT_EQ(pbft_block.getFinalChainHash(), state_root);
 
     pbft_block = node->getPbftChain()->getPbftBlockInChain(pbft_block.getPrevBlockHash());
   }


### PR DESCRIPTION
Replace `state_root_hash` with `final_chain block hash` in the cornus hf to improve state tracking in pbft blocks 