### PR TITLE
fix: always return full data for newHeads subscription

### DIFF
--- a/doc/RPC.md
+++ b/doc/RPC.md
@@ -59,10 +59,6 @@ Creates a new subscription for particular events. The node returns a subscriptio
 
 Fires a notification when new header is appended to the chain
 
-#### Params
-
-1. `BOOLEAN` - returns full data if true. Only hash otherwise. Default is false
-
 #### Example
 
 ```json

--- a/libraries/core_libs/network/include/network/subscriptions.hpp
+++ b/libraries/core_libs/network/include/network/subscriptions.hpp
@@ -35,14 +35,11 @@ class Subscription {
 
 class HeadsSubscription : public Subscription {
  public:
-  explicit HeadsSubscription(int id, bool hash_only = false) : Subscription(id), full_data_(hash_only) {}
+  explicit HeadsSubscription(int id) : Subscription(id) {}
   static constexpr SubscriptionType type = SubscriptionType::HEADS;
 
   SubscriptionType getType() const override { return type; }
   std::string processPayload(Json::Value payload) const override;
-
- private:
-  bool full_data_ = false;
 };
 
 class DagBlocksSubscription : public Subscription {

--- a/libraries/core_libs/network/rpc/jsonrpc_ws_server.cpp
+++ b/libraries/core_libs/network/rpc/jsonrpc_ws_server.cpp
@@ -76,7 +76,7 @@ std::string JsonRpcWsSession::handleSubscription(const Json::Value &req) {
 
   if (params.size() > 0) {
     if (params[0].asString() == "newHeads") {
-      subscriptions_.addSubscription(std::make_shared<HeadsSubscription>(subscription_id, options.asBool()));
+      subscriptions_.addSubscription(std::make_shared<HeadsSubscription>(subscription_id));
     } else if (params[0].asString() == "newPendingTransactions") {
       subscriptions_.addSubscription(std::make_shared<TransactionsSubscription>(subscription_id));
     } else if (params[0].asString() == "newDagBlocks") {

--- a/libraries/core_libs/network/src/subscriptions.cpp
+++ b/libraries/core_libs/network/src/subscriptions.cpp
@@ -68,9 +68,6 @@ std::string makeEthSubscriptionResponse(int id, const Json::Value& payload) {
 }
 
 std::string HeadsSubscription::processPayload(Json::Value payload) const {
-  if (!full_data_) {
-    payload = payload["hash"];
-  }
   return makeEthSubscriptionResponse(id_, payload);
 }
 


### PR DESCRIPTION
## Purpose
<!-- Provide any information reviewers might need to have context on your changes. -->


## How does the solution address the problem
<!-- Describe your solution. -->


## Changes made
<!-- Summary or changes that have been made. -->
