### PR TITLE
chore: improve gas pricer

### DIFF
--- a/libraries/app/src/app.cpp
+++ b/libraries/app/src/app.cpp
@@ -117,10 +117,10 @@ void App::init(const cli::Config &cli_conf) {
   }
 
   final_chain_ = std::make_shared<final_chain::FinalChain>(db_, conf_, node_addr);
-  gas_pricer_ = std::make_shared<GasPricer>(conf_.genesis, conf_.is_light_node, db_);
   key_manager_ = std::make_shared<KeyManager>(final_chain_);
   trx_mgr_ = std::make_shared<TransactionManager>(conf_, db_, final_chain_, node_addr);
-
+  gas_pricer_ = std::make_shared<GasPricer>(conf_.genesis, conf_.is_light_node, conf_.blocks_gas_pricer, trx_mgr_, db_);
+  
   auto genesis_hash = conf_.genesis.genesisHash();
   auto genesis_hash_from_db = db_->getGenesisHash();
   if (!genesis_hash_from_db.has_value()) {

--- a/libraries/config/include/config/config.hpp
+++ b/libraries/config/include/config/config.hpp
@@ -61,6 +61,9 @@ struct FullNodeConfig {
   // config values that limits transactions pool
   uint32_t transactions_pool_size = kDefaultTransactionPoolSize;
 
+  // Use blocks legacy gas pricer, if false gas pricer is based on transaction pool
+  bool blocks_gas_pricer = false;
+
   // Report malicious behaviour like double voting, etc... to slashing/jailing contract
   bool report_malicious_behaviour = false;
 

--- a/libraries/config/src/config.cpp
+++ b/libraries/config/src/config.cpp
@@ -76,6 +76,8 @@ void FullNodeConfig::overwriteConfigFromJson(const Json::Value &root) {
   // config values that limits transactions and blocks memory pools
   transactions_pool_size = getConfigDataAsUInt(root, {"transactions_pool_size"}, true, kDefaultTransactionPoolSize);
 
+  blocks_gas_pricer = getConfigDataAsBoolean(root, {"blocks_gas_pricer"}, true, blocks_gas_pricer);
+
   dec_json(root["network"], network);
 
   dec_json(root["db_config"], db_config);

--- a/libraries/core_libs/consensus/include/transaction/gas_pricer.hpp
+++ b/libraries/core_libs/consensus/include/transaction/gas_pricer.hpp
@@ -9,6 +9,7 @@
 namespace taraxa {
 
 class DbStorage;
+class TransactionManager;
 
 /** @addtogroup Transaction
  * @{
@@ -21,7 +22,8 @@ class DbStorage;
  */
 class GasPricer {
  public:
-  GasPricer(const GenesisConfig &config, bool is_light_node = false, std::shared_ptr<DbStorage> db = {});
+  GasPricer(const GenesisConfig &config, bool is_light_node = false, bool is_blocks_gas_pricer = false,
+            std::shared_ptr<TransactionManager> trx_mgr = nullptr, std::shared_ptr<DbStorage> db = {});
   ~GasPricer();
 
   GasPricer(const GasPricer &) = delete;
@@ -60,6 +62,8 @@ class GasPricer {
   boost::circular_buffer<u256> price_list_;
 
   std::unique_ptr<std::thread> init_daemon_;
+  const bool kBlocksGasPricer;
+  std::shared_ptr<TransactionManager> trx_mgr_;
 };
 
 /** @}*/

--- a/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
+++ b/libraries/core_libs/consensus/include/transaction/transaction_manager.hpp
@@ -235,6 +235,13 @@ class TransactionManager : public std::enable_shared_from_this<TransactionManage
    */
   bool transactionsDropped() const;
 
+  /**
+   * @brief Returns minimum gas price needed for transaction to be included
+   *  in the next proposed dag block
+   * @return Gas price
+   */
+  val_t getMinGasPriceForBlockInclusion() const;
+
   std::shared_ptr<Transaction> getTransaction(const trx_hash_t &hash) const;
   std::shared_ptr<Transaction> getNonFinalizedTransaction(const trx_hash_t &hash) const;
   unsigned long getTransactionCount() const;

--- a/libraries/core_libs/consensus/include/transaction/transaction_queue.hpp
+++ b/libraries/core_libs/consensus/include/transaction/transaction_queue.hpp
@@ -134,6 +134,14 @@ class TransactionQueue {
    */
   bool nonProposableTransactionsOverTheLimit() const;
 
+  
+  /**
+   * @brief Returns minimum gas price needed for transaction to be included
+   *  in the next proposed dag block
+   * @return Gas price
+   */
+  val_t getMinGasPriceForBlockInclusion(uint64_t limit) const;
+
  private:
   /**
    * @brief add transaction to queue
@@ -165,6 +173,9 @@ class TransactionQueue {
 
   // Transactions in the queue per trx hash
   std::unordered_map<trx_hash_t, std::shared_ptr<Transaction>> queue_transactions_;
+
+  // Amount of gas per gas prices in queue
+  std::map<val_t, uint64_t, std::greater<val_t>> queue_transactions_gas_prices_;
 
   // Low nonce and insufficient balance transactions which should not be included in proposed dag blocks but it is
   // possible because of dag reordering that some dag block might arrive requiring these transactions.

--- a/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
+++ b/libraries/core_libs/consensus/src/transaction/transaction_manager.cpp
@@ -585,4 +585,9 @@ bool TransactionManager::transactionsDropped() const {
   return transactions_pool_.transactionsDropped();
 }
 
+val_t TransactionManager::getMinGasPriceForBlockInclusion() const {
+  std::shared_lock transactions_lock(transactions_mutex_);
+  return transactions_pool_.getMinGasPriceForBlockInclusion(kConf.propose_dag_gas_limit);
+}
+
 }  // namespace taraxa

--- a/tests/gas_pricer_test.cpp
+++ b/tests/gas_pricer_test.cpp
@@ -1,29 +1,17 @@
 #include "transaction/gas_pricer.hpp"
+#include "config/config.hpp"
+#include "test_util/test_util.hpp"
 
 #include <gtest/gtest.h>
 
 namespace taraxa::core_tests {
-
-// Do not use NodesTest from "test_util/gtest.hpp" as its functionality is not needed in this test
-struct NodesTest : virtual testing::Test {
-  testing::UnitTest* current_test = ::testing::UnitTest::GetInstance();
-  testing::TestInfo const* current_test_info = current_test->current_test_info();
-
-  NodesTest() = default;
-  virtual ~NodesTest() = default;
-
-  NodesTest(const NodesTest&) = delete;
-  NodesTest(NodesTest&&) = delete;
-  NodesTest& operator=(const NodesTest&) = delete;
-  NodesTest& operator=(NodesTest&&) = delete;
-};
 
 struct GasPricerTest : NodesTest {};
 
 const auto secret = secret_t::random();
 
 TEST_F(GasPricerTest, basic_test) {
-  GasPricer gp(GenesisConfig{});
+  GasPricer gp(GenesisConfig{}, false, true);
   EXPECT_EQ(gp.bid(), 1);
 
   gp.update({std::make_shared<Transaction>(0, 0, 1 /*gas_price*/, 0, bytes(), secret)});
@@ -42,6 +30,22 @@ TEST_F(GasPricerTest, basic_test) {
   EXPECT_EQ(gp.bid(), 3);
 }
 
+TEST_F(GasPricerTest, basic_test_with_trx_pool) {
+  TransactionQueue priority_queue(nullptr);
+  auto trx = std::make_shared<Transaction>(1, 0, 2 /*gas_price*/, 100000, bytes(), secret);
+  priority_queue.insert(std::move(trx), true, 1);
+
+  EXPECT_EQ(priority_queue.getMinGasPriceForBlockInclusion(90000), 3);
+  EXPECT_EQ(priority_queue.getMinGasPriceForBlockInclusion(110000), 1);
+
+  auto trx2 = std::make_shared<Transaction>(2, 0, 3 /*gas_price*/, 200000, bytes(), secret);
+  priority_queue.insert(std::move(trx2), true, 1);
+  EXPECT_EQ(priority_queue.getMinGasPriceForBlockInclusion(190000), 4);
+  EXPECT_EQ(priority_queue.getMinGasPriceForBlockInclusion(210000), 3);
+  EXPECT_EQ(priority_queue.getMinGasPriceForBlockInclusion(290000), 3);
+  EXPECT_EQ(priority_queue.getMinGasPriceForBlockInclusion(310000), 1);
+}
+
 TEST_F(GasPricerTest, random_test) {
   std::srand(std::time(nullptr));
 
@@ -50,7 +54,7 @@ TEST_F(GasPricerTest, random_test) {
   config.gas_price.blocks = 100 + std::rand() % 200;
   config.gas_price.minimum_price = 0;
 
-  GasPricer gp(config);
+  GasPricer gp(config, false, true);
 
   std::vector<size_t> prices;
   prices.reserve(config.gas_price.blocks);


### PR DESCRIPTION
Gas pricer now supports two configurable modes. 
One is the old mode of getting gas price based on last N blocks.
New default config for getting gas price estimate is to get the gas price that will include the transaction in the next proposed dag block based on the current state of transaction pool.