### PR TITLE
fix: tips gas estimation limit

### DIFF
--- a/libraries/core_libs/consensus/include/dag/dag_block_proposer.hpp
+++ b/libraries/core_libs/consensus/include/dag/dag_block_proposer.hpp
@@ -143,6 +143,7 @@ class DagBlockProposer {
   const vrf_wrapper::vrf_sk_t vrf_sk_;
   const vrf_wrapper::vrf_pk_t vrf_pk_;
 
+  const uint64_t kDagProposeGasLimit;
   const uint64_t kPbftGasLimit;
   const uint64_t kDagGasLimit;
 

--- a/libraries/core_libs/consensus/src/dag/dag_block_proposer.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_block_proposer.cpp
@@ -26,10 +26,12 @@ DagBlockProposer::DagBlockProposer(const FullNodeConfig& config, std::shared_ptr
       node_sk_(config.node_secret),
       vrf_sk_(config.vrf_secret),
       vrf_pk_(vrf_wrapper::getVrfPublicKey(vrf_sk_)),
-      kPbftGasLimit(
-          std::min(config.propose_pbft_gas_limit, config.genesis.getGasLimits(final_chain_->lastBlockNumber()).second)),
-      kDagGasLimit(
+      kDagProposeGasLimit(
           std::min(config.propose_dag_gas_limit, config.genesis.getGasLimits(final_chain_->lastBlockNumber()).first)),
+      kPbftGasLimit(
+          config.genesis.getGasLimits(final_chain_->lastBlockNumber()).second),
+      kDagGasLimit(
+          config.genesis.getGasLimits(final_chain_->lastBlockNumber()).first),
       kHardforks(config.genesis.state.hardforks),
       kValidatorMaxVote(config.genesis.state.dpos.validator_maximum_stake /
                         config.genesis.state.dpos.vote_eligibility_balance_step) {
@@ -119,7 +121,7 @@ bool DagBlockProposer::proposeDagBlock() {
     }
   }
 
-  auto [transactions, estimations] = getShardedTrxs(*proposal_period, kDagGasLimit);
+  auto [transactions, estimations] = getShardedTrxs(*proposal_period, kDagProposeGasLimit);
   if (transactions.empty()) {
     last_propose_level_ = propose_level;
     num_tries_ = 0;


### PR DESCRIPTION
When limiting how many tips to choose for a dag block there is a check:
if (frontier.tips.size() > kDagBlockMaxTips || (frontier.tips.size() + 1) > kPbftGasLimit / kDagGasLimit)

This check needs to be done with the genesis/hardfork gas limt and not with a propose limit. When used with a propose limit incorrect value was used which made it possible to produce oversized DAG blocks which would fail validation in DagManager::VerifyBlock