### PR TITLE
chore: trusted nodes

### DIFF
--- a/libraries/aleth/libp2p/Host.cpp
+++ b/libraries/aleth/libp2p/Host.cpp
@@ -287,7 +287,8 @@ void Host::startPeerSession(Public const& _id, RLP const& _hello, unique_ptr<RLP
       }
     }
   }
-  if (!disconnect_reason && !peerSlotsAvailable()) {
+  auto is_trusted_node = m_netConfig.trustedNodes.contains(peer->address());
+  if (!disconnect_reason && (!peerSlotsAvailable() && !is_trusted_node)) {
     cnetdetails << "Too many peers, can't connect. peer count: " << peer_count_()
                 << " pending peers: " << m_pendingPeerConns.size();
     disconnect_reason = TooManyPeers;
@@ -411,7 +412,9 @@ void Host::runAcceptor() {
           return;
         }
         auto socket = make_shared<RLPXSocket>(std::move(_socket));
-        if (peer_count_() > peerSlots(Ingress)) {
+        // Since a connecting peer might be a trusted node which should always connect allow up to max number of trusted
+        // nodes above the limit
+        if (peer_count_() > (peerSlots(Ingress) + m_netConfig.trustedNodes.size())) {
           cnetdetails << "Dropping incoming connect due to maximum peer count (" << Ingress
                       << " * ideal peer count): " << socket->remoteEndpoint();
           socket->close();

--- a/libraries/aleth/libp2p/Network.h
+++ b/libraries/aleth/libp2p/Network.h
@@ -45,6 +45,9 @@ struct NetworkConfig {
   std::string listenIPAddress;
   uint16_t listenPort = c_defaultListenPort;
 
+  /// Trusted Nodes
+  std::unordered_set<dev::p2p::NodeID> trustedNodes;
+
   /// Preferences
 
   bool traverseNAT = true;

--- a/libraries/cli/include/cli/config_jsons/testnet/testnet_config.json
+++ b/libraries/cli/include/cli/config_jsons/testnet/testnet_config.json
@@ -30,7 +30,7 @@
     "listen_port": 10002,
     "transaction_interval_ms": 100,
     "ideal_peer_count": 10,
-    "max_peer_count": 50,
+    "max_peer_count": 20,
     "sync_level_size": 10,
     "packets_processing_threads": 14,
     "peer_blacklist_timeout": 600,

--- a/libraries/config/include/config/network.hpp
+++ b/libraries/config/include/config/network.hpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "common/types.hpp"
+#include "libp2p/Common.h"
 
 namespace taraxa {
 
@@ -82,6 +83,7 @@ struct NetworkConfig {
   bool disable_peer_blacklist = false;
   uint16_t deep_syncing_threshold = 10;
   DdosProtectionConfig ddos_protection;
+  std::unordered_set<dev::p2p::NodeID> trusted_nodes;
 
   std::optional<ConnectionConfig> rpc;
   std::optional<ConnectionConfig> graphql;

--- a/libraries/config/src/network.cpp
+++ b/libraries/config/src/network.cpp
@@ -133,6 +133,12 @@ void dec_json(const Json::Value &json, NetworkConfig &network) {
   network.listen_port = getConfigDataAsUInt(json, {"listen_port"});
   network.transaction_interval_ms = getConfigDataAsUInt(json, {"transaction_interval_ms"});
   network.ideal_peer_count = getConfigDataAsUInt(json, {"ideal_peer_count"});
+  Json::Value priority_nodes = json["priority_nodes"];
+  if (!priority_nodes.isNull()) {
+    for (const auto &item : priority_nodes) {
+      network.trusted_nodes.insert(dev::p2p::NodeID(item.asString()));
+    }
+  }
   network.max_peer_count = getConfigDataAsUInt(json, {"max_peer_count"});
   network.sync_level_size = getConfigDataAsUInt(json, {"sync_level_size"});
   network.packets_processing_threads = getConfigDataAsUInt(json, {"packets_processing_threads"});

--- a/libraries/core_libs/network/src/network.cpp
+++ b/libraries/core_libs/network/src/network.cpp
@@ -58,6 +58,7 @@ Network::Network(const FullNodeConfig &config, const h256 &genesis_hash, std::fi
   net_conf.traverseNAT = false;
   net_conf.publicIPAddress = config.network.public_ip;
   net_conf.pin = false;
+  net_conf.trustedNodes = config.network.trusted_nodes;
 
   dev::p2p::TaraxaNetworkConfig taraxa_net_conf;
   taraxa_net_conf.ideal_peer_count = config.network.ideal_peer_count;


### PR DESCRIPTION
Add trusted nodes configuration option which will prioritize trusted nodes connection and always accept a connection to a trusted node even if over the max connection limit. 