### PR TITLE
Sharding improvements

### DIFF
--- a/libraries/core_libs/consensus/include/dag/dag_block_proposer.hpp
+++ b/libraries/core_libs/consensus/include/dag/dag_block_proposer.hpp
@@ -149,6 +149,7 @@ class DagBlockProposer {
 
   const HardforksConfig kHardforks;
   const uint64_t kValidatorMaxVote;
+  const uint64_t kShardProposePeriodInterval = 10;
 
   LOG_OBJECTS_DEFINE
 };

--- a/libraries/core_libs/consensus/src/dag/dag_block_proposer.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_block_proposer.cpp
@@ -254,10 +254,11 @@ std::pair<SharedTransactions, std::vector<uint64_t>> DagBlockProposer::getSharde
   SharedTransactions sharded_trxs;
   std::vector<uint64_t> sharded_estimations;
   for (uint32_t i = 0; i < transactions.size(); i++) {
-    auto shard = std::stoull(transactions[i]->getHash().toString().substr(0, 10), NULL, 16);
+    auto shard = std::stoull(transactions[i]->getSender().toString().substr(0, 10), NULL, 16) +
+                 proposal_period / kShardProposePeriodInterval;
     if (shard % total_trx_shards_ == my_trx_shard_) {
       sharded_trxs.emplace_back(transactions[i]);
-      estimations.emplace_back(estimations[i]);
+      sharded_estimations.emplace_back(estimations[i]);
     }
   }
   if (sharded_trxs.empty()) {


### PR DESCRIPTION
Sharding is still disabled but some improvements and fixes are made:
- Sharding is done based on the sender and not hash to avoid reordering of trnasactions from same sender
- Every 10 period sharding is shuffled not to have same sender always use the same nodes