### PR TITLE
fix: propose gas limit validation

### DIFF
--- a/libraries/config/include/config/config_utils.hpp
+++ b/libraries/config/include/config/config_utils.hpp
@@ -16,10 +16,8 @@ Json::Value getConfigData(Json::Value root, const std::vector<std::string> &path
 std::string getConfigDataAsString(const Json::Value &root, const std::vector<std::string> &path, bool optional = false,
                                   const std::string &value = {});
 
-uint32_t getConfigDataAsUInt(const Json::Value &root, const std::vector<std::string> &path, bool optional = false,
+uint64_t getConfigDataAsUInt(const Json::Value &root, const std::vector<std::string> &path, bool optional = false,
                              uint32_t value = 0);
-
-uint64_t getConfigDataAsUInt64(const Json::Value &root, const std::vector<std::string> &path);
 
 bool getConfigDataAsBoolean(const Json::Value &root, const std::vector<std::string> &path, bool optional = false,
                             bool value = false);

--- a/libraries/config/src/config.cpp
+++ b/libraries/config/src/config.cpp
@@ -54,8 +54,8 @@ std::vector<logger::Config> FullNodeConfig::loadLoggingConfigs(const Json::Value
             output.target = log_path;
             output.file_name = (log_path / getConfigDataAsString(o, {"file_name"})).string();
             output.format = getConfigDataAsString(o, {"format"});
-            output.max_size = getConfigDataAsUInt64(o, {"max_size"});
-            output.rotation_size = getConfigDataAsUInt64(o, {"rotation_size"});
+            output.max_size = getConfigDataAsUInt(o, {"max_size"});
+            output.rotation_size = getConfigDataAsUInt(o, {"rotation_size"});
             output.time_based_rotation = getConfigDataAsString(o, {"time_based_rotation"});
           }
           logging.outputs.push_back(output);
@@ -200,22 +200,6 @@ void FullNodeConfig::validate() const {
 
   if (transactions_pool_size < kMinTransactionPoolSize) {
     throw ConfigException("transactions_pool_size cannot be smaller than " + std::to_string(kMinTransactionPoolSize));
-  }
-
-  if (genesis.pbft.gas_limit < propose_pbft_gas_limit ||
-      (genesis.state.hardforks.cornus_hf.block_num != uint64_t(-1) &&
-       genesis.state.hardforks.cornus_hf.pbft_gas_limit < propose_pbft_gas_limit)) {
-    throw ConfigException("Propose pbft gas limit:" + std::to_string(propose_pbft_gas_limit) +
-                          " greater than max allowed pbft gas limit:" + std::to_string(genesis.pbft.gas_limit) + ":" +
-                          std::to_string(genesis.state.hardforks.cornus_hf.pbft_gas_limit));
-  }
-
-  if (genesis.dag.gas_limit < propose_dag_gas_limit ||
-      (genesis.state.hardforks.cornus_hf.block_num != uint64_t(-1) &&
-       genesis.state.hardforks.cornus_hf.dag_gas_limit < propose_dag_gas_limit)) {
-    throw ConfigException("Propose dag gas limit:" + std::to_string(propose_pbft_gas_limit) +
-                          " greater than max allowed pbft gas limit:" + std::to_string(genesis.pbft.gas_limit) + ":" +
-                          std::to_string(genesis.state.hardforks.cornus_hf.pbft_gas_limit));
   }
 
   // TODO: add validation of other config values

--- a/libraries/config/src/config_utils.cpp
+++ b/libraries/config/src/config_utils.cpp
@@ -7,6 +7,7 @@
 #include <fstream>
 
 #include "common/config_exception.hpp"
+#include "libdevcore/CommonJS.h"
 
 namespace taraxa {
 
@@ -44,27 +45,19 @@ std::string getConfigDataAsString(const Json::Value &root, const std::vector<std
   }
 }
 
-uint32_t getConfigDataAsUInt(const Json::Value &root, const std::vector<std::string> &path, bool optional,
+uint64_t getConfigDataAsUInt(const Json::Value &root, const std::vector<std::string> &path, bool optional,
                              uint32_t value) {
   try {
     Json::Value ret = getConfigData(root, path, optional);
     if (ret.isNull()) {
       return value;
     } else {
-      return ret.asUInt();
+      return dev::getUInt(ret);
     }
   } catch (Json::Exception &e) {
     if (optional) {
       return value;
     }
-    throw ConfigException(getConfigErr(path) + e.what());
-  }
-}
-
-uint64_t getConfigDataAsUInt64(const Json::Value &root, const std::vector<std::string> &path) {
-  try {
-    return getConfigData(root, path).asUInt64();
-  } catch (Json::Exception &e) {
     throw ConfigException(getConfigErr(path) + e.what());
   }
 }

--- a/libraries/config/src/network.cpp
+++ b/libraries/config/src/network.cpp
@@ -75,10 +75,9 @@ DdosProtectionConfig dec_ddos_protection_config_json(const Json::Value &json) {
   ddos_protection.packets_stats_time_period_ms =
       std::chrono::milliseconds{getConfigDataAsUInt(json, {"packets_stats_time_period_ms"})};
   ddos_protection.peer_max_packets_processing_time_us =
-      std::chrono::microseconds{getConfigDataAsUInt64(json, {"peer_max_packets_processing_time_us"})};
-  ddos_protection.peer_max_packets_queue_size_limit =
-      getConfigDataAsUInt64(json, {"peer_max_packets_queue_size_limit"});
-  ddos_protection.max_packets_queue_size = getConfigDataAsUInt64(json, {"max_packets_queue_size"});
+      std::chrono::microseconds{getConfigDataAsUInt(json, {"peer_max_packets_processing_time_us"})};
+  ddos_protection.peer_max_packets_queue_size_limit = getConfigDataAsUInt(json, {"peer_max_packets_queue_size_limit"});
+  ddos_protection.max_packets_queue_size = getConfigDataAsUInt(json, {"max_packets_queue_size"});
   return ddos_protection;
 }
 

--- a/libraries/core_libs/consensus/src/dag/dag_block_proposer.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_block_proposer.cpp
@@ -26,8 +26,10 @@ DagBlockProposer::DagBlockProposer(const FullNodeConfig& config, std::shared_ptr
       node_sk_(config.node_secret),
       vrf_sk_(config.vrf_secret),
       vrf_pk_(vrf_wrapper::getVrfPublicKey(vrf_sk_)),
-      kPbftGasLimit(config.propose_pbft_gas_limit),
-      kDagGasLimit(config.propose_dag_gas_limit),
+      kPbftGasLimit(
+          std::min(config.propose_pbft_gas_limit, config.genesis.getGasLimits(final_chain_->lastBlockNumber()).second)),
+      kDagGasLimit(
+          std::min(config.propose_dag_gas_limit, config.genesis.getGasLimits(final_chain_->lastBlockNumber()).first)),
       kHardforks(config.genesis.state.hardforks),
       kValidatorMaxVote(config.genesis.state.dpos.validator_maximum_stake /
                         config.genesis.state.dpos.vote_eligibility_balance_step) {


### PR DESCRIPTION
- Allow setting propose gas limits in config file as hex by modifying getConfigDataAsUInt to accept hex strings
- Remove validation of propose gas limits from FullNodeConfig::validate since the validation depends if over the cornus HF. Add validation in DagBlockProposer constructor by reducing the value to the maximum gas limit allowed