### PR TITLE
fix: propose old dag blocks

### DIFF
--- a/libraries/core_libs/consensus/src/dag/dag_block_proposer.cpp
+++ b/libraries/core_libs/consensus/src/dag/dag_block_proposer.cpp
@@ -69,7 +69,6 @@ bool DagBlockProposer::proposeDagBlock() {
 
   if (*proposal_period + kDagExpiryLevelLimit < final_chain_->lastBlockNumber()) {
     LOG(log_wr_) << "Trying to propose old block " << propose_level;
-    return false;
   }
 
   if (!isValidDposProposer(*proposal_period)) {


### PR DESCRIPTION
When no dag blocks are proposed for a long time this incorrect error check would occur preventing from new dag blocks being created