### PR TITLE
fix: pillar block save

### DIFF
--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -41,6 +41,17 @@ PbftManager::PbftManager(const FullNodeConfig &conf, std::shared_ptr<DbStorage> 
   const auto &node_addr = node_addr_;
   LOG_OBJECTS_CREATE("PBFT_MGR");
 
+  auto current_pbft_period = pbft_chain_->getPbftChainSize();
+  if (kGenesisConfig.state.hardforks.ficus_hf.isPillarBlockPeriod(current_pbft_period)) {
+    const auto current_pillar_block = pillar_chain_mgr_->getCurrentPillarBlock();
+    // There is a race condition where pbt block could have been saved and node stopped before saving pillar block
+    if (current_pbft_period ==
+        current_pillar_block->getPeriod() + kGenesisConfig.state.hardforks.ficus_hf.pillar_blocks_interval)
+      LOG(log_er_) << "Pillar block was not processed before restart, current period: " << current_pbft_period
+                   << ", current pillar block period: " << current_pillar_block->getPeriod();
+    processPillarBlock(current_pbft_period);
+  }
+
   for (auto period = final_chain_->lastBlockNumber() + 1, curr_period = pbft_chain_->getPbftChainSize();
        period <= curr_period; ++period) {
     auto period_raw = db_->getPeriodDataRaw(period);


### PR DESCRIPTION
When creating snapshot and possibly in some other condition it is possible that pbft block was pushed to the chain but pillar block has not been saved when node is stopped. Handle this on restarting the node by calling processPillarBlock if needed