### PR TITLE
fix: prioritize non-empty pbft blocks

### DIFF
--- a/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
+++ b/libraries/core_libs/consensus/src/pbft/pbft_manager.cpp
@@ -1386,8 +1386,10 @@ std::shared_ptr<PbftBlock> PbftManager::identifyLeaderBlock_(PbftRound round, Pb
       continue;
     }
 
-    if (leader_block->getPivotDagBlockHash() == kNullBlockHash && empty_leader_block == nullptr) {
-      empty_leader_block = leader_block;
+    if (leader_block->getPivotDagBlockHash() == kNullBlockHash) {
+      if(empty_leader_block == nullptr) {
+        empty_leader_block = leader_block;
+      }
       continue;
     }
     return leader_block;


### PR DESCRIPTION
Fixed an issue where empty pbft block could be identified as leader even with non-empty ones proposed