### PR TITLE
chore: pruning optimization

### DIFF
--- a/libraries/core_libs/consensus/src/dag/dag_block_proposer.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_block_proposer.cpp
@@ -69,6 +69,11 @@ bool DagBlockProposer::proposeDagBlock() {
     return false;
   }
 
+  if(*proposal_period + kDagExpiryLevelLimit < final_chain_->lastBlockNumber()) {
+    LOG(log_wr_) << "Trying to propose old block " << propose_level;
+    return false;
+  }
+
   if (!isValidDposProposer(*proposal_period)) {
     return false;
   }
@@ -85,6 +90,11 @@ bool DagBlockProposer::proposeDagBlock() {
     max_vote_count = final_chain_->dposEligibleTotalVoteCount(*proposal_period);
   } else {
     max_vote_count = kValidatorMaxVote;
+  }
+
+  if (max_vote_count == 0) {
+    LOG(log_er_) << "Total vote count 0 at proposal period:" << *proposal_period;
+    return false;
   }
 
   const auto period_block_hash = db_->getPeriodBlockHash(*proposal_period);

--- a/libraries/core_libs/consensus/src/dag/dag_manager.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_manager.cpp
@@ -312,7 +312,7 @@ void DagManager::clearLightNodeHistory(uint64_t light_node_history) {
       dag_level_to_keep = dag_expiry_level_ - max_levels_per_period_;
     }
 
-    db_->clearPeriodDataHistory(end, dag_level_to_keep);
+    db_->clearPeriodDataHistory(end, dag_level_to_keep, last_block_number);
   }
 }
 

--- a/libraries/core_libs/storage/include/storage/storage.hpp
+++ b/libraries/core_libs/storage/include/storage/storage.hpp
@@ -223,7 +223,7 @@ class DbStorage : public std::enable_shared_from_this<DbStorage> {
 
   // Period data
   void savePeriodData(const PeriodData& period_data, Batch& write_batch);
-  void clearPeriodDataHistory(PbftPeriod period, uint64_t dag_level_to_keep);
+  void clearPeriodDataHistory(PbftPeriod period, uint64_t dag_level_to_keep, PbftPeriod last_block_number);
   dev::bytes getPeriodDataRaw(PbftPeriod period) const;
   std::optional<PeriodData> getPeriodData(PbftPeriod period) const;
   std::optional<PbftBlock> getPbftBlock(PbftPeriod period) const;

--- a/tests/full_node_test.cpp
+++ b/tests/full_node_test.cpp
@@ -1443,8 +1443,8 @@ TEST_F(FullNodeTest, light_node) {
     // broadcast dummy transaction
     nodes[1]->getTransactionManager()->insertTransaction(dummy_trx);
     thisThreadSleepForMilliSeconds(200);
-    nodes[1]->getDagManager()->clearLightNodeHistory(node_cfgs[1].light_node_history);
   }
+  nodes[1]->getDagManager()->clearLightNodeHistory(node_cfgs[1].light_node_history);
   EXPECT_HAPPENS({10s, 1s}, [&](auto &ctx) {
     // Verify full node and light node sync without any issues
     WAIT_EXPECT_EQ(ctx, nodes[0]->getPbftChain()->getPbftChainSizeExcludingEmptyPbftBlocks(),


### PR DESCRIPTION
When clearing history for any table that has a hash for the key do not delete entry one by one but select values to keep for last 1000 blocks and delete all rest by recreating column.