### PR TITLE
chore: improve syncing

### DIFF
--- a/libraries/common/include/common/thread_pool.hpp
+++ b/libraries/common/include/common/thread_pool.hpp
@@ -34,11 +34,11 @@ class ThreadPool : std::enable_shared_from_this<ThreadPool> {
   bool is_running() const;
   void stop();
 
-  void post(uint64_t do_in_ms, asio_callback action);
-  void post(uint64_t err, std::function<void()> action);
+  std::future<void> post(uint64_t do_in_ms, asio_callback action);
+  std::future<void> post(uint64_t do_in_ms, std::function<void()> action);
 
   template <typename Action>
-  auto post(Action &&action) {
+  std::future<void> post(Action &&action) {
     return post(0, std::forward<Action>(action));
   }
 

--- a/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
+++ b/libraries/core_libs/consensus/include/pbft/pbft_manager.hpp
@@ -576,6 +576,9 @@ class PbftManager {
   std::shared_ptr<TransactionManager> trx_mgr_;
   std::shared_ptr<final_chain::FinalChain> final_chain_;
   std::shared_ptr<pillar_chain::PillarChainManager> pillar_chain_mgr_;
+  
+  const uint32_t kSyncingThreadPoolSize;
+  std::shared_ptr<util::ThreadPool> sync_thread_pool_; // Thread pool used for transaction sender retrieval in syncing blocks
 
   const addr_t node_addr_;
   const secret_t node_sk_;


### PR DESCRIPTION
On syncing get transactions sender in parallel. This improves syncing speed since getSender() is a bottleneck 