### PR TITLE
chore: large gas limit transactions handling

### DIFF
--- a/tests/pbft_manager_test.cpp
+++ b/tests/pbft_manager_test.cpp
@@ -538,8 +538,8 @@ TEST_F(PbftManagerWithDagCreation, dag_generation) {
 
 TEST_F(PbftManagerWithDagCreation, limit_dag_block_size) {
   auto node_cfgs = make_node_cfgs(1, 1, 5, true);
-  node_cfgs.front().genesis.dag.gas_limit = 500000;
-  node_cfgs.front().propose_dag_gas_limit = 500000;
+  node_cfgs.front().genesis.dag.gas_limit = 1000000;
+  node_cfgs.front().propose_dag_gas_limit = 1000000;
   makeNodeFromConfig(node_cfgs);
   deployContract();
 
@@ -573,7 +573,7 @@ TEST_F(PbftManagerWithDagCreation, limit_dag_block_size) {
   const uint32_t additional_trx_count = 30;
   insertTransactions(makeTransactions(additional_trx_count));
 
-  uint64_t should_be_in_one_dag_block = node->getConfig().genesis.dag.gas_limit / trxEstimation();
+  uint64_t should_be_in_one_dag_block = (node->getConfig().genesis.dag.gas_limit - TEST_TX_GAS_LIMIT) / trxEstimation() + 1;
   EXPECT_HAPPENS({10s, 250ms}, [&](auto &ctx) {
     WAIT_EXPECT_EQ(ctx, node->getDB()->getNumTransactionExecuted(), trxs_before + additional_trx_count)
     WAIT_EXPECT_EQ(ctx, node->getTransactionManager()->getTransactionCount(), trxs_before + additional_trx_count)


### PR DESCRIPTION
Any transaction over the propose dag gas limit should not be proposable in pool.

Include smaller gas limit transactions in packtrxs if large one does not fit.