### PR TITLE
dag proposal improvements

### DIFF
--- a/libraries/common/include/common/constants.hpp
+++ b/libraries/common/include/common/constants.hpp
@@ -29,6 +29,7 @@ const uint64_t kMinTxGas{21000};
 constexpr uint32_t kMinTransactionPoolSize{30000};
 constexpr uint32_t kDefaultTransactionPoolSize{200000};
 constexpr uint32_t kMaxNonFinalizedTransactions{1000000};
+constexpr uint32_t kMaxNonFinalizedDagBlocks{100};
 
 const size_t kV3NetworkVersion = 3;
 

--- a/libraries/core_libs/consensus/include/dag/dag_manager.hpp
+++ b/libraries/core_libs/consensus/include/dag/dag_manager.hpp
@@ -184,6 +184,8 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
    */
   std::pair<size_t, size_t> getNonFinalizedBlocksSize() const;
 
+  uint32_t getNonFinalizedBlocksMinDifficulty() const;
+
   util::Event<DagManager, DagBlock> const block_verified_{};
 
   /**
@@ -258,6 +260,7 @@ class DagManager : public std::enable_shared_from_this<DagManager> {
   blk_hash_t old_anchor_;  // anchor of the second to last period
   PbftPeriod period_;      // last period
   std::map<uint64_t, std::unordered_set<blk_hash_t>> non_finalized_blks_;
+  uint32_t non_finalized_blks_min_difficulty_ = UINT32_MAX;
   DagFrontier frontier_;
   SortitionParamsManager sortition_params_manager_;
   const DagConfig &dag_config_;

--- a/libraries/core_libs/consensus/src/dag/dag_block_proposer.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_block_proposer.cpp
@@ -89,6 +89,17 @@ bool DagBlockProposer::proposeDagBlock() {
   vdf_sortition::VdfSortition vdf(sortition_params, vrf_sk_,
                                   VrfSortitionBase::makeVrfInput(propose_level, period_block_hash), vote_count,
                                   max_vote_count);
+
+  auto anchor = dag_mgr_->getAnchors().second;
+  if (frontier.pivot != anchor) {
+    if (dag_mgr_->getNonFinalizedBlocksSize().second > kMaxNonFinalizedDagBlocks) {
+      return false;
+    }
+    if (dag_mgr_->getNonFinalizedBlocksMinDifficulty() < vdf.getDifficulty()) {
+      return false;
+    }
+  }
+
   if (vdf.isStale(sortition_params)) {
     if (last_propose_level_ == propose_level) {
       if (num_tries_ < max_num_tries_) {


### PR DESCRIPTION
To avoid proposing too many dag blocks when network is not progressing or slow to progress:
- only propose a block with same or smaller difficulty than the min difficulty of non finalized dag blocks
- limit max number of non finalized dag blocks to 100