### PR TITLE
fix: gossip votes to all capability version

### DIFF
--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -279,6 +279,14 @@ class PbftManager {
    */
   bool validatePillarDataInPeriodData(const PeriodData &period_data) const;
 
+  /**
+   * @brief Gossips vote to the other peers
+   *
+   * @param vote
+   * @param voted_block
+   */
+  void gossipVote(const std::shared_ptr<PbftVote> &vote, const std::shared_ptr<PbftBlock> &voted_block);
+
  private:
   /**
    * @brief Broadcast or rebroadcast 2t+1 soft/reward/previous round next votes + all own votes if needed
@@ -411,7 +419,6 @@ class PbftManager {
    *
    * @param vote
    * @param voted_block
-   * @return true if successful, otherwise false
    */
   void gossipNewVote(const std::shared_ptr<PbftVote> &vote, const std::shared_ptr<PbftBlock> &voted_block);
 

--- a/libraries/core_libs/network/src/tarcap/packets_handlers/latest/vote_packet_handler.cpp
+++ b/libraries/core_libs/network/src/tarcap/packets_handlers/latest/vote_packet_handler.cpp
@@ -81,7 +81,8 @@ void VotePacketHandler::process(const threadpool::PacketData &packet_data, const
 
   // Do not mark it before, as peers have small caches of known votes. Only mark gossiping votes
   peer->markPbftVoteAsKnown(vote_hash);
-  onNewPbftVote(vote, pbft_block);
+
+  pbft_mgr_->gossipVote(vote, pbft_block);
 }
 
 void VotePacketHandler::onNewPbftVote(const std::shared_ptr<PbftVote> &vote, const std::shared_ptr<PbftBlock> &block,


### PR DESCRIPTION
Since different version capabilities have different handlers sending votes from within a single handler resulted in sending votes only to nodes with the same version. 

Gossiping votes with pbft manager gossip vote ensures that the vote is sent to all node versions.