### PR TITLE
chore: improve dag proposal

### DIFF
--- a/libraries/core_libs/consensus/src/dag/dag_block_proposer.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_block_proposer.cpp
@@ -105,7 +105,9 @@ bool DagBlockProposer::proposeDagBlock() {
                                   max_vote_count);
 
   auto anchor = dag_mgr_->getAnchors().second;
-  if (frontier.pivot != anchor) {
+  auto ghost_path = dag_mgr_->getGhostPath(anchor);
+  const uint32_t min_ghost_path = 5;
+  if (ghost_path.size() > min_ghost_path) {
     if (dag_mgr_->getNonFinalizedBlocksSize().second > kMaxNonFinalizedDagBlocks) {
       return false;
     }


### PR DESCRIPTION
Reduce dag blocks being proposed if ghost path is smaller than 5 blocks to prevent huge number of dag blocks being proposed when network stalls.
Previously we had this limited to a single new anchor block which caused delays in dag block proposal and created empty pbft blocks often.