### PR TITLE
Increase initial testnet VRF threshold

### DIFF
--- a/libraries/cli/include/cli/config_jsons/testnet/testnet_genesis.json
+++ b/libraries/cli/include/cli/config_jsons/testnet/testnet_genesis.json
@@ -122,7 +122,7 @@
     "changing_interval": 200,
     "computation_interval": 50,
     "vrf": {
-      "threshold_upper": "0x2710"
+      "threshold_upper": "0x4e20"
     },
     "vdf": {
       "difficulty_max": 21,


### PR DESCRIPTION
Increase initial testnet VRF threshold to increase DAG production on starting the network