### PR TITLE
chore: remove unneeded assert

### DIFF
--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -830,7 +830,6 @@ void PbftManager::gossipVote(const std::shared_ptr<PbftVote> &vote, const std::s
   auto net = network_.lock();
   if (!net) {
     LOG(log_er_) << "Could not obtain net - cannot gossip new vote";
-    assert(false);
     return;
   }
 


### PR DESCRIPTION
It is normal on closing the node that within order of destruction a net weak ptr can be null. The assert was causing tests to fail on test destruction