### PR TITLE
Bump MPFR to 4.2.2 to solve Clang and glibc 2.41 build issues

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -23,7 +23,7 @@ class TaraxaConan(ConanFile):
         self.requires("rocksdb/9.10.0")
         self.requires("prometheus-cpp/1.3.0")
         self.requires("jsoncpp/1.9.6")
-        self.requires("mpfr/4.2.1")
+        self.requires("mpfr/4.2.2")
         self.requires("gmp/6.3.0")
         self.requires("rapidjson/1.1.0")
 


### PR DESCRIPTION
## Purpose

MPFR 4.2.1 causes build issues with Clang and glibc 2.41 (see release notes: https://www.mpfr.org/mpfr-current/)

## How does the solution address the problem

MPFR 4.2.2 has addressed the issue, so bumping up to lates will solve the build issues.

## Changes made

MPFR 4.2.1 -> MPFR 4.2.2 version bump in the conanfile.
