### PR TITLE
chore: transaction handling optimization

### DIFF
--- a/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
+++ b/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
@@ -149,6 +149,14 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
   std::unordered_set<trx_hash_t> excludeFinalizedTransactions(const std::vector<trx_hash_t> &hashes);
 
   /**
+   * @brief Verify transactions not finalized
+   *
+   * @param trxs
+   * @return True if all transactions are not finalized
+   */
+  bool verifyTransactionsNotFinalized(const SharedTransactions &trxs);
+
+  /**
    * @brief Get the block transactions
    *
    * @param blk


### PR DESCRIPTION
Use nonce to check if transaction is not executed which is significantly faster than checking full transaction history