### PR TITLE
fix: dont throw on unsupported or invalid subscription

### DIFF
--- a/libraries/core_libs/network/rpc/jsonrpc_ws_server.cpp
+++ b/libraries/core_libs/network/rpc/jsonrpc_ws_server.cpp
@@ -84,8 +84,6 @@ std::string JsonRpcWsSession::handleSubscription(const Json::Value &req) {
       if (params.size() == 2 && params[1].asString() == "includeSignatures") {
         include_pillar_block_signatures = true;
       }
-    } else {
-      throw std::runtime_error("Invalid subscription type");
     }
   }
 


### PR DESCRIPTION
Revert a change where node is throwing an error on an unknown subscription to avoid node crashing. Should be handled differently(probably handleSubscription should be inside of handleRequest)