### PR TITLE
chore: improve dag anchor selection

### DIFF
--- a/libraries/common/include/common/constants.hpp
+++ b/libraries/common/include/common/constants.hpp
@@ -31,6 +31,7 @@ constexpr uint32_t kMinTransactionPoolSize{30000};
 constexpr uint32_t kDefaultTransactionPoolSize{200000};
 constexpr uint32_t kMaxNonFinalizedTransactions{1000000};
 constexpr uint32_t kMaxNonFinalizedDagBlocks{100};
+constexpr uint32_t kMaxNonFinalizedDagBlocksLowDifficulty{5};
 
 const size_t kV4NetworkVersion = 4;
 

--- a/libraries/core_libs/consensus/src/dag/dag_block_proposer.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_block_proposer.cpp
@@ -107,7 +107,8 @@ bool DagBlockProposer::proposeDagBlock() {
     if (dag_mgr_->getNonFinalizedBlocksSize().second > kMaxNonFinalizedDagBlocks) {
       return false;
     }
-    if (dag_mgr_->getNonFinalizedBlocksMinDifficulty() < vdf.getDifficulty()) {
+    if (dag_mgr_->getNonFinalizedBlocksMinDifficulty() < vdf.getDifficulty() &&
+        dag_mgr_->getNonFinalizedBlocksSize().second > kMaxNonFinalizedDagBlocksLowDifficulty) {
       return false;
     }
   }
@@ -149,7 +150,7 @@ bool DagBlockProposer::proposeDagBlock() {
   while (result.wait_for(std::chrono::milliseconds(100)) != std::future_status::ready) {
     auto latest_frontier = dag_mgr_->getDagFrontier();
     const auto latest_level = getProposeLevel(latest_frontier.pivot, latest_frontier.tips) + 1;
-    if (latest_level > propose_level && vdf.getDifficulty() > sortition_params.vdf.difficulty_min) {
+    if (latest_level > propose_level + 1 && vdf.getDifficulty() > sortition_params.vdf.difficulty_min) {
       cancellation_token = true;
       break;
     }


### PR DESCRIPTION
If no new dag block pointing to last anchor, use any non finalized dag block with maximum level to avoid creating empty pbft blocks.

Adjust canceling proposing dag block to only give up if a block of higher level is already created. This makes creation of dag block with different difficulties and timing which makes dag creation less bursty.